### PR TITLE
Validate declared type of LHS, not refined type.

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -839,11 +839,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         visitorState.setAssignmentContext(Pair.of((Tree) node, atypeFactory.getAnnotatedType(node)));
 
         try {
-            boolean valid = validateTypeOf(node);
             // If there's no assignment in this variable declaration, skip it.
-            if (valid && node.getInitializer() != null) {
+            if (node.getInitializer() != null) {
                 commonAssignmentCheck(node, node.getInitializer(),
                         "assignment.type.incompatible");
+            } else {
+                // commonAssignmentCheck validates the type of node,
+                // so only validate if commonAssignmentCheck wasn't called
+                validateTypeOf(node);
             }
             return super.visitVariable(node, p);
         } finally {
@@ -1797,12 +1800,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     protected void commonAssignmentCheck(Tree varTree, ExpressionTree valueExp,
             /*@CompilerMessageKey*/ String errorKey) {
-        if (!validateTypeOf(varTree)) {
-            return;
-        }
-
         AnnotatedTypeMirror var = atypeFactory.getAnnotatedTypeLhs(varTree);
         assert var != null : "no variable found for tree: " + varTree;
+
+        if (!validateType(varTree, var)) {
+            return;
+        }
 
         checkAssignability(var, varTree);
 

--- a/framework/tests/polyall/TypeRefinement.java
+++ b/framework/tests/polyall/TypeRefinement.java
@@ -1,0 +1,18 @@
+import polyall.quals.*;
+import polyall.quals.H1Invalid;
+import polyall.quals.H1S2;
+
+class TypeRefinement {
+
+    @H1Top Object o = new @H1S1 Object();
+    //:: error: (polyall.h1invalid.forbidden)
+    @H1Top Object o2 = new @H1Invalid Object();
+    //:: error: (polyall.h1invalid.forbidden)
+    @H1Top Object o3 = getH1Invalid();
+
+    //:: error: (polyall.h1invalid.forbidden)
+    @H1Invalid Object getH1Invalid() {
+        //:: error: (polyall.h1invalid.forbidden)
+        return new @H1Invalid Object();
+    }
+}

--- a/framework/tests/test-polyall/polyall/PolyAllAnnotatedTypeFactory.java
+++ b/framework/tests/test-polyall/polyall/PolyAllAnnotatedTypeFactory.java
@@ -1,15 +1,16 @@
 package polyall;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy.MultiGraphFactory;
 
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
 import polyall.quals.H1Bot;
+import polyall.quals.H1Invalid;
 import polyall.quals.H1Poly;
 import polyall.quals.H1S1;
 import polyall.quals.H1S2;
@@ -32,7 +33,7 @@ public class PolyAllAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return getBundledTypeQualifiersWithPolyAll(
                 H1Top.class, H1S1.class, H1S2.class, H1Bot.class,
                 H2Top.class, H2S1.class, H2S2.class, H2Bot.class,
-                H1Poly.class, H2Poly.class);
+                H1Poly.class, H2Poly.class, H1Invalid.class);
     }
 
     @Override

--- a/framework/tests/test-polyall/polyall/PolyAllVisitor.java
+++ b/framework/tests/test-polyall/polyall/PolyAllVisitor.java
@@ -1,0 +1,48 @@
+package polyall;
+
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.common.basetype.BaseTypeValidator;
+import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.framework.source.Result;
+import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
+import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.javacutil.AnnotationUtils;
+
+import javax.lang.model.element.AnnotationMirror;
+
+import com.sun.source.tree.Tree;
+
+import polyall.quals.H1Invalid;
+
+public class PolyAllVisitor
+        extends BaseTypeVisitor<PolyAllAnnotatedTypeFactory> {
+
+    public PolyAllVisitor(BaseTypeChecker checker) {
+        super(checker);
+    }
+
+    @Override
+    protected BaseTypeValidator createTypeValidator() {
+        return new PolyAllTypeValidator(checker, this, atypeFactory);
+    }
+
+    private final class PolyAllTypeValidator extends BaseTypeValidator {
+
+        public PolyAllTypeValidator(BaseTypeChecker checker,
+                BaseTypeVisitor<?> visitor, AnnotatedTypeFactory atypeFactory) {
+            super(checker, visitor, atypeFactory);
+        }
+
+        @Override
+        public Void visitDeclared(AnnotatedDeclaredType type, Tree p) {
+            AnnotationMirror h1Invalid = AnnotationUtils.fromClass(elements,
+                                                              H1Invalid.class);
+            if (AnnotatedTypes.containsModifier(type, h1Invalid)) {
+                checker.report(Result.failure("polyall.h1invalid.forbidden",
+                        type.getAnnotations(), type.toString()), p);
+            }
+            return super.visitDeclared(type, p);
+        }
+    }
+}

--- a/framework/tests/test-polyall/polyall/quals/H1Bot.java
+++ b/framework/tests/test-polyall/polyall/quals/H1Bot.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@SubtypeOf({H1S1.class, H1S2.class})
+@SubtypeOf({H1S1.class, H1S2.class, H1Invalid.class})
 @ImplicitFor(literals = LiteralKind.NULL)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/framework/tests/test-polyall/polyall/quals/H1Invalid.java
+++ b/framework/tests/test-polyall/polyall/quals/H1Invalid.java
@@ -1,0 +1,16 @@
+package polyall.quals;
+
+import org.checkerframework.framework.qual.SubtypeOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@SubtypeOf({H1Top.class})
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface H1Invalid {
+}


### PR DESCRIPTION
(This is an alternative to #634.)

````
 @H1Top Object o = new @H1Invalid Object();
````
Two invalid type errors used to be issued for this code. One for the new Object and one for `o`.