### PR TITLE
add above-java7-jdk-skip-test annotation

### DIFF
--- a/checker/tests/README
+++ b/checker/tests/README
@@ -177,6 +177,10 @@ need runtime support (e.g. lambdas) or depends on Java 8 APIs
 Tests that only exercise the static type annotation API do not need
 this marker, as the tests will be executed with a Java 8 compiler.
 
+Write @above-java7-jdk-skip-test anywhere in a test file to disable that
+test if the executing JDK version is higher than 7.
+This is useful if a test has a mismatch between Java 7 and Java 8 (e.g. Tests of Information Flow Checker), and need to ignore this test on Java 8.
+
 To disable all tests for a given type system, temporarily move away a file;
 for example,
   mv $CHECKERFRAMEWORK/checker/tests/src/tests/OIGJTest.java $CHECKERFRAMEWORK/checker/tests/src/tests/OIGJTest.java-SAVE

--- a/framework/src/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework/src/org/checkerframework/framework/test/TestUtilities.java
@@ -135,7 +135,8 @@ public class TestUtilities {
             String nextLine = in.nextLine();
             if (nextLine.contains("@skip-test") ||
                     (!isJSR308Compiler && nextLine.contains("@non-308-skip-test")) ||
-                    (!isAtLeast8Jvm && nextLine.contains("@below-java8-jdk-skip-test"))) {
+                    (!isAtLeast8Jvm && nextLine.contains("@below-java8-jdk-skip-test")) ||
+                    (isAtLeast8Jvm && nextLine.contains("@above-java8-jdk-skip-test"))) {
                 in.close();
                 return false;
             }

--- a/framework/src/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework/src/org/checkerframework/framework/test/TestUtilities.java
@@ -136,7 +136,7 @@ public class TestUtilities {
             if (nextLine.contains("@skip-test") ||
                     (!isJSR308Compiler && nextLine.contains("@non-308-skip-test")) ||
                     (!isAtLeast8Jvm && nextLine.contains("@below-java8-jdk-skip-test")) ||
-                    (isAtLeast8Jvm && nextLine.contains("@above-java8-jdk-skip-test"))) {
+                    (isAtLeast8Jvm && nextLine.contains("@above-java7-jdk-skip-test"))) {
                 in.close();
                 return false;
             }


### PR DESCRIPTION
1. Add "@above-java7-jdk-skip-test" in TestUtilities class.
2. Add documentation of this new feature in checker/tests/README.