### PR TITLE
ToString output format change in MultiGraphQualifierHierarchy

### DIFF
--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -234,30 +235,48 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
     @SideEffectFree
     @Override
     public String toString() {
-        // TODO: it would be easier to debug if the graph and map were sorted by the key.
-        // Simply creating a TreeMap here doesn't work, because AnnotationMirrors are not comparable.
+        StringBuilder sb = new StringBuilder();
+        sb.append("Supertypes Graph: ");
 
-        String output = "Supertypes Graph: ";
-        for (AnnotationMirror key : supertypesGraph.keySet()) {
-            output += "\n\t" + key.toString() + "=" + supertypesGraph.get(key);
+        for (Entry<AnnotationMirror, Set<AnnotationMirror>> qual : supertypesGraph.entrySet()) {
+            sb.append("\n\t");
+            sb.append(qual.getKey());
+            sb.append(" = ");
+            sb.append(qual.getValue());
         }
 
-        output += "\nSupertypes Map: ";
-        for (AnnotationMirror mapKey : supertypesMap.keySet()) {
-            output += "\n\t" + mapKey.toString() + "=[";
-            if (!supertypesMap.get(mapKey).isEmpty()) {
-                for (AnnotationMirror mapValKey : supertypesMap.get(mapKey)) {
-                    output += mapValKey.toString() + ", ";
-                }
-                output = output.substring(0, output.length() - 2);
+        sb.append("\nSupertypes Map: ");
+
+        for (Entry<AnnotationMirror, Set<AnnotationMirror>> qual : supertypesMap.entrySet()) {
+            sb.append("\n\t");
+            sb.append(qual.getKey());
+            sb.append(" = [");
+
+            Set<AnnotationMirror> supertypes = qual.getValue();
+
+            // if there's only 1 supertype for this qual, then directly display that in the same row
+            if (supertypes.size() == 1) {
+                sb.append(supertypes.iterator().next());
             }
-            output += "]";
+            // otherwise, display each supertype in its own row
+            else {
+                for (Iterator<AnnotationMirror> iterator = supertypes.iterator(); iterator.hasNext(); ) {
+                    sb.append("\n\t\t");                            // new line and tabbing
+                    sb.append(iterator.next());                     // display the supertype
+                    sb.append(iterator.hasNext() ? ", " : "");      // add a comma delimiter if it isn't the last value
+                }
+                sb.append("\n\t\t");    // new line and tab indentation for the trailing bracket
+            }
+
+            sb.append("]");
         }
 
-        output += "\nTops: " + tops +
-                "\nBottoms: " + bottoms;
+        sb.append("\nTops: ");
+        sb.append(tops);
+        sb.append("\nBottoms: ");
+        sb.append(bottoms);
 
-        return output;
+        return sb.toString();
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -236,10 +236,28 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
     public String toString() {
         // TODO: it would be easier to debug if the graph and map were sorted by the key.
         // Simply creating a TreeMap here doesn't work, because AnnotationMirrors are not comparable.
-        return "Supertypes Graph: " + supertypesGraph.toString() +
-                "\nSupertypes Map: " + String.valueOf(supertypesMap) +
-                "\nTops: " + tops +
+
+        String output = "Supertypes Graph: ";
+        for (AnnotationMirror key : supertypesGraph.keySet()) {
+            output += "\n\t" + key.toString() + "=" + supertypesGraph.get(key);
+        }
+
+        output += "\nSupertypes Map: ";
+        for (AnnotationMirror mapKey : supertypesMap.keySet()) {
+            output += "\n\t" + mapKey.toString() + "=[";
+            if (!supertypesMap.get(mapKey).isEmpty()) {
+                for (AnnotationMirror mapValKey : supertypesMap.get(mapKey)) {
+                    output += mapValKey.toString() + ", ";
+                }
+                output = output.substring(0, output.length() - 2);
+            }
+            output += "]";
+        }
+
+        output += "\nTops: " + tops +
                 "\nBottoms: " + bottoms;
+
+        return output;
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -254,12 +254,11 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
 
             Set<AnnotationMirror> supertypes = qual.getValue();
 
-            // if there's only 1 supertype for this qual, then directly display that in the same row
             if (supertypes.size() == 1) {
+                // if there's only 1 supertype for this qual, then directly display that in the same row
                 sb.append(supertypes.iterator().next());
-            }
-            // otherwise, display each supertype in its own row
-            else {
+            } else {
+                // otherwise, display each supertype in its own row
                 for (Iterator<AnnotationMirror> iterator = supertypes.iterator(); iterator.hasNext(); ) {
                     sb.append("\n\t\t");                            // new line and tabbing
                     sb.append(iterator.next());                     // display the supertype


### PR DESCRIPTION
Updates the ToString method of MultiGraphQualifierHierarchy to make it visually easier to debug type hierarchy problems.

The old format clumps everything into 1 giant continuous block of text. The new format adds new lines and tab indentations to the output to visually distinguish the type qualifiers and their supertypes.

This request has been reviewed at https://github.com/wmdietl/checker-framework/pull/3 and the feedback has been incorporated.