### PR TITLE
Add TYPE_PARAMETER to @Target on type qualifiers

### DIFF
--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumBottom.java
@@ -1,14 +1,18 @@
 package org.checkerframework.checker.fenum.qual;
 
-import java.lang.annotation.*;
-
-import com.sun.source.tree.Tree;
-
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.sun.source.tree.Tree;
 
 /**
  * The bottom qualifier for fenums, its relationships are setup via the
@@ -19,7 +23,7 @@ import org.checkerframework.framework.qual.TargetLocations;
 @Documented
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({}) //subtype relationships are set up by passing this class as a bottom
                //to the multigraph hierarchy constructor
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
+++ b/checker/src/org/checkerframework/checker/fenum/qual/FenumTop.java
@@ -1,15 +1,15 @@
 package org.checkerframework.checker.fenum.qual;
 
+import org.checkerframework.framework.qual.DefaultFor;
+import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.TypeUseLocation;
-import org.checkerframework.framework.qual.SubtypeOf;
-import org.checkerframework.framework.qual.TargetLocations;
 
 /**
  * The top of the fake enumeration type hierarchy.
@@ -20,7 +20,7 @@ import org.checkerframework.framework.qual.TargetLocations;
 @DefaultFor({ TypeUseLocation.LOCAL_VARIABLE, TypeUseLocation.RESOURCE_VARIABLE })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface FenumTop {}

--- a/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
+++ b/checker/src/org/checkerframework/checker/formatter/qual/FormatBottom.java
@@ -1,9 +1,13 @@
 package org.checkerframework.checker.formatter.qual;
 
+import org.checkerframework.framework.qual.DefaultFor;
+import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-
-import org.checkerframework.framework.qual.*;
 
 import com.sun.source.tree.Tree;
 
@@ -14,7 +18,7 @@ import com.sun.source.tree.Tree;
  * @author Konstantin Weitz
  */
 @SubtypeOf({Format.class,InvalidFormat.class})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
@@ -1,13 +1,13 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 import com.sun.source.tree.Tree;
 
@@ -19,7 +19,7 @@ import com.sun.source.tree.Tree;
  * @author Siwakorn Srisakaokul
  */
 @SubtypeOf({ I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
@@ -1,13 +1,13 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
-
-import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
 
 /**
  * The top qualifier.
@@ -22,7 +22,7 @@ import org.checkerframework.framework.qual.TargetLocations;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface I18nUnknownFormat {

--- a/checker/src/org/checkerframework/checker/igj/IGJBottom.java
+++ b/checker/src/org/checkerframework/checker/igj/IGJBottom.java
@@ -22,7 +22,7 @@ import com.sun.source.tree.Tree.Kind;
         typeClasses = { AnnotatedPrimitiveType.class }
 )
 @DefaultFor({ TypeUseLocation.LOWER_BOUND })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @interface IGJBottom {}

--- a/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
+++ b/checker/src/org/checkerframework/checker/initialization/qual/FBCBottom.java
@@ -21,7 +21,7 @@ import com.sun.source.tree.Tree;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface FBCBottom {

--- a/checker/src/org/checkerframework/checker/oigj/qual/OIGJMutabilityBottom.java
+++ b/checker/src/org/checkerframework/checker/oigj/qual/OIGJMutabilityBottom.java
@@ -19,7 +19,7 @@ import com.sun.source.tree.Tree.Kind;
  */
 @SubtypeOf({Mutable.class, Immutable.class, I.class,
     Modifier.class, O.class})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @ImplicitFor(

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/RegexBottom.java
@@ -19,7 +19,7 @@ import com.sun.source.tree.Tree;
   typeNames = {java.lang.Void.class})
 @SubtypeOf({Regex.class, PartialRegex.class})
 @DefaultFor(value={ TypeUseLocation.LOWER_BOUND })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface RegexBottom {}

--- a/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/qual/UnknownRegex.java
@@ -17,7 +17,7 @@ import org.checkerframework.framework.qual.TargetLocations;
 @InvisibleQualifier
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface UnknownRegex {}

--- a/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
+++ b/checker/src/org/checkerframework/checker/signature/qual/SignatureBottom.java
@@ -16,7 +16,7 @@ import com.sun.source.tree.Tree;
     FieldDescriptorForArray.class,
     MethodDescriptor.class
     })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @ImplicitFor(trees = {Tree.Kind.NULL_LITERAL},

--- a/checker/src/org/eclipse/jdt/annotation/NonNull.java
+++ b/checker/src/org/eclipse/jdt/annotation/NonNull.java
@@ -4,6 +4,6 @@ import java.lang.annotation.*;
 
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface NonNull {
 }

--- a/checker/src/org/eclipse/jdt/annotation/Nullable.java
+++ b/checker/src/org/eclipse/jdt/annotation/Nullable.java
@@ -4,6 +4,6 @@ import java.lang.annotation.*;
 
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface Nullable {
 }

--- a/checker/src/org/eclipse/jgit/annotations/NonNull.java
+++ b/checker/src/org/eclipse/jgit/annotations/NonNull.java
@@ -4,6 +4,6 @@ import java.lang.annotation.*;
 
 @Documented
 @Retention(RetentionPolicy.CLASS)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface NonNull {
 }

--- a/checker/src/org/eclipse/jgit/annotations/Nullable.java
+++ b/checker/src/org/eclipse/jgit/annotations/Nullable.java
@@ -4,6 +4,6 @@ import java.lang.annotation.*;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface Nullable {
 }

--- a/framework/src/org/checkerframework/common/aliasing/qual/Unique.java
+++ b/framework/src/org/checkerframework/common/aliasing/qual/Unique.java
@@ -27,7 +27,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @SubtypeOf({MaybeAliased.class})
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface Unique {}

--- a/framework/src/org/checkerframework/common/reflection/qual/ClassBound.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/ClassBound.java
@@ -15,7 +15,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf({ UnknownClass.class })
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE })
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface ClassBound {
     /** The <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">binary name</a>
      * of the class or classes that upper-bound the values of this Class object. */

--- a/framework/src/org/checkerframework/common/reflection/qual/ClassVal.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/ClassVal.java
@@ -17,7 +17,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf({ UnknownClass.class })
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE })
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface ClassVal {
     /** The <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">binary name</a>
      * of the class that this Class object represents. */

--- a/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/ClassValBottom.java
@@ -20,7 +20,7 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ClassVal.class, ClassBound.class })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface ClassValBottom {

--- a/framework/src/org/checkerframework/common/reflection/qual/MethodVal.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/MethodVal.java
@@ -22,7 +22,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf({ UnknownMethod.class })
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE_USE })
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface MethodVal {
     /** The <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-13.html#jls-13.1">binary name</a>
      * of the class that declares this method. */

--- a/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/MethodValBottom.java
@@ -20,7 +20,7 @@ import com.sun.source.tree.Tree;
 @InvisibleQualifier
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ MethodVal.class })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface MethodValBottom {

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownClass.java
@@ -20,7 +20,7 @@ import org.checkerframework.framework.qual.TargetLocations;
  */
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @DefaultQualifierInHierarchy

--- a/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
+++ b/framework/src/org/checkerframework/common/reflection/qual/UnknownMethod.java
@@ -22,7 +22,7 @@ import org.checkerframework.framework.qual.TargetLocations;
  */
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 @DefaultQualifierInHierarchy

--- a/framework/src/org/checkerframework/common/util/report/qual/ReportUnqualified.java
+++ b/framework/src/org/checkerframework/common/util/report/qual/ReportUnqualified.java
@@ -17,5 +17,5 @@ import java.lang.annotation.Target;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface ReportUnqualified { }

--- a/framework/src/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/org/checkerframework/common/value/qual/BottomVal.java
@@ -21,7 +21,7 @@ import org.checkerframework.framework.qual.TargetLocations;
 @ImplicitFor(trees = { Tree.Kind.NULL_LITERAL }, typeNames = { java.lang.Void.class })
 @SubtypeOf({ ArrayLen.class, BoolVal.class, DoubleVal.class,
         IntVal.class, StringVal.class })
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface BottomVal {

--- a/framework/src/org/checkerframework/framework/qual/Bottom.java
+++ b/framework/src/org/checkerframework/framework/qual/Bottom.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * @see org.checkerframework.framework.type.QualifierHierarchy#getBottomAnnotations()
  */
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @TargetLocations({ TypeUseLocation.EXPLICIT_LOWER_BOUND,
     TypeUseLocation.EXPLICIT_UPPER_BOUND })
 public @interface Bottom { }

--- a/framework/src/org/checkerframework/framework/util/PurityUnqualified.java
+++ b/framework/src/org/checkerframework/framework/util/PurityUnqualified.java
@@ -18,5 +18,5 @@ import java.lang.annotation.Target;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 public @interface PurityUnqualified { }

--- a/framework/tests/src/tests/util/MonotonicOdd.java
+++ b/framework/tests/src/tests/util/MonotonicOdd.java
@@ -10,6 +10,6 @@ import org.checkerframework.framework.qual.Unqualified;
 
 @Inherited
 @SubtypeOf(Unqualified.class)
-@Target({ElementType.TYPE_USE})
+@Target({ ElementType.TYPE_USE, ElementType.TYPE_PARAMETER })
 @MonotonicQualifier(Odd.class)
 public @interface MonotonicOdd {}


### PR DESCRIPTION
Type qualifiers should have ElementType.TYPE_PARAMETER in their`@Target` meta-annotation unless the qualifier should be forbidden on type parameter lower bounds and wildcard upper bounds.  

For example:
````
@TP T extends Object
````
The lower bound of `T` is `@TP null`

````
@TP ? super CharSequence
````
The upper bound of `?` is `@TP Object`

(When we reviewed and merged #533, we forgot that TYPE_PARAMETER was required.  This PR fixes that.)