### PR TITLE
Re-use checker source/javadoc JARs for checker-qual and checker-compat-qual

### DIFF
--- a/maven-plugin/release/README-checker-compat-qual
+++ b/maven-plugin/release/README-checker-compat-qual
@@ -1,9 +1,0 @@
-This jar is a stand in for either source/javadoc for the annotations
-used by the Checker Framework to type check source code.   The
-checker-qual-compat.jar contains annotations that are compatible
-with JDK 7 and previous, which do not support type annotations
-(https://docs.oracle.com/javase/tutorial/java/annotations/type_annotations.html).
-
-For Checker Framework information visit:
-http://checkerframework.org/
-

--- a/maven-plugin/release/README-checker-qual
+++ b/maven-plugin/release/README-checker-qual
@@ -1,6 +1,0 @@
-This jar is a stand in for either source/javadoc for the annotations
-used by the Checker Framework to type check source code.
-
-For Checker Framework information visit:
-http://checkerframework.org/
-

--- a/release/release.xml
+++ b/release/release.xml
@@ -386,18 +386,15 @@
         <!-- All Maven artifacts should have a sources/javadoc jar in order to be submitted to Maven central.
              At the moment we only have these for the checker artifact so for now we can create dummies with
              READMEs in them and pass those to Central.  This is the recommended way of handling this
-             situation.  See: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide -->
+             situation.  See: https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide
+
+             The checker artifact source/javadoc jars contain all the resources needed for checker-qual and
+             checker-compat-qual, so those jars are re-used for these other artifacts. -->
 
         <fail unless="maven.plugin.dir" message="maven.plugin.dir property is not set!"  />
         <fail unless="dest.dir"         message="dest.dir property is not set!" />
 
         <property name="maven.release.dir" value="${maven.plugin.dir}/release"/>
-
-        <jar destfile="${dest.dir}/checker-qual-source.jar"  basedir="${maven.release.dir}" includes="README-checker-qual"/>
-        <jar destfile="${dest.dir}/checker-qual-javadoc.jar" basedir="${maven.release.dir}" includes="README-checker-qual"/>
-
-        <jar destfile="${dest.dir}/checker-compat-qual-source.jar"  basedir="${maven.release.dir}" includes="README-checker-compat-qual"/>
-        <jar destfile="${dest.dir}/checker-compat-qual-javadoc.jar" basedir="${maven.release.dir}" includes="README-checker-compat-qual"/>
 
         <jar destfile="${dest.dir}/compiler-source.jar"  basedir="${maven.release.dir}" includes="README-compiler"/>
         <jar destfile="${dest.dir}/compiler-javadoc.jar" basedir="${maven.release.dir}" includes="README-compiler"/>

--- a/release/release_push.py
+++ b/release/release_push.py
@@ -88,15 +88,17 @@ def stage_maven_artifacts_in_maven_central(new_checker_version):
                             CHECKER_SOURCE, CHECKER_JAVADOC,
                             pgp_user, pgp_passphrase)
 
+    # checker.jar is a superset of checker-qual.jar, so use the same source/javadoc jars
     mvn_sign_and_deploy_all(SONATYPE_OSS_URL, SONATYPE_STAGING_REPO_ID, CHECKER_QUAL_RELEASE_POM, CHECKER_QUAL,
-                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, "checker-qual-source.jar"),
-                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, "checker-qual-javadoc.jar"),
+                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, CHECKER_SOURCE),
+                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, CHECKER_JAVADOC),
                             pgp_user, pgp_passphrase)
 
+    # checker.jar is a superset of checker-compat-qual.jar, so use the same source/javadoc jars
     mvn_sign_and_deploy_all(SONATYPE_OSS_URL, SONATYPE_STAGING_REPO_ID, CHECKER_COMPAT_QUAL_RELEASE_POM,
                             CHECKER_COMPAT_QUAL,
-                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, "checker-compat-qual-source.jar"),
-                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, "checker-compat-qual-javadoc.jar"),
+                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, CHECKER_SOURCE),
+                            os.path.join(MAVEN_RELEASE_DIR, mvn_dist, CHECKER_JAVADOC),
                             pgp_user, pgp_passphrase)
 
     mvn_sign_and_deploy_all(SONATYPE_OSS_URL, SONATYPE_STAGING_REPO_ID, JAVAC_BINARY_RELEASE_POM, JAVAC_BINARY,


### PR DESCRIPTION
This addresses the primary need identified in issue #182, which is to
provide proper IDE support for the pre-defined type annotations provided
by the Checker Framework.