### PR TITLE
Update MavenExample

### DIFF
--- a/checker/examples/MavenExample/pom.xml
+++ b/checker/examples/MavenExample/pom.xml
@@ -15,7 +15,10 @@
     <!-- These properties will be set by the Maven Dependency plugin -->
     <!-- Change to jdk7 if using Java 7 -->
     <annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
-    <typeAnnotationsJavac>${org.checkerframework:compiler:jar}</typeAnnotationsJavac>
+    <checkerFrameworkVersion><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></checkerFrameworkVersion>
+      <!-- The type annotations compiler is required if using Java 7. -->
+      <!-- Uncomment the following line if using Java 7. -->
+      <!--<typeAnnotationsJavac>${org.checkerframework:compiler:jar}</typeAnnotationsJavac>-->
   </properties>
 
   <dependencies>
@@ -29,23 +32,24 @@
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
-      <version><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></version>
+      <version>${checkerFrameworkVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker</artifactId>
-      <version><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></version>
+      <version>${checkerFrameworkVersion}</version>
     </dependency>
-    <dependency>
+    <!-- The type annotations compiler - uncomment if using Java 7 -->
+    <!--<dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>compiler</artifactId>
-      <version><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></version>
-    </dependency>
+      <version>${checkerFrameworkVersion}</version>
+    </dependency>-->
     <!-- The annotated JDK to use (change to jdk7 if using Java 7) -->
     <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>jdk8</artifactId>
-      <version><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></version>
+      <version>${checkerFrameworkVersion}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -83,8 +87,7 @@
               <source>1.8</source>
               <target>1.8</target>
               <fork>true</fork>
-              <!-- should an error reported by a checker cause a build failure, or only be logged as a warning; defaults to true -->
-              <failOnError>false</failOnError>
+              <showWarnings>true</showWarnings>
               <annotationProcessors>
                   <!-- Add all the checkers you want to enable here -->
                   <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>
@@ -92,7 +95,10 @@
               <compilerArgs>
                   <!-- location of the annotated JDK, which comes from a Maven dependency -->
                   <arg>-Xbootclasspath/p:${annotatedJdk}</arg>
-                  <arg>-J-Xbootclasspath/p:${typeAnnotationsJavac}</arg>
+                  <!--treat Checker Framework errors as warnings-->
+                  <arg>-Awarns</arg>
+                  <!-- Uncomment the following line if using Java 7. -->
+                  <!--<arg>-J-Xbootclasspath/p:${typeAnnotationsJavac}</arg>-->
                   <arg>-Alint</arg>
               </compilerArgs>
           </configuration>

--- a/checker/examples/MavenExample/pom.xml
+++ b/checker/examples/MavenExample/pom.xml
@@ -16,9 +16,9 @@
     <!-- Change to jdk7 if using Java 7 -->
     <annotatedJdk>${org.checkerframework:jdk8:jar}</annotatedJdk>
     <checkerFrameworkVersion><!-- checker-framework-version -->1.9.11<!-- /checker-framework-version --></checkerFrameworkVersion>
-      <!-- The type annotations compiler is required if using Java 7. -->
-      <!-- Uncomment the following line if using Java 7. -->
-      <!--<typeAnnotationsJavac>${org.checkerframework:compiler:jar}</typeAnnotationsJavac>-->
+     <!-- The type annotations compiler is required if using Java 7. -->
+     <!-- Uncomment the following line if using Java 7. -->
+     <!--<typeAnnotationsJavac>${org.checkerframework:compiler:jar}</typeAnnotationsJavac>-->
   </properties>
 
   <dependencies>
@@ -96,7 +96,7 @@
                   <!-- location of the annotated JDK, which comes from a Maven dependency -->
                   <arg>-Xbootclasspath/p:${annotatedJdk}</arg>
                   <!--treat Checker Framework errors as warnings-->
-                  <arg>-Awarns</arg>
+                  <!-- <arg>-Awarns</arg> -->
                   <!-- Uncomment the following line if using Java 7. -->
                   <!--<arg>-J-Xbootclasspath/p:${typeAnnotationsJavac}</arg>-->
                   <arg>-Alint</arg>

--- a/release/sanity_checks.py
+++ b/release/sanity_checks.py
@@ -113,8 +113,7 @@ def maven_sanity_check( sub_sanity_dir_name, repo_url, release_version ):
         maven_example_pom = os.path.join( maven_example_dir, "pom.xml" )
         add_repo_information( maven_example_pom, repo_url )
 
-        print("TODO: mvn compile is working because of a quick fix to set JAVA_HOME to JAVA_8_HOME.")
-        print("Look for a permanent fix.")
+        print("TODO: The Maven example is only tested with Java 8.")
 
         os.environ['JAVA_HOME']   =  os.environ['JAVA_8_HOME']
         execute_write_to_file( "mvn compile", output_log, False, maven_example_dir )


### PR DESCRIPTION
Comment parts of the Maven pom that are not required when using Java 8
This makes the example consistent with the instructions in the manual.