### PR TITLE
Rawtypes (continuation of #621)

### DIFF
--- a/checker/jtreg/rawtypes/RawTypeFail.java
+++ b/checker/jtreg/rawtypes/RawTypeFail.java
@@ -1,6 +1,7 @@
 /*
  * @test
  * @summary Test that raw types sometimes produces unwanted errors
+ * @ignore Renable once Issue #635 is fixed (https://github.com/typetools/checker-framework/issues/635)
  *
  * @compile/fail/ref=RawTypeFail.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -AprintErrorStack -Alint -Anomsgtext RawTypeFail.java
  * @compile/ref=RawTypeFailIgnored.out -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker -AprintErrorStack -Alint -Anomsgtext -AignoreRawTypeArguments RawTypeFail.java

--- a/checker/src/org/checkerframework/checker/igj/IGJAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/igj/IGJAnnotatedTypeFactory.java
@@ -35,7 +35,6 @@ import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
-import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -847,7 +846,7 @@ public class IGJAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected TypeHierarchy createTypeHierarchy() {
         return new IGJTypeHierarchy(checker, getQualifierHierarchy(),
-                                    checker.hasOption("ignoreRawTypeArguments"),
+                                    checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                                     checker.hasOption("invariantArrays"));
     }
 

--- a/checker/src/org/checkerframework/checker/javari/JavariAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/javari/JavariAnnotatedTypeFactory.java
@@ -779,7 +779,7 @@ public class JavariAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected TypeHierarchy createTypeHierarchy() {
         return new JavariTypeHierarchy(checker, qualHierarchy,
-                                       checker.hasOption("ignoreRawTypeArguments"),
+                                       checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                                        checker.hasOption("invariantArrays"));
     }
 

--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -329,7 +329,7 @@ public class KeyForAnnotatedTypeFactory extends
   @Override
   protected TypeHierarchy createTypeHierarchy() {
       return new KeyForTypeHierarchy(checker, getQualifierHierarchy(),
-                                     checker.hasOption("ignoreRawTypeArguments"),
+                                     checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                                      checker.hasOption("invariantArrays"));
   }
 

--- a/checker/src/org/checkerframework/checker/oigj/ImmutabilityAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/oigj/ImmutabilityAnnotatedTypeFactory.java
@@ -863,7 +863,7 @@ public class ImmutabilityAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     protected TypeHierarchy createTypeHierarchy() {
         return new OIGJImmutabilityTypeHierarchy(checker, getQualifierHierarchy(),
-                                                 checker.hasOption("ignoreRawTypeArguments"),
+                                                 checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                                                  checker.hasOption("invariantArrays"));
     }
 

--- a/checker/tests/nullness/RawTypesAssignment.java
+++ b/checker/tests/nullness/RawTypesAssignment.java
@@ -1,0 +1,34 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RawTypesAssignment {
+    Map rawMap = new HashMap();
+    Map<String, List<String>> notRawMapDiamondRec = new HashMap<>();
+    //:: warning: [unchecked] unchecked conversion
+    Map<String, List<String>> notRawMapRawHashMapRec = new HashMap();
+
+    Map<String, CharSequence> notRawMapDiamond = new HashMap<>();
+    //:: warning: [unchecked] unchecked conversion
+    Map<String, CharSequence> notRawMapRawHashMap = new HashMap();
+
+    Map<Object, Object> notRawMapDiamondObjectObject = new HashMap<>();
+    //:: warning: [unchecked] unchecked conversion
+    Map<Object, Object> notRawMapDiamondObjectObjectRaw = new HashMap();
+
+    RecursiveGeneric rawRecursiveGeneric = new RecursiveGeneric();
+    RecursiveGeneric<MyClass> notRawRecursiveGenericDiamond = new RecursiveGeneric<>();
+    //:: warning: [unchecked] unchecked conversion
+    RecursiveGeneric<MyClass> notRawRecursiveGenericRaw = new RecursiveGeneric();
+
+    class Generic<G extends @Nullable Object> {
+    }
+
+    class RecursiveGeneric<R extends Generic<R>> {
+    }
+
+    class MyClass extends Generic<MyClass> {
+    }
+}

--- a/checker/tests/nullness/RawTypesBounded.java
+++ b/checker/tests/nullness/RawTypesBounded.java
@@ -1,0 +1,72 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Generic<G extends  @Nullable Object>{
+}
+class MyClass extends Generic<MyClass> {}
+class BoundedGeneric<B extends @Nullable CharSequence>{}
+class RawTypes {
+    Generic rawReturn() {
+        return new Generic();
+    }
+    Generic rawField = new Generic();
+
+    void use(){
+        Generic rawLocal = new Generic<String>();
+        Generic<?> generic1 = rawReturn();
+        Generic<?> generic2 = rawField;
+        Generic<?> generic3 = rawLocal;
+    }
+}
+class TestBounded {
+    BoundedGeneric rawReturn() {
+        return new BoundedGeneric<>();
+    }
+    BoundedGeneric rawField = new BoundedGeneric();
+
+    void useWildCard() {
+        BoundedGeneric rawLocal = new BoundedGeneric<String>();
+        BoundedGeneric<?> generic1 = rawReturn();
+        BoundedGeneric<?> generic2 = rawField;
+        BoundedGeneric<?> generic3 = rawLocal;
+    }
+
+    void useBoundedWildCard(){
+        BoundedGeneric rawLocal = new BoundedGeneric<String>();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends Object> generic1 = rawReturn();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends Object> generic2 = rawField;
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends Object> generic3 = rawLocal;
+    }
+
+    void useBoundedWildCard2(){
+        BoundedGeneric rawLocal = new BoundedGeneric<String>();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends CharSequence> generic1 = rawReturn();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends CharSequence> generic2 = rawField;
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<? extends CharSequence> generic3 = rawLocal;
+    }
+
+    void useTypeArg(){
+        BoundedGeneric rawLocal = new BoundedGeneric<String>();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<String> generic1 = rawReturn();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<String> generic2 = rawField;
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<String> generic3 = rawLocal;
+    }
+
+    void useAnnotatedTypeArg(){
+        BoundedGeneric rawLocal = new BoundedGeneric<String>();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<@Nullable String> generic1 = rawReturn();
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<@Nullable String> generic2 = rawField;
+        //:: warning: [unchecked] unchecked conversion
+        BoundedGeneric<@Nullable String> generic3 = rawLocal;
+    }
+}

--- a/checker/tests/nullness/RawTypesUses.java
+++ b/checker/tests/nullness/RawTypesUses.java
@@ -1,0 +1,50 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public abstract class RawTypesUses {
+    class Generic<G extends @Nullable Object> {
+        G foo() {
+            throw new RuntimeException();
+        }
+    }
+
+    void foo() {
+        Generic<@Nullable String> notRawNullable = new Generic<@Nullable String>();
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o1 = notRawNullable.foo();
+
+        Generic rawNullable = new Generic<@Nullable String>();
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o2 = rawNullable.foo();
+
+        Generic<@NonNull String> notRawNonNull = new Generic<@NonNull String>();
+        @NonNull Object o3 = notRawNonNull.foo();
+
+        Generic rawNonNull = new Generic<@NonNull String>();
+        Generic rawNonNullAlais = rawNonNull;
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o4 = rawNonNull.foo();
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o5 = rawNonNullAlais.foo();
+    }
+
+    abstract Generic rawReturn();
+    void bar() {
+        //:: warning: [unchecked] unchecked conversion
+        Generic<@Nullable String> notRawNullable = rawReturn();
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o1 = notRawNullable.foo();
+
+        Generic rawNullable = rawReturn();
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o2 = rawNullable.foo();
+
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o3 = rawReturn().foo();
+
+        Generic local = rawReturn();
+        Generic localAlias = local;
+        //:: error: (assignment.type.incompatible)
+        @NonNull Object o4 = local.foo();
+    }
+}

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -1680,12 +1680,6 @@ public abstract class SourceChecker
     // TODO I would like to rename getLintOption to hasLintOption
     @Override
     public final boolean hasOption(String name) {
-
-        // Always ignore errors from raw type arguments.
-        // See https://github.com/typetools/checker-framework/issues/635
-        if (name.equals("ignoreRawTypeArguments")) {
-            return true;
-        }
         return getOptions().containsKey(name);
     }
 

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -1680,6 +1680,12 @@ public abstract class SourceChecker
     // TODO I would like to rename getLintOption to hasLintOption
     @Override
     public final boolean hasOption(String name) {
+
+        // Always ignore errors from raw type arguments.
+        // See https://github.com/typetools/checker-framework/issues/635
+        if (name.equals("ignoreRawTypeArguments")) {
+            return true;
+        }
         return getOptions().containsKey(name);
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -539,7 +539,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     protected TypeHierarchy createTypeHierarchy() {
         return new DefaultTypeHierarchy(checker, getQualifierHierarchy(),
-                                        checker.hasOption("ignoreRawTypeArguments"),
+                                        checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                                         checker.hasOption("invariantArrays"));
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1113,6 +1113,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // treat Raw as generic!
         // TODO: This doesn't handle recursive type parameter
         // e.g. class Pair<Y extends List<Y>> { ... }
+        // Type argument inference for raw types can be improved. See Issue 635.
+        // https://github.com/typetools/checker-framework/issues/635
         if (result.getKind() == TypeKind.DECLARED) {
             AnnotatedDeclaredType dt = (AnnotatedDeclaredType) result;
             if (dt.wasRaw()) {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1114,31 +1114,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         // TODO: This doesn't handle recursive type parameter
         // e.g. class Pair<Y extends List<Y>> { ... }
         if (result.getKind() == TypeKind.DECLARED) {
-            AnnotatedDeclaredType dt = (AnnotatedDeclaredType)result;
+            AnnotatedDeclaredType dt = (AnnotatedDeclaredType) result;
             if (dt.wasRaw()) {
-                List<AnnotatedTypeMirror> typeArgs;
-                Pair<Tree, AnnotatedTypeMirror> ctx = this.visitorState.getAssignmentContext();
-                if (ctx != null) {
-                    if (ctx.second.getKind() == TypeKind.DECLARED &&
-                            types.isSameType(types.erasure(ctx.second.actualType), types.erasure(dt.actualType))) {
-                        typeArgs = ((AnnotatedDeclaredType) ctx.second).getTypeArguments();
-                    } else {
-                        // TODO: we want a way to go from the raw type to an instantiation of the raw type
-                        // that is compatible with the context.
-                        typeArgs = null;
-                    }
-                } else {
-                    // TODO: the context is null, use uninstantiated wildcards instead.
-                    typeArgs = new ArrayList<AnnotatedTypeMirror>();
-                    AnnotatedDeclaredType declaration = fromElement((TypeElement)dt.getUnderlyingType().asElement());
-                    for (AnnotatedTypeMirror typeParam : declaration.getTypeArguments()) {
-                        AnnotatedWildcardType wct = getUninferredWildcardType((AnnotatedTypeVariable) typeParam);
-                        typeArgs.add(wct);
-                    }
+                List<AnnotatedTypeMirror> typeArgs = new ArrayList<AnnotatedTypeMirror>();
+                AnnotatedDeclaredType declaration = fromElement((TypeElement) dt.getUnderlyingType().asElement());
+                for (AnnotatedTypeMirror typeParam : declaration.getTypeArguments()) {
+                    AnnotatedWildcardType wct = getUninferredWildcardType((AnnotatedTypeVariable) typeParam);
+                    typeArgs.add(wct);
                 }
                 dt.setTypeArguments(typeArgs);
             }
         }
+
         annotateInheritedFromClass(result);
         if (shouldCache)
             fromTreeCache.put(tree, result.deepCopy());

--- a/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -645,11 +645,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
     public Boolean visitPrimitive_Wildcard(AnnotatedPrimitiveType subtype, AnnotatedWildcardType supertype, VisitHistory visitHistory) {
         //this can occur when passing a primitive to a method on a raw type (see test checker/tests/nullness/RawAndPrimitive.java)
         //this can also occur because we don't box primitives when we should and don't capture convert
-        if (supertype.isTypeArgHack()) {
-            return isPrimarySubtype(subtype, supertype.getSuperBound());
-        } else {
-            return isPrimarySubtype(subtype, supertype.getSuperBound());
-        }
+        return isPrimarySubtype(subtype, supertype.getSuperBound());
     }
 
     //------------------------------------------------------------------------

--- a/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -19,9 +19,6 @@ import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TypesUtils;
 
-import static org.checkerframework.framework.util.AnnotatedTypes.isDeclarationOfJavaLangEnum;
-import static org.checkerframework.framework.util.AnnotatedTypes.isEnum;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -34,6 +31,9 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
+
+import static org.checkerframework.framework.util.AnnotatedTypes.isDeclarationOfJavaLangEnum;
+import static org.checkerframework.framework.util.AnnotatedTypes.isEnum;
 
 /**
  * Default implementation of TypeHierarchy that implements the JLS specification with minor
@@ -646,13 +646,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
         //this can occur when passing a primitive to a method on a raw type (see test checker/tests/nullness/RawAndPrimitive.java)
         //this can also occur because we don't box primitives when we should and don't capture convert
         if (supertype.isTypeArgHack()) {
-            if (ignoreRawTypes) {
-                return true;
-
-            } else {
-                return isPrimarySubtype(subtype, supertype.getSuperBound());
-            }
-
+            return isPrimarySubtype(subtype, supertype.getSuperBound());
         } else {
             return isPrimarySubtype(subtype, supertype.getSuperBound());
         }

--- a/framework/src/org/checkerframework/qualframework/base/QualifiedTypeFactoryAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/QualifiedTypeFactoryAdapter.java
@@ -122,7 +122,7 @@ class QualifiedTypeFactoryAdapter<Q> extends BaseAnnotatedTypeFactory {
                 getCheckerAdapter().getTypeMirrorConverter(),
                 getCheckerAdapter(),
                 getQualifierHierarchyAdapter(),
-                checker.hasOption("ignoreRawTypeArguments"),
+                checker.getOption("ignoreRawTypeArguments", "true").equals("true"),
                 checker.hasOption("invariantArrays"));
 
         // TODO: Move this check (and others like it) into the adapter


### PR DESCRIPTION
Type arguments for raw types are inferred using assignment context -- even if the raw type isn't begin assigned.  For example:
```` 
class MyGeneric<T extends @Nullable Object> {
    MyGeneric<T> id() {...}
}
void use(MyGeneric raw1) {
    // no error 
    MyGeneric<String> myGeneric = raw1.id();
}
````
2 problems with this (as it is currently implemented )
 
1.. It's doesn't work for all raw types the same way.  For example:
`````
MyGeneric getRaw() { ... }
void use(MyGeneric raw1) {
    // no error 
    MyGeneric<String> myGeneric = raw1.id();
    // assignment.type.incompatible 
    MyGeneric<String> myGeneri5 = getRaw().id();
}
````
2.. During data flow, the assignment context is null, so raw type inference fails and the result is cached.  This means that when caching is turned on, (more) errors are issued because of raw types. (d0b246abb842ebba648f420bf1d8fbb05333cb42 shows the different errors.)

This pull request removes the code that infers type arguments of raw types in order to avoid the above problems.  Type argument inference for raw types should be improved in the future (see #635). In order to avoid issuing errors about raw types, the "ignoreRawTypeArugments" option is always assumed to have been used. 