### PR TITLE
Remove redundant calls to String#intern in AnnotationUtils

### DIFF
--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -223,7 +223,7 @@ public class AnnotationUtils {
             Class<? extends Annotation> anno) {
         /*@Interned*/ String canonicalName;
         if (annotationClassNames.containsKey(anno)) {
-            canonicalName = annotationClassNames.get(anno).intern();
+            canonicalName = annotationClassNames.get(anno);
         } else {
             canonicalName = anno.getCanonicalName().intern();
             annotationClassNames.put(anno, canonicalName);


### PR DESCRIPTION
`AnnotationUtils#areSameByClass` uses a cache of interned strings; however, it still invokes `String#intern` on values retrieved from the cache. The added overhead can be significant: my test case showed a fairly significant reduction in the number of calls to `String#intern` (from ~2500 to ~1600), which resulted in a compilation time savings of around 90 seconds