### PR TITLE
Add byfile compile policy argument

### DIFF
--- a/framework/src/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerMain.java
@@ -354,6 +354,7 @@ public class CheckerMain {
             args.add(quote(PluginUtil.join(File.pathSeparator, cpOpts)));
         }
 
+        args.add("-XDcompilePolicy=byfile");
         args.addAll(toolOpts);
         return args;
     }


### PR DESCRIPTION
In different locations in the Checker Framework we assume that compilation occurs by compilation unit and not by class.  An example of this is that we clear the tree -> type cache on a per-compilation unit basis.  However, the compiler actually compiles on a class-by-class basis as needed.  This has caused a few issues within Inference and means that at times, if I look up a path to a tree in the compilation unit I am currently visiting, that tree might have already passed onto to the next compilation phase .  E.g,  The framework runs after flow, I have run into trees that have had their type arguments erased.  

There is an "secret" option in the compiler that allows us to specify what unit of code is passed from phase to phase.    It is -XDcompilePolicy.  For those who are unfamiliar with -XD options.  They are deliberately undocumented because the compiler writers suggest that users should not rely on them.  They can be set much like -D properties.  E.g., The option added by this pull request is passed as follows:
-XDcompilePolicy=byfile

For more information you can consult the enum: 
com.sun.tools.javac.main.JavacMain.CompilePolicy

This pull-requests changes the compile-policy to "byfile" rather "bytodo" (the default).
I have run the Checker Framework tests but ran into configuration issues when running on Daikon.  The main concern with this change is that it could have a performance hit.  The whole reason that "bytodo" was used in the first place is to reduce memory footprint.  That said, we think that, given modern hardware, memory should no longer be a problem.

To complete this, someone must typecheck daikon and monitor compile time/memory usage.