### PR TITLE
Validate the declared type without refinement

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -219,7 +219,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     /**
      * Constructs an instance of the appropriate type factory for the
      * implemented type system.
-     *
+     *eof
      * The default implementation uses the checker naming convention to create
      * the appropriate type factory.  If no factory is found, it returns
      * {@link BaseAnnotatedTypeFactory}.  It reflectively invokes the
@@ -3106,7 +3106,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
             break;
         default:
-            type = atypeFactory.getAnnotatedType(tree);
+        	type = atypeFactory.getDefaultedAnnotatedType(tree);
         }
         return validateType(tree, type);
     }


### PR DESCRIPTION
There are two changes here:
1. We need method getDefaultedAnnotatedType to get declared type instead of refined type, which reduces the number of error messages from type refinement during type validation.
2. Second parameter of method getDefaultedAnnotatedType is removed. This change hasn't been reflected in BaseTypeVisitor yet.