### PR TITLE
Don't cache or read caches when checking (some) fields in Initialization Checker

### DIFF
--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -140,13 +140,28 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
                 // (var2). Then, we take the child annotation from var2 and use it
                 // for var.
                 AnnotatedTypeMirror var = atypeFactory.getAnnotatedType(lhs);
-                boolean old = atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER;
+
+                boolean oldHackDCPAM = atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER;
                 atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = true;
-                boolean old2 = atypeFactory.shouldReadCache;
+
+                //TODO: turning off caching to get correct results is masking
+                // a larger problem with caching fields.
+                // checker/tests/nullness/Issue345.java and
+                // checker/tests/nullness/AssignmentDuringInitialization.java
+                // fail when caching is turned on here.  (There maybe other
+                // test cases that fail, too.)
+                // See Issue #601
+                boolean oldShouldReadCache = atypeFactory.shouldReadCache;
                 atypeFactory.shouldReadCache = false;
+                boolean oldShouldCache = atypeFactory.shouldCache;
+                atypeFactory.shouldCache = false;
+
                 AnnotatedTypeMirror var2 = atypeFactory.getAnnotatedType(lhs);
-                atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = old;
-                atypeFactory.shouldReadCache = old2;
+
+                atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = oldHackDCPAM;
+                atypeFactory.shouldReadCache = oldShouldReadCache;
+                atypeFactory.shouldCache = oldShouldCache;
+
 
                 final AnnotationMirror invariantAnno = atypeFactory.getFieldInvariantAnnotation();
 

--- a/checker/tests/nullness/AssignmentDuringInitialization.java
+++ b/checker/tests/nullness/AssignmentDuringInitialization.java
@@ -1,9 +1,14 @@
 // This test covers Issue345 at:
 // https://github.com/typetools/checker-framework/issues/345
-/* @skip-test */
 public class AssignmentDuringInitialization {
     String f1;
     String f2;
+
+    String f3;
+    String f4;
+
+    String f5;
+    String f6;
 
     {
         //:: error:  (assignment.type.incompatible)
@@ -14,18 +19,21 @@ public class AssignmentDuringInitialization {
 
     public AssignmentDuringInitialization() {
         //:: error:  (assignment.type.incompatible)
-        f1 = f2;
-        f2 = f1;
-        f2.toString();   //Null pointer exception here
+        f3 = f4;
+        f4 = f3;
+        f4.toString();   //Null pointer exception here
+
+        f5 = "hello";
+        f6 = f5;
     }
 
     public void goodBehavior() {
         //this isn't a constructor or initializer
         //the receiver of this method should already be initialized
         //and therefore f1 and f2 should already be initialized
-        f1 = f2;
-        f2 = f1;
-        f2.toString();   //No exception here
+        f5 = f6;
+        f6 = f5;
+        f6.toString();   //No exception here
     }
 
     public static void main(String [] args) {

--- a/checker/tests/nullness/Issue345.java
+++ b/checker/tests/nullness/Issue345.java
@@ -1,9 +1,11 @@
-/*@skip-test*/
+// This is a test case for Issue 345:
+// https://github.com/typetools/checker-framework/issues/345
 public class Issue345 {
     String f1;
     String f2;
 
     {
+        //:: error: (assignment.type.incompatible)
         f1 = f2;
         f2 = f1;
         f2.toString();   //Null pointer exception here


### PR DESCRIPTION
The goal of this pull request is to fix Issue #345 -- not fix or improve caching generally.  Other places in the code set shouldCache or shouldReadCache to false (but not the other).  These are probably also bugs; I'm looking into them, too.

Also, as stated in the ToDo in the code, this is a hack around a larger issue with caching fields; see Issue #601.

I checked [plume-lib](https://travis-ci.org/smillst/plume-lib-typecheck/builds/111246124) and [daikon](https://travis-ci.org/smillst/daikon-typecheck-nullness/jobs/111244072) with this change an no new errors were issued.  