### PR TITLE
Renamings of Default{,Qualifier}ForUnannotatedCode

### DIFF
--- a/checker/manual/advanced-features.tex
+++ b/checker/manual/advanced-features.tex
@@ -568,8 +568,8 @@ suppress the warnings (see Section~\ref{suppressing-warnings}).
 % external libraries.
 
 % TODO: document
-% the \refqualclass{framework/qual}{DefaultForUnannotatedCode}
-% and \refqualclass{framework/qual}{DefaultQualifierForUnannotatedCode}
+% the \refqualclass{framework/qual}{DefaultInUncheckedCodeFor}
+% and \refqualclass{framework/qual}{DefaultQualifierInHierarchyInUncheckedCode}
 % annotations for type system designers.
 
 

--- a/checker/src/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
@@ -33,7 +33,7 @@ public class FenumAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         this.postInit();
         // flow.setDebug(System.err);
-        defaults.addAbsoluteDefault(FENUM_BOTTOM, DefaultLocation.LOWER_BOUNDS);
+        defaults.addCheckedCodeDefault(FENUM_BOTTOM, DefaultLocation.LOWER_BOUNDS);
     }
 
     /** Copied from SubtypingChecker.

--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -93,7 +93,7 @@ public class KeyForAnnotatedTypeFactory extends
 
         this.postInit();
 
-        this.defaults.addAbsoluteDefault(UNKNOWNKEYFOR, DefaultLocation.ALL);
+        this.defaults.addCheckedCodeDefault(UNKNOWNKEYFOR, DefaultLocation.ALL);
 
         // Add compatibility annotations:
         addAliasedAnnotation(org.checkerframework.checker.nullness.compatqual.KeyForDecl.class, KEYFOR);

--- a/checker/src/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/checker/src/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -10,10 +10,7 @@ import javax.lang.model.type.TypeKind;
 
 import org.checkerframework.checker.initialization.InitializationChecker;
 import org.checkerframework.checker.nullness.AbstractNullnessChecker;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
@@ -61,7 +58,7 @@ import com.sun.source.tree.Tree;
         Tree.Kind.DOUBLE_LITERAL, Tree.Kind.FLOAT_LITERAL,
         Tree.Kind.INT_LITERAL, Tree.Kind.LONG_LITERAL, Tree.Kind.STRING_LITERAL })
 @DefaultQualifierInHierarchy
-@DefaultForUnannotatedCode({ DefaultLocation.PARAMETERS, DefaultLocation.LOWER_BOUNDS })
+@DefaultInUncheckedCodeFor({ DefaultLocation.PARAMETERS, DefaultLocation.LOWER_BOUNDS })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })

--- a/checker/src/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/checker/src/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -7,11 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.checkerframework.checker.nullness.AbstractNullnessChecker;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -34,7 +31,7 @@ import com.sun.source.tree.Tree;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @DefaultFor({ DefaultLocation.LOCAL_VARIABLE, DefaultLocation.RESOURCE_VARIABLE,
             DefaultLocation.IMPLICIT_UPPER_BOUNDS })
-@DefaultForUnannotatedCode({ DefaultLocation.RETURNS, DefaultLocation.UPPER_BOUNDS })
+@DefaultInUncheckedCodeFor({ DefaultLocation.RETURNS, DefaultLocation.UPPER_BOUNDS })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })

--- a/checker/src/org/checkerframework/checker/propkey/PropertyKeyAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/propkey/PropertyKeyAnnotatedTypeFactory.java
@@ -48,7 +48,7 @@ public class PropertyKeyAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         PROPKEY_BOTTOM = AnnotationUtils.fromClass(elements, PropertyKeyBottom.class);
 
         this.postInit();
-        this.defaults.addAbsoluteDefault(PROPKEY_BOTTOM, DefaultLocation.LOWER_BOUNDS);
+        this.defaults.addCheckedCodeDefault(PROPKEY_BOTTOM, DefaultLocation.LOWER_BOUNDS);
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/regex/RegexChecker.java
+++ b/checker/src/org/checkerframework/checker/regex/RegexChecker.java
@@ -25,12 +25,12 @@ public class RegexChecker extends CheckerAdapter<QualParams<Regex>> {
 
     @Override
     public void setupDefaults(QualifierDefaults defaults) {
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         new QualParams<>(new GroundQual<>(Regex.BOTTOM))),
                 DefaultLocation.LOWER_BOUNDS);
 
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         new QualParams<>(new GroundQual<>(Regex.TOP))),
                 DefaultLocation.LOCAL_VARIABLE);

--- a/checker/src/org/checkerframework/checker/tainting/TaintingChecker.java
+++ b/checker/src/org/checkerframework/checker/tainting/TaintingChecker.java
@@ -20,12 +20,12 @@ public class TaintingChecker extends CheckerAdapter<QualParams<Tainting>> {
 
     @Override
     public void setupDefaults(QualifierDefaults defaults) {
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         new QualParams<>(new GroundQual<>(Tainting.UNTAINTED))),
                 DefaultLocation.IMPLICIT_LOWER_BOUNDS);
 
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         new QualParams<>(new GroundQual<>(Tainting.TAINTED))),
                 DefaultLocation.LOCAL_VARIABLE);

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -227,8 +227,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected QualifierDefaults createQualifierDefaults() {
         QualifierDefaults defaults = super.createQualifierDefaults();
-        defaults.addAbsoluteDefault(UNKNOWNVAL, DefaultLocation.OTHERWISE);
-        defaults.addAbsoluteDefault(BOTTOMVAL, DefaultLocation.LOWER_BOUNDS);
+        defaults.addCheckedCodeDefault(UNKNOWNVAL, DefaultLocation.OTHERWISE);
+        defaults.addCheckedCodeDefault(BOTTOMVAL, DefaultLocation.LOWER_BOUNDS);
 
         return defaults;
     }

--- a/framework/src/org/checkerframework/framework/qual/DefaultInUncheckedCodeFor.java
+++ b/framework/src/org/checkerframework/framework/qual/DefaultInUncheckedCodeFor.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  *
  * @see AnnotatedFor
  * @see DefaultQualifier
- * @see DefaultQualifierForUnannotatedCode
+ * @see DefaultQualifierInHierarchyInUncheckedCode
  * @see ImplicitFor
  * @checker_framework.manual #defaults-classfile Default qualifiers for .class files (conservative library defaults)
  * @checker_framework.manual #compiling-libraries Compiling partially-annotated libraries
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
-public @interface DefaultForUnannotatedCode {
+public @interface DefaultInUncheckedCodeFor {
     /**
      * @return the locations to which the annotation should be applied
      */

--- a/framework/src/org/checkerframework/framework/qual/DefaultQualifierInHierarchyInUncheckedCode.java
+++ b/framework/src/org/checkerframework/framework/qual/DefaultQualifierInHierarchyInUncheckedCode.java
@@ -18,7 +18,7 @@ import java.lang.annotation.*;
  * <p>
  *
  * Each type qualifier hierarchy may have at most one qualifier marked as
- * {@code DefaultQualifierForUnannotatedCode}.
+ * {@code DefaultQualifierInHierarchyInUncheckedCode}.
  * <p>
  *
  * Note, this annotation is analogous to
@@ -26,11 +26,11 @@ import java.lang.annotation.*;
  * unannotated type uses.
  * This qualifier is for type system developers, not end-users.
  * @see AnnotatedFor
- * @see DefaultForUnannotatedCode
+ * @see DefaultInUncheckedCodeFor
  * @checker_framework.manual #defaults-classfile Default qualifiers for .class files (conservative library defaults)
  * @checker_framework.manual #compiling-libraries Compiling partially-annotated libraries
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ANNOTATION_TYPE)
-public @interface DefaultQualifierForUnannotatedCode {}
+public @interface DefaultQualifierInHierarchyInUncheckedCode {}

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -176,14 +176,14 @@ import com.sun.tools.javac.util.Log;
     "concurrentSemantics",
 
     // Whether to use conservative checks for unannotated bytecode; these are configured
-    // by the specific type checker using @Default[Qualifier]ForUnannotatedCode.
+    // by the specific type checker using @DefaultInUncheckedCodeFor and @DefaultQualifierInHierarchyInUncheckedCode.
     // They may require more annotations or stub files.
     // "unsafeDefaultsForUnannotatedBytecode",
     // TODO: temporary option to turn on sound behavior.
     "safeDefaultsForUnannotatedBytecode",
 
     // Whether to use conservative checks for unannotated source code; these are configured
-    // by the specific type checker using @Default[Qualifier]ForUnannotatedCode
+    // by the specific type checker using @DefaultInUncheckedCodeFor and @DefaultQualifierInHierarchyInUncheckedCode
     // and only apply to source code that is not marked as @AnnotatedFor the checker
     // that is being executed.
     "useSafeDefaultsForUnannotatedSourceCode",

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -26,10 +26,10 @@ import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifier;
-import org.checkerframework.framework.qual.DefaultQualifierForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchyInUncheckedCode;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.MonotonicQualifier;
@@ -354,7 +354,7 @@ public abstract class GenericAnnotatedTypeFactory<
             DefaultFor defaultFor = qual.getAnnotation(DefaultFor.class);
             if (defaultFor != null) {
                 final DefaultLocation [] locations = defaultFor.value();
-                defs.addAbsoluteDefaults(AnnotationUtils.fromClass(elements,qual), locations);
+                defs.addCheckedCodeDefaults(AnnotationUtils.fromClass(elements, qual), locations);
 
                 foundDefaultOtherwise = foundDefaultOtherwise ||
                         Arrays.asList(locations).contains(DefaultLocation.OTHERWISE);
@@ -368,7 +368,7 @@ public abstract class GenericAnnotatedTypeFactory<
                             "qualifier has both @DefaultFor and @DefaultQualifierInHierarchy annotations: " +
                             qual.getCanonicalName());
                 } else {
-                    defs.addAbsoluteDefault(AnnotationUtils.fromClass(elements, qual),
+                    defs.addCheckedCodeDefault(AnnotationUtils.fromClass(elements, qual),
                             DefaultLocation.OTHERWISE);
                     foundDefaultOtherwise = true;
                 }
@@ -380,25 +380,25 @@ public abstract class GenericAnnotatedTypeFactory<
                     checker.hasOption("safeDefaultsForUnannotatedBytecode") ||
                     // This block may need to be split after safeDefaults... is reverted to unsafeDefaults...
                     checker.hasOption("useSafeDefaultsForUnannotatedSourceCode")) {
-                DefaultForUnannotatedCode defaultForUnannotated = qual.getAnnotation(DefaultForUnannotatedCode.class);
+                DefaultInUncheckedCodeFor defaultForUnannotated = qual.getAnnotation(DefaultInUncheckedCodeFor.class);
 
                 if (defaultForUnannotated != null) {
                     final DefaultLocation [] locations = defaultForUnannotated.value();
-                    defs.addUnannotatedDefaults(AnnotationUtils.fromClass(elements, qual), locations);
+                    defs.addUncheckedCodeDefaults(AnnotationUtils.fromClass(elements, qual), locations);
                     // TODO: here and for source code above, should ALL also be handled?
                     foundDefaultOtherwiseForUnannotatedCode = foundDefaultOtherwiseForUnannotatedCode ||
                             Arrays.asList(locations).contains(DefaultLocation.OTHERWISE);
                 }
 
-                if (qual.getAnnotation(DefaultQualifierForUnannotatedCode.class) != null) {
+                if (qual.getAnnotation(DefaultQualifierInHierarchyInUncheckedCode.class) != null) {
                     if (defaultForUnannotated != null) {
-                        // A type qualifier should either have a DefaultForUnannotatedCode or
-                        // a DefaultQualifierForUnannotatedCode annotation.
+                        // A type qualifier should either have a DefaultInUncheckedCodeFor or
+                        // a DefaultQualifierInHierarchyInUncheckedCode annotation.
                         ErrorReporter.errorAbort("GenericAnnotatedTypeFactory.createQualifierDefaults: " +
-                                "qualifier has both @DefaultForUnannotatedCode and @DefaultQualifierForUnannotatedCode annotations: " +
+                                "qualifier has both @DefaultInUncheckedCodeFor and @DefaultQualifierInHierarchyInUncheckedCode annotations: " +
                                 qual.getCanonicalName());
                     } else {
-                        defs.addUnannotatedDefault(AnnotationUtils.fromClass(elements, qual),
+                        defs.addUncheckedCodeDefault(AnnotationUtils.fromClass(elements, qual),
                                     DefaultLocation.OTHERWISE);
                         foundDefaultOtherwiseForUnannotatedCode = true;
                     }
@@ -411,8 +411,7 @@ public abstract class GenericAnnotatedTypeFactory<
         AnnotationMirror unqualified = AnnotationUtils.fromClass(elements, Unqualified.class);
         if (!foundDefaultOtherwise &&
                 this.isSupportedQualifier(unqualified)) {
-            defs.addAbsoluteDefault(unqualified,
-                    DefaultLocation.OTHERWISE);
+            defs.addCheckedCodeDefault(unqualified, DefaultLocation.OTHERWISE);
         }
 
         // Add defaults for unannotated code if conservative unannotated flag is passed and
@@ -425,14 +424,14 @@ public abstract class GenericAnnotatedTypeFactory<
                 !foundDefaultOtherwiseForUnannotatedCode) {
             Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
             for (AnnotationMirror top : tops) {
-                defs.addUnannotatedDefault(top, DefaultLocation.RETURNS);
-                defs.addUnannotatedDefault(top, DefaultLocation.UPPER_BOUNDS);
+                defs.addUncheckedCodeDefault(top, DefaultLocation.RETURNS);
+                defs.addUncheckedCodeDefault(top, DefaultLocation.UPPER_BOUNDS);
             }
             Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
             for (AnnotationMirror bot : bottoms) {
-                defs.addUnannotatedDefault(bot, DefaultLocation.PARAMETERS);
-                defs.addUnannotatedDefault(bot, DefaultLocation.LOWER_BOUNDS);
-                defs.addUnannotatedDefault(bot, DefaultLocation.FIELD);
+                defs.addUncheckedCodeDefault(bot, DefaultLocation.PARAMETERS);
+                defs.addUncheckedCodeDefault(bot, DefaultLocation.LOWER_BOUNDS);
+                defs.addUncheckedCodeDefault(bot, DefaultLocation.FIELD);
                 // TODO: this isn't simply DefaultLocation.OTHERWISE, because that would
                 // also apply to type declarations, which isn't currently working as desired.
                 // See: https://groups.google.com/d/msg/checker-framework-dev/vk2V6ZFKPLk/v3hENw-e7gsJ

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -83,8 +83,8 @@ public class QualifierDefaults {
     private final AnnotatedTypeFactory atypeFactory;
     private final List<String> upstreamCheckerNames;
 
-    private final DefaultSet absoluteDefaults = new DefaultSet();
-    private final DefaultSet unannotatedDefaults = new DefaultSet();
+    private final DefaultSet checkedCodeDefaults = new DefaultSet();
+    private final DefaultSet uncheckedCodeDefaults = new DefaultSet();
 
     /** Mapping from an Element to the source Tree of the declaration. */
     private static final int CACHE_SIZE = 300;
@@ -105,9 +105,9 @@ public class QualifierDefaults {
     private final Map<Element, Boolean> elementAnnotatedFors = new IdentityHashMap<>();
 
     /**
-     * List of DefaultLocations which are valid for unannotated code defaults.
+     * List of DefaultLocations which are valid for unchecked code defaults.
      */
-    private static final DefaultLocation[] validUnannotatedDefaultLocations = {
+    private static final DefaultLocation[] validUncheckedCodeDefaultLocations = {
         DefaultLocation.FIELD,
         DefaultLocation.PARAMETERS,
         DefaultLocation.RETURNS,
@@ -119,12 +119,12 @@ public class QualifierDefaults {
     };
 
     /**
-     * Returns an array of locations that are valid for the unannotated value
+     * Returns an array of locations that are valid for the unchecked value
      * defaults.  These are simply by syntax, since an entire file is typechecked,
-     * it is not possible for local variables to be unannotated.
+     * it is not possible for local variables to be unchecked.
      */
-    public static DefaultLocation[] validLocationsForUnannotated() {
-        return validUnannotatedDefaultLocations;
+    public static DefaultLocation[] validLocationsForUncheckedCodeDefaults() {
+        return validUncheckedCodeDefaultLocations;
     }
 
     /**
@@ -141,33 +141,33 @@ public class QualifierDefaults {
      * Sets the default annotations.  A programmer may override this by
      * writing the @DefaultQualifier annotation on an element.
      */
-    public void addAbsoluteDefault(AnnotationMirror absoluteDefaultAnno, DefaultLocation location) {
-        checkDuplicates(absoluteDefaults, absoluteDefaultAnno, location);
-        absoluteDefaults.add(new Default(absoluteDefaultAnno, location));
+    public void addCheckedCodeDefault(AnnotationMirror absoluteDefaultAnno, DefaultLocation location) {
+        checkDuplicates(checkedCodeDefaults, absoluteDefaultAnno, location);
+        checkedCodeDefaults.add(new Default(absoluteDefaultAnno, location));
     }
 
     /**
-     * Sets the default annotation for unannotated elements.
+     * Sets the default annotation for unchecked elements.
      */
-    public void addUnannotatedDefault(AnnotationMirror unannotatedDefaultAnno, DefaultLocation location) {
-        checkDuplicates(unannotatedDefaults, unannotatedDefaultAnno, location);
-        checkIsValidUnannotatedLocation(unannotatedDefaultAnno, location);
+    public void addUncheckedCodeDefault(AnnotationMirror uncheckedDefaultAnno, DefaultLocation location) {
+        checkDuplicates(uncheckedCodeDefaults, uncheckedDefaultAnno, location);
+        checkIsValidUncheckedCodeLocation(uncheckedDefaultAnno, location);
 
-        unannotatedDefaults.add(new Default(unannotatedDefaultAnno, location));
+        uncheckedCodeDefaults.add(new Default(uncheckedDefaultAnno, location));
     }
 
     /**
-     * Sets the default annotation for unannotated elements, with specific locations.
+     * Sets the default annotation for unchecked elements, with specific locations.
      */
-    public void addUnannotatedDefaults(AnnotationMirror absoluteDefaultAnno, DefaultLocation[] locations) {
+    public void addUncheckedCodeDefaults(AnnotationMirror absoluteDefaultAnno, DefaultLocation[] locations) {
         for (DefaultLocation location : locations) {
-            addUnannotatedDefault(absoluteDefaultAnno, location);
+            addUncheckedCodeDefault(absoluteDefaultAnno, location);
         }
     }
 
-    public void addAbsoluteDefaults(AnnotationMirror absoluteDefaultAnno, DefaultLocation[] locations) {
+    public void addCheckedCodeDefaults(AnnotationMirror absoluteDefaultAnno, DefaultLocation[] locations) {
         for (DefaultLocation location : locations) {
-            addAbsoluteDefault(absoluteDefaultAnno, location);
+            addCheckedCodeDefault(absoluteDefaultAnno, location);
         }
     }
 
@@ -185,9 +185,9 @@ public class QualifierDefaults {
         elementDefaults.put(elem, prevset);
     }
 
-    private void checkIsValidUnannotatedLocation(AnnotationMirror unannotatedDefaultAnno, DefaultLocation location) {
+    private void checkIsValidUncheckedCodeLocation(AnnotationMirror uncheckedDefaultAnno, DefaultLocation location) {
         boolean isValidUntypeLocation = false;
-        for (DefaultLocation validLoc : validLocationsForUnannotated()) {
+        for (DefaultLocation validLoc : validLocationsForUncheckedCodeDefaults()) {
             if (location == validLoc) {
                 isValidUntypeLocation = true;
                 break;
@@ -196,7 +196,7 @@ public class QualifierDefaults {
 
         if (!isValidUntypeLocation) {
             ErrorReporter.errorAbort(
-                    "Invalid unannotated default location: " + location + " -> " + unannotatedDefaultAnno );
+                    "Invalid unchecked code default location: " + location + " -> " + uncheckedDefaultAnno );
         }
 
     }
@@ -503,13 +503,13 @@ public class QualifierDefaults {
     }
 
     /*
-     * Given an element, returns whether the unannotated (i.e. conservative defaults)
+     * Given an element, returns whether the unchecked code default (i.e. conservative defaults)
      * should be applied for it. Handles elements from bytecode or source code.
      */
-    public boolean applyUnannotatedDefaults(final Element annotationScope) {
+    public boolean applyUncheckedCodeDefaults(final Element annotationScope) {
         boolean annotatedForThisChecker = isElementAnnotatedForThisChecker(annotationScope);
 
-        if (unannotatedDefaults.size() > 0) {
+        if (uncheckedCodeDefaults.size() > 0) {
             // TODO: I would expect this:
             //   atypeFactory.isFromByteCode(annotationScope)) {
             // to work instead of the
@@ -552,13 +552,13 @@ public class QualifierDefaults {
             applier.apply(def);
         }
 
-        if (applyUnannotatedDefaults(annotationScope)) {
-            for (Default def : unannotatedDefaults) {
+        if (applyUncheckedCodeDefaults(annotationScope)) {
+            for (Default def : uncheckedCodeDefaults) {
                 applier.apply(def);
             }
         }
 
-        for (Default def : absoluteDefaults) {
+        for (Default def : checkedCodeDefaults) {
             applier.apply(def);
         }
     }

--- a/framework/src/org/checkerframework/qualframework/base/CheckerAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/CheckerAdapter.java
@@ -164,11 +164,11 @@ public class CheckerAdapter<Q> extends BaseTypeChecker {
     }
 
     public void setupDefaults(QualifierDefaults defaults) {
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         underlying.getTypeFactory().getQualifierHierarchy().getBottom()),
                 DefaultLocation.IMPLICIT_LOWER_BOUNDS);
-        defaults.addAbsoluteDefault(
+        defaults.addCheckedCodeDefault(
                 getTypeMirrorConverter().getAnnotation(
                         underlying.getTypeFactory().getQualifierHierarchy().getTop()),
                 DefaultLocation.LOCAL_VARIABLE);

--- a/framework/tests/src/tests/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/tests/src/tests/util/FlowTestAnnotatedTypeFactory.java
@@ -33,7 +33,7 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         this.postInit();
 
         addTypeNameImplicit(java.lang.Void.class, BOTTOM);
-        this.defaults.addAbsoluteDefault(BOTTOM, DefaultLocation.LOWER_BOUNDS);
+        this.defaults.addCheckedCodeDefault(BOTTOM, DefaultLocation.LOWER_BOUNDS);
     }
 
     @Override

--- a/framework/tests/src/tests/util/SubQual.java
+++ b/framework/tests/src/tests/util/SubQual.java
@@ -3,12 +3,12 @@ package tests.util;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** A subtype of SuperQual. */
 @SubtypeOf(SuperQual.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@DefaultForUnannotatedCode({ DefaultLocation.PARAMETERS, DefaultLocation.LOWER_BOUNDS })
+@DefaultInUncheckedCodeFor({ DefaultLocation.PARAMETERS, DefaultLocation.LOWER_BOUNDS })
 public @interface SubQual {}

--- a/framework/tests/src/tests/util/SuperQual.java
+++ b/framework/tests/src/tests/util/SuperQual.java
@@ -3,7 +3,7 @@ package tests.util;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -12,5 +12,5 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@DefaultForUnannotatedCode({ DefaultLocation.RETURNS, DefaultLocation.UPPER_BOUNDS })
+@DefaultInUncheckedCodeFor({ DefaultLocation.RETURNS, DefaultLocation.UPPER_BOUNDS })
 public @interface SuperQual {}

--- a/framework/tests/src/tests/util/TestChecker.java
+++ b/framework/tests/src/tests/util/TestChecker.java
@@ -73,7 +73,7 @@ class TestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         this.postInit();
 
         addTypeNameImplicit(java.lang.Void.class, BOTTOM);
-        this.defaults.addAbsoluteDefault(BOTTOM, DefaultLocation.LOWER_BOUNDS);
+        this.defaults.addCheckedCodeDefault(BOTTOM, DefaultLocation.LOWER_BOUNDS);
     }
 
     @Override

--- a/framework/tests/test-lubglb/lubglb/quals/B.java
+++ b/framework/tests/test-lubglb/lubglb/quals/B.java
@@ -6,12 +6,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf({A.class})
-@DefaultForUnannotatedCode({DefaultLocation.PARAMETERS})
+@DefaultInUncheckedCodeFor({DefaultLocation.PARAMETERS})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/framework/tests/test-lubglb/lubglb/quals/F.java
+++ b/framework/tests/test-lubglb/lubglb/quals/F.java
@@ -7,7 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.DefaultForUnannotatedCode;
+import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultLocation;
 import org.checkerframework.framework.qual.SubtypeOf;
 
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @DefaultFor({DefaultLocation.LOWER_BOUNDS})
-@DefaultForUnannotatedCode({DefaultLocation.RETURNS})
+@DefaultInUncheckedCodeFor({DefaultLocation.RETURNS})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface F { }


### PR DESCRIPTION
Rename DefaultForUnannotatedCode to DefaultInUncheckedCodeFor.
Rename DefaultQualifierForUnannotatedCode to DefaultQualifierInHierarchyInUncheckedCode.