### PR TITLE
Rename TypeHierarchy#isSubtype to TypeHierarchy#isSubtypeOrConvertible 

### DIFF
--- a/checker/src/org/checkerframework/checker/fenum/FenumVisitor.java
+++ b/checker/src/org/checkerframework/checker/fenum/FenumVisitor.java
@@ -31,8 +31,8 @@ public class FenumVisitor extends BaseTypeVisitor<FenumAnnotatedTypeFactory> {
 
             AnnotatedTypeMirror lhs = atypeFactory.getAnnotatedType(node.getLeftOperand());
             AnnotatedTypeMirror rhs = atypeFactory.getAnnotatedType(node.getRightOperand());
-            if (!(atypeFactory.getTypeHierarchy().isSubtype(lhs, rhs)
-                  || atypeFactory.getTypeHierarchy().isSubtype(rhs, lhs))) {
+            if (!(atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(lhs, rhs)
+                  || atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(rhs, lhs))) {
                 checker.report(Result.failure("binary.type.incompatible", lhs, rhs), node);
             }
         }

--- a/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -732,7 +732,7 @@ public abstract class InitializationAnnotatedTypeFactory<
         /**
          * Subtype testing for initialization annotations.
          * Will return false if either qualifier is not an initialization annotation.
-         * Subclasses should override isSubtype and call this method for
+         * Subclasses should override isSubtypeOrConvertible and call this method for
          * initialization qualifiers.
          */
         public boolean isSubtypeInitialization(AnnotationMirror rhs, AnnotationMirror lhs) {

--- a/checker/src/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -220,7 +220,7 @@ public class LockAnnotatedTypeFactory
 
             if ((isGuardedBy(a1) && isGuardedBy(a2)) ||
                 (isGuardSatisfied(a1) && isGuardSatisfied(a2))) {
-                // isSubtype(a1, a2) is symmetrical to isSubtype(a2, a1) since two
+                // isSubtypeOrConvertible(a1, a2) is symmetrical to isSubtypeOrConvertible(a2, a1) since two
                 // @GuardedBy annotations are considered subtypes of each other
                 // if and only if their values match exactly, and two @GuardSatisfied
                 // annotations are considered subtypes of each other if and only if

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -403,12 +403,12 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
                     return;
                 }
-            } else if (!atypeFactory.getTypeHierarchy().isSubtype(valueType, varType)) {
+            } else if (!atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(valueType, varType)) {
                 // Special case: replace the @GuardSatisfied primary annotation on the LHS with @GuardedBy({}) and see if it type checks.
 
                 AnnotatedTypeMirror varType2 = varType.deepCopy(); // TODO: Would shallowCopy be sufficient?
                 varType2.replaceAnnotation(atypeFactory.GUARDEDBY);
-                if (atypeFactory.getTypeHierarchy().isSubtype(valueType, varType2)) {
+                if (atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(valueType, varType2)) {
                     return;
                 }
             }

--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -350,7 +350,7 @@ public class KeyForAnnotatedTypeFactory extends
       }
 
       @Override
-      public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, VisitHistory visited) {
+      public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, VisitHistory visited) {
 
           //TODO: THIS IS FROM THE OLD TYPE HIERARCHY.  WE SHOULD FIX DATA-FLOW/PROPAGATION TO DO THE RIGHT THING
           if (supertype.getKind() == TypeKind.TYPEVAR &&
@@ -366,7 +366,7 @@ public class KeyForAnnotatedTypeFactory extends
           if (subtype.hasAnnotation(KeyForBottom.class)) {
               return true;
           }
-          return super.isSubtype(subtype, supertype, visited);
+          return super.isSubtypeOrConvertible(subtype, supertype, visited);
       }
 
 

--- a/checker/src/org/checkerframework/checker/regex/classic/RegexClassicVisitor.java
+++ b/checker/src/org/checkerframework/checker/regex/classic/RegexClassicVisitor.java
@@ -124,7 +124,7 @@ public class RegexClassicVisitor extends BaseTypeVisitor<RegexClassicAnnotatedTy
         if (!useType.getExplicitAnnotations().isEmpty()) {
             Types typeUtils = env.getTypeUtils();
             for (TypeMirror type : legalReferenceTypes) {
-                if (typeUtils.isSubtype(declarationType.getUnderlyingType(), type)) {
+                if (typeUtils.isSubtypeOrConvertible(declarationType.getUnderlyingType(), type)) {
                     return true;
                 }
             }

--- a/checker/src/org/checkerframework/checker/units/UnitsVisitor.java
+++ b/checker/src/org/checkerframework/checker/units/UnitsVisitor.java
@@ -30,7 +30,7 @@ public class UnitsVisitor extends BaseTypeVisitor<UnitsAnnotatedTypeFactory> {
         Kind kind = node.getKind();
 
         if ( (kind == Kind.PLUS_ASSIGNMENT || kind == Kind.MINUS_ASSIGNMENT)) {
-            if (!atypeFactory.getTypeHierarchy().isSubtype(exprType, varType)) {
+            if (!atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(exprType, varType)) {
                 checker.report(Result.failure("compound.assignment.type.incompatible",
                         varType, exprType), node);
             }

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -385,7 +385,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
 
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
-                            !checker.getQualifierHierarchy().isSubtype(aOnVar,
+                            !checker.getQualifierHierarchy().isSubtypeOrConvertible(aOnVar,
                                     upper.getAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }
@@ -432,7 +432,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 AnnotatedTypeMirror upper = type.getExtendsBoundField();
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
-                            !atypeFactory.getQualifierHierarchy().isSubtype(aOnVar,
+                            !atypeFactory.getQualifierHierarchy().isSubtypeOrConvertible(aOnVar,
                                     upper.getAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2671,7 +2671,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     overrider.getReceiverType().getErased().shallowCopy(false);
             overriddenReceiver.addAnnotations(overridden.getReceiverType().getAnnotations());
             if (!atypeFactory.getTypeHierarchy().isSubtypeOrConvertible(overriddenReceiver,
-                                                                        overrider.getReceiverType().getErased())) {
+                    overrider.getReceiverType().getErased())) {
+
                 checker.report(Result.failure("override.receiver.invalid",
                                 overriderMeth, overriderTyp, overriddenMeth, overriddenTyp,
                                 overrider.getReceiverType(),

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -131,7 +131,7 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements
             // 'null' is 'top'
             return true;
         }
-        return typeHierarchy.isSubtype(type, other.getType());
+        return typeHierarchy.isSubtypeOrConvertible(type, other.getType());
     }
 
     /**
@@ -143,7 +143,7 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements
      * <p>
      * If neither of the two is more specific for one of the hierarchies (i.e.,
      * if the two are incomparable as determined by
-     * {@link TypeHierarchy#isSubtype(AnnotatedTypeMirror, AnnotatedTypeMirror)}
+     * {@link TypeHierarchy#isSubtypeOrConvertible(AnnotatedTypeMirror, AnnotatedTypeMirror)}
      * , then the respective value from {@code backup} is used.
      *
      * <p>
@@ -372,10 +372,10 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements
 
         boolean annotated = true;
         for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
-            if (typeHierarchy.isSubtype(fixedType1, fixedType2, top)) {
+            if (typeHierarchy.isSubtypeOrConvertible(fixedType1, fixedType2, top)) {
                 annotateTypeVarResult(qualifierHierarchy, types, result, fixedType1, top);
 
-            } else if (typeHierarchy.isSubtype(fixedType2, fixedType1, top)) {
+            } else if (typeHierarchy.isSubtypeOrConvertible(fixedType2, fixedType1, top)) {
                 annotateTypeVarResult(qualifierHierarchy, types, result, fixedType2, top);
 
             } else {

--- a/framework/src/org/checkerframework/framework/flow/util/LubTypeVariableAnnotator.java
+++ b/framework/src/org/checkerframework/framework/flow/util/LubTypeVariableAnnotator.java
@@ -112,9 +112,9 @@ public class LubTypeVariableAnnotator {
 
             } else {
                 final TypeHierarchy typeHierarchy = typeFactory.getTypeHierarchy();
-                if (typeHierarchy.isSubtype(subAsLub, lub, top)) {
+                if (typeHierarchy.isSubtypeOrConvertible(subAsLub, lub, top)) {
                     // do nothing lub is already above top
-                } else if (typeHierarchy.isSubtype(lub, subAsLub, top)) {
+                } else if (typeHierarchy.isSubtypeOrConvertible(lub, subAsLub, top)) {
                     if (lubPrimary != null) { //&& subPrimary == null
                         // since primary annotations are added to the bounds
                         // we need to replace the upper/lower bound annotations

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1987,11 +1987,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
                 type.setTypeArguments(newArgs);
 
-                /* It would be nice to call isSubtype for a basic sanity check.
+                /* It would be nice to call isSubtypeOrConvertible for a basic sanity check.
                  * However, the type might not have been completely initialized yet,
-                 * so isSubtype might fail.
+                 * so isSubtypeOrConvertible might fail.
                  *
-                if (!typeHierarchy.isSubtype(type, ctxtype)) {
+                if (!typeHierarchy.isSubtypeOrConvertible(type, ctxtype)) {
                     // Simply taking the newArgs didn't result in a valid subtype.
                     // Give up and simply use the inferred types.
                     type.setTypeArguments(oldArgs);

--- a/framework/src/org/checkerframework/framework/type/DefaultRawnessComparer.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultRawnessComparer.java
@@ -103,10 +103,10 @@ public class DefaultRawnessComparer extends AbstractAtmComboVisitor<Boolean, Vis
         }
 
         if (currentTop == null) {
-            return typeHierarchy.isSubtype(subtypeUpper, supertypeUpper);
+            return typeHierarchy.isSubtypeOrConvertible(subtypeUpper, supertypeUpper);
         }
 
-        return typeHierarchy.isSubtype(subtypeUpper, supertypeUpper, currentTop);
+        return typeHierarchy.isSubtypeOrConvertible(subtypeUpper, supertypeUpper, currentTop);
     }
 
     @Override

--- a/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -165,7 +165,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
      */
     @Override
     public boolean isSubtypeOrConvertible(final AnnotatedTypeMirror subtype, final AnnotatedTypeMirror supertype,
-                                          final AnnotationMirror top) {
+                          final AnnotationMirror top) {
         currentTop = top;
         return isSubtypeOrConvertible(subtype, supertype, new VisitHistory());
     }

--- a/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
@@ -112,7 +112,7 @@ class GeneralQualifierHierarchy extends MultiGraphQualifierHierarchy {
     // Not needed - raises error.
     @Override
     public boolean isSubtype(AnnotationMirror anno1, AnnotationMirror anno2) {
-        ErrorReporter.errorAbort("GeneralQualifierHierarchy.isSubtype() was called! It shouldn't be called.");
+        ErrorReporter.errorAbort("GeneralQualifierHierarchy.isSubtypeOrConvertible() was called! It shouldn't be called.");
         return false;
     }
 
@@ -127,7 +127,7 @@ class GeneralQualifierHierarchy extends MultiGraphQualifierHierarchy {
     @Override
     public boolean isSubtype(Collection<? extends AnnotationMirror> rhs,
             Collection<? extends AnnotationMirror> lhs) {
-        ErrorReporter.errorAbort("GeneralQualifierHierarchy.isSubtype() was called! It shouldn't be called.");
+        ErrorReporter.errorAbort("GeneralQualifierHierarchy.isSubtypeOrConvertible() was called! It shouldn't be called.");
         return false;
     }
 

--- a/framework/src/org/checkerframework/framework/type/TypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/TypeHierarchy.java
@@ -11,10 +11,10 @@ public interface TypeHierarchy {
     /**
      * @return true if subtype {@literal <:} supertype for all qualifier hierarchies in the type system
      */
-    public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype);
+    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype);
 
     /**
      * @return true  if subtype {@literal <:} supertype in the qualifier hierarchy rooted by the top annotation
      */
-    public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top);
+    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top);
 }

--- a/framework/src/org/checkerframework/framework/type/TypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/TypeHierarchy.java
@@ -9,12 +9,27 @@ import javax.lang.model.element.AnnotationMirror;
 public interface TypeHierarchy {
 
     /**
-     * @return true if subtype {@literal <:} supertype for all qualifier hierarchies in the type system
+     * Returns true if {@code subtype} is a subtype of or convertible to {@code supertype}
+     * for all hierarchies present.  The underlying Java type of {@code subtype} must be a subtype of
+     * or convertible to the underlying Java type of {@code supertype}.
+     *
+     * @param subtype   possible subtype
+     * @param supertype possible supertype
+     * @return true if {@code subtype} is a subtype of {@code supertype} for all hierarchies present.
      */
-    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype);
+    boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype);
 
     /**
-     * @return true  if subtype {@literal <:} supertype in the qualifier hierarchy rooted by the top annotation
+     * Returns true if {@code subtype} is a subtype of {@code supertype} in the qualifier hierarchy
+     * whose top is {@code top} The underlying Java type of {@code subtype} must be a subtype of
+     * or convertible to the underlying Java type of {@code supertype}.
+     *
+     * @param subtype   possible subtype
+     * @param supertype possible supertype
+     * @param top       the qualifier at the top of the heirarchy for which the subtype check should be preformed.
+     * @return Returns true if {@code subtype} is a subtype of {@code supertype} in the qualifier hierarchy
+     * whose top is {@code top}
      */
-    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top);
+    boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top);
+
 }

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -452,7 +452,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
         for (AnnotationMirror top : tops) {
             System.out.println("Looking at top: " + tops + " and " + anno1);
             // We cannot use getRootAnnotation, as that would use subtyping and recurse
-            if (isSubtype(anno1, top) && AnnotationUtils.areSame(top, anno2)) {
+            if (isSubtypeOrConvertible(anno1, top) && AnnotationUtils.areSame(top, anno2)) {
             return true;
             }
         }*/

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -515,7 +515,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             if (equalityInferred != null && equalityInferred instanceof InferredType) {
 
                 if (supertypeInferred != null && supertypeInferred instanceof InferredType) {
-                    if (typeHierarchy.isSubtype(((InferredType) supertypeInferred).type, ((InferredType) equalityInferred).type)) {
+                    if (typeHierarchy.isSubtypeOrConvertible(((InferredType) supertypeInferred).type, ((InferredType) equalityInferred).type)) {
                         outputValue = equalityInferred;
                     } else {
                         outputValue = supertypeInferred;

--- a/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
@@ -96,7 +96,7 @@ public class GlbUtil {
         // there are two types  in glbTypes that are incomparable and we need to use bottom (AnnotatedNullType)
         boolean incomparable = false;
         for (final AnnotatedTypeMirror type : glbTypes) {
-            if (!incomparable && !typeHierarchy.isSubtype(glbType, type) && type.getKind() != TypeKind.NULL) {
+            if (!incomparable && !typeHierarchy.isSubtypeOrConvertible(glbType, type) && type.getKind() != TypeKind.NULL) {
                 incomparable = true;
             }
         }

--- a/framework/src/org/checkerframework/qualframework/base/TypeHierarchyAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/TypeHierarchyAdapter.java
@@ -26,14 +26,14 @@ class TypeHierarchyAdapter<Q> extends org.checkerframework.framework.type.Defaul
 
 
     @Override
-    public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype) {
+    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype) {
         return underlying.isSubtype(
                 converter.getQualifiedType(subtype),
                 converter.getQualifiedType(supertype));
     }
 
     @Override
-    public boolean isSubtype(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top) {
+    public boolean isSubtypeOrConvertible(AnnotatedTypeMirror subtype, AnnotatedTypeMirror supertype, AnnotationMirror top) {
         // NOTE: This may be insufficient for multi-rooted qualifier hierarchies.  David McArthur and
         // Jonathan Burke have had a discussion on this.  This method will work for single-root hierarchies
         // which are the only ones that have a Qual implementation at the moment.  We will take this up again
@@ -48,7 +48,7 @@ class TypeHierarchyAdapter<Q> extends org.checkerframework.framework.type.Defaul
         //                    // tq varies by qualifier hierarchy.  In the Nullness hierarchy, it is the primary
         //                    // annotation.  In the initialization hierarchy, it is the lower bound.
         //
-        // To deal with this issue, this method isSubtype(subtype, supertype, top) handles these
+        // To deal with this issue, this method isSubtypeOrConvertible(subtype, supertype, top) handles these
         // hierarchies individually.  However, for the qualifier system there is only 1 qualifier for both
         // hierarchies.  So QualifiedTypeMirrors would not be able to model the above situation.
 
@@ -73,7 +73,7 @@ class TypeHierarchyAdapter<Q> extends org.checkerframework.framework.type.Defaul
     }
 
     boolean superIsSubtype(QualifiedTypeMirror<Q> subtype, QualifiedTypeMirror<Q> supertype) {
-        return super.isSubtype(
+        return super.isSubtypeOrConvertible(
                 converter.getAnnotatedType(subtype),
                 converter.getAnnotatedType(supertype),
                 qualifierHierarchy.getTopAnnotations().iterator().next());


### PR DESCRIPTION
`TypeHierarchy#isSubtype(AnnotatedTypeMirror, AnnotatedTypeMirror)` is implemented to accept combinations of AnntotatedTypeMirrors where the underlying Java types are not subtypes, but are convertible.  For example AnnotatedDeclaredType, AnnotatedPrimitiveType, see implementation [here]( https://github.com/typetools/checker-framework/blob/isSubTypeRenaming/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java#L527-535). So the name should really be isSubtypeOrConvertible.

It would make the transition easier if isSubtype could be deprecated, but because TypeHierarchy is an interface, then all implementations would have to implement both isSubtype and isSubtypeOrConvertible.    And then once isSubtype is removed, the implementations would have to change again.  It's really a question of whether we think more clients call TypeHierarchy#isSubtype than implement TypeHierarchy.  I would appreciate input on this. 

Most of the changes are from automatic refactoring.  I also improved the Javadoc on [isSutypeOrConvertible](https://github.com/typetools/checker-framework/pull/709/files#diff-97ff8d0c334410fa4bacbb5a77782f5b), which should be reviewed more carefully than the other changes.