### PR TITLE
No default qualifier stack trace output enhancement

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -59,12 +59,14 @@ import java.lang.annotation.ElementType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -754,15 +756,45 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * <p>
      * Subclasses cannot override this method; they should override
-     * {@link #createSupportedTypeQualifiers createSupportedTypeQualifiers} instead.
-
+     * {@link #createSupportedTypeQualifiers createSupportedTypeQualifiers}
+     * instead.
+     *
      * @see #createSupportedTypeQualifiers()
      *
-     * @return the type qualifiers supported this processor, or an empty
-     * set if none
+     * @return an immutable HashSet of the supported type qualifiers, or an
+     *         empty set if no qualifiers are supported
      */
     public final Set<Class<? extends Annotation>> getSupportedTypeQualifiers() {
         return supportedQuals;
+    }
+
+    /**
+     * Defines alphabetical sort ordering for qualifiers
+     */
+    private static final Comparator<Class<? extends Annotation>> QUALIFIER_SORT_ORDERING
+    = new Comparator<Class<? extends Annotation>>() {
+        @Override
+        public int compare(Class<? extends Annotation> a1, Class<? extends Annotation> a2) {
+            return a1.getCanonicalName().compareTo(a2.getCanonicalName());
+        }
+    };
+
+    /**
+     * Returns an alphabetically sorted immutable set of the type qualifiers
+     * supported by this checker. This method is useful for debug printing
+     * purposes, but otherwise returns the same set as
+     * {@link #getSupportedTypeQualifiers()}.
+     *
+     * @see #getSupportedTypeQualifiers()
+     *
+     * @return a sorted and immutable TreeSet of the supported type qualifiers,
+     *         or an empty set if no qualifiers are supported
+     */
+    public final Set<Class<? extends Annotation>> getSortedSupportedTypeQualifiers() {
+        // perform sorting by insertion into a TreeSet.
+        Set<Class<? extends Annotation>> sortedSupportedQuals = new TreeSet<Class<? extends Annotation>>(QUALIFIER_SORT_ORDERING);
+        sortedSupportedQuals.addAll(getSupportedTypeQualifiers());
+        return Collections.unmodifiableSet(sortedSupportedQuals);
     }
 
     // **********************************************************************

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -66,7 +66,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -780,21 +779,22 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     };
 
     /**
-     * Returns an alphabetically sorted immutable set of the type qualifiers
+     * Returns an alphabetically sorted immutable list of the type qualifiers
      * supported by this checker. This method is useful for debug printing
-     * purposes, but otherwise returns the same set as
+     * purposes, but otherwise returns the same qualifiers as
      * {@link #getSupportedTypeQualifiers()}.
      *
      * @see #getSupportedTypeQualifiers()
      *
-     * @return a sorted and immutable TreeSet of the supported type qualifiers,
-     *         or an empty set if no qualifiers are supported
+     * @return an immutable sorted list of the supported type qualifiers, or an
+     *         immutable empty list if no qualifiers are supported
      */
-    public final Set<Class<? extends Annotation>> getSortedSupportedTypeQualifiers() {
-        // perform sorting by insertion into a TreeSet.
-        Set<Class<? extends Annotation>> sortedSupportedQuals = new TreeSet<Class<? extends Annotation>>(QUALIFIER_SORT_ORDERING);
+    public final List<Class<? extends Annotation>> getSortedSupportedTypeQualifiers() {
+        // insert into an array list then sort it alphabetically
+        List<Class<? extends Annotation>> sortedSupportedQuals = new ArrayList<Class<? extends Annotation>>();
         sortedSupportedQuals.addAll(getSupportedTypeQualifiers());
-        return Collections.unmodifiableSet(sortedSupportedQuals);
+        sortedSupportedQuals.sort(QUALIFIER_SORT_ORDERING);
+        return Collections.unmodifiableList(sortedSupportedQuals);
     }
 
     // **********************************************************************

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -59,7 +59,6 @@ import java.lang.annotation.ElementType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -760,41 +759,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * @see #createSupportedTypeQualifiers()
      *
-     * @return an immutable HashSet of the supported type qualifiers, or an
+     * @return an immutable set of the supported type qualifiers, or an
      *         empty set if no qualifiers are supported
      */
     public final Set<Class<? extends Annotation>> getSupportedTypeQualifiers() {
         return supportedQuals;
-    }
-
-    /**
-     * Defines alphabetical sort ordering for qualifiers
-     */
-    private static final Comparator<Class<? extends Annotation>> QUALIFIER_SORT_ORDERING
-    = new Comparator<Class<? extends Annotation>>() {
-        @Override
-        public int compare(Class<? extends Annotation> a1, Class<? extends Annotation> a2) {
-            return a1.getCanonicalName().compareTo(a2.getCanonicalName());
-        }
-    };
-
-    /**
-     * Returns an alphabetically sorted immutable list of the type qualifiers
-     * supported by this checker. This method is useful for debug printing
-     * purposes, but otherwise returns the same qualifiers as
-     * {@link #getSupportedTypeQualifiers()}.
-     *
-     * @see #getSupportedTypeQualifiers()
-     *
-     * @return an immutable sorted list of the supported type qualifiers, or an
-     *         immutable empty list if no qualifiers are supported
-     */
-    public final List<Class<? extends Annotation>> getSortedSupportedTypeQualifiers() {
-        // insert into an array list then sort it alphabetically
-        List<Class<? extends Annotation>> sortedSupportedQuals = new ArrayList<Class<? extends Annotation>>();
-        sortedSupportedQuals.addAll(getSupportedTypeQualifiers());
-        Collections.sort(sortedSupportedQuals, QUALIFIER_SORT_ORDERING);
-        return Collections.unmodifiableList(sortedSupportedQuals);
     }
 
     // **********************************************************************

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -793,7 +793,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // insert into an array list then sort it alphabetically
         List<Class<? extends Annotation>> sortedSupportedQuals = new ArrayList<Class<? extends Annotation>>();
         sortedSupportedQuals.addAll(getSupportedTypeQualifiers());
-        sortedSupportedQuals.sort(QUALIFIER_SORT_ORDERING);
+        Collections.sort(sortedSupportedQuals, QUALIFIER_SORT_ORDERING);
         return Collections.unmodifiableList(sortedSupportedQuals);
     }
 

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -354,6 +354,39 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     /**
+     * Creates and returns a string containing the number of qualifiers and the
+     * canonical class names of each qualifier that has been added to this
+     * checker's supported qualifier set. The names are alphabetically sorted.
+     *
+     * @return a string containing the number of qualifiers and canonical names
+     *         of each qualifier.
+     */
+    private final String getSortedQualifierNames() {
+        Set<Class<? extends Annotation>> sortedQuals = getSortedSupportedTypeQualifiers();
+
+        // display the number of qualifiers as well as the names of each
+        // qualifier.
+        StringBuilder sb = new StringBuilder();
+        sb.append(" ");
+        sb.append(sortedQuals.size());
+        sb.append(" qualifiers examined");
+
+        if (sortedQuals.size() > 0) {
+            sb.append(": ");
+            // for each qualifier, add its canonical name, a comma and a space
+            // to the string.
+            for (Class<? extends Annotation> qual : sortedQuals) {
+                sb.append(qual.getCanonicalName());
+                sb.append(", ");
+            }
+            // remove last comma and space
+            return sb.substring(0, sb.length() - 2);
+        } else {
+            return sb.toString();
+        }
+    }
+
+    /**
      * Adds default qualifiers for type-checked code by
      * reading  {@link DefaultFor} and {@link DefaultQualifierInHierarchy}
      * meta-annotations.
@@ -398,7 +431,7 @@ public abstract class GenericAnnotatedTypeFactory<
             ErrorReporter
                     .errorAbort("GenericAnnotatedTypeFactory.createQualifierDefaults: "
                                         + "@DefaultQualifierInHierarchy or @DefaultFor(DefaultLocation.OTHERWISE) not found. "
-                                        + "Every checker must specify a default qualifier.");
+                                        + "Every checker must specify a default qualifier." + getSortedQualifierNames());
         }
     }
 

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -54,6 +54,8 @@ import org.checkerframework.javacutil.TreeUtils;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -354,6 +356,17 @@ public abstract class GenericAnnotatedTypeFactory<
     }
 
     /**
+     * Defines alphabetical sort ordering for qualifiers
+     */
+    private static final Comparator<Class<? extends Annotation>> QUALIFIER_SORT_ORDERING
+    = new Comparator<Class<? extends Annotation>>() {
+        @Override
+        public int compare(Class<? extends Annotation> a1, Class<? extends Annotation> a2) {
+            return a1.getCanonicalName().compareTo(a2.getCanonicalName());
+        }
+    };
+
+    /**
      * Creates and returns a string containing the number of qualifiers and the
      * canonical class names of each qualifier that has been added to this
      * checker's supported qualifier set. The names are alphabetically sorted.
@@ -361,21 +374,24 @@ public abstract class GenericAnnotatedTypeFactory<
      * @return a string containing the number of qualifiers and canonical names
      *         of each qualifier.
      */
-    private final String getSortedQualifierNames() {
-        List<Class<? extends Annotation>> sortedQuals = getSortedSupportedTypeQualifiers();
+    protected final String getSortedQualifierNames() {
+        // Create a list of the supported qualifiers and sort the list
+        // alphabetically
+        List<Class<? extends Annotation>> sortedSupportedQuals = new ArrayList<Class<? extends Annotation>>();
+        sortedSupportedQuals.addAll(getSupportedTypeQualifiers());
+        Collections.sort(sortedSupportedQuals, QUALIFIER_SORT_ORDERING);
 
         // display the number of qualifiers as well as the names of each
         // qualifier.
         StringBuilder sb = new StringBuilder();
-        sb.append(" ");
-        sb.append(sortedQuals.size());
+        sb.append(sortedSupportedQuals.size());
         sb.append(" qualifiers examined");
 
-        if (sortedQuals.size() > 0) {
+        if (sortedSupportedQuals.size() > 0) {
             sb.append(": ");
             // for each qualifier, add its canonical name, a comma and a space
             // to the string.
-            for (Class<? extends Annotation> qual : sortedQuals) {
+            for (Class<? extends Annotation> qual : sortedSupportedQuals) {
                 sb.append(qual.getCanonicalName());
                 sb.append(", ");
             }
@@ -431,7 +447,7 @@ public abstract class GenericAnnotatedTypeFactory<
             ErrorReporter
                     .errorAbort("GenericAnnotatedTypeFactory.createQualifierDefaults: "
                                         + "@DefaultQualifierInHierarchy or @DefaultFor(DefaultLocation.OTHERWISE) not found. "
-                                        + "Every checker must specify a default qualifier." + getSortedQualifierNames());
+                                        + "Every checker must specify a default qualifier. " + getSortedQualifierNames());
         }
     }
 

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -362,7 +362,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *         of each qualifier.
      */
     private final String getSortedQualifierNames() {
-        Set<Class<? extends Annotation>> sortedQuals = getSortedSupportedTypeQualifiers();
+        List<Class<? extends Annotation>> sortedQuals = getSortedSupportedTypeQualifiers();
 
         // display the number of qualifiers as well as the names of each
         // qualifier.


### PR DESCRIPTION
In the scenarios where @DefaultQualifierInHierarchy or @DefaultFor(DefaultLocation.OTHERWISE) are not found in any of the qualifiers added to the supported qualifier set, or if that set is empty, the stack trace does not display how many or which qualifiers are examined. This fix updates the stack trace output to print out the number of qualifiers in the set as well as the canonical names of the qualifiers in an alphabetically sorted order. Below are some examples of the new stack trace output:

// No default qualifier:
com.sun.tools.javac.Main.main(Main.java:42)
  Underlying Exception: org.checkerframework.framework.source.SourceChecker$CheckerError: GenericAnnotatedTypeFactory.createQualifierDefaults: @DefaultQualifierInHierarchy or @DefaultFor(DefaultLocation.OTHERWISE) not found. Every checker must specify a default qualifier. 33 qualifiers examined: org.checkerframework.checker.units.qual.A, org.checkerframework.checker.units.qual.Acceleration, org.checkerframework.checker.units.qual.Angle, org.checkerframework.checker.units.qual.Area, org.checkerframework.checker.units.qual.C, org.checkerframework.checker.units.qual.Current, org.checkerframework.checker.units.qual.K, org.checkerframework.checker.units.qual.Length, org.checkerframework.checker.units.qual.Luminance, org.checkerframework.checker.units.qual.Mass, org.checkerframework.checker.units.qual.PolyUnit, org.checkerframework.checker.units.qual.Speed, org.checkerframework.checker.units.qual.Substance, org.checkerframework.checker.units.qual.Temperature, org.checkerframework.checker.units.qual.Time, org.checkerframework.checker.units.qual.UnitsBottom, org.checkerframework.checker.units.qual.UnknownUnits, org.checkerframework.checker.units.qual.cd, org.checkerframework.checker.units.qual.degrees, org.checkerframework.checker.units.qual.g, org.checkerframework.checker.units.qual.h, org.checkerframework.checker.units.qual.km2, org.checkerframework.checker.units.qual.kmPERh, org.checkerframework.checker.units.qual.m, org.checkerframework.checker.units.qual.m2, org.checkerframework.checker.units.qual.mPERs, org.checkerframework.checker.units.qual.mPERs2, org.checkerframework.checker.units.qual.min, org.checkerframework.checker.units.qual.mm2, org.checkerframework.checker.units.qual.mol, org.checkerframework.checker.units.qual.radians, org.checkerframework.checker.units.qual.s, org.checkerframework.framework.qual.PolyAll; Stack trace: org.checkerframework.framework.source.SourceChecker.errorAbort(SourceChecker.java:667)
  org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:28)

// No qualifiers at all in supportedQualifiers set:
  com.sun.tools.javac.Main.main(Main.java:42)
  Underlying Exception: org.checkerframework.framework.source.SourceChecker$CheckerError: GenericAnnotatedTypeFactory.createQualifierDefaults: @DefaultQualifierInHierarchy or @DefaultFor(DefaultLocation.OTHERWISE) not found. Every checker must specify a default qualifier. 0 qualifiers examined; Stack trace: org.checkerframework.framework.source.SourceChecker.errorAbort(SourceChecker.java:667)
  org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:28) 
  
