### PR TITLE
getDefaultedAnnotatedType and other clean ups

### DIFF
--- a/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -78,8 +78,30 @@ public abstract class InitializationAnnotatedTypeFactory<
         Flow extends CFAbstractAnalysis<Value, Store, Transfer>>
     extends GenericAnnotatedTypeFactory<Value, Store, Transfer, Flow> {
 
-    /** Annotation constants */
-    protected final AnnotationMirror COMMITTED, FREE, FBCBOTTOM, NOT_ONLY_COMMITTED, UNCLASSIFIED;
+    /**
+     * UnknownInitialization or Raw
+     */
+    protected final AnnotationMirror UNCLASSIFIED;
+
+    /**
+     * Initialized or NonRaw
+     */
+    protected final AnnotationMirror COMMITTED;
+
+    /**
+     * UnderInitialization or null
+     */
+    protected final AnnotationMirror FREE;
+
+    /**
+     * NotOnlyInitialized or null
+     */
+    protected final AnnotationMirror NOT_ONLY_COMMITTED;
+
+    /**
+     * FBCBottom or NonRaw
+     */
+    protected final AnnotationMirror FBCBOTTOM;
 
     /**
      * Should the initialization type system be FBC? If not, the rawness type
@@ -589,19 +611,12 @@ public abstract class InitializationAnnotatedTypeFactory<
                 // The receiver is initialized for this frame.
                 // Change the type of the field to @UnknownInitialization so that
                 // anything can be assigned to this field.
-                type.replaceAnnotation(qualHierarchy.getTopAnnotation(UNCLASSIFIED));
+                type.replaceAnnotation(UNCLASSIFIED);
 
             } else if(computingAnnotatedTypeMirrorOfLHS) {
                 // The receiver is not initialized for this frame, and the type of a lhs is being computed.
-                // Only replace initialization annotations.
-                Set<AnnotationMirror> set = AnnotationUtils.createAnnotationSet();
-                set.addAll(type.getAnnotations());
-                for (AnnotationMirror anno : set) {
-                    if (isInitializationAnnotation(anno)) {
-                        type.removeAnnotation(anno);
-                        type.addAnnotation(qualHierarchy.getTopAnnotation(anno));
-                    }
-                }
+                // Only replace initialization annotation.
+                type.replaceAnnotation(UNCLASSIFIED);
             } else {
                 // The receiver is not initialized for this frame and the type being computed is not a LHS.
                 // Replace all annotations with the top annotation for that hierarchy.

--- a/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -79,27 +79,27 @@ public abstract class InitializationAnnotatedTypeFactory<
     extends GenericAnnotatedTypeFactory<Value, Store, Transfer, Flow> {
 
     /**
-     * UnknownInitialization or Raw
+     * {@link UnknownInitialization} or {@link Raw}
      */
     protected final AnnotationMirror UNCLASSIFIED;
 
     /**
-     * Initialized or NonRaw
+     * {@link Initialized or {@link NonRaw}
      */
     protected final AnnotationMirror COMMITTED;
 
     /**
-     * UnderInitialization or null
+     *{@link  UnderInitialization} or null
      */
     protected final AnnotationMirror FREE;
 
     /**
-     * NotOnlyInitialized or null
+     * {@link NotOnlyInitialized} or null
      */
     protected final AnnotationMirror NOT_ONLY_COMMITTED;
 
     /**
-     * FBCBottom or NonRaw
+     * {@link FBCBottom} or {@link NonRaw}
      */
     protected final AnnotationMirror FBCBOTTOM;
 
@@ -609,13 +609,13 @@ public abstract class InitializationAnnotatedTypeFactory<
             boolean isInitializedForFrame = isInitializedForFrame(receiverType, fieldDeclarationType);
             if (isInitializedForFrame) {
                 // The receiver is initialized for this frame.
-                // Change the type of the field to @UnknownInitialization so that
+                // Change the type of the field to @UnknownInitialization or @Raw so that
                 // anything can be assigned to this field.
                 type.replaceAnnotation(UNCLASSIFIED);
-
-            } else if(computingAnnotatedTypeMirrorOfLHS) {
-                // The receiver is not initialized for this frame, and the type of a lhs is being computed.
-                // Only replace initialization annotation.
+            } else if (computingAnnotatedTypeMirrorOfLHS) {
+                // The receiver is not initialized for this frame, but the type of a lhs is being computed.
+                // Change the type of the field to @UnknownInitialization or @Raw so that
+                // anything can be assigned to this field.
                 type.replaceAnnotation(UNCLASSIFIED);
             } else {
                 // The receiver is not initialized for this frame and the type being computed is not a LHS.

--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -18,13 +18,10 @@ import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
-import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
-import org.checkerframework.framework.type.visitor.AnnotatedTypeMerger;
 import org.checkerframework.framework.util.AnnotationFormatter;
 import org.checkerframework.framework.util.DefaultAnnotationFormatter;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
@@ -40,7 +37,6 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.TypeKind;
 
 import com.sun.source.tree.BlockTree;
 import com.sun.source.tree.ClassTree;
@@ -130,55 +126,6 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
                     checker.report(Result.failure(err, varTree), varTree);
                     return; // prevent issuing another errow about subtyping
                 }
-                // for field access on the current object, make sure that we don't
-                // allow invalid assignments. that is, even though reading this.f in a
-                // constructor yields @Nullable (or similar for other typesystems),
-                // it is not allowed to write @Nullable to a @NonNull field.
-                // This is done by first getting the type as usual (var), and then
-                // again not using the postAsMember method (which takes care of
-                // transforming the type of o.f for a free receiver to @Nullable)
-                // (var2). Then, we take the child annotation from var2 and use it
-                // for var.
-                AnnotatedTypeMirror var = atypeFactory.getAnnotatedType(lhs);
-
-                boolean oldHackDCPAM = atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER;
-                atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = true;
-
-                //TODO: turning off caching to get correct results is masking
-                // a larger problem with caching fields.
-                // checker/tests/nullness/Issue345.java and
-                // checker/tests/nullness/AssignmentDuringInitialization.java
-                // fail when caching is turned on here.  (There maybe other
-                // test cases that fail, too.)
-                // See Issue #601
-                boolean oldShouldCache = atypeFactory.shouldCache;
-                atypeFactory.shouldCache = false;
-
-                AnnotatedTypeMirror var2 = atypeFactory.getAnnotatedType(lhs);
-
-                atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = oldHackDCPAM;
-                atypeFactory.shouldCache = oldShouldCache;
-
-
-                final AnnotationMirror invariantAnno = atypeFactory.getFieldInvariantAnnotation();
-
-                // AnnotatedTypeMerger.merge requires that the first two arguments have the
-                // same TypeKind.
-                if (var.getKind() != var2.getKind() &&
-                        var2.getKind() == TypeKind.DECLARED) {
-                    switch (var.getKind()) {
-                    case WILDCARD:
-                        var = ((AnnotatedWildcardType) var).getExtendsBound();
-                        break;
-                    default:
-                        ErrorReporter.errorAbort("Unexpected comparison between " + var + " and " + var2);
-                    }
-                }
-                AnnotatedTypeMerger.merge(var2, var, invariantAnno);
-
-                checkAssignability(var, varTree);
-                commonAssignmentCheck(var, valueExp, errorKey, false);
-                return;
             }
         }
         super.commonAssignmentCheck(varTree, valueExp, errorKey);

--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -151,15 +151,12 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
                 // fail when caching is turned on here.  (There maybe other
                 // test cases that fail, too.)
                 // See Issue #601
-                boolean oldShouldReadCache = atypeFactory.shouldReadCache;
-                atypeFactory.shouldReadCache = false;
                 boolean oldShouldCache = atypeFactory.shouldCache;
                 atypeFactory.shouldCache = false;
 
                 AnnotatedTypeMirror var2 = atypeFactory.getAnnotatedType(lhs);
 
                 atypeFactory.HACK_DONT_CALL_POST_AS_MEMBER = oldHackDCPAM;
-                atypeFactory.shouldReadCache = oldShouldReadCache;
                 atypeFactory.shouldCache = oldShouldCache;
 
 

--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -295,20 +295,6 @@ public class NullnessAnnotatedTypeFactory
         return result;
     }
 
-    protected AnnotatedTypeMirror getDeclaredAndDefaultedAnnotatedType(Tree tree) {
-        boolean oldHDCPAM = HACK_DONT_CALL_POST_AS_MEMBER;
-        boolean oldShouldCache = shouldCache;
-
-        HACK_DONT_CALL_POST_AS_MEMBER = true;
-        shouldCache = false;
-
-        AnnotatedTypeMirror type = getAnnotatedType(tree);
-
-        shouldCache = oldShouldCache;
-        HACK_DONT_CALL_POST_AS_MEMBER = oldHDCPAM;
-        return type;
-    }
-
     @Override
     protected TypeAnnotator createTypeAnnotator() {
         ImplicitsTypeAnnotator implicitsTypeAnnotator = new ImplicitsTypeAnnotator(this);

--- a/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -296,15 +296,16 @@ public class NullnessAnnotatedTypeFactory
     }
 
     protected AnnotatedTypeMirror getDeclaredAndDefaultedAnnotatedType(Tree tree) {
-        HACK_DONT_CALL_POST_AS_MEMBER = true;
+        boolean oldHDCPAM = HACK_DONT_CALL_POST_AS_MEMBER;
         boolean oldShouldCache = shouldCache;
+
+        HACK_DONT_CALL_POST_AS_MEMBER = true;
         shouldCache = false;
 
         AnnotatedTypeMirror type = getAnnotatedType(tree);
 
         shouldCache = oldShouldCache;
-        HACK_DONT_CALL_POST_AS_MEMBER = false;
-
+        HACK_DONT_CALL_POST_AS_MEMBER = oldHDCPAM;
         return type;
     }
 

--- a/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -195,23 +195,6 @@ public class NullnessVisitor extends InitializationVisitor<NullnessAnnotatedType
                 return;
             }
         }
-
-        if (TreeUtils.isFieldAccess(varTree)) {
-            AnnotatedTypeMirror valueType = atypeFactory.getAnnotatedType(valueExp);
-            // special case writing to NonNull field for free/unc receivers
-            AnnotatedTypeMirror annos = atypeFactory.getDeclaredAndDefaultedAnnotatedType(varTree);
-            // receiverType is null for static field accesses
-            AnnotatedTypeMirror receiverType = atypeFactory.getReceiverType((ExpressionTree) varTree);
-            if (receiverType != null
-                    && (atypeFactory.isFree(receiverType) || atypeFactory.isUnclassified(receiverType))) {
-                if (annos.hasEffectiveAnnotation(NONNULL)
-                        && !valueType.hasEffectiveAnnotation(NONNULL)) {
-                    checker.report(Result.failure(ASSIGNMENT_TYPE_INCOMPATIBLE,
-                            valueType.toString(),
-                            annos.toString()), varTree);
-                }
-            }
-        }
         super.commonAssignmentCheck(varTree, valueExp, errorKey);
     }
 

--- a/checker/tests/src/tests/NullnessRawTypesNoCachingTest.java
+++ b/checker/tests/src/tests/NullnessRawTypesNoCachingTest.java
@@ -16,7 +16,7 @@ public class NullnessRawTypesNoCachingTest extends CheckerFrameworkTest {
                 org.checkerframework.checker.nullness.NullnessChecker.class,
                 "nullness",
                 "-Anomsgtext",
-              "-AatfDoNotCache" ,"-AatfDoNotReadCache");
+              "-AatfDoNotCache");
     }
 
     @Parameters

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1812,7 +1812,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             return;
         }
 
-        AnnotatedTypeMirror var = atypeFactory.getDefaultedAnnotatedType(varTree);
+        AnnotatedTypeMirror var = atypeFactory.getAnnotatedTypeLhs(varTree);
         assert var != null : "no variable found for tree: " + varTree;
 
         checkAssignability(var, varTree);

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -18,6 +18,7 @@ import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGMethod;
 import org.checkerframework.dataflow.cfg.UnderlyingAST.Kind;
 import org.checkerframework.dataflow.cfg.node.AbstractNodeVisitor;
 import org.checkerframework.dataflow.cfg.node.ArrayAccessNode;
+import org.checkerframework.dataflow.cfg.node.AssignmentContext;
 import org.checkerframework.dataflow.cfg.node.AssignmentNode;
 import org.checkerframework.dataflow.cfg.node.CaseNode;
 import org.checkerframework.dataflow.cfg.node.ClassNameNode;
@@ -146,19 +147,20 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
         Pair<Tree, AnnotatedTypeMirror> preCtxt = factory.getVisitorState().getAssignmentContext();
         analysis.setCurrentTree(tree);
         // is there an assignment context node available?
-        if (node != null && node.getAssignmentContext() != null) {
+        AssignmentContext assignmentContext = node.getAssignmentContext();
+        if (node != null && assignmentContext != null) {
             // get the declared type of the assignment context by looking up the
             // assignment context tree's type in the factory while flow is
             // disabled.
-            Tree contextTree = node.getAssignmentContext().getContextTree();
+            Tree contextTree = assignmentContext.getContextTree();
             AnnotatedTypeMirror assCtxt = null;
             if (contextTree != null) {
                 assCtxt = factory.getAnnotatedTypeLhs(contextTree);
-            } else if( node.getAssignmentContext().getElementForType() != null) {
+            } else if ( assignmentContext.getElementForType() != null) {
                 // if contextTree is null, use the element to get the type
-                assCtxt = factory.getAnnotatedType(node.getAssignmentContext().getElementForType());
+                assCtxt = factory.getAnnotatedType(assignmentContext.getElementForType());
             }
-            if(assCtxt != null) {
+            if (assCtxt != null) {
                 if (assCtxt instanceof AnnotatedExecutableType) {
                     // For a MethodReturnContext, we get the full type of the
                     // method, but we only want the return type.
@@ -166,7 +168,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
                             .getReturnType();
                 }
                 factory.getVisitorState().setAssignmentContext(
-                        Pair.of(node.getAssignmentContext().getContextTree(),
+                        Pair.of(assignmentContext.getContextTree(),
                                 assCtxt));
             }
         }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -150,13 +150,15 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
             // get the declared type of the assignment context by looking up the
             // assignment context tree's type in the factory while flow is
             // disabled.
-            // Note: Since we use getAnnotatedType(Element), flow is not used in
-            // any case, so we would not have to disable it.
-            boolean oldFlow = factory.getUseFlow();
-            factory.setUseFlow(false);
-            Element element = node.getAssignmentContext().getElementForType();
-            if (element != null) {
-                AnnotatedTypeMirror assCtxt = factory.getAnnotatedType(element);
+            Tree contextTree = node.getAssignmentContext().getContextTree();
+            AnnotatedTypeMirror assCtxt = null;
+            if (contextTree != null) {
+                assCtxt = factory.getAnnotatedTypeLhs(contextTree);
+            } else if( node.getAssignmentContext().getElementForType() != null) {
+                // if contextTree is null, use the element to get the type
+                assCtxt = factory.getAnnotatedType(node.getAssignmentContext().getElementForType());
+            }
+            if(assCtxt != null) {
                 if (assCtxt instanceof AnnotatedExecutableType) {
                     // For a MethodReturnContext, we get the full type of the
                     // method, but we only want the return type.
@@ -167,7 +169,6 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
                         Pair.of(node.getAssignmentContext().getContextTree(),
                                 assCtxt));
             }
-            factory.setUseFlow(oldFlow);
         }
         AnnotatedTypeMirror at = factory.getAnnotatedType(tree);
         analysis.setCurrentTree(preTree);

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -162,7 +162,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
                 }
             }
 
-            if(assCtxt != null) {
+            if (assCtxt != null) {
                 if (assCtxt instanceof AnnotatedExecutableType) {
                     // For a MethodReturnContext, we get the full type of the
                     // method, but we only want the return type.

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -280,9 +280,6 @@ import com.sun.tools.javac.util.Log;
     // Set the cache size for caches in AnnotatedTypeFactory
     "atfCacheSize",
 
-    // Sets AnnotatedTypeFactory shouldReadCache to false
-    "atfDoNotReadCache",
-
     // Sets AnnotatedTypeFactory shouldCache to false
     "atfDoNotCache"
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -332,12 +332,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         this.cacheDeclAnnos = new HashMap<Element, Set<AnnotationMirror>>();
 
         this.shouldCache = !checker.hasOption("atfDoNotCache");
-        int cacheSize = shouldCache ? getCacheSize() : 0;
-        this.treeCache = CollectionUtils.createLRUCache(cacheSize);
-        this.fromTreeCache = CollectionUtils.createLRUCache(cacheSize);
-        this.elementCache = CollectionUtils.createLRUCache(cacheSize);
-        this.elementToTreeCache = CollectionUtils.createLRUCache(cacheSize);
-
+        if (shouldCache) {
+            int cacheSize = getCacheSize();
+            this.treeCache = CollectionUtils.createLRUCache(cacheSize);
+            this.fromTreeCache = CollectionUtils.createLRUCache(cacheSize);
+            this.elementCache = CollectionUtils.createLRUCache(cacheSize);
+            this.elementToTreeCache = CollectionUtils.createLRUCache(cacheSize);
+        } else {
+            this.treeCache = null;
+            this.fromTreeCache = null;
+            this.elementCache = null;
+            this.elementToTreeCache = null;
+        }
         this.typeFormatter = createAnnotatedTypeFormatter();
         this.annotationFormatter = createAnnotationFormatter();
     }

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -945,9 +945,7 @@ public abstract class GenericAnnotatedTypeFactory<
         AnnotatedTypeMirror res = null;
         boolean oldUseFlow = useFlow;
         boolean oldShouldCache = shouldCache;
-        boolean oldShouldReadCache = shouldReadCache;
         useFlow = false;
-        shouldReadCache = false;
         // Don't cache the result because getAnnotatedType(lhsTree) could
         // be called and would expect a different result.
         shouldCache = false;
@@ -964,7 +962,6 @@ public abstract class GenericAnnotatedTypeFactory<
                                      + "lhsTree: "+lhsTree+"\nTree.Kind: "+lhsTree.getKind());
         }
         useFlow = oldUseFlow;
-        shouldReadCache = oldShouldReadCache;
         shouldCache = oldShouldCache;
         return res;
     }

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -124,10 +124,14 @@ public abstract class GenericAnnotatedTypeFactory<
 
     // Flow related fields
 
-    /** Should use flow-sensitive type refinement analysis?
+    /**
+     * Should use flow-sensitive type refinement analysis?
      * This value can be changed when an AnnotatedTypeMirror
-     * without annotations from data flow is required. */
-    protected boolean useFlow;
+     * without annotations from data flow is required.
+     *
+     * @see #getAnnotatedTypeLhs(Tree)
+     */
+    private boolean useFlow;
 
     /** Is this type factory configured to use flow-sensitive type refinement? */
     private final boolean everUseFlow;
@@ -1080,14 +1084,6 @@ public abstract class GenericAnnotatedTypeFactory<
 
     public Store getEmptyStore() {
         return emptyStore;
-    }
-
-    public boolean getUseFlow() {
-        return useFlow;
-    }
-
-    public void setUseFlow(boolean useFlow) {
-        this.useFlow = useFlow;
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -947,7 +947,7 @@ public abstract class GenericAnnotatedTypeFactory<
         boolean oldShouldCache = shouldCache;
         useFlow = false;
         // Don't cache the result because getAnnotatedType(lhsTree) could
-        // be called and would expect a different result.
+        // be called from elsewhere and would expect expect flow-sensitive type refinements.
         shouldCache = false;
         switch (lhsTree.getKind()) {
         case VARIABLE:

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -947,7 +947,7 @@ public abstract class GenericAnnotatedTypeFactory<
         boolean oldShouldCache = shouldCache;
         useFlow = false;
         // Don't cache the result because getAnnotatedType(lhsTree) could
-        // be called from elsewhere and would expect expect flow-sensitive type refinements.
+        // be called from elsewhere and would expect flow-sensitive type refinements.
         shouldCache = false;
         switch (lhsTree.getKind()) {
         case VARIABLE:

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -132,6 +132,15 @@ public abstract class GenericAnnotatedTypeFactory<
     /** Is this type factory configured to use flow-sensitive type refinement? */
     private final boolean everUseFlow;
 
+    /**
+     * Should the local variable default annotation be applied to type variables?<p>
+     * It is initialized to true if data flow is used by the checker.
+     * It is set to false when getting the assignment context for type argument inference.
+     *
+     * @see GenericAnnotatedTypeFactory#getAnnotatedTypeLhsNoTypeVarDefault
+     */
+    private boolean shouldDefaultTypeVarLocals;
+
     /** An empty store. */
     private Store emptyStore;
 
@@ -146,6 +155,7 @@ public abstract class GenericAnnotatedTypeFactory<
         super(checker);
 
         this.everUseFlow = useFlow;
+        this.shouldDefaultTypeVarLocals = useFlow;
         this.useFlow = useFlow;
         this.analyses = new LinkedList<>();
         this.scannedClasses = new HashMap<>();
@@ -896,31 +906,62 @@ public abstract class GenericAnnotatedTypeFactory<
         return null;
     }
 
+    /**
+     * Returns the type of the left-hand side of an assignment without
+     * applying local variable defaults to type variables.
+     *
+     * The type variables that are types of local variables are defaulted to
+     * top so that they can be refined by dataflow.  When these types are used
+     * as context during type argument inference, this default is too conservative.
+     * So this method is used instead of
+     * {@link GenericAnnotatedTypeFactory#getAnnotatedTypeLhs(Tree)}.
+     *
+     * @param lhsTree left-hand side of an assignment
+     * @return AnnotatedTypeMirror of {@code lhsTree}
+     */
+    public AnnotatedTypeMirror getAnnotatedTypeLhsNoTypeVarDefault(Tree lhsTree) {
+        boolean old = this.shouldDefaultTypeVarLocals;
+        shouldDefaultTypeVarLocals = false;
+        AnnotatedTypeMirror type = getAnnotatedTypeLhs(lhsTree);
+        this.shouldDefaultTypeVarLocals = old;
+        return type;
+    }
 
     /**
-     * Get the defaulted type of a variable, without considering
-     * flow inference from the initializer expression.
-     * This is needed to determine the type of the assignment context,
-     * which should have the "default" meaning, without flow inference.
-     * TODO: describe and generalize
+     * Returns the type of a left-hand side of an assignment.
+     *
+     * The default implementation returns the type without considering
+     * dataflow type refinement.  Subclass calculate override this method
+     * and add additional logic for computing the type of a LHS.
+     *
+     * @param lhsTree left-hand side of an assignment
+     * @return AnnotatedTypeMirror of {@code lhsTree}
      */
-    public AnnotatedTypeMirror getDefaultedAnnotatedType(Tree tree) {
+    public AnnotatedTypeMirror getAnnotatedTypeLhs(Tree lhsTree) {
         AnnotatedTypeMirror res = null;
-        if (tree instanceof VariableTree) {
-            res = fromMember(tree);
-            annotateImplicit(tree, res, false);
-        } else if (tree instanceof AssignmentTree) {
-            res = fromExpression(((AssignmentTree) tree).getVariable());
-            annotateImplicit(tree, res, false);
-        } else if (tree instanceof CompoundAssignmentTree) {
-            res = fromExpression(((CompoundAssignmentTree) tree).getVariable());
-            annotateImplicit(tree, res, false);
-        } else if (TreeUtils.isExpressionTree(tree)) {
-            res = fromExpression((ExpressionTree) tree);
-            annotateImplicit(tree, res, false);
+        boolean oldUseFlow = useFlow;
+        boolean oldShouldCache = shouldCache;
+        boolean oldShouldReadCache = shouldReadCache;
+        useFlow = false;
+        shouldReadCache = false;
+        // Don't cache the result because getAnnotatedType(lhsTree) could
+        // be called and would expect a different result.
+        shouldCache = false;
+        if (lhsTree instanceof VariableTree) {
+            res = getAnnotatedType(lhsTree);
+        } else if (lhsTree instanceof AssignmentTree) {
+            res = getAnnotatedType(((AssignmentTree) lhsTree).getVariable());
+        } else if (lhsTree instanceof CompoundAssignmentTree) {
+            res = getAnnotatedType(((CompoundAssignmentTree) lhsTree).getVariable());
+        } else if (TreeUtils.isExpressionTree(lhsTree)) {
+            res = getAnnotatedType(lhsTree);
         } else {
-            assert false;
+            ErrorReporter.errorAbort("GenericAnnotatedTypeFactory: Unexpected tree passed to getAnnotatedTypeLhs.\n"
+                                     + "lhsTree: "+lhsTree+"\nTree.Kind: "+lhsTree.getKind());
         }
+        useFlow = oldUseFlow;
+        shouldReadCache = oldShouldReadCache;
+        shouldCache = oldShouldCache;
         return res;
     }
 
@@ -1054,5 +1095,17 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>, U extends BaseTypeChecker> T getTypeFactoryOfSubchecker(Class<U> checkerClass) {
         return checker.getTypeFactoryOfSubchecker(checkerClass);
+    }
+
+    /**
+     * Should the local variable default annotation be applied to type variables?<p>
+     * It is initialized to true if data flow is used by the checker.
+     * It is set to false when getting the assignment context for type argument inference.
+     *
+     * @see GenericAnnotatedTypeFactory#getAnnotatedTypeLhsNoTypeVarDefault
+     * @return shouldDefaultTypeVarLocals
+     */
+    public boolean getShouldDefaultTypeVarLocals() {
+        return shouldDefaultTypeVarLocals;
     }
 }

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -143,7 +143,7 @@ public class TypesIntoElements {
             // TODO: this is rather ugly: we do not want refinement from the
             // initializer of the field. We need a general way to get
             // the "defaulted" type of a variable.
-            type = ((GenericAnnotatedTypeFactory<?, ?, ?, ?>)atypeFactory).getDefaultedAnnotatedType(var);
+            type = ((GenericAnnotatedTypeFactory<?, ?, ?, ?>)atypeFactory).getAnnotatedTypeLhs(var);
         } else {
             type = atypeFactory.getAnnotatedType(var);
         }

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -437,10 +437,10 @@ public class QualifierDefaults {
         //        " gives elt: " + elt + "(" + elt.getKind() + ")");
 
         if (elt != null) {
-            boolean useFlow = (atypeFactory instanceof GenericAnnotatedTypeFactory<?,?,?,?>)
-                           && (((GenericAnnotatedTypeFactory<?,?,?,?>) atypeFactory).getUseFlow());
+            boolean defaultTypeVarLocals = (atypeFactory instanceof GenericAnnotatedTypeFactory<?,?,?,?>)
+                           && (((GenericAnnotatedTypeFactory<?,?,?,?>) atypeFactory).getShouldDefaultTypeVarLocals());
 
-            applyToTypeVar = useFlow
+            applyToTypeVar = defaultTypeVarLocals
                           && elt.getKind() == ElementKind.LOCAL_VARIABLE
                           && type.getKind() == TypeKind.TYPEVAR
                           && atypeFactory.type(tree).getKind() == TypeKind.TYPEVAR;

--- a/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -1,6 +1,5 @@
 package org.checkerframework.framework.util.typeinference;
 
-import com.sun.source.tree.LambdaExpressionTree;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
@@ -35,6 +34,7 @@ import javax.lang.model.util.Types;
 import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
@@ -217,12 +217,7 @@ public class TypeArgInferenceUtil {
         } else if (assignmentContext instanceof VariableTree) {
             if (atypeFactory instanceof GenericAnnotatedTypeFactory<?,?,?,?>) {
                 final GenericAnnotatedTypeFactory<?,?,?,?> gatf = ((GenericAnnotatedTypeFactory<?,?,?,?>) atypeFactory);
-                boolean oldFlow = gatf.getUseFlow();
-                gatf.setUseFlow(false);
-                final AnnotatedTypeMirror type = gatf.getAnnotatedType(assignmentContext);
-                gatf.setUseFlow(oldFlow);
-                return type;
-
+                return gatf.getAnnotatedTypeLhsNoTypeVarDefault(assignmentContext);
             } else {
                 return atypeFactory.getAnnotatedType(assignmentContext);
             }


### PR DESCRIPTION
This pull request covers included several related refactorings.
1. getDefaultedAnnotatedType renamed to getAnnotatedTypeLhs (Name and use of method is up for debate.)
2. getAnnotatedTypeLhs now calls getAnnotatedType with `useFlow` set to false, and caching turned off.
3. New method getAnnotatedTypeLhsNoTypeVarDefault that returns the type of a type variable with out dataflow refinement and without local variable defaulting.  (Used during type argument inference)
4. shouldCache and shouldReadCache merged into one variable, shouldCache
5. "postAsMemberHack" in the Initialization and Nullness Checkers has been simplified and documented.

(Note, this is a pull request to the rawtypes branch because without the rawtypes changes, the changes in this pull request will cause tests to fail.)