### PR TITLE
Remove dead code from BaseTypeVisitor

### DIFF
--- a/checker/src/org/checkerframework/checker/fenum/FenumVisitor.java
+++ b/checker/src/org/checkerframework/checker/fenum/FenumVisitor.java
@@ -50,7 +50,7 @@ public class FenumVisitor extends BaseTypeVisitor<FenumAnnotatedTypeFactory> {
                 AnnotatedTypeMirror caseType = atypeFactory.getAnnotatedType(realCaseExpr);
 
                 this.commonAssignmentCheck(exprType, caseType, caseExpr,
-                        "switch.type.incompatible", false);
+                        "switch.type.incompatible");
             }
         }
         return super.visitSwitch(node, p);

--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -180,7 +180,7 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
                 AnnotatedTypeMerger.merge(var2, var, invariantAnno);
 
                 checkAssignability(var, varTree);
-                commonAssignmentCheck(var, valueExp, errorKey, false);
+                commonAssignmentCheck(var, valueExp, errorKey);
                 return;
             }
         }

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -78,15 +78,14 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
     @Override
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey,
-            boolean isLocalVariableAssignement) {
+            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey) {
 
         if (valueType.getKind() == TypeKind.NULL) {
             // Avoid issuing warnings about 'null' not matching the type of the variable.
             return;
         }
 
-        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey, isLocalVariableAssignement);
+        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey);
     }
 
     private void reportFailure(/*@CompilerMessageKey*/ String messageKey,

--- a/checker/src/org/checkerframework/checker/nullness/KeyForVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForVisitor.java
@@ -33,12 +33,11 @@ public class KeyForVisitor extends BaseTypeVisitor<KeyForAnnotatedTypeFactory> {
 
     @Override
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey,
-            boolean isLocalVariableAssignement) {
+            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey) {
 
         atypeFactory.keyForCanonicalizeValues(varType, valueType, getCurrentPath());
 
-        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey, isLocalVariableAssignement);
+        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey);
     }
 
     /**

--- a/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -217,14 +217,13 @@ public class NullnessVisitor extends InitializationVisitor<NullnessAnnotatedType
 
     @Override
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType, ExpressionTree valueExp,
-                                         /*@CompilerMessageKey*/ String errorKey,
-                                         boolean isLocalVariableAssignment) {
+                                         /*@CompilerMessageKey*/ String errorKey) {
         // Use the valueExp as the context because data flow will have a value for that tree.
         // It might not have a value for the var tree.  This is sound because
         // if data flow has determined @PolyNull is @Nullable at the RHS, then
         // it is also @Nullable for the LHS.
         atypeFactory.replacePolyQualifier(varType, valueExp);
-        super.commonAssignmentCheck(varType, valueExp, errorKey, isLocalVariableAssignment);
+        super.commonAssignmentCheck(varType, valueExp, errorKey);
     }
     /** Case 1: Check for null dereferencing */
     @Override

--- a/framework/src/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -182,10 +182,8 @@ public class AliasingVisitor extends
 
     @Override
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey,
-            boolean isLocalVariableAssignement) {
-        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey,
-                isLocalVariableAssignement);
+            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey) {
+        super.commonAssignmentCheck(varType, valueType, valueTree, errorKey);
 
         // If we are visiting a pseudo-assignment, visitorLeafKind is either
         // Kind.NEW_CLASS or Kind.METHOD_INVOCATION.

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -887,7 +887,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         boolean valid = validateTypeOf(node.getVariable());
         if (valid) {
             commonAssignmentCheck(var, iteratedType, node.getExpression(),
-                    "enhancedfor.type.incompatible", true);
+                    "enhancedfor.type.incompatible");
         }
         return super.visitEnhancedForLoop(node, p);
     }
@@ -1203,8 +1203,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 passedAsArray.getComponentType(),
                 receiverAsVector.getTypeArguments().get(0),
                 node.getArguments().get(0),
-                "vector.copyinto.type.incompatible",
-                false);
+                "vector.copyinto.type.incompatible");
     }
 
     /**
@@ -1261,7 +1260,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             if (ret.getKind() != TypeKind.VOID) {
                 visitorState.setAssignmentContext(Pair.of((Tree) node, ret));
                 commonAssignmentCheck(ret, (ExpressionTree) node.getBody(),
-                        "return.type.incompatible", false);
+                        "return.type.incompatible");
             }
         }
 
@@ -1269,7 +1268,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         for (int i = 0; i < overridden.getParameterTypes().size(); ++i) {
             AnnotatedTypeMirror overridingParm = atypeFactory.getAnnotatedType(node.getParameters().get(i));
             commonAssignmentCheck(overridingParm, overridden.getParameterTypes().get(i), node.getParameters().get(i),
-                    "lambda.param.type.incompatible", false);
+                    "lambda.param.type.incompatible");
         }
 
         // TODO: Post conditions?
@@ -1318,7 +1317,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 visitorState.setAssignmentContext(Pair.of((Tree) node, ret));
 
                 commonAssignmentCheck(ret, node.getExpression(),
-                        "return.type.incompatible", false);
+                        "return.type.incompatible");
             }
             return super.visitReturn(node, p);
         } finally {
@@ -1405,18 +1404,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 if (expected.getKind() != TypeKind.ARRAY) {
                     // Expected is not an array -> direct comparison.
                     commonAssignmentCheck(expected, actual, at.getExpression(),
-                            "annotation.type.incompatible", false);
+                            "annotation.type.incompatible");
                 } else {
                     if (actual.getKind() == TypeKind.ARRAY) {
                         // Both actual and expected are arrays.
                         commonAssignmentCheck(expected, actual, at.getExpression(),
-                                "annotation.type.incompatible", false);
+                                "annotation.type.incompatible");
                     } else {
                         // The declaration is an array type, but just a single
                         // element is given.
                         commonAssignmentCheck(((AnnotatedArrayType) expected).getComponentType(),
                                 actual, at.getExpression(),
-                                "annotation.type.incompatible", false);
+                                "annotation.type.incompatible");
                     }
                 }
             } finally {
@@ -1435,23 +1434,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     @Override
     public Void visitConditionalExpression(ConditionalExpressionTree node, Void p) {
         AnnotatedTypeMirror cond = atypeFactory.getAnnotatedType(node);
-        Pair<Tree, AnnotatedTypeMirror> ctx = visitorState.getAssignmentContext();
-        Tree assignmentContext = ctx == null ? null : ctx.first;
-        boolean isLocalVariableAssignment = false;
-        if (assignmentContext != null) {
-            if (assignmentContext instanceof VariableTree) {
-                isLocalVariableAssignment = assignmentContext instanceof IdentifierTree
-                        && !TreeUtils.isFieldAccess(assignmentContext);
-            }
-            if (assignmentContext instanceof VariableTree) {
-                isLocalVariableAssignment = TreeUtils
-                        .enclosingMethod(getCurrentPath()) != null;
-            }
-        }
         this.commonAssignmentCheck(cond, node.getTrueExpression(),
-                "conditional.type.incompatible", isLocalVariableAssignment);
+                "conditional.type.incompatible");
         this.commonAssignmentCheck(cond, node.getFalseExpression(),
-                "conditional.type.incompatible", isLocalVariableAssignment);
+                "conditional.type.incompatible");
         return super.visitConditionalExpression(node, p);
     }
 
@@ -1820,18 +1806,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
         checkAssignability(var, varTree);
 
-        boolean isLocalVariableAssignment = false;
-        if (varTree instanceof AssignmentTree) {
-            Tree rhs = ((AssignmentTree) varTree).getVariable();
-            isLocalVariableAssignment = rhs instanceof IdentifierTree
-                    && !TreeUtils.isFieldAccess(rhs);
-        }
-        if (varTree instanceof VariableTree) {
-            isLocalVariableAssignment = TreeUtils.enclosingMethod(getCurrentPath()) != null;
-        }
-
-        commonAssignmentCheck(var, valueExp, errorKey,
-                isLocalVariableAssignment);
+        commonAssignmentCheck(var, valueExp, errorKey);
     }
 
     /**
@@ -1843,13 +1818,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * @param valueExp the AST node for the value
      * @param errorKey the error message to use if the check fails (must be a
      *        compiler message key, see {@link org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey})
-     * @param isLocalVariableAssignment
-     *            Are we dealing with an assignment and is the lhs a local
-     *            variable?
      */
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-            ExpressionTree valueExp, /*@CompilerMessageKey*/ String errorKey,
-            boolean isLocalVariableAssignment) {
+            ExpressionTree valueExp, /*@CompilerMessageKey*/ String errorKey) {
         if (shouldSkipUses(valueExp))
             return;
         if (varType.getKind() == TypeKind.ARRAY
@@ -1865,8 +1836,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
         AnnotatedTypeMirror valueType = atypeFactory.getAnnotatedType(valueExp);
         assert valueType != null : "null type for expression: " + valueExp;
-        commonAssignmentCheck(varType, valueType, valueExp, errorKey,
-                isLocalVariableAssignment);
+        commonAssignmentCheck(varType, valueType, valueExp, errorKey);
     }
 
     /**
@@ -1879,13 +1849,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * @param valueTree the location to use when reporting the error message
      * @param errorKey the error message to use if the check fails (must be a
      *        compiler message key, see {@link org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey})
-     * @param isLocalVariableAssignment
-     *            Are we dealing with an assignment and is the lhs a local
-     *            variable?
      */
     protected void commonAssignmentCheck(AnnotatedTypeMirror varType,
-            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey,
-            boolean isLocalVariableAssignment) {
+            AnnotatedTypeMirror valueType, Tree valueTree, /*@CompilerMessageKey*/ String errorKey) {
 
         String valueTypeString = valueType.toString();
         String varTypeString = varType.toString();
@@ -1951,7 +1917,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // Also in AbstractFlow.
         for (ExpressionTree init : initializers)
             commonAssignmentCheck(type, init,
-                    "array.initializer.type.incompatible", false);
+                    "array.initializer.type.incompatible");
     }
 
     /**
@@ -2006,11 +1972,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 // I hope this is less confusing for users.
                 commonAssignmentCheck(paramUpperBound,
                         typeArg, toptree,
-                        "type.argument.type.incompatible", false);
+                        "type.argument.type.incompatible");
             } else {
                 commonAssignmentCheck(paramUpperBound, typeArg,
                         typeargTrees.get(typeargs.indexOf(typeArg)),
-                        "type.argument.type.incompatible", false);
+                        "type.argument.type.incompatible");
             }
 
             if (!atypeFactory.getTypeHierarchy().isSubtype(bounds.getLowerBound(), typeArg)) {
@@ -2224,7 +2190,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             for (int i = 0; i < requiredArgs.size(); ++i) {
                 visitorState.setAssignmentContext(Pair.<Tree, AnnotatedTypeMirror>of((Tree) null, (AnnotatedTypeMirror) requiredArgs.get(i)));
                 commonAssignmentCheck(requiredArgs.get(i), passedArgs.get(i),
-                        "argument.type.incompatible", false);
+                        "argument.type.incompatible");
                 // Also descend into the argument within the correct assignment
                 // context.
                 scan(passedArgs.get(i), null);


### PR DESCRIPTION
Removing dead code that was pointed out by Michael Coblenz.
The isLocalVariableAssignment parameter is now dead code after this change:
https://github.com/typetools/checker-framework/commit/54034e0db91a98b0f43d4adf24dead06d37987eb#diff-45171d06cf5f30b2b7221369fabf4a94L1589
