### PR TITLE
AnnotatedTypeFactory: reduce number of public methods and improve Javadocs

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -863,29 +863,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Determines the annotated type of an AST node.
-     *
-     * <p>
-     *
-     * The type is determined as follows:
-     * <ul>
-     *  <li>if {@code tree} is a class declaration, determine its type via
-     *    {@link #fromClass}</li>
-     *  <li>if {@code tree} is a method or variable declaration, determine its
-     *    type via {@link #fromMember(Tree)}</li>
-     *  <li>if {@code tree} is an {@link ExpressionTree}, determine its type
-     *    via {@link #fromExpression(ExpressionTree)}</li>
-     *  <li>otherwise, throw an {@link UnsupportedOperationException}</li>
-     * </ul>
+     * Returns an AnnotatedTypeMirror representing the qualified type for {@code tree}.
      *
      * @param tree the AST node
      * @return the annotated type of {@code tree}
-     *
-     * @see #fromClass(ClassTree)
-     * @see #fromMember(Tree)
-     * @see #fromExpression(ExpressionTree)
      */
-    // I wish I could make this method protected
     public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
         if (tree == null) {
             ErrorReporter.errorAbort("AnnotatedTypeFactory.getAnnotatedType: null tree");

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -829,14 +829,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Determines the annotated type of an element using
-     * {@link #fromElement(Element)}.
+     * Returns an AnnotatedTypeMirror representing the qualified type of {@code elt}.
      *
      * @param elt the element
-     * @return the annotated type of {@code elt}
-     * @throws IllegalArgumentException if {@code elt} is null
+     * @return the qualified type of {@code elt}
      *
-     * @see #fromElement(Element)
      */
     public AnnotatedTypeMirror getAnnotatedType(Element elt) {
         if (elt == null) {
@@ -863,10 +860,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns an AnnotatedTypeMirror representing the qualified type for {@code tree}.
+     * Returns an AnnotatedTypeMirror representing the qualified type of {@code tree}.
      *
      * @param tree the AST node
-     * @return the annotated type of {@code tree}
+     * @return the qualified type of {@code tree}
      */
     public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
         if (tree == null) {
@@ -952,10 +949,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     // **********************************************************************
 
     /**
-     * Determines the annotated type of an element.
+     * Creates an AnnotatedTypeMirror for {@code elt} that includes:
+     * annotations explicitly written on the element and annotations from stub files
      *
      * @param elt the element
-     * @return the annotated type of the element
+     * @return AnnotatedTypeMirror of the element with explicity and stub file annotations
      */
     public AnnotatedTypeMirror fromElement(Element elt) {
         if (shouldCache && elementCache.containsKey(elt)) {
@@ -967,6 +965,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         // Because of a bug in Java 8, annotations on type parameters are not stored in elements,
         // so get explicit annotations from the tree. (This bug has been fixed in Java 9.)
+        // Also, since annotations computed by the AnnotatedTypeFactory are stored in the element,
+        // the annotations have to be retrived from the tree so that only explicit annotations are returned.
         Tree decl = declarationFromElement(elt);
 
         if (decl == null && typesFromStubFiles != null && typesFromStubFiles.containsKey(elt)) {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1905,7 +1905,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         if (newClassTree.getClassBody() != null) {
             // If newClassTree creates an anonymous class, then annotations in this location:
-            // new @HERE Class(){}
+            // new @HERE Class() {}
             // are on not on the identifier newClassTree, but rather on the modifier newClassTree.
             List<? extends AnnotationTree> annos = newClassTree.getClassBody().getModifiers().getAnnotations();
             // replace the annotation because a different annotation could have been

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2091,14 +2091,14 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * @see #getAnnotatedType(Element)
+     * @see #fromElement(Element)
      */
     public final AnnotatedDeclaredType fromElement(TypeElement elt) {
         return (AnnotatedDeclaredType)fromElement((Element)elt);
     }
 
     /**
-     * @see #getAnnotatedType(Element)
+     * @see #fromElement(Element)
      */
     public final AnnotatedExecutableType fromElement(ExecutableElement elt) {
         return (AnnotatedExecutableType)fromElement((Element)elt);

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -838,10 +838,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns an AnnotatedTypeMirror representing the qualified type of {@code elt}.
+     * Returns an AnnotatedTypeMirror representing the annotated type of {@code elt}.
      *
      * @param elt the element
-     * @return the qualified type of {@code elt}
+     * @return the annotated type of {@code elt}
      *
      */
     public AnnotatedTypeMirror getAnnotatedType(Element elt) {
@@ -869,10 +869,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Returns an AnnotatedTypeMirror representing the qualified type of {@code tree}.
+     * Returns an AnnotatedTypeMirror representing the annotated type of {@code tree}.
      *
      * @param tree the AST node
-     * @return the qualified type of {@code tree}
+     * @return the annotated type of {@code tree}
      */
     public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
         if (tree == null) {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -608,17 +608,19 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * In total, there are 5 ways to indicate annotations that are supported by a
      * checker:
-     * <p>
      *
-     * 1) Only support annotations located in a checker's {@literal qual} directory,
+     * <ol>
+     * <li>
+     * Only support annotations located in a checker's {@literal qual} directory,
      * and {@link PolyAll}:
      * <p>
      *
      * This is the default behavior. Simply place those annotations within the
      * {@literal qual} directory.
-     * <p>
+     * </li>
      *
-     * 2) Support annotations located in a checker's {@literal qual} directory, but
+     * <li>
+     * Support annotations located in a checker's {@literal qual} directory, but
      * without {@link PolyAll}:
      * <p>
      *
@@ -632,8 +634,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *      return getBundledTypeQualifiersWithoutPolyAll();
      *  } }
      * </pre>
+     * </li>
      *
-     * 3) Support annotations located in a checker's {@literal qual} directory,
+     * <li>
+     * Support annotations located in a checker's {@literal qual} directory,
      * {@link PolyAll}, and a list of other annotations:
      * <p>
      *
@@ -647,8 +651,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *      return getBundledTypeQualifiersWithPolyAll(Regex.class, PartialRegex.class, RegexBottom.class, UnknownRegex.class);
      *  } }
      * </pre>
+     * </li>
      *
-     * 4) Support annotations located in a checker's {@literal qual} directory and a
+     * <li>
+     * Support annotations located in a checker's {@literal qual} directory and a
      * list of other annotations, but without supporting {@link PolyAll}:
      * <p>
      *
@@ -662,8 +668,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *      return getBundledTypeQualifiersWithoutPolyAll(UnknownFormat.class, FormatBottom.class);
      *  } }
      * </pre>
+     * </li>
      *
-     * 5) Supporting only annotations that are explicitly listed:
+     * <li>
+     * Supporting only annotations that are explicitly listed:
      *
      * Override
      * {@link #createSupportedTypeQualifiers()} and return an immutable
@@ -683,7 +691,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * {@link #getBundledTypeQualifiersWithoutPolyAll(Class...)} and
      * {@link #getBundledTypeQualifiersWithPolyAll(Class...)} each
      * return an immutable set.
-     * <p>
+     * </li>
+     * </ol>
      *
      * @return the type qualifiers supported this processor, or an empty set if
      *         none

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1039,12 +1039,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
 
     /**
-     * Returns an AnnotatedDeclaredType with explicit annotations on the class declaration.
+     * Returns an AnnotatedDeclaredType with explicit annotations from the
+     * ClassTree {@code tree}.
      *
      * @param tree the class declaration
      * @return AnnotatedDeclaredType with explicit annotations from {@code tree}
      */
-    private final AnnotatedDeclaredType fromClass(ClassTree tree) {
+    private AnnotatedDeclaredType fromClass(ClassTree tree) {
         return TypeFromTree.fromClassTree(this, tree);
     }
 
@@ -1082,18 +1083,20 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * The AnnotatedTypeMirror contains explicit annotations written with on the expression,
      * annotations inherited from class declarations, and for some expressions, annotations
      * from sub-expressions that could have been explicitly written, implicited, defaulted,
-     * refined, or otherwise computed.
-     *
+     * refined, or otherwise computed. (Expression whose type include annotations from sub-
+     * expressions are: ArrayAccessTree, ConditionalExpressionTree, IdentifierTree,
+     * MemberSelectTree, and MethodInvocationTree.)
+     * <p>
      * For example, the AnnotatedTypeMirror returned for an array access expression is the
      * fully annotated type of the array component of the array being accessed.
      *
      * @param tree an expression
-     * @return AnnotatedTypeMirror of the expressions either fully-annotated or partialy
+     * @return AnnotatedTypeMirror of the expressions either fully-annotated or partially
      * annotated depending on the kind of expression
      *
      * @see TypeFromExpressionVisitor
      */
-    private final AnnotatedTypeMirror fromExpression(ExpressionTree tree) {
+    private AnnotatedTypeMirror fromExpression(ExpressionTree tree) {
         if (shouldCache && fromTreeCache.containsKey(tree))
             return fromTreeCache.get(tree).deepCopy();
 
@@ -1670,7 +1673,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Returns the receiver type of the expression tree, or null if it does not exist.
-     *
+     * <p>
      * The only trees that could potentially have a receiver are:
      * <ul>
      *  <li> Array Access
@@ -1809,19 +1812,19 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /**
      * Determines the type of the invoked constructor based on the passed new
      * class tree.
-     *
+     * <p>
      * The returned method type has all type variables resolved, whether based
      * on receiver type, passed type parameters if any, and constructor invocation
      * parameter.
-     *
+     * <p>
      * Subclasses may override this method to customize inference of types
      * or qualifiers based on constructor invocation parameters.
-     *
+     * <p>
      * As an implementation detail, this method depends on
      * {@link AnnotatedTypes#asMemberOf(Types, AnnotatedTypeFactory, AnnotatedTypeMirror, Element)},
      * and customization based on receiver type should be in accordance with its
      * specification.
-     *
+     * <p>
      * The return type is a pair of the type of the invoked constructor and
      * the (inferred) type arguments.
      * Note that neither the explicitly passed nor the inferred type arguments
@@ -1829,7 +1832,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * See method
      * {@link org.checkerframework.common.basetype.BaseTypeVisitor#checkTypeArguments(Tree, List, List, List)}
      * for the checks of type argument well-formedness.
-     *
+     * <p>
      * Note that "this" and "super" constructor invocations are handled by
      * method {@link #methodFromUse}. This method only handles constructor invocations
      * in a "new" expression.

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -953,7 +953,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * annotations explicitly written on the element and annotations from stub files
      *
      * @param elt the element
-     * @return AnnotatedTypeMirror of the element with explicity and stub file annotations
+     * @return AnnotatedTypeMirror of the element with explicitly-written and stub file annotations
      */
     public AnnotatedTypeMirror fromElement(Element elt) {
         if (shouldCache && elementCache.containsKey(elt)) {
@@ -1042,7 +1042,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /**
      * Creates an AnnotatedTypeMirror for a variable or method declaration tree.
      * The AnnotatedTypeMirror contains annotations explicitly written on the tree
-     * and annotations inherited from the class declaration of types
+     * and annotations inherited from the class declarations
      * {@link #annotateInheritedFromClass(AnnotatedTypeMirror)}.
      * <p>
      * If a VariableTree is a parameter to a lambda, this method also adds
@@ -1099,8 +1099,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Creates an AnnotatedTypeMirror for the tree.  The AnnotatedTypeMirror contains
-     * annotations explicitly written on the tree and annotations inherited from the class
-     * declaration of types {@link #annotateInheritedFromClass(AnnotatedTypeMirror)}.
+     * annotations explicitly written on the tree and annotations inherited from  class
+     * declarations {@link #annotateInheritedFromClass(AnnotatedTypeMirror)}.
      * It also adds type arguments to raw types that include annotations from the element
      * declaration of the type {@link #fromElement(Element)}.
      * <p>
@@ -1810,7 +1810,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *
      * As an implementation detail, this method depends on
      * {@link AnnotatedTypes#asMemberOf(Types, AnnotatedTypeFactory, AnnotatedTypeMirror, Element)},
-     * and customization based on receiver type should be in accordance to its
+     * and customization based on receiver type should be in accordance with its
      * specification.
      *
      * The return type is a pair of the type of the invoked constructor and
@@ -1883,7 +1883,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Creates an AnnotatedDeclaredType for a NewClassTree.  Adds explicit annotations
-     * and annotations inherited from the class declaration {@link #annotateInheritedFromClass(AnnotatedTypeMirror)}.
+     * and annotations inherited from class declarations {@link #annotateInheritedFromClass(AnnotatedTypeMirror)}.
      * <p>
      * If the NewClassTree has type arguments, then any explicit (or inherited from class) annotations
      * on those type arguments are included. If the NewClassTree has a diamond operator, then
@@ -1897,7 +1897,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         if (!TreeUtils.isDiamondTree(newClassTree)) {
             // If newClassTree does not create anonymous class,
             // newClassTree.getIdentifier includes the explicit annotations in this location:
-            // new @HERE Class()
+            //   new @HERE Class()
             type = (AnnotatedDeclaredType) fromTypeTree(newClassTree.getIdentifier());
         } else {
             type = (AnnotatedDeclaredType) toAnnotatedType(InternalUtils.typeOf(newClassTree), false);
@@ -1905,10 +1905,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         if (newClassTree.getClassBody() != null) {
             // If newClassTree creates an anonymous class, then annotations in this location:
-            // new @HERE Class() {}
+            //   new @HERE Class() {}
             // are on not on the identifier newClassTree, but rather on the modifier newClassTree.
             List<? extends AnnotationTree> annos = newClassTree.getClassBody().getModifiers().getAnnotations();
-            // replace the annotation because a different annotation could have been
+            // Replace the annotation because a different annotation could have been
             // inherited from the class declaration.
             type.replaceAnnotations(InternalUtils.annotationsFromTypeAnnotationTrees(annos));
         }

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1021,7 +1021,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * instead.
      */
     @Override
-    public final void annotateImplicit(Tree tree, AnnotatedTypeMirror type) {
+    protected final void annotateImplicit(Tree tree, AnnotatedTypeMirror type) {
         annotateImplicit(tree, type, this.useFlow);
     }
 

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -273,12 +273,12 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     }
 
     /**
-     * Creates an AnnotatedDeclaredType for the NewClassTree and adds one of:
+     * Creates an AnnotatedDeclaredType for the NewClassTree and adds, for each hierarchy, one of:
      * <ul>
-     *   <li>explicit annotations from the new class expression ({@code new @HERE MyClass()} ), or</li>
-     *   <li>explicit annotations from the declaration of the class ({@code @HERE class MyClass {}} ), or</li>
-     *   <li>explicit annotations from the declaration of the constructor ({@code @HERE public MyClass() {}} ), or</li>
-     *   <li>no annotations.</li>
+     *   <li>an explicit annotation on the new class expression ({@code new @HERE MyClass()} ), or</li>
+     *   <li>an explicit annotation on the declaration of the class ({@code @HERE class MyClass {}} ), or</li>
+     *   <li>an explicit annotation on the declaration of the constructor ({@code @HERE public MyClass() {}} ), or</li>
+     *   <li>no annotation for a this hierarchy.</li>
      * </ul>
      *
      * @param node NewClassTree

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -273,13 +273,15 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     }
 
     /**
-     * The type of a NewClassTree is the type of the Identifier
-     * plus any explicit annotations (including polymorphic qualifiers)
-     * on the constructor.
+     * Creates an AnnotatedDeclaredType for the NewClassTree and adds: <br>
+     *  - either explicit annotations from the new class expression ({@code new @HERE MyClass()} ), <br>
+     *  - or explicit annotations from the declaration of the class ({@code @HERE class MyClass {}} ), <br>
+     *  - or explicit annotations from the declaration of the constructor ({@code @HERE public MyClass() {}} ), <br>
+     *  - or no annotations.
      *
-     * @param node the NewClassTree
+     * @param node NewClassTree
      * @param f the type factory
-     * @return the type of the new class
+     * @return AnnotatedDeclaredType of {@code node}
      */
     @Override
     public AnnotatedTypeMirror visitNewClass(NewClassTree node,

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -273,11 +273,13 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     }
 
     /**
-     * Creates an AnnotatedDeclaredType for the NewClassTree and adds: <br>
-     *  - either explicit annotations from the new class expression ({@code new @HERE MyClass()} ), <br>
-     *  - or explicit annotations from the declaration of the class ({@code @HERE class MyClass {}} ), <br>
-     *  - or explicit annotations from the declaration of the constructor ({@code @HERE public MyClass() {}} ), <br>
-     *  - or no annotations.
+     * Creates an AnnotatedDeclaredType for the NewClassTree and adds one of:
+     * <ul>
+     *   <li>explicit annotations from the new class expression ({@code new @HERE MyClass()} ), or</li>
+     *   <li>explicit annotations from the declaration of the class ({@code @HERE class MyClass {}} ), or</li>
+     *   <li>explicit annotations from the declaration of the constructor ({@code @HERE public MyClass() {}} ), or</li>
+     *   <li>no annotations.</li>
+     * </ul>
      *
      * @param node NewClassTree
      * @param f the type factory


### PR DESCRIPTION
Improve docs and make methods final and non-public where possible.

(Note this requires PR #648, #649, #650, and #651 to be merged first.  So this PR is against a branch with all 4 PRs merged.)