### PR TITLE
Permit per-field suppression of field initialization warnings

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -662,21 +662,21 @@
     </target>
 
     <target name="nullness-base-tests" depends="jar,build-tests"
-            description="Run base tests for the Nullness Checker">
+            description="Run base tests for the FBC Nullness Checker">
         <antcall target="-run-tests">
             <param name="param" value="tests.NullnessFbcTest"/>
         </antcall>
     </target>
 
     <target name="nullness-uninit-tests" depends="jar,build-tests"
-            description="Run uninit tests for the Nullness Checker">
+            description="Run base tests for the rawness Nullness Checker">
         <antcall target="-run-tests">
             <param name="param" value="tests.NullnessRawnessTest"/>
         </antcall>
     </target>
 
     <target name="nullness-base-tests-with-asserts" depends="jar,build-tests"
-            description="Run base tests for the Nullness Checker">
+            description="Run base tests for the FBC Nullness Checker, with assertions">
         <antcall target="-run-tests">
             <param name="param" value="tests.NullnessFbcTestWithAsserts"/>
         </antcall>
@@ -684,14 +684,14 @@
 
 
     <target name="nullness-assume-assertions-are-enabled-tests" depends="jar,build-tests"
-            description="Run uninit tests for the Nullness Checker">
+            description="Run base tests for the Nullness Checker, assuming assertions are disabled">
         <antcall target="-run-tests">
             <param name="param" value="tests.NullnessAssumeAssertionsAreDisabled"/>
         </antcall>
     </target>
 
     <target name="nullness-uninit-tests-with-asserts" depends="jar,build-tests"
-            description="Run uninit tests for the Nullness Checker">
+            description="Run base tests for the rawness Nullness Checker, with assertions">
         <antcall target="-run-tests">
             <param name="param" value="tests.NullnessRawnessTestWithAsserts"/>
         </antcall>

--- a/checker/manual/nullness-checker.tex
+++ b/checker/manual/nullness-checker.tex
@@ -1622,7 +1622,7 @@ initialization was actually complete, then the receiver should have type
 You can suppress warnings related to partially-initialized objects with
 \<@SuppressWarnings("initialization")>.
 This can be placed on a single field; on a constructor; or on a class to
-suppress all initialization warnings for all construtors.
+suppress all initialization warnings for all constructors.
 \end{sloppypar}
 
 \paragraph{Checking initialization of all fields, not just \code{@NonNull} ones\label{initialization-checking-all-fields}}
@@ -2170,4 +2170,4 @@ annotation has nothing to do with the raw types of Java Generics.
 %  LocalWords:  NullnessRawnessChecker mymap mykey KeyType ValueType 5cm
 %  LocalWords:  dereferenced dereference Dereferencing initializers 5in
 %  LocalWords:  initHelper helperMethod NoSuchElementException 4cm 5in 2in
-%%  LocalWords:  75in
+%  LocalWords:  75in forbidnonnullarraycomponents

--- a/checker/tests/initialization/fbc/FieldSuppressWarnings.java
+++ b/checker/tests/initialization/fbc/FieldSuppressWarnings.java
@@ -1,24 +1,30 @@
-import org.checkerframework.checker.nullness.qual.*;
-
-import java.util.*;
-
-//:: error: (initialization.fields.uninitialized)
 public class FieldSuppressWarnings {
 
-  private Object notInitialized;
+  //:: error: (initialization.fields.uninitialized)
+  static class FieldSuppressWarnings1 {
+    private Object notInitialized;
+  }
 
-  @SuppressWarnings("initialization.fields.uninitialized")
-  private Object notInitializedButSuppressed1;
+  static class FieldSuppressWarnings2 {
+    @SuppressWarnings("initialization.fields.uninitialized")
+    private Object notInitializedButSuppressed1;
+  }
 
-  @SuppressWarnings("initialization")
-  private Object notInitializedButSuppressed2;
+  static class FieldSuppressWarnings3 {
+    @SuppressWarnings("initialization")
+    private Object notInitializedButSuppressed2;
+  }
 
-  private Object initialized1;
+  static class FieldSuppressWarnings4 {
+    private Object initialized1;
 
-  private Object initialized2 = new Object();
+    {
+      initialized1 = new Object();
+    }
+  }
 
-  {
-    initialized1 = new Object();
+  static class FieldSuppressWarnings5 {
+    private Object initialized2 = new Object();
   }
 
 }

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -1266,6 +1266,19 @@ public abstract class SourceChecker
         return false;
     }
 
+    /**
+     * Determines whether all the warnings pertaining to a given tree
+     * should be suppressed.  Returns true if the element is within the scope
+     * of a @SuppressWarnings annotation, one of whose values suppresses
+     * the checker's warnings.  The list of keys that suppress a checker's
+     * warnings is provided by the {@link
+     * SourceChecker#getSuppressWarningsKey} method.
+     *
+     * @param elt the Element that might be a source of, or related to, a warning
+     * @return true if no warning should be emitted for the given tree because
+     *         it is contained by a declaration with an appropriately-valued
+     *         @SuppressWarnings annotation; false otherwise
+     */
     // Public so it can be called from InitializationVisitor.checkerFieldsInitialized
     public boolean shouldSuppressWarnings(/*@Nullable*/ Element elt, String err) {
 

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -1214,12 +1214,12 @@ public abstract class SourceChecker
      * of a @SuppressWarnings annotation, one of whose values suppresses
      * the checker's warnings.  The list of keys that suppress a checker's
      * warnings is provided by the {@link
-     * SourceChecker#getSuppressWarningsKey} method.
+     * SourceChecker#getSuppressWarningsKeys} method.
      *
      * @param tree the tree that might be a source of a warning
      * @return true if no warning should be emitted for the given tree because
      *         it is contained by a declaration with an appropriately-valued
-     *         @SuppressWarnings annotation; false otherwise
+     *         {@literal @}SuppressWarnings annotation; false otherwise
      */
     private boolean shouldSuppressWarnings(Tree tree, String err) {
 
@@ -1272,12 +1272,12 @@ public abstract class SourceChecker
      * of a @SuppressWarnings annotation, one of whose values suppresses
      * the checker's warnings.  The list of keys that suppress a checker's
      * warnings is provided by the {@link
-     * SourceChecker#getSuppressWarningsKey} method.
+     * SourceChecker#getSuppressWarningsKeys} method.
      *
      * @param elt the Element that might be a source of, or related to, a warning
      * @return true if no warning should be emitted for the given tree because
      *         it is contained by a declaration with an appropriately-valued
-     *         @SuppressWarnings annotation; false otherwise
+     *         {@literal @}SuppressWarnings annotation; false otherwise
      */
     // Public so it can be called from InitializationVisitor.checkerFieldsInitialized
     public boolean shouldSuppressWarnings(/*@Nullable*/ Element elt, String err) {


### PR DESCRIPTION
This patch enables a user to suppress field initialization warnings per field instead of only per constructor or per class.