### PR TITLE
Optimize comparison of com.sun.tools.javac.util.Name instances

### DIFF
--- a/javacutil/src/org/checkerframework/javacutil/TypeAnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TypeAnnotationUtils.java
@@ -1,6 +1,7 @@
 package org.checkerframework.javacutil;
 
 import java.lang.reflect.InvocationTargetException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.tree.JCTree.JCLambda;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Pair;
 
 /**
@@ -49,7 +51,7 @@ public class TypeAnnotationUtils {
      */
     public static boolean isTypeCompoundContained(Types types, List<TypeCompound> list, TypeCompound tc) {
         for (Attribute.TypeCompound rawat : list) {
-            if (rawat.type.tsym.name.contentEquals(tc.type.tsym.name) &&
+            if (contentEquals(rawat.type.tsym.name, tc.type.tsym.name) &&
                     // TODO: in previous line, it would be nicer to use reference equality:
                     //   rawat.type == tc.type &&
                     // or at least "isSameType":
@@ -61,6 +63,14 @@ public class TypeAnnotationUtils {
             }
         }
         return false;
+    }
+
+    private static boolean contentEquals(Name n1, Name n2) {
+        // Views of underlying bytes, not copies as with Name#contentEquals
+        ByteBuffer b1 = ByteBuffer.wrap(n1.getByteArray(), n1.getByteOffset(), n1.getByteLength());
+        ByteBuffer b2 = ByteBuffer.wrap(n2.getByteArray(), n2.getByteOffset(), n2.getByteLength());
+
+        return b1.equals(b2);
     }
 
     /**


### PR DESCRIPTION
This change is inspired by a test case I've been dealing with: https://groups.google.com/forum/#!topic/checker-framework-discuss/O8C19Lwy49A

Using a profiler, I found a significant number of calls to `com.sun.tools.javac.util.Convert#utf2string` originating from `com.sun.tools.javac.util.Name#contentEquals` when invoked by `org.checkerframework.javacutil.TypeAnnotationUtils#isTypeCompoundContained`.

Because `TypeAnnotationUtils#isTypeCompoundContained` only compares `Name` instances to other `Name` instances, it is possible to optimize the comparison by bypassing the String conversion step and comparing the underlying byte arrays directly.

This change resulted in a 10% improvement in compilation time (from 11 minutes to 10 minutes) for the test case linked above.