### PR TITLE
Fixes #607

### DIFF
--- a/checker/tests/nullness-extra/Makefile
+++ b/checker/tests/nullness-extra/Makefile
@@ -2,10 +2,10 @@
 .PHONY: all skipped Bug109 multiple-errors package-anno issue265 issue309 compat shorthand issue502 issue559 issue594 issue607
 
 # Tests that are currently passing
-all: Bug109 compat issue265 issue309 issue502 multiple-errors package-anno shorthand
+all: Bug109 compat issue265 issue309 issue502 multiple-errors package-anno shorthand issue607
 
 # Tests that are currently not passing
-skipped: issue559 issue594 issue607
+skipped: issue559 issue594
 
 
 Bug109:

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2987,7 +2987,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 NewClassTree newClass = (NewClassTree) parentTree;
                 int indexOfLambda = newClass.getArguments().indexOf(lambdaTree);
                 Pair<AnnotatedExecutableType, List<AnnotatedTypeMirror>> con = this.constructorFromUse(newClass);
-                AnnotatedTypeMirror constructorParam = AnnotatedTypes.unwrapVarargs(con.first.getElement().isVarArgs(),con.first.getParameterTypes(), indexOfLambda);
+                AnnotatedTypeMirror constructorParam = AnnotatedTypes.getAnnotatedTypeMirrorOfParameter(con.first, indexOfLambda);
                 assertFunctionalInterface(javacTypes, (Type) constructorParam.getUnderlyingType(), parentTree, lambdaTree);
                 return (AnnotatedDeclaredType) constructorParam;
 
@@ -2995,7 +2995,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 MethodInvocationTree method = (MethodInvocationTree) parentTree;
                 int index = method.getArguments().indexOf(lambdaTree);
                 Pair<AnnotatedExecutableType, List<AnnotatedTypeMirror>> exe = this.methodFromUse(method);
-                AnnotatedTypeMirror param = AnnotatedTypes.unwrapVarargs(exe.first.getElement().isVarArgs(),exe.first.getParameterTypes(), index);
+                AnnotatedTypeMirror param = AnnotatedTypes.getAnnotatedTypeMirrorOfParameter(exe.first, index);
                 assertFunctionalInterface(javacTypes, (Type)param.getUnderlyingType(), parentTree, lambdaTree);
                 return (AnnotatedDeclaredType) param;
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2987,7 +2987,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 NewClassTree newClass = (NewClassTree) parentTree;
                 int indexOfLambda = newClass.getArguments().indexOf(lambdaTree);
                 Pair<AnnotatedExecutableType, List<AnnotatedTypeMirror>> con = this.constructorFromUse(newClass);
-                AnnotatedTypeMirror constructorParam = AnnotatedTypes.unwrapVarargs(con.first.getParameterTypes(), indexOfLambda);
+                AnnotatedTypeMirror constructorParam = AnnotatedTypes.unwrapVarargs(con.first.getElement().isVarArgs(),con.first.getParameterTypes(), indexOfLambda);
                 assertFunctionalInterface(javacTypes, (Type) constructorParam.getUnderlyingType(), parentTree, lambdaTree);
                 return (AnnotatedDeclaredType) constructorParam;
 
@@ -2995,7 +2995,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 MethodInvocationTree method = (MethodInvocationTree) parentTree;
                 int index = method.getArguments().indexOf(lambdaTree);
                 Pair<AnnotatedExecutableType, List<AnnotatedTypeMirror>> exe = this.methodFromUse(method);
-                AnnotatedTypeMirror param = AnnotatedTypes.unwrapVarargs(exe.first.getParameterTypes(), index);
+                AnnotatedTypeMirror param = AnnotatedTypes.unwrapVarargs(exe.first.getElement().isVarArgs(),exe.first.getParameterTypes(), index);
                 assertFunctionalInterface(javacTypes, (Type)param.getUnderlyingType(), parentTree, lambdaTree);
                 return (AnnotatedDeclaredType) param;
 

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1259,19 +1259,20 @@ public class AnnotatedTypes {
      * Given a list of types representing the formal parameters to a method, get the parameter type
      * expect at the indexth position (unwrapping var args if necessary).
      *
+     * @param hasVarArg whether or not that last parameter is a vararg
      * @param parameterTypes The list of formal parameters to a method
      * @param index The index into parameterTypes of the parameter we want
      * @return If that parameter is a varArgs, return the component of the var args and NOT the array type.
      *         Otherwise, return the exact type of the parameter in the index position
      */
-    public static AnnotatedTypeMirror unwrapVarargs(List<AnnotatedTypeMirror> parameterTypes, int index) {
+    public static AnnotatedTypeMirror unwrapVarargs(boolean hasVarArg,List<AnnotatedTypeMirror> parameterTypes, int index) {
         final int lastIndex = parameterTypes.size() - 1;
         final AnnotatedTypeMirror lastType = parameterTypes.get(lastIndex);
         final boolean parameterBeforeVarargs = index < lastIndex;
         if (!parameterBeforeVarargs && lastType instanceof AnnotatedArrayType) {
             final AnnotatedArrayType arrayType = (AnnotatedArrayType) lastType;
             final Type.ArrayType underlyingType = (Type.ArrayType) arrayType.getUnderlyingType();
-            if (underlyingType.isVarargs()) {
+            if (hasVarArg) {
                 return arrayType.getComponentType();
             }
         }

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1256,22 +1256,23 @@ public class AnnotatedTypes {
     }
 
     /**
-     * Given a list of types representing the formal parameters to a method, get the parameter type
+     * Given an AnnotatedExecutableType of a method or constructor declaration, get the parameter type
      * expect at the indexth position (unwrapping var args if necessary).
      *
-     * @param hasVarArg whether or not that last parameter is a vararg
-     * @param parameterTypes The list of formal parameters to a method
-     * @param index The index into parameterTypes of the parameter we want
+     * @param methodType AnnotatedExecutableType of method or constructor containing parameter to return
+     * @param index position of parameter type to return
      * @return If that parameter is a varArgs, return the component of the var args and NOT the array type.
      *         Otherwise, return the exact type of the parameter in the index position
      */
-    public static AnnotatedTypeMirror unwrapVarargs(boolean hasVarArg, List<AnnotatedTypeMirror> parameterTypes, int index) {
+    public static AnnotatedTypeMirror getAnnotatedTypeMirrorOfParameter(AnnotatedExecutableType methodType, int index) {
+        List<AnnotatedTypeMirror> parameterTypes = methodType.getParameterTypes();
+        boolean hasVarArg = methodType.getElement().isVarArgs();
+
         final int lastIndex = parameterTypes.size() - 1;
         final AnnotatedTypeMirror lastType = parameterTypes.get(lastIndex);
         final boolean parameterBeforeVarargs = index < lastIndex;
         if (!parameterBeforeVarargs && lastType instanceof AnnotatedArrayType) {
             final AnnotatedArrayType arrayType = (AnnotatedArrayType) lastType;
-            final Type.ArrayType underlyingType = (Type.ArrayType) arrayType.getUnderlyingType();
             if (hasVarArg) {
                 return arrayType.getComponentType();
             }

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1265,7 +1265,7 @@ public class AnnotatedTypes {
      * @return If that parameter is a varArgs, return the component of the var args and NOT the array type.
      *         Otherwise, return the exact type of the parameter in the index position
      */
-    public static AnnotatedTypeMirror unwrapVarargs(boolean hasVarArg,List<AnnotatedTypeMirror> parameterTypes, int index) {
+    public static AnnotatedTypeMirror unwrapVarargs(boolean hasVarArg, List<AnnotatedTypeMirror> parameterTypes, int index) {
         final int lastIndex = parameterTypes.size() - 1;
         final AnnotatedTypeMirror lastType = parameterTypes.get(lastIndex);
         final boolean parameterBeforeVarargs = index < lastIndex;


### PR DESCRIPTION
`isVarArgs()` should be called on a method element rather than the parameter element.