### PR TITLE
Debug printout for QualifierDefaults and typo fixes

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1252,7 +1252,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * <p>
      *
      * An example of an adaptation follows.  Suppose, I have a declaration:
-     * class MyClass&lt;E extends Listlt;E&gt;&gt;
+     * class MyClass&lt;E extends List&lt;E&gt;&gt;
      * And an instantiation:
      * new MyClass&lt;@NonNull String&gt;()
      *

--- a/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -89,9 +89,8 @@ public abstract class QualifierHierarchy {
     // **********************************************************************
 
     /**
-     * Tests whether anno1 is a sub-qualifier of anno2, according to the
-     * type qualifier hierarchy.  This checks only the qualifiers, not the
-     * Java type.
+     * Tests whether rhs is a sub-qualifier of lhs, according to the type
+     * qualifier hierarchy. This checks only the qualifiers, not the Java type.
      *
      * @return true iff rhs is a sub qualifier of lhs
      */

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -481,7 +481,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
         if (a == null) {
             ErrorReporter.errorAbort("MultiGraphQualifierHierarchy found an unqualified type.  Please ensure that " +
                     "your implicit rules cover all cases and/or " +
-                    "use a @DefaulQualifierInHierarchy annotation.");
+                    "use a @DefaultQualifierInHierarchy annotation.");
         } else {
             // System.out.println("MultiGraphQH: " + this);
             ErrorReporter.errorAbort("MultiGraphQualifierHierarchy found the unrecognized qualifier: " + a +

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -1,9 +1,9 @@
 package org.checkerframework.framework.util.defaults;
 
 import org.checkerframework.framework.qual.AnnotatedFor;
-import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import org.checkerframework.framework.qual.DefaultQualifiers;
+import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
@@ -17,6 +17,7 @@ import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.CheckerMain;
+import org.checkerframework.framework.util.PluginUtil;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.CollectionUtils;
 import org.checkerframework.javacutil.ElementUtils;
@@ -50,7 +51,6 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeParameterTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
-
 import com.sun.tools.javac.code.Type.WildcardType;
 
 /**
@@ -168,6 +168,20 @@ public class QualifierDefaults {
         this.upstreamCheckerNames = atypeFactory.getContext().getChecker().getUpstreamCheckerNames();
         this.useUncheckedCodeDefaultsBytecode = atypeFactory.getContext().getChecker().useUncheckedCodeDefault("bytecode");
         this.useUncheckedCodeDefaultsSource = atypeFactory.getContext().getChecker().useUncheckedCodeDefault("source");
+    }
+
+    @Override
+    public String toString() {
+        // displays the checked and unchecked code defaults
+        StringBuilder sb = new StringBuilder();
+        sb.append("Checked Code Defaults: ");
+        sb.append(System.lineSeparator());
+        sb.append(PluginUtil.join(System.lineSeparator(), checkedCodeDefaults));
+        sb.append(System.lineSeparator());
+        sb.append("Unchecked Code Defaults: ");
+        sb.append(System.lineSeparator());
+        sb.append(PluginUtil.join(System.lineSeparator(), uncheckedCodeDefaults));
+        return sb.toString();
     }
 
     /**
@@ -1023,7 +1037,7 @@ public class QualifierDefaults {
         }
 
         if (type instanceof AnnotatedWildcardType) {
-            return getWilcardBoundType((AnnotatedWildcardType) type, typeFactory);
+            return getWildcardBoundType((AnnotatedWildcardType) type, typeFactory);
         }
 
         ErrorReporter.errorAbort("Unexpected type kind: type=" + type);
@@ -1083,7 +1097,7 @@ public class QualifierDefaults {
      * @return the BoundType of annotatedWildcard.  If it is unbounded, use the type parameter to
      * which its an argument
      */
-    public static BoundType getWilcardBoundType(final AnnotatedWildcardType annotatedWildcard,
+    public static BoundType getWildcardBoundType(final AnnotatedWildcardType annotatedWildcard,
                                                 final AnnotatedTypeFactory typeFactory) {
 
         final WildcardType wildcard = (WildcardType) annotatedWildcard.getUnderlyingType();

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -174,13 +174,20 @@ public class QualifierDefaults {
     public String toString() {
         // displays the checked and unchecked code defaults
         StringBuilder sb = new StringBuilder();
-        sb.append("Checked Code Defaults: ");
+        sb.append("Checked code defaults: ");
         sb.append(System.lineSeparator());
         sb.append(PluginUtil.join(System.lineSeparator(), checkedCodeDefaults));
         sb.append(System.lineSeparator());
-        sb.append("Unchecked Code Defaults: ");
+        sb.append("Unchecked code defaults: ");
         sb.append(System.lineSeparator());
         sb.append(PluginUtil.join(System.lineSeparator(), uncheckedCodeDefaults));
+        sb.append(System.lineSeparator());
+        sb.append("useUncheckedCodeDefaultsSource: ");
+        sb.append(useUncheckedCodeDefaultsSource);
+        sb.append(System.lineSeparator());
+        sb.append("useUncheckedCodeDefaultsBytecode: ");
+        sb.append(useUncheckedCodeDefaultsBytecode);
+        sb.append(System.lineSeparator());
         return sb.toString();
     }
 


### PR DESCRIPTION
- added debug printout code for checked and unchecked code defaults
- fixed a few other typos found in the framework

A call to `defaults.toString()` in an ATF will display the defaults. Here's a sample output of the debug printout when using Formatter checker:

```
Checked Code Defaults: 
( LOCAL_VARIABLE => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( RESOURCE_VARIABLE => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( EXCEPTION_PARAMETER => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( LOWER_BOUND => @org.checkerframework.checker.formatter.qual.FormatBottom )
( IMPLICIT_LOWER_BOUND => @org.checkerframework.checker.formatter.qual.FormatBottom )
( IMPLICIT_UPPER_BOUND => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( OTHERWISE => @org.checkerframework.checker.formatter.qual.UnknownFormat )
Unchecked Code Defaults: 
( FIELD => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( PARAMETER => @org.checkerframework.checker.formatter.qual.FormatBottom )
( RETURN => @org.checkerframework.checker.formatter.qual.UnknownFormat )
( LOWER_BOUND => @org.checkerframework.checker.formatter.qual.FormatBottom )
( UPPER_BOUND => @org.checkerframework.checker.formatter.qual.UnknownFormat )
```

