### PR TITLE
Re: [checker-framework] Stub parser fails to parse type parameters of the form <@Nullable T> (#460)

### DIFF
--- a/framework/src/org/checkerframework/framework/stub/StubParser.java
+++ b/framework/src/org/checkerframework/framework/stub/StubParser.java
@@ -680,6 +680,7 @@ public class StubParser {
             TypeParameter param = typeParameters.get(i);
             AnnotatedTypeVariable paramType = (AnnotatedTypeVariable)typeArguments.get(i);
 
+            annotate(paramType, param.getAnnotations());
             if (param.getTypeBound() != null && param.getTypeBound().size() == 1) {
                 annotate(paramType.getUpperBound(), param.getTypeBound().get(0));
             }

--- a/stubparser/src/org/checkerframework/stubparser/ASTParser.java
+++ b/stubparser/src/org/checkerframework/stubparser/ASTParser.java
@@ -751,9 +751,11 @@ final class ASTParser implements ASTParserConstants {
 
   final public TypeParameter TypeParameter() throws ParseException {
         String name;
+        List annotations = null;
         List typeBound = null;
         int line;
         int column;
+    annotations = Annotationsopt();
     jj_consume_token(IDENTIFIER);
                   name = token.image; line=token.beginLine; column=token.beginColumn;
     switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
@@ -764,7 +766,7 @@ final class ASTParser implements ASTParserConstants {
       jj_la1[27] = jj_gen;
       ;
     }
-     {if (true) return new TypeParameter(line, column, token.endLine, token.endColumn,name, typeBound);}
+     {if (true) return new TypeParameter(line, column, token.endLine, token.endColumn, name, annotations, typeBound);}
     throw new Error("Missing return statement in function");
   }
 
@@ -5323,6 +5325,7 @@ final class ASTParser implements ASTParserConstants {
   }
 
   private boolean jj_3R_168() {
+    if (jj_3R_77()) return true;
     if (jj_scan_token(IDENTIFIER)) return true;
     Token xsp;
     xsp = jj_scanpos;

--- a/stubparser/src/org/checkerframework/stubparser/ast/TypeParameter.java
+++ b/stubparser/src/org/checkerframework/stubparser/ast/TypeParameter.java
@@ -23,6 +23,7 @@ package org.checkerframework.stubparser.ast;
 
 import java.util.List;
 
+import org.checkerframework.stubparser.ast.expr.AnnotationExpr;
 import org.checkerframework.stubparser.ast.type.ClassOrInterfaceType;
 import org.checkerframework.stubparser.ast.visitor.GenericVisitor;
 import org.checkerframework.stubparser.ast.visitor.VoidVisitor;
@@ -48,17 +49,20 @@ public final class TypeParameter extends Node {
 
     private String name;
 
+    private List<AnnotationExpr> annotations;
+
     private List<ClassOrInterfaceType> typeBound;
 
     public TypeParameter() {
     }
 
-    public TypeParameter(String name, List<ClassOrInterfaceType> typeBound) {
+    public TypeParameter(String name, List<AnnotationExpr> annotations, List<ClassOrInterfaceType> typeBound) {
         this.name = name;
+        this.annotations = annotations;
         this.typeBound = typeBound;
     }
 
-    public TypeParameter(int beginLine, int beginColumn, int endLine, int endColumn, String name, List<ClassOrInterfaceType> typeBound) {
+    public TypeParameter(int beginLine, int beginColumn, int endLine, int endColumn, String name, List<AnnotationExpr> annotations, List<ClassOrInterfaceType> typeBound) {
         super(beginLine, beginColumn, endLine, endColumn);
         this.name = name;
         this.typeBound = typeBound;
@@ -111,6 +115,10 @@ public final class TypeParameter extends Node {
      */
     public void setTypeBound(List<ClassOrInterfaceType> typeBound) {
         this.typeBound = typeBound;
+    }
+
+    public List<AnnotationExpr> getAnnotations() {
+        return annotations;
     }
 
 }

--- a/stubparser/src/org/checkerframework/stubparser/ast/visitor/EqualsVisitor.java
+++ b/stubparser/src/org/checkerframework/stubparser/ast/visitor/EqualsVisitor.java
@@ -204,6 +204,10 @@ public class EqualsVisitor implements GenericVisitor<Boolean, Node> {
     public Boolean visit(TypeParameter n1, Node arg) {
         TypeParameter n2 = (TypeParameter) arg;
 
+        if (!nodesEquals(n1.getAnnotations(), n2.getAnnotations())) {
+            return Boolean.FALSE;
+        }
+
         if (!objEquals(n1.getName(), n2.getName())) {
             return Boolean.FALSE;
         }

--- a/stubparser/src/org/checkerframework/stubparser/ast/visitor/GenericVisitorAdapter.java
+++ b/stubparser/src/org/checkerframework/stubparser/ast/visitor/GenericVisitorAdapter.java
@@ -757,6 +757,11 @@ public abstract class GenericVisitorAdapter<R, A> implements GenericVisitor<R, A
     }
 
     public R visit(TypeParameter n, A arg) {
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
         if (n.getTypeBound() != null) {
             for (ClassOrInterfaceType c : n.getTypeBound()) {
                 c.accept(this, arg);

--- a/stubparser/src/org/checkerframework/stubparser/ast/visitor/ModifierVisitorAdapter.java
+++ b/stubparser/src/org/checkerframework/stubparser/ast/visitor/ModifierVisitorAdapter.java
@@ -865,6 +865,13 @@ public abstract class ModifierVisitorAdapter<A> implements GenericVisitor<Node, 
     }
 
     public Node visit(TypeParameter n, A arg) {
+        List<AnnotationExpr> annotations = n.getAnnotations();
+        if (annotations != null) {
+            for (int i = 0; i < annotations.size(); i++) {
+                annotations.set(i, (AnnotationExpr) annotations.get(i).accept(this, arg));
+            }
+            removeNulls(annotations);
+        }
         List<ClassOrInterfaceType> typeBound = n.getTypeBound();
         if (typeBound != null) {
             for (int i = 0; i < typeBound.size(); i++) {

--- a/stubparser/src/org/checkerframework/stubparser/ast/visitor/VoidVisitorAdapter.java
+++ b/stubparser/src/org/checkerframework/stubparser/ast/visitor/VoidVisitorAdapter.java
@@ -692,6 +692,11 @@ public abstract class VoidVisitorAdapter<A> implements VoidVisitor<A> {
     }
 
     public void visit(TypeParameter n, A arg) {
+        if (n.getAnnotations() != null) {
+            for (AnnotationExpr a : n.getAnnotations()) {
+                a.accept(this, arg);
+            }
+        }
         if (n.getTypeBound() != null) {
             for (ClassOrInterfaceType c : n.getTypeBound()) {
                 c.accept(this, arg);

--- a/stubparser/src/org/checkerframework/stubparser/java_1_5.jj
+++ b/stubparser/src/org/checkerframework/stubparser/java_1_5.jj
@@ -1436,13 +1436,15 @@ List TypeParameters():
 TypeParameter TypeParameter():
 {
 	String name;
+	List annotations = null;
 	List typeBound = null;
 	int line;
 	int column;
 }
 {
+   annotations = Annotationsopt()
    <IDENTIFIER> { name = token.image; line=token.beginLine; column=token.beginColumn;} [ typeBound = TypeBound() ]
-   { return new TypeParameter(line, column, token.endLine, token.endColumn,name, typeBound); }
+   { return new TypeParameter(line, column, token.endLine, token.endColumn,name, annotations, typeBound); }
 }
 
 List TypeBound():

--- a/stubparser/test/japa/parser/ast/test/classes/DumperTestClass.java
+++ b/stubparser/test/japa/parser/ast/test/classes/DumperTestClass.java
@@ -7,6 +7,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -322,7 +324,7 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
     class A<T extends Integer & Serializable> implements XXX, Serializable {
 
         @AnnotationTest
-        public <ABC> A(Integer integer, ABC string) throws Exception, IOException {
+        public <@TypeAnnotationTest ABC> A(Integer integer, ABC string) throws Exception, IOException {
         }
     }
 
@@ -358,6 +360,11 @@ public class DumperTestClass<T extends List<int[]>, X> extends Base implements S
         AnnotationTest valueA2() default @AnnotationTest("qwe");
 
         AnnotationTest valueA3() default @AnnotationTest(value = "qwe", valueI = { 1 });
+    }
+
+    @Documented
+    @Target({ElementType.TYPE_USE})
+    public @interface TypeAnnotationTest {
     }
 
     ;


### PR DESCRIPTION
Allows annotations on type parameters (not just bounds thereof).