### PR TITLE
Add org.eclipse.jgit.annotations.Nullable and NonNull to aliased annotations

### DIFF
--- a/checker/manual/nullness-checker.tex
+++ b/checker/manual/nullness-checker.tex
@@ -848,6 +848,7 @@ Nullness Checker, as described in Figure~\ref{fig-nullness-refactoring}.
  ~javax.validation.constraints.NotNull~ \\ \hline
  ~lombok.NonNull~ \\ \hline
  ~org.eclipse.jdt.annotation.NonNull~ \\ \hline
+ ~org.eclipse.jgit.annotations.NonNull~ \\ \hline
  ~org.jetbrains.annotations.NotNull~ \\ \hline
  ~org.jmlspecs.annotation.NonNull~ \\ \hline
  ~org.netbeans.api.annotations.common.NonNull~ \\ \hline
@@ -869,6 +870,7 @@ $\Rightarrow$
  ~javax.annotation.Nullable~ \\ \hline
  ~javax.annotation.CheckForNull~ \\ \hline
  ~org.eclipse.jdt.annotation.Nullable~ \\ \hline
+ ~org.eclipse.jgit.annotations.Nullable~ \\ \hline
  ~org.jetbrains.annotations.Nullable~ \\ \hline
  ~org.jmlspecs.annotation.Nullable~ \\ \hline
  ~org.netbeans.api.annotations.common.NullAllowed~ \\ \hline

--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -109,6 +109,7 @@ public class NullnessAnnotatedTypeFactory
         addAliasedAnnotation(javax.validation.constraints.NotNull.class, NONNULL);
         addAliasedAnnotation(lombok.NonNull.class, NONNULL);
         addAliasedAnnotation(org.eclipse.jdt.annotation.NonNull.class, NONNULL);
+        addAliasedAnnotation(org.eclipse.jgit.annotations.NonNull.class, NONNULL);
         addAliasedAnnotation(org.jetbrains.annotations.NotNull.class, NONNULL);
         addAliasedAnnotation(org.netbeans.api.annotations.common.NonNull.class, NONNULL);
         addAliasedAnnotation(org.jmlspecs.annotation.NonNull.class, NONNULL);
@@ -123,6 +124,7 @@ public class NullnessAnnotatedTypeFactory
         addAliasedAnnotation(javax.annotation.CheckForNull.class, NULLABLE);
         addAliasedAnnotation(javax.annotation.Nullable.class, NULLABLE);
         addAliasedAnnotation(org.eclipse.jdt.annotation.Nullable.class, NULLABLE);
+        addAliasedAnnotation(org.eclipse.jgit.annotations.Nullable.class, NULLABLE);
         addAliasedAnnotation(org.jetbrains.annotations.Nullable.class, NULLABLE);
         addAliasedAnnotation(org.netbeans.api.annotations.common.CheckForNull.class, NULLABLE);
         addAliasedAnnotation(org.netbeans.api.annotations.common.NullAllowed.class, NULLABLE);

--- a/checker/src/org/eclipse/jgit/annotations/NonNull.java
+++ b/checker/src/org/eclipse/jgit/annotations/NonNull.java
@@ -1,0 +1,12 @@
+package org.eclipse.jgit.annotations;
+
+import java.lang.annotation.*;
+
+import org.checkerframework.framework.qual.TypeQualifier;
+
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE_USE})
+@TypeQualifier
+public @interface NonNull {
+}

--- a/checker/src/org/eclipse/jgit/annotations/Nullable.java
+++ b/checker/src/org/eclipse/jgit/annotations/Nullable.java
@@ -1,0 +1,12 @@
+package org.eclipse.jgit.annotations;
+
+import java.lang.annotation.*;
+
+import org.checkerframework.framework.qual.TypeQualifier;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE})
+@TypeQualifier
+public @interface Nullable {
+}


### PR DESCRIPTION
JGit versions 4.2 and newer are annotated using a custom Nullable and NonNull class.  ([1] explains why JGit didn't use one of the existing Nullable annotations.)  This patch teaches checker-framework about these so it can be used to check jgit and jgit callers for nullness errors.

JGit 4.2 hasn't been released yet, so alternatively if there is some way for it to avoid using a custom Nullable class, it's not too late to fix it.

[1] https://eclipse.googlesource.com/jgit/jgit/+/e12482deed7b