### PR TITLE
Refactor calls to AnnotatedTypeFactory methods

### DIFF
--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -134,7 +134,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
                     node.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT);
             if (node.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT) {
                 ExpressionTree src = ((MemberSelectTree)node.getMethodSelect()).getExpression();
-                srcType = atypeFactory.fromExpression(src);
+                srcType = atypeFactory.getAnnotatedType(src);
             } else {
                 // Tree.Kind.IDENTIFIER, e.g. a direct call like "super()"
                 srcType = visitorState.getMethodReceiver();

--- a/checker/src/org/checkerframework/checker/javari/JavariVisitor.java
+++ b/checker/src/org/checkerframework/checker/javari/JavariVisitor.java
@@ -45,7 +45,7 @@ public class JavariVisitor extends BaseTypeVisitor<JavariAnnotatedTypeFactory> {
      */
     @Override
     public Void visitClass(ClassTree node, Void p) {
-        if (atypeFactory.fromClass(node).hasEffectiveAnnotation(atypeFactory.POLYREAD))
+        if (atypeFactory.getAnnotatedType(node).hasEffectiveAnnotation(atypeFactory.POLYREAD))
                 /* TODO: what was this meant to do?
             && !atypeFactory.getSelfType(node).hasEffectiveAnnotation(atypeFactory.POLYREAD)*/
             checker.report(Result.failure("polyread.type"), node);

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -187,7 +187,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
     protected V getValueWithSameAnnotations(TypeMirror type, V annotatedValue) {
         if (annotatedValue == null) return null;
         GenericAnnotatedTypeFactory<V, S, T, ? extends CFAbstractAnalysis<V, S, T>> factory = analysis.atypeFactory;
-        AnnotatedTypeMirror at = factory.toAnnotatedType(type, false);
+        AnnotatedTypeMirror at = AnnotatedTypeMirror.createType(type, factory, false);
         at.replaceAnnotations(annotatedValue.getType().getAnnotations());
         return analysis.createAbstractValue(at);
     }

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -463,8 +463,7 @@ public class QualifierDefaults {
 
             applyToTypeVar = defaultTypeVarLocals
                           && elt.getKind() == ElementKind.LOCAL_VARIABLE
-                          && type.getKind() == TypeKind.TYPEVAR
-                          && atypeFactory.type(tree).getKind() == TypeKind.TYPEVAR;
+                          && type.getKind() == TypeKind.TYPEVAR;
             applyDefaultsElement(elt, type);
             applyToTypeVar = false;
         }


### PR DESCRIPTION
These changes are so that various AnnotatedTypeFactory methods can be marked non-public.