### PR TITLE
Annotate primitive class literals correctly

### DIFF
--- a/framework/build.xml
+++ b/framework/build.xml
@@ -393,6 +393,13 @@
         </antcall>
     </target>
 
+    <target name="defaulting-field-tests" depends="jar,build-tests"
+            description="Run tests for the Checker Framework">
+        <antcall target="-run-tests">
+            <param name="param" value="tests.DefaultingFieldTest"/>
+        </antcall>
+    </target>
+
 
     <target name="lubglb-tests" depends="jar,build-tests"
             description="Run tests for the Lubglb Checker">

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -184,7 +184,6 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         if (elt.getKind().isClass() || elt.getKind().isInterface())
             return f.fromElement(elt);
 
-        // The expression might be a primitive type (as in "int.class").
         if (!(node.getExpression() instanceof PrimitiveTypeTree)) {
             // TODO: why don't we use getSelfType here?
             if (node.getIdentifier().contentEquals("this")) {
@@ -367,14 +366,16 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     @Override
     public AnnotatedTypeMirror visitPrimitiveType(PrimitiveTypeTree node,
                                                   AnnotatedTypeFactory f) {
-        // for e.g. "int.class"
+        // Node is the primitive type when primitive class literals are visited.
+        // for e.g. "int" when "int.class" is visited
         return f.fromTypeTree(node);
     }
 
     @Override
     public AnnotatedTypeMirror visitArrayType(ArrayTypeTree node,
                                               AnnotatedTypeFactory f) {
-        // for e.g. "int[].class"
+        // Node is the array type when array class literals are visited.
+        // for e.g. "int[]" in "int[].class" or "Object[]" in "Object[].class"
         return f.fromTypeTree(node);
     }
 

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -195,6 +195,11 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
             if (t instanceof AnnotatedDeclaredType || t instanceof AnnotatedArrayType || t instanceof AnnotatedTypeVariable) {
                 return AnnotatedTypes.asMemberOf(f.types, f, t, elt).asUse();
             }
+        } else {
+            if(node.getIdentifier().contentEquals("class")){
+                // Handle class literals for primitive types (as in int.class)
+                return f.getAnnotatedType(elt);
+            }
         }
 
         return f.fromElement(elt);

--- a/framework/tests/defaulting/field/MemberSelectDefaulting.java
+++ b/framework/tests/defaulting/field/MemberSelectDefaulting.java
@@ -1,0 +1,20 @@
+package defaulting.field;
+
+import tests.defaulting.FieldQual.*;
+
+import java.lang.Comparable;
+import java.lang.Object;
+import java.lang.Override;
+
+public class MemberSelectDefaulting {
+
+    // Sanity check.
+    @F_FIELD Short max = Short.MAX_VALUE;
+
+    // The type of Short.class and short.class should be identical
+    // short.class use to have the type @F_MEMBER_SELECT Class<@F_TOP Short>
+    // because the ImplicitsTreeAnnotator was used to add annotations.
+    @F_FIELD Class<@F_TOP Short> o1 = Short.class;
+    @F_FIELD Class<@F_TOP Short> o2 = short.class;
+    @F_FIELD Short s = new  java.lang. @F_FIELD Short("2");
+}

--- a/framework/tests/src/tests/DefaultingFieldTest.java
+++ b/framework/tests/src/tests/DefaultingFieldTest.java
@@ -5,9 +5,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.io.File;
 
-/**
- * Created by jburke on 9/29/14.
- */
 public class DefaultingFieldTest extends CheckerFrameworkTest {
 
     public DefaultingFieldTest(File testFile) {

--- a/framework/tests/src/tests/DefaultingFieldTest.java
+++ b/framework/tests/src/tests/DefaultingFieldTest.java
@@ -1,0 +1,25 @@
+package tests;
+
+import org.checkerframework.framework.test.CheckerFrameworkTest;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.io.File;
+
+/**
+ * Created by jburke on 9/29/14.
+ */
+public class DefaultingFieldTest extends CheckerFrameworkTest {
+
+    public DefaultingFieldTest(File testFile) {
+        super(testFile,
+                tests.defaulting.DefaultingFieldChecker.class,
+                "defaulting",
+                "-Anomsgtext"
+        );
+    }
+
+    @Parameters
+    public static String [] getTestDirs() {
+        return new String[]{"defaulting/field"};
+    }
+}

--- a/framework/tests/src/tests/defaulting/DefaultingFieldChecker.java
+++ b/framework/tests/src/tests/defaulting/DefaultingFieldChecker.java
@@ -1,0 +1,11 @@
+package tests.defaulting;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.qual.TypeQualifiers;
+
+/**
+ * Created by smillst on 11/3/15.
+ */
+@TypeQualifiers({FieldQual.F_FIELD.class, FieldQual.F_BOTTOM.class, FieldQual.F_TOP.class, FieldQual.F_MEMBER_SELECT.class})
+public class DefaultingFieldChecker extends BaseTypeChecker {
+}

--- a/framework/tests/src/tests/defaulting/FieldQual.java
+++ b/framework/tests/src/tests/defaulting/FieldQual.java
@@ -1,0 +1,48 @@
+package tests.defaulting;
+
+import com.sun.source.tree.Tree.Kind;
+import org.checkerframework.framework.qual.*;
+
+import java.lang.annotation.*;
+
+public class FieldQual {
+
+    @DefaultQualifierInHierarchy
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @SubtypeOf({})
+    @Target({ElementType.TYPE_USE})
+    public static @interface F_TOP {
+    }
+
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @SubtypeOf(F_TOP.class)
+    @ImplicitFor(trees = Kind.MEMBER_SELECT)
+    @Target({ElementType.TYPE_USE})
+    /**
+     * This annotation should not be applied implicitly
+     * because the type of a member select should
+     * the type of the member.
+     */
+    public static @interface F_MEMBER_SELECT {
+    }
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @SubtypeOf(F_TOP.class)
+    @DefaultFor(DefaultLocation.FIELD)
+    @Target({ElementType.TYPE_USE})
+    public static @interface F_FIELD {
+    }
+
+
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @SubtypeOf({F_FIELD.class, F_MEMBER_SELECT.class})
+    @Target({ElementType.TYPE_USE})
+    public static @interface F_BOTTOM {
+    }
+
+}


### PR DESCRIPTION
This fixes typetools/checker-framework-inference#7. 

Primitive class literals were annotated using the default qualifier (the annotation with @DefaultQualifierInHierarchy or whatever DefaultLocation.OTHERWISE) rather than whatever defaulting is applied to fields in class files.  For the Nullness Checker (and most other checkers) this results in the same qualified type.  However, this cause the inference framework to not insert VarAnnots on primitive class literals, which causes  typetools/checker-framework-inference#7.
I've ran all-tests and the Nullness Checker on daikon and both pass.   