### PR TITLE
Remove second argument to getDefaultedAnnotatedType

### DIFF
--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -55,7 +55,6 @@ import javax.lang.model.util.Elements;
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.CompoundAssignmentTree;
-import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -200,14 +199,6 @@ public class NullnessAnnotatedTypeFactory
     protected void annotateImplicit(Tree tree, AnnotatedTypeMirror type, boolean useFlow) {
         super.annotateImplicit(tree, type, useFlow);
         dependentTypes.handle(tree, type);
-    }
-
-
-    @Override
-    public AnnotatedTypeMirror getDefaultedAnnotatedType(Tree varTree,
-            ExpressionTree valueTree) {
-        AnnotatedTypeMirror result = super.getDefaultedAnnotatedType(varTree, valueTree);
-        return handlePolyNull(result, valueTree);
     }
 
     /**

--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -203,7 +203,7 @@ public class NullnessAnnotatedTypeFactory
 
     /**
      * For types of left-hand side of an assignment, this method replaces {@link PolyNull} or
-     * {@link PolyAll} with  {@link Nullable} if the org.checkerframework.dataflow analysis
+     * {@link PolyAll} with {@link Nullable} if the org.checkerframework.dataflow analysis
      * has determined that this is allowed soundly.
      * For example:
      *
@@ -217,12 +217,10 @@ public class NullnessAnnotatedTypeFactory
      * }
      * </pre>
      *
-     * @param lhsType  Type to replace
+     * @param lhsType  Type to replace whose polymorphic qualifier will be replaced
      * @param context Tree used to get dataflow value
-     * @return altered lhsType
      */
-    protected AnnotatedTypeMirror replacePolyQualifier(AnnotatedTypeMirror lhsType,
-            Tree context) {
+    protected void replacePolyQualifier(AnnotatedTypeMirror lhsType, Tree context) {
         if (lhsType.hasAnnotation(PolyNull.class)
                 || lhsType.hasAnnotation(PolyAll.class)) {
             NullnessValue inferred = getInferredValueFor(context);
@@ -230,7 +228,6 @@ public class NullnessAnnotatedTypeFactory
                 lhsType.replaceAnnotation(NULLABLE);
             }
         }
-        return lhsType;
     }
 
     // handle dependent types
@@ -293,7 +290,9 @@ public class NullnessAnnotatedTypeFactory
 
     @Override
     public AnnotatedTypeMirror getMethodReturnType(MethodTree m, ReturnTree r) {
-        return replacePolyQualifier(super.getMethodReturnType(m, r), r);
+        AnnotatedTypeMirror result = super.getMethodReturnType(m, r);
+        replacePolyQualifier(result, r);
+        return result;
     }
 
     protected AnnotatedTypeMirror getDeclaredAndDefaultedAnnotatedType(Tree tree) {

--- a/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -216,11 +216,15 @@ public class NullnessVisitor extends InitializationVisitor<NullnessAnnotatedType
     }
 
     @Override
-    protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-                                         ExpressionTree valueExp, /*@CompilerMessageKey*/ String errorKey,
+    protected void commonAssignmentCheck(AnnotatedTypeMirror varType, ExpressionTree valueExp,
+                                         /*@CompilerMessageKey*/ String errorKey,
                                          boolean isLocalVariableAssignment) {
-        varType = atypeFactory.handlePolyNull(varType,valueExp);
-        super.commonAssignmentCheck(varType,valueExp,errorKey,isLocalVariableAssignment);
+        // Use the valueExp as the context because data flow will have a value for that tree.
+        // It might not have a value for the var tree.  This is sound because if
+        // if data flow has determined @PolyNull is @Nullable at the RHS, then
+        // it is also @Nullable for the LHS.
+        varType = atypeFactory.replacePolyQualifier(varType, valueExp);
+        super.commonAssignmentCheck(varType, valueExp, errorKey, isLocalVariableAssignment);
     }
     /** Case 1: Check for null dereferencing */
     @Override

--- a/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -220,10 +220,10 @@ public class NullnessVisitor extends InitializationVisitor<NullnessAnnotatedType
                                          /*@CompilerMessageKey*/ String errorKey,
                                          boolean isLocalVariableAssignment) {
         // Use the valueExp as the context because data flow will have a value for that tree.
-        // It might not have a value for the var tree.  This is sound because if
+        // It might not have a value for the var tree.  This is sound because
         // if data flow has determined @PolyNull is @Nullable at the RHS, then
         // it is also @Nullable for the LHS.
-        varType = atypeFactory.replacePolyQualifier(varType, valueExp);
+        atypeFactory.replacePolyQualifier(varType, valueExp);
         super.commonAssignmentCheck(varType, valueExp, errorKey, isLocalVariableAssignment);
     }
     /** Case 1: Check for null dereferencing */

--- a/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -215,6 +215,13 @@ public class NullnessVisitor extends InitializationVisitor<NullnessAnnotatedType
         super.commonAssignmentCheck(varTree, valueExp, errorKey);
     }
 
+    @Override
+    protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
+                                         ExpressionTree valueExp, /*@CompilerMessageKey*/ String errorKey,
+                                         boolean isLocalVariableAssignment) {
+        varType = atypeFactory.handlePolyNull(varType,valueExp);
+        super.commonAssignmentCheck(varType,valueExp,errorKey,isLocalVariableAssignment);
+    }
     /** Case 1: Check for null dereferencing */
     @Override
     public Void visitMemberSelect(MemberSelectTree node, Void p) {

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -83,7 +83,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic.Kind;
@@ -1813,7 +1812,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             return;
         }
 
-        AnnotatedTypeMirror var = atypeFactory.getDefaultedAnnotatedType(varTree, valueExp);
+        AnnotatedTypeMirror var = atypeFactory.getDefaultedAnnotatedType(varTree);
         assert var != null : "no variable found for tree: " + varTree;
 
         checkAssignability(var, varTree);

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -904,7 +904,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * which should have the "default" meaning, without flow inference.
      * TODO: describe and generalize
      */
-    public AnnotatedTypeMirror getDefaultedAnnotatedType(Tree tree, ExpressionTree valueTree) {
+    public AnnotatedTypeMirror getDefaultedAnnotatedType(Tree tree) {
         AnnotatedTypeMirror res = null;
         if (tree instanceof VariableTree) {
             res = fromMember(tree);

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -143,7 +143,7 @@ public class TypesIntoElements {
             // TODO: this is rather ugly: we do not want refinement from the
             // initializer of the field. We need a general way to get
             // the "defaulted" type of a variable.
-            type = ((GenericAnnotatedTypeFactory<?, ?, ?, ?>)atypeFactory).getDefaultedAnnotatedType(var, var.getInitializer());
+            type = ((GenericAnnotatedTypeFactory<?, ?, ?, ?>)atypeFactory).getDefaultedAnnotatedType(var);
         } else {
             type = atypeFactory.getAnnotatedType(var);
         }


### PR DESCRIPTION
Daikon still type-checks with this change:
https://travis-ci.org/smillst/daikon-typecheck-nullness/builds/113541950