### PR TITLE
Fix Issue #457

### DIFF
--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -998,7 +998,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
         V operandValue = p.getValueOfSubNode(n.getOperand());
 
         // Combine the two.
-        V mostPreciseValue = moreSpecificValue(factoryValue, operandValue);
+        V mostPreciseValue = moreSpecificValue(operandValue, factoryValue);
 
         // Insert into the store if possible.
         Receiver operandInternal = FlowExpressions.internalReprOf(

--- a/framework/tests/all-systems/Issue457.java
+++ b/framework/tests/all-systems/Issue457.java
@@ -1,0 +1,17 @@
+import java.lang.SuppressWarnings;
+
+// See gist: https://gist.github.com/JonathanBurke/6c1c1c28161a451611ad
+// for more information on what was going wrong here
+class Issue457<T extends Number> {
+   void callMe(T t) {
+   }
+   
+   @SuppressWarnings({"unused", "javari"})
+   public void f(T t) {
+      final T obj = t;
+      
+      Float objFloat = (obj instanceof Float) ? (Float) obj : null;
+
+      callMe(obj);
+   }
+}

--- a/framework/tests/all-systems/Issue457.java
+++ b/framework/tests/all-systems/Issue457.java
@@ -1,17 +1,14 @@
-import java.lang.SuppressWarnings;
-
 // See gist: https://gist.github.com/JonathanBurke/6c1c1c28161a451611ad
 // for more information on what was going wrong here
 class Issue457<T extends Number> {
-   void callMe(T t) {
-   }
-   
-   @SuppressWarnings({"unused", "javari"})
-   public void f(T t) {
-      final T obj = t;
-      
-      Float objFloat = (obj instanceof Float) ? (Float) obj : null;
 
-      callMe(obj);
-   }
+    @SuppressWarnings({"unused", "javari"})
+    public void f(T t) {
+        final T obj = t;
+      
+        Float objFloat = (obj instanceof Float) ? (Float) obj : null;
+
+        //An error will be emitted on this line before the fix for Issue457
+        t = obj;
+    }
 }


### PR DESCRIPTION
Make the instanceof operand the backup type when calculating mostSpecific
This a fix for https://github.com/typetools/checker-framework/issues/457