### PR TITLE
Move code that creates AnnotatedNullType to ATF

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1306,14 +1306,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Return an AnnotatedNullType with {@code annosToAdd} added
-     * @param annosToAdd annotations to add to the AnnotatedNullType
-     * @return AnnotatedNullType with {@code annosToAdd} added
+     * Creates and returns an AnnotatedNullType qualified with {@code annotations}.
+     * @param annotations Set of AnnotationMirrors to qualify the returned type with
+     * @return AnnotatedNullType qualified with {@code annotations}
      */
-    public AnnotatedNullType getAnnotatedNullType(Set<? extends AnnotationMirror> annosToAdd) {
+    public AnnotatedNullType getAnnotatedNullType(Set<? extends AnnotationMirror> annotations) {
         final AnnotatedTypeMirror.AnnotatedNullType nullType = (AnnotatedNullType)
                 toAnnotatedType(processingEnv.getTypeUtils().getNullType(), false);
-        nullType.addAnnotations(annosToAdd);
+        nullType.addAnnotations(annotations);
         return nullType;
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -27,6 +27,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayTyp
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedIntersectionType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedNullType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiveType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
@@ -1302,6 +1303,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     protected void annotateInheritedFromClass(/*@Mutable*/ AnnotatedTypeMirror type,
             Set<AnnotationMirror> fromClass) {
         type.addMissingAnnotations(fromClass);
+    }
+
+    /**
+     * Return an AnnotatedNullType with {@code annosToAdd} added
+     * @param annosToAdd annotations to add to the AnnotatedNullType
+     * @return AnnotatedNullType with {@code annosToAdd} added
+     */
+    public AnnotatedNullType getAnnotatedNullType(Set<? extends AnnotationMirror> annosToAdd) {
+        final AnnotatedTypeMirror.AnnotatedNullType nullType = (AnnotatedNullType)
+                toAnnotatedType(processingEnv.getTypeUtils().getNullType(), false);
+        nullType.addAnnotations(annosToAdd);
+        return nullType;
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
@@ -114,10 +114,7 @@ public class GlbUtil {
      */
     private static AnnotatedNullType createBottom(final AnnotatedTypeFactory typeFactory,
                                            final Set<? extends AnnotationMirror> annos) {
-        final AnnotatedNullType nullType = (AnnotatedNullType)
-                typeFactory.toAnnotatedType(typeFactory.getProcessingEnv().getTypeUtils().getNullType(), false);
-        nullType.addAnnotations(annos);
-        return nullType;
+        return typeFactory.getAnnotatedNullType(annos);
     }
 
     /**


### PR DESCRIPTION
This change allows AnnotatedTypeFactory#toAnnotatedType to be marked protected.  (It's not changed to protected in this pull request because there are additional calls that have to be change first.)