### PR TITLE
Remove Plug-in Development Environment dependencies from the Eclipse plug-in

### DIFF
--- a/eclipse/checker-framework-eclipse-feature/feature.xml
+++ b/eclipse/checker-framework-eclipse-feature/feature.xml
@@ -384,10 +384,6 @@ as provided by Sun in the LICENSE file that accompanied this code.&quot;
       <import plugin="org.eclipse.jdt.ui"/>
       <import plugin="org.eclipse.ui.ide"/>
       <import plugin="org.junit"/>
-      <import plugin="org.eclipse.pde.build" version="3.7.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.pde.core" version="3.7.1" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.pde.launching" version="3.6.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.pde.ui" version="3.6.100" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/eclipse/checker-framework-eclipse-plugin/META-INF/MANIFEST.MF
+++ b/eclipse/checker-framework-eclipse-plugin/META-INF/MANIFEST.MF
@@ -105,11 +105,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.console,
  org.eclipse.jdt.ui,
  org.eclipse.ui.ide,
- org.junit,
- org.eclipse.pde.build;bundle-version="3.7.0",
- org.eclipse.pde.core;bundle-version="3.7.1",
- org.eclipse.pde.launching;bundle-version="3.6.0",
- org.eclipse.pde.ui;bundle-version="3.6.100"
+ org.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor


### PR DESCRIPTION
My only concern with these changes is that we don't have an Eclipse plug-in test suite to test them. However, they did pass the sanity test that is done before each release.