### PR TITLE
fixes for jenkins CI for the annotation class loader

### DIFF
--- a/framework/build.xml
+++ b/framework/build.xml
@@ -358,21 +358,23 @@
     <target name="loader-tests" depends="loader-dir-test,loader-jar-test"
                 description="Run tests for the annotation class loader"/>
 
-    <target name="loader-jar-test" depends="jar"
-            description="Run tests for the annotation class loader by loading from jar file">
-        <exec executable="make" failonerror="${halt.on.test.failure}">
-            <env key="JAVAC" value="${env.JAVA_HOME}/bin/javac"/>
-            <arg line="-C tests/annotationclassloader/"/>
-            <arg line="load-from-jar-test"/>
-        </exec>
-    </target>
-
     <target name="loader-dir-test" depends="build-tests"
             description="Run tests for the annotation class loader by loading from build directories">
         <exec executable="make" failonerror="${halt.on.test.failure}">
             <env key="JAVAC" value="${env.JAVA_HOME}/bin/javac"/>
+            <env key="JAVACJAR" value="${jsr308.langtools.dist}/lib/javac.jar"/>
             <arg line="-C tests/annotationclassloader/"/>
             <arg line="load-from-dir-test"/>
+        </exec>
+    </target>
+
+    <target name="loader-jar-test" depends="jar"
+            description="Run tests for the annotation class loader by loading from jar file">
+        <exec executable="make" failonerror="${halt.on.test.failure}">
+            <env key="JAVAC" value="${env.JAVA_HOME}/bin/javac"/>
+            <env key="JAVACJAR" value="${jsr308.langtools.dist}/lib/javac.jar"/>
+            <arg line="-C tests/annotationclassloader/"/>
+            <arg line="load-from-jar-test"/>
         </exec>
     </target>
 

--- a/framework/tests/annotationclassloader/Makefile
+++ b/framework/tests/annotationclassloader/Makefile
@@ -1,20 +1,23 @@
-# this makefile contains the commands to test the AnnotationClassLoader
-# it uses the aliasing checker as it is one of the framework checkers that has a qual directory with qualifiers that must be loaded using the loader
+# This makefile contains the commands to test the AnnotationClassLoader.
+# Tt uses the aliasing checker as it is one of the framework checkers that has a
+# qual directory with qualifiers that must be loaded using the loader.
 
-# when called by the ant tests, JAVAC is defined as $JAVA_HOME/bin/javac, which could be jdk8 or jdk7
-# when executed as a demo, we'll use openjdk 8 located in the following directory (change to your setup):
-# ?= sets JAVAC only if JAVAC is undefined
+# When called by the ant tests, JAVAC is defined as $JAVA_HOME/bin/javac, which
+# could be jdk8 or jdk7. When executed as a demo, we'll use openjdk 8 located in
+# the following directory (change to your setup):
 JAVAC ?= /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
 
-# gets the full path to the directory of the make file, which is also the root dir of the qual folder
-# for custom projects, it is best to encode the full root path as a variable
+# Gets the full path to the directory of the make file, which is also the root
+# directory of the qual folder.
+# For custom projects, it is best to encode the full root path as a variable.
 PROJECTDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 FRAMEWORKJAR := $(PROJECTDIR)/../../dist/framework.jar
 
-# when called by the ant tests, JAVACJAR is defined as ${jsr308.langtools.dist}/lib/javac.jar
-# when executed as a demo, we'll use javac.jar located in a directory structure which assumes that the jsr308-langtools project is located in the same directory as checker-framework (change to your setup):
-# ?= sets JAVACJAR only if JAVACJAR is undefined
+# When called by the ant tests, JAVACJAR is defined as ${jsr308.langtools.dist}/lib/javac.jar
+# When executed as a demo, we'll use javac.jar located in a directory structure
+# which assumes that the jsr308-langtools project is located in the same
+# directory as checker-framework (change to your setup):
 JAVACJAR ?= $(PROJECTDIR)/../../../../jsr308-langtools/dist/lib/javac.jar
 
 # build directories
@@ -50,15 +53,27 @@ demo2:
 	LoaderTest.java
 
 # ======================================================
-# ant test usage
+# ant test usage:
 # loads from build directories
 load-from-dir-test:
-	-$(JAVAC) -J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) -processor org.checkerframework.common.aliasing.AliasingChecker -Anomsgtext -AprintErrorStack -Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub LoaderTest.java > Out.txt 2>&1
+	-$(JAVAC) \
+	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) \
+	-processor org.checkerframework.common.aliasing.AliasingChecker \
+	-Anomsgtext \
+	-AprintErrorStack \
+	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
+	LoaderTest.java > Out.txt 2>&1
 	diff -u Out.txt Expected.txt
 	-rm Out.txt
 
-#loads from framework.jar
+# loads from framework.jar
 load-from-jar-test:
-	-$(JAVAC) -J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) -processor org.checkerframework.common.aliasing.AliasingChecker -Anomsgtext -AprintErrorStack -Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub LoaderTest.java > Out.txt 2>&1
+	-$(JAVAC) \
+	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) \
+	-processor org.checkerframework.common.aliasing.AliasingChecker \
+	-Anomsgtext \
+	-AprintErrorStack \
+	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
+	LoaderTest.java > Out.txt 2>&1
 	diff -u Out.txt Expected.txt
 	-rm Out.txt

--- a/framework/tests/annotationclassloader/Makefile
+++ b/framework/tests/annotationclassloader/Makefile
@@ -1,21 +1,23 @@
 # this makefile contains the commands to test the AnnotationClassLoader
 # it uses the aliasing checker as it is one of the framework checkers that has a qual directory with qualifiers that must be loaded using the loader
 
-JAVAOPTS=-source 7 -target 7
-
 # when called by the ant tests, JAVAC is defined as $JAVA_HOME/bin/javac, which could be jdk8 or jdk7
-# when executed as a demo, we'll use openjdk 8
-ifndef JAVAC
-	JAVAC?=/usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-endif
+# when executed as a demo, we'll use openjdk 8 located in the following directory (change to your setup):
+# ?= sets JAVAC only if JAVAC is undefined
+JAVAC ?= /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
 
 # gets the full path to the directory of the make file, which is also the root dir of the qual folder
 # for custom projects, it is best to encode the full root path as a variable
 PROJECTDIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 FRAMEWORKJAR := $(PROJECTDIR)/../../dist/framework.jar
-JAVACJAR := $(PROJECTDIR)/../../../../jsr308-langtools/dist/lib/javac.jar
 
+# when called by the ant tests, JAVACJAR is defined as ${jsr308.langtools.dist}/lib/javac.jar
+# when executed as a demo, we'll use javac.jar located in a directory structure which assumes that the jsr308-langtools project is located in the same directory as checker-framework (change to your setup):
+# ?= sets JAVACJAR only if JAVACJAR is undefined
+JAVACJAR ?= $(PROJECTDIR)/../../../../jsr308-langtools/dist/lib/javac.jar
+
+# build directories
 DATAFLOWBUILD := $(PROJECTDIR)/../../../dataflow/build/
 JAVACUTILBUILD := $(PROJECTDIR)/../../../javacutil/build/
 STUBPARSERBUILD := $(PROJECTDIR)/../../../stubparser/build/
@@ -23,20 +25,11 @@ FRAMEWORKBUILD := $(PROJECTDIR)/../../build/
 
 all: load-from-dir-test load-from-jar-test
 
-demo: demo1 demo2
-
-# loads from framework.jar
+# ======================================================
+# demo or manual test usage:
+# loads from build directories
 demo1:
-	$(JAVAC) \
-	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) \
-	-processor org.checkerframework.common.aliasing.AliasingChecker \
-	-Anomsgtext \
-	-AprintErrorStack \
-	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
-	LoaderTest.java
-
-# loads from framework/build
-demo2:
+	@echo "***** This command is expected to produce an error on line 7:"
 	$(JAVAC) \
 	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) \
 	-processor org.checkerframework.common.aliasing.AliasingChecker \
@@ -45,11 +38,26 @@ demo2:
 	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
 	LoaderTest.java
 
+# loads from framework.jar
+demo2:
+	@echo "***** This command is expected to produce an error on line 7:"
+	$(JAVAC) \
+	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) \
+	-processor org.checkerframework.common.aliasing.AliasingChecker \
+	-Anomsgtext \
+	-AprintErrorStack \
+	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
+	LoaderTest.java
+
+# ======================================================
+# ant test usage
+# loads from build directories
 load-from-dir-test:
 	-$(JAVAC) -J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) -processor org.checkerframework.common.aliasing.AliasingChecker -Anomsgtext -AprintErrorStack -Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub LoaderTest.java > Out.txt 2>&1
 	diff -u Out.txt Expected.txt
 	-rm Out.txt
 
+#loads from framework.jar
 load-from-jar-test:
 	-$(JAVAC) -J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) -processor org.checkerframework.common.aliasing.AliasingChecker -Anomsgtext -AprintErrorStack -Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub LoaderTest.java > Out.txt 2>&1
 	diff -u Out.txt Expected.txt

--- a/framework/tests/annotationclassloader/README
+++ b/framework/tests/annotationclassloader/README
@@ -1,7 +1,8 @@
-This directory tests the annotation class loader's basic capabilities of loading from the qual directory of a checker in two ways:
+This directory tests the annotation class loader's basic capabilities of loading
+from the qual directory of a checker in two ways:
 1) from a file directory
 2) from a jar
 
-To see the demo, edit the Makefile with the location of your JDK 7 or 8's javac (variable JAVAC) and the location of the jsr308-langtools project for javac.jar (variable JAVACJAR)
-
-then run: make demo1 or make demo2
+To see the demo, edit the Makefile with the location of your JDK 7 or 8's javac
+(variable JAVAC) and the location of the jsr308-langtools project for javac.jar
+(variable JAVACJAR) then run: make demo1 or make demo2

--- a/framework/tests/annotationclassloader/README
+++ b/framework/tests/annotationclassloader/README
@@ -1,5 +1,7 @@
-This directory tests the annotation class loader's basic capabilities of loading from the qual directory of a checker in two ways;
-1) from a jar
-2) from a file directory
+This directory tests the annotation class loader's basic capabilities of loading from the qual directory of a checker in two ways:
+1) from a file directory
+2) from a jar
 
-To see the demo, run: make demo
+To see the demo, edit the Makefile with the location of your JDK 7 or 8's javac (variable JAVAC) and the location of the jsr308-langtools project for javac.jar (variable JAVACJAR)
+
+then run: make demo1 or make demo2


### PR DESCRIPTION
Fixed an environment variable definition bug in annotationclassloader/Makefile for the location of javac.jar

It was previously assumed that the jsr308-langtools project was located in the same directory as the checker-framework project, and it had used relative paths to point to javac.jar.
It will now receive the proper jsr308-langtools project directory from ant if called by ant script.
If it is directly executed from command line, it will still utilize the old directory (users are asked to update the makefile in such a scenario to reflect their project configurations)

Also updated readme, makefile, and build target so that the ordering is always the loading from directory test followed by the loading from jar test