### PR TITLE
Initialization: get explicit annotations from Tree

### DIFF
--- a/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -49,12 +49,10 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 
-import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
@@ -633,24 +631,6 @@ public abstract class InitializationAnnotatedTypeFactory<
                 type.replaceAnnotation(COMMITTED);
             }
         }
-    }
-
-    /**
-     * Returns the annotations explicitly written on a constructor result.
-     * Callers should check that {@code constructorDeclaration} is in fact a declaration
-     * of a constructor.
-     *
-     * @param constructorDeclaration Declaration tree of constructor
-     * @return set of annotations explicit on the resulting type of the constructor
-     */
-    public Set<AnnotationMirror> getExplicitAnnotationsOnConstructorResult(MethodTree constructorDeclaration) {
-        Set<AnnotationMirror> annotationSet = AnnotationUtils.createAnnotationSet();
-        ModifiersTree modifiersTree = constructorDeclaration.getModifiers();
-        if (modifiersTree != null) {
-            List<? extends AnnotationTree> annotationTrees = modifiersTree.getAnnotations();
-            annotationSet.addAll(InternalUtils.annotationsFromTypeAnnotationTrees(annotationTrees));
-        }
-        return annotationSet;
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -49,10 +49,12 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
@@ -631,6 +633,24 @@ public abstract class InitializationAnnotatedTypeFactory<
                 type.replaceAnnotation(COMMITTED);
             }
         }
+    }
+
+    /**
+     * Returns the annotations explicitly written on a constructor result.
+     * Callers should check that {@code constructorDeclaration} is in fact a declaration
+     * of a constructor.
+     *
+     * @param constructorDeclaration Declaration tree of constructor
+     * @return set of annotations explicit on the resulting type of the constructor
+     */
+    public Set<AnnotationMirror> getExplicitAnnotationsOnConstructorResult(MethodTree constructorDeclaration) {
+        Set<AnnotationMirror> annotationSet = AnnotationUtils.createAnnotationSet();
+        ModifiersTree modifiersTree = constructorDeclaration.getModifiers();
+        if (modifiersTree != null) {
+            List<? extends AnnotationTree> annotationTrees = modifiersTree.getAnnotations();
+            annotationSet.addAll(InternalUtils.annotationsFromTypeAnnotationTrees(annotationTrees));
+        }
+        return annotationSet;
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -328,7 +328,7 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
     @Override
     public Void visitMethod(MethodTree node, Void p) {
         if (TreeUtils.isConstructor(node)) {
-            Collection<? extends AnnotationMirror> returnTypeAnnotations = atypeFactory.getExplicitAnnotationsOnConstructorResult(node);
+            Collection<? extends AnnotationMirror> returnTypeAnnotations = AnnotationUtils.getExplicitAnnotationsOnConstructorResult(node);
             // check for invalid constructor return type
             for (Class<? extends Annotation> c : atypeFactory.getInvalidConstructorReturnTypeAnnotations()) {
                 for (AnnotationMirror a : returnTypeAnnotations) {

--- a/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -328,7 +328,7 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
     @Override
     public Void visitMethod(MethodTree node, Void p) {
         if (TreeUtils.isConstructor(node)) {
-            Collection<? extends AnnotationMirror> returnTypeAnnotations = getExplicitReturnTypeAnnotations(node);
+            Collection<? extends AnnotationMirror> returnTypeAnnotations = atypeFactory.getExplicitAnnotationsOnConstructorResult(node);
             // check for invalid constructor return type
             for (Class<? extends Annotation> c : atypeFactory.getInvalidConstructorReturnTypeAnnotations()) {
                 for (AnnotationMirror a : returnTypeAnnotations) {
@@ -429,10 +429,4 @@ public class InitializationVisitor<Factory extends InitializationAnnotatedTypeFa
         }
     }
 
-    public Set<AnnotationMirror> getExplicitReturnTypeAnnotations(MethodTree node) {
-        AnnotatedTypeMirror t = atypeFactory.fromMember(node);
-        assert t instanceof AnnotatedExecutableType;
-        AnnotatedExecutableType type = (AnnotatedExecutableType) t;
-        return type.getReturnType().getAnnotations();
-    }
 }

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -33,6 +33,9 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 
+import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.ModifiersTree;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.model.JavacElements;
@@ -555,5 +558,23 @@ public class AnnotationUtils {
             result.addAll(newQual);
         }
         map.put(key, Collections.unmodifiableSet(result));
+    }
+
+    /**
+     * Returns the annotations explicitly written on a constructor result.
+     * Callers should check that {@code constructorDeclaration} is in fact a declaration
+     * of a constructor.
+     *
+     * @param constructorDeclaration Declaration tree of constructor
+     * @return set of annotations explicit on the resulting type of the constructor
+     */
+    public static Set<AnnotationMirror> getExplicitAnnotationsOnConstructorResult(MethodTree constructorDeclaration) {
+        Set<AnnotationMirror> annotationSet = AnnotationUtils.createAnnotationSet();
+        ModifiersTree modifiersTree = constructorDeclaration.getModifiers();
+        if (modifiersTree != null) {
+            List<? extends AnnotationTree> annotationTrees = modifiersTree.getAnnotations();
+            annotationSet.addAll(InternalUtils.annotationsFromTypeAnnotationTrees(annotationTrees));
+        }
+        return annotationSet;
     }
 }


### PR DESCRIPTION
AnnotatedTypeFactory#fromMember should not  be used to get explicit annotations. 