### PR TITLE
Treat primitive class literals the same as other class literals.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -8,6 +8,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcard
 import org.checkerframework.framework.type.visitor.AnnotatedTypeMerger;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.ConstructorReturnUtil;
+import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
@@ -179,25 +180,33 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     @Override
     public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree node,
                                                  AnnotatedTypeFactory f) {
-
         Element elt = TreeUtils.elementFromUse(node);
-        if (elt.getKind().isClass() || elt.getKind().isInterface())
-            return f.fromElement(elt);
+        switch (elt.getKind()) {
+            case METHOD:
+            case PACKAGE: // "java.lang" in new java.lang.Short("2")
+            case CLASS:  // o instanceof MyClass.InnerClass
+            case ENUM:
+            case INTERFACE: // o instanceof MyClass.InnerInterface
+            case ANNOTATION_TYPE:
+                return f.fromElement(elt);
+        }
 
-        // The expression might be a primitive type (as in "int.class").
-        if (!(node.getExpression() instanceof PrimitiveTypeTree)) {
+        if (node.getIdentifier().contentEquals("this")) {
             // TODO: why don't we use getSelfType here?
-            if (node.getIdentifier().contentEquals("this")) {
-                return f.getEnclosingType((TypeElement) InternalUtils.symbol(node.getExpression()), node);
-            }
+            return f.getEnclosingType((TypeElement) InternalUtils.symbol(node.getExpression()), node);
+        } else if (node.getExpression().getKind() == Tree.Kind.PRIMITIVE_TYPE) {
+            // Handle class literals for primitive types (as in int.class)
+            return f.getAnnotatedType(elt);
+        } else {
             // We need the original t with the implicit annotations
             AnnotatedTypeMirror t = f.getAnnotatedType(node.getExpression());
-            if (t instanceof AnnotatedDeclaredType || t instanceof AnnotatedArrayType || t instanceof AnnotatedTypeVariable) {
+            if (t instanceof AnnotatedDeclaredType || t instanceof AnnotatedArrayType
+                    || t instanceof AnnotatedTypeVariable) {
                 return AnnotatedTypes.asMemberOf(f.types, f, t, elt).asUse();
             }
         }
-
-        return f.fromElement(elt);
+        ErrorReporter.errorAbort("TypeFromExpressionVisitor.visitMemberSelect unexpected element or type: " + node.toString());
+        return null; //dead code
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -181,6 +181,11 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree node,
                                                  AnnotatedTypeFactory f) {
         Element elt = TreeUtils.elementFromUse(node);
+
+        if(TreeUtils.isClassLiteral(node)){
+            // the type of a class literal is the type of the "class" element.
+            return f.getAnnotatedType(elt);
+        }
         switch (elt.getKind()) {
             case METHOD:
             case PACKAGE: // "java.lang" in new java.lang.Short("2")
@@ -194,9 +199,6 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         if (node.getIdentifier().contentEquals("this")) {
             // TODO: why don't we use getSelfType here?
             return f.getEnclosingType((TypeElement) InternalUtils.symbol(node.getExpression()), node);
-        } else if (node.getExpression().getKind() == Tree.Kind.PRIMITIVE_TYPE) {
-            // Handle class literals for primitive types (as in int.class)
-            return f.getAnnotatedType(elt);
         } else {
             // We need the original t with the implicit annotations
             AnnotatedTypeMirror t = f.getAnnotatedType(node.getExpression());

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -182,7 +182,7 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
                                                  AnnotatedTypeFactory f) {
         Element elt = TreeUtils.elementFromUse(node);
 
-        if(TreeUtils.isClassLiteral(node)){
+        if (TreeUtils.isClassLiteral(node)) {
             // the type of a class literal is the type of the "class" element.
             return f.getAnnotatedType(elt);
         }


### PR DESCRIPTION
Annotations are added to the type of "Integer.class" by:
TypeFromExpressionVisitor.visitMemberSelect(...) which calls
AnnotatedTypes.asMemberOf(...) which calls AnnotatedTypeFactory.getAnnotatedType(Element) which calls AnnotatedTypeFactory.annotateImplicit(Element, AnnotatedTypeMirror)

Annotations are added to the type of "int.class" by:
TypeFromExpressionVisitor.visitMemberSelect(...) which returns
AnnotatedTypeFactory.fromElement() to
AnnotatedTypeFactory.getAnnotatedType(Tree) which calls AnnotatedTypeFactory.annotateImplicit(Tree, AnnotatedTypeMirror)

With this change, Annotations are added to the type of "int.class" by:
TypeFromExpressionVisitor.visitMemberSelect(...) which calls
AnnotatedTypeFactory.getAnnotatedType(Element) which calls AnnotatedTypeFactory.annotateImplicit(Element, AnnotatedTypeMirror))

Fixes typetools/checker-framework-inference#7

(This pull request is the corrected version of #499)   