### PR TITLE
@StubFiles should not be inherited

### DIFF
--- a/framework/src/org/checkerframework/framework/qual/StubFiles.java
+++ b/framework/src/org/checkerframework/framework/qual/StubFiles.java
@@ -7,9 +7,13 @@ import java.lang.annotation.*;
  * stub files that should be used in addition to jdk.astub.
  * This allows larger compound checkers to separate the annotations
  * into multiple files.
+ *
+ * This annotation is not inherited, that means if a checker with
+ * this annotation is subclassed, then this annotation must be copied
+ * to the subclass and the stub file must also be copied to the directory
+ * that contains the subclass.
  */
 @Documented
-@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface StubFiles {

--- a/framework/src/org/checkerframework/framework/qual/StubFiles.java
+++ b/framework/src/org/checkerframework/framework/qual/StubFiles.java
@@ -7,8 +7,9 @@ import java.lang.annotation.*;
  * stub files that should be used in addition to jdk.astub.
  * This allows larger compound checkers to separate the annotations
  * into multiple files.
+ * <p>
  *
- * This annotation is not inherited, that means if a checker with
+ * This annotation is not inherited.  That means that if a checker with
  * this annotation is subclassed, then this annotation must be copied
  * to the subclass and the stub file must also be copied to the directory
  * that contains the subclass.


### PR DESCRIPTION
If `@StubFiles` is inherited and a checker with this annotation is subclassed, then the `AnnotatedTypeFactory` looks for those stub files in the directory of that subclass (and the user directory) and issues an error if they do not exist.   This is currently causing the SPARTA Jenkins job to fail:

http://tern.cs.washington.edu:8080/job/sparta/4542/console
