### PR TITLE
Refactor member reference code

### DIFF
--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -549,7 +549,7 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     public AnnotatedTypeMirror getResultingTypeOfConstructorMemberReference(MemberReferenceTree memberReferenceTree,
                                                                             AnnotatedExecutableType constructorType) {
-        assert memberReferenceTree.getMode() != MemberReferenceTree.ReferenceMode.NEW;
+        assert memberReferenceTree.getMode() == MemberReferenceTree.ReferenceMode.NEW;
 
         // The return type for constructors should only have explicit annotations from the constructor
         // Recreate some of the logic from TypeFromTree.visitNewClass here.

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -549,9 +549,7 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     public AnnotatedTypeMirror getResultingTypeOfConstructorMemberReference(MemberReferenceTree memberReferenceTree,
                                                                             AnnotatedExecutableType constructorType) {
-        if (memberReferenceTree.getMode() != MemberReferenceTree.ReferenceMode.NEW) {
-            ErrorReporter.errorAbort("");
-        }
+        assert memberReferenceTree.getMode() != MemberReferenceTree.ReferenceMode.NEW;
 
         // The return type for constructors should only have explicit annotations from the constructor
         // Recreate some of the logic from TypeFromTree.visitNewClass here.


### PR DESCRIPTION
- Move code that gets the return type of a member reference constructor to
AnnotatedTypeFactory.
- Move code that checks is method type argument inference is required to private method.