### PR TITLE
Method type argument inference fix for null literals

### DIFF
--- a/framework/src/org/checkerframework/framework/type/DefaultRawnessComparer.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultRawnessComparer.java
@@ -2,6 +2,7 @@ package org.checkerframework.framework.type;
 
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedNullType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiveType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
@@ -114,6 +115,19 @@ public class DefaultRawnessComparer extends AbstractAtmComboVisitor<Boolean, Vis
             return false;
         }
         return this.isValid(subtype.getComponentType(), supertype.getComponentType(), visited);
+    }
+
+    @Override
+    public Boolean visitNull_Declared(AnnotatedNullType subtype, AnnotatedDeclaredType supertype, VisitHistory visited) {
+        if (checkOrAdd(subtype, supertype, visited)) {
+            return true;
+        }
+
+        if (!arePrimaryAnnotationsEqual(subtype, supertype)) {
+            return false;
+        }
+
+        return !supertype.wasRaw();
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -45,7 +45,6 @@ import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.util.Types;
 
@@ -543,8 +542,6 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
 
     /**
      * For any types we have not inferred, use a wildcard with the bounds from the original type parameter.
-     * For any types we have inferred to be an AnnotatedNullType, create a wildcard but apply the primary
-     * annotations from that AnnotatedNullType.
      */
     private void handleUninferredTypeVariables(AnnotatedTypeFactory typeFactory, AnnotatedExecutableType methodType,
                                                Set<TypeVariable> targets, Map<TypeVariable, AnnotatedTypeMirror> inferredArgs) {
@@ -554,13 +551,9 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             if (targets.contains(typeVar)) {
                 final AnnotatedTypeMirror inferredType = inferredArgs.get(typeVar);
 
-                if (inferredType == null || inferredType.getKind() == TypeKind.NULL) {
+                if (inferredType == null) {
                     AnnotatedTypeMirror dummy = typeFactory.getUninferredWildcardType(atv);
                     inferredArgs.put(atv.getUnderlyingType(), dummy);
-
-                    if (inferredType != null) { //then the type kind must be TypeKind.NULL
-                        dummy.replaceAnnotations(inferredType.getAnnotations());
-                    }
                 }
             }
         }

--- a/framework/tests/all-systems/InferNullType.java
+++ b/framework/tests/all-systems/InferNullType.java
@@ -1,0 +1,11 @@
+class InferNullType {
+
+    <T extends Object> T toInfer(T input) {
+        return input;
+    }
+
+    void x() {
+        @SuppressWarnings("nullness:type.argument.type.incompatible")
+        Object m = toInfer(null);
+    }
+}


### PR DESCRIPTION
In method type argument inference, null literals should be inferred and kept as an AnnotatedNullType, and not be replaced by a AnnotatedWildcardType.

If the null literal was passed as the argument to a method such as the following,
```
<T extends Object> T toInfer(T input) {
        return input;
}
```
the type argument is currently inferred as a AnnotatedNullType, but then an AnnotatedWildcardType is created and return with the AnnotatedNullType's annotations applied to its extends bound. It should remain as an AnnotatedNullType.

From the included InferNullType.java test case (and with the SuppressWarnings commented out for demonstration purposes), running it with the Nullness checker produces the following outputs:
```
// Output prior to this fix
$ javac -processor Nullness InferNullType.java
InferNullType.java:9: error: [type.argument.type.incompatible] incompatible types in type argument.
        Object m = toInfer(null);
                          ^
  found   : @Initialized @Nullable ? extends @Initialized @Nullable Object
  required: @Initialized @NonNull Object
1 error

// Output with this fix
$ javac -processor Nullness InferNullType.java
InferNullType.java:9: error: [type.argument.type.incompatible] incompatible types in type argument.
        Object m = toInfer(null);
                          ^
  found   : null
  required: @Initialized @NonNull Object
1 error
```
The ```type.argument.type.incompatible``` error is expected when using the Nullness checker due to the implicit upper bound of ```@NonNull``` in the declaration of ```<T extends Object>```.