### PR TITLE
@TargetLocations meta-annotation

### DIFF
--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
@@ -20,7 +20,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @Documented
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @SubtypeOf({}) //subtype relationships are set up by passing this class as a bottom
                //to the multigraph hierarchy constructor
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
@@ -3,8 +3,11 @@ package org.checkerframework.checker.fenum.qual;
 import java.lang.annotation.*;
 
 import com.sun.source.tree.Tree;
+
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -15,7 +18,9 @@ import org.checkerframework.framework.qual.TypeQualifier;
  */
 @TypeQualifier
 @Documented
-@Target({})    //empty target prevents programmers from writing this in a program
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({}) //subtype relationships are set up by passing this class as a bottom
                //to the multigraph hierarchy constructor
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.fenum.qual;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -8,6 +9,7 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -24,5 +26,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @DefaultFor({ DefaultLocation.LOCAL_VARIABLE, DefaultLocation.RESOURCE_VARIABLE })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface FenumTop {}

--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
@@ -26,7 +26,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @DefaultFor({ DefaultLocation.LOCAL_VARIABLE, DefaultLocation.RESOURCE_VARIABLE })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface FenumTop {}

--- a/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
+++ b/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import org.checkerframework.framework.qual.*;
@@ -18,7 +19,9 @@ import com.sun.source.tree.Tree;
  */
 @TypeQualifier
 @SubtypeOf({Format.class,InvalidFormat.class})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},
   typeNames = {java.lang.Void.class})
 @DefaultFor(value = {DefaultLocation.LOWER_BOUNDS})

--- a/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
+++ b/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
@@ -19,7 +19,7 @@ import com.sun.source.tree.Tree;
  */
 @TypeQualifier
 @SubtypeOf({Format.class,InvalidFormat.class})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
@@ -1,11 +1,13 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 import com.sun.source.tree.Tree;
@@ -23,8 +25,9 @@ import com.sun.source.tree.Tree;
  */
 @TypeQualifier
 @SubtypeOf({ I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class })
-@Target({})
-// empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @DefaultFor(value = {DefaultLocation.LOWER_BOUNDS})
 public @interface I18nFormatBottom {

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
@@ -25,7 +25,7 @@ import com.sun.source.tree.Tree;
  */
 @TypeQualifier
 @SubtypeOf({ I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class })
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
@@ -1,10 +1,13 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -25,6 +28,8 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface I18nUnknownFormat {
 }

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
@@ -28,7 +28,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface I18nUnknownFormat {

--- a/checker/src/org/checkerframework/checker/igj/IGJBottom.java
+++ b/checker/src/org/checkerframework/checker/igj/IGJBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.igj;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import org.checkerframework.checker.igj.qual.I;
@@ -26,5 +27,7 @@ import com.sun.source.tree.Tree.Kind;
         typeClasses = { AnnotatedPrimitiveType.class }
 )
 @DefaultFor({DefaultLocation.LOWER_BOUNDS})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @interface IGJBottom {}

--- a/checker/src/org/checkerframework/checker/igj/IGJBottom.java
+++ b/checker/src/org/checkerframework/checker/igj/IGJBottom.java
@@ -27,7 +27,7 @@ import com.sun.source.tree.Tree.Kind;
         typeClasses = { AnnotatedPrimitiveType.class }
 )
 @DefaultFor({DefaultLocation.LOWER_BOUNDS})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @interface IGJBottom {}

--- a/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
+++ b/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
@@ -5,6 +5,7 @@ import org.checkerframework.checker.initialization.qual.Initialized;
 import org.checkerframework.checker.initialization.qual.UnderInitialization;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,7 +30,8 @@ import com.sun.source.tree.Tree;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-// empty target prevents programmers from writing this in a program
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface FBCBottom {
 }

--- a/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
+++ b/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.Tree;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface FBCBottom {

--- a/checker/src/org/checkerframework/checker/oigj/OIGJMutabilityBottom.java
+++ b/checker/src/org/checkerframework/checker/oigj/OIGJMutabilityBottom.java
@@ -30,7 +30,7 @@ import com.sun.source.tree.Tree.Kind;
 @TypeQualifier
 @SubtypeOf({Mutable.class, Immutable.class, I.class,
     Modifier.class, O.class})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(

--- a/checker/src/org/checkerframework/checker/oigj/OIGJMutabilityBottom.java
+++ b/checker/src/org/checkerframework/checker/oigj/OIGJMutabilityBottom.java
@@ -9,9 +9,11 @@ import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiveType;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import com.sun.source.tree.Tree.Kind;
@@ -28,7 +30,9 @@ import com.sun.source.tree.Tree.Kind;
 @TypeQualifier
 @SubtypeOf({Mutable.class, Immutable.class, I.class,
     Modifier.class, O.class})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(
         trees = { Kind.NULL_LITERAL, Kind.CLASS, Kind.ENUM,
                 Kind.INTERFACE, Kind.ANNOTATION_TYPE,

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
@@ -24,7 +24,7 @@ import com.sun.source.tree.Tree;
   typeNames = {java.lang.Void.class})
 @SubtypeOf({Regex.class, PartialRegex.class})
 @DefaultFor(value={DefaultLocation.LOWER_BOUNDS})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface RegexBottom {}

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.regex.classic.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import org.checkerframework.checker.regex.qual.Regex;
@@ -23,5 +24,7 @@ import com.sun.source.tree.Tree;
   typeNames = {java.lang.Void.class})
 @SubtypeOf({Regex.class, PartialRegex.class})
 @DefaultFor(value={DefaultLocation.LOWER_BOUNDS})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface RegexBottom {}

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
@@ -1,10 +1,13 @@
 package org.checkerframework.checker.regex.classic.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -21,5 +24,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @InvisibleQualifier
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface UnknownRegex {}

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
@@ -24,7 +24,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @InvisibleQualifier
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface UnknownRegex {}

--- a/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
+++ b/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 import org.checkerframework.framework.qual.*;
@@ -20,7 +21,9 @@ import com.sun.source.tree.Tree;
     FieldDescriptorForArray.class,
     MethodDescriptor.class
     })
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},
   typeNames = {java.lang.Void.class})
 @DefaultFor({DefaultLocation.LOWER_BOUNDS})

--- a/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
+++ b/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
@@ -21,7 +21,7 @@ import com.sun.source.tree.Tree;
     FieldDescriptorForArray.class,
     MethodDescriptor.class
     })
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},

--- a/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
@@ -26,7 +26,7 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ClassVal.class, ClassBound.class })
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface ClassValBottom {

--- a/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
@@ -1,10 +1,13 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 import com.sun.source.tree.Tree;
@@ -23,6 +26,8 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ClassVal.class, ClassBound.class })
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface ClassValBottom {
 }

--- a/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
@@ -1,10 +1,13 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 import com.sun.source.tree.Tree;
@@ -23,6 +26,8 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ MethodVal.class })
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface MethodValBottom {
 }

--- a/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
@@ -26,7 +26,7 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ MethodVal.class })
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface MethodValBottom {

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
@@ -23,7 +23,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @TypeQualifier
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @DefaultQualifierInHierarchy

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
@@ -1,10 +1,13 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -20,7 +23,9 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @TypeQualifier
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @DefaultQualifierInHierarchy
 public @interface UnknownClass {
 }

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
@@ -1,10 +1,13 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -22,7 +25,9 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @TypeQualifier
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @DefaultQualifierInHierarchy
 public @interface UnknownMethod {
 }

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
@@ -25,7 +25,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @TypeQualifier
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 @DefaultQualifierInHierarchy

--- a/framework/src/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/org/checkerframework/common/value/qual/BottomVal.java
@@ -27,7 +27,7 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ArrayLen.class, BoolVal.class, DoubleVal.class,
         IntVal.class, StringVal.class })
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface BottomVal {

--- a/framework/src/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/org/checkerframework/common/value/qual/BottomVal.java
@@ -2,11 +2,14 @@ package org.checkerframework.common.value.qual;
 
 import com.sun.source.tree.Tree;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeQualifier;
 
 /**
@@ -24,7 +27,8 @@ import org.checkerframework.framework.qual.TypeQualifier;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ArrayLen.class, BoolVal.class, DoubleVal.class,
         IntVal.class, StringVal.class })
-@Target({})
-// empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface BottomVal {
 }

--- a/framework/src/org/checkerframework/framework/qual/Bottom.java
+++ b/framework/src/org/checkerframework/framework/qual/Bottom.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  */
 @TypeQualifier
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Target({ElementType.TYPE_USE})
 @TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
     DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface Bottom { }

--- a/framework/src/org/checkerframework/framework/qual/Bottom.java
+++ b/framework/src/org/checkerframework/framework/qual/Bottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.framework.qual;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 /**
@@ -29,5 +30,7 @@ import java.lang.annotation.Target;
  */
 @TypeQualifier
 @SubtypeOf({})
-@Target({}) // empty target prevents programmers from writing this in a program
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({DefaultLocation.EXPLICIT_LOWER_BOUNDS,
+    DefaultLocation.EXPLICIT_UPPER_BOUNDS})
 public @interface Bottom { }

--- a/framework/src/org/checkerframework/framework/qual/TargetLocations.java
+++ b/framework/src/org/checkerframework/framework/qual/TargetLocations.java
@@ -11,8 +11,9 @@ import java.lang.annotation.Target;
  * qualifier may be written.  When written together with
  * {@code @Target({ElementType.TYPE_USE})}, the given type qualifier may be
  * written only at locations listed in the {@code @TargetLocations(...)}
- * meta-annotation.  The absence of {@code @TargetLocations(...)}
- * means that the qualifier can be written on any type use.
+ * meta-annotation.  {@code @Target({ElementType.TYPE_USE})} together with no
+ * {@code @TargetLocations(...)} means that the qualifier can be written on any
+ * type use.
  * <p>
  *
  * This enables a type system designer to permit a qualifier to be written
@@ -23,11 +24,9 @@ import java.lang.annotation.Target;
  * This meta-annotation is a declarative, coarse-grained approach to enable
  * that. A {@link org.checkerframework.common.basetype.TypeValidator} must be
  * implemented if a more fine-grained control is necessary.
- * <p>
  *
- * TODO: Verify this meta-annotation (step 3 in
- * <a href="https://github.com/typetools/checker-framework/issues/515">Issue #515</a>).
  */
+// TODO: Verify this meta-annotation (step 3 in https://github.com/typetools/checker-framework/issues/515).
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)

--- a/framework/src/org/checkerframework/framework/qual/TargetLocations.java
+++ b/framework/src/org/checkerframework/framework/qual/TargetLocations.java
@@ -7,23 +7,34 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A meta-annotation that indicates locations where a particular qualifier
- * can be written.
- * The absence of {@link org.checkerframework.framework.qual.TargetLocations}
- * means that the qualifier can be written on any target location.
+ * A meta-annotation that restricts the type-use locations where a type
+ * qualifier may be written.  When written together with
+ * {@code @Target({ElementType.TYPE_USE})}, the given type qualifier may be
+ * written only at locations listed in the {@code @TargetLocations(...)}
+ * meta-annotation.  The absence of {@code @TargetLocations(...)}
+ * means that the qualifier can be written on any type use.
+ * <p>
  *
- * This meta-annotation takes as argument a list of
- * {@link org.checkerframework.framework.qual.DefaultLocation} at which the
- * qualifier is permitted.
- *
- * The reason this is needed is that {@link ElementType} is too coarse.
- * An example is that many type systems' bottom qualifier
- * (such as {@link org.checkerframework.checker.nullness.qual.KeyForBottom})
+ * This enables a type system designer to permit a qualifier to be written
+ * only in certain locations.  For example, some type systems' top and bottom
+ * qualifier (such as
+ * {@link org.checkerframework.checker.nullness.qual.KeyForBottom})
  * should only be written on an explicit wildcard upper or lower bound.
+ * This meta-annotation is a declarative, coarse-grained approach to enable
+ * that. A {@link org.checkerframework.common.basetype.TypeValidator} must be
+ * implemented if a more fine-grained control is necessary.
+ * <p>
+ *
+ * TODO: Verify this meta-annotation (step 3 in
+ * <a href="https://github.com/typetools/checker-framework/issues/515">Issue #515</a>).
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface TargetLocations {
+    /**
+     * Type uses at which the qualifier is permitted to be written
+     * in source code.
+     */
     DefaultLocation[] value();
 }

--- a/framework/src/org/checkerframework/framework/qual/TargetLocations.java
+++ b/framework/src/org/checkerframework/framework/qual/TargetLocations.java
@@ -1,0 +1,29 @@
+package org.checkerframework.framework.qual;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A meta-annotation that indicates locations where a particular qualifier
+ * can be written.
+ * The absence of {@link org.checkerframework.framework.qual.TargetLocations}
+ * means that the qualifier can be written on any target location.
+ *
+ * This meta-annotation takes as argument a list of
+ * {@link org.checkerframework.framework.qual.DefaultLocation} at which the
+ * qualifier is permitted.
+ *
+ * The reason this is needed is that {@link ElementType} is too coarse.
+ * An example is that many type systems' bottom qualifier
+ * (such as {@link org.checkerframework.checker.nullness.qual.KeyForBottom})
+ * should only be written on an explicit wildcard upper or lower bound.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface TargetLocations {
+    DefaultLocation[] value();
+}


### PR DESCRIPTION
Adds a new meta-annotation, \@TargetLocations, that indicates locations where a particular qualifier can be written. The absence of this meta-annotation means that the qualifier can be written anywhere.

This pull request also adds \@TargetLocations to existing Top/Bottom type qualifiers in the Checker Framework.

TODO: Verify this meta-annotation.

Tests done:
cd checker; ant all-tests