### PR TITLE
Add Intersection_Primitive and Typevar_Primitive combinations to isSubtype

### DIFF
--- a/checker/tests/interning/TypeVarPrimitives.java
+++ b/checker/tests/interning/TypeVarPrimitives.java
@@ -1,0 +1,16 @@
+// Unannotated version in framework/tests/all-systems/TypeVarPrimitives.java
+import org.checkerframework.checker.interning.qual.*;
+public class TypeVarPrimitives {
+    <T extends @UnknownInterned Long> void method(T tLong) {
+        long l = tLong;
+    }
+    <T extends @UnknownInterned Long & @UnknownInterned Cloneable> void methodIntersection(T tLong) {
+        long l = tLong;
+    }
+    <T extends @Interned Long> void method2(T tLong) {
+        long l = tLong;
+    }
+    <T extends @Interned Long & @Interned Cloneable> void methodIntersection2(T tLong) {
+        long l = tLong;
+    }
+}

--- a/checker/tests/nullness/TypeVarPrimitives.java
+++ b/checker/tests/nullness/TypeVarPrimitives.java
@@ -1,0 +1,26 @@
+// Unannotated version in framework/tests/all-systems/Primitives.java
+import org.checkerframework.checker.nullness.qual.*;
+public class TypeVarPrimitives {
+    <T extends @Nullable Long> void method(T tLong) {
+        //:: error: (assignment.type.incompatible)
+        long l = tLong;
+    }
+    <T extends @Nullable Long & @Nullable Cloneable> void methodIntersection(T tLong) {
+        //:: error: (assignment.type.incompatible)
+        long l = tLong;
+    }
+    <T extends @Nullable Long> void method2(@NonNull T tLong) {
+        long l = tLong;
+    }
+    <T extends @Nullable Long & @Nullable Cloneable> void methodIntersection2(@NonNull T tLong) {
+        long l = tLong;
+    }
+    <T extends @Nullable Long> void method3(@Nullable T tLong) {
+        //:: error: (assignment.type.incompatible)
+        long l = tLong;
+    }
+    <T extends @Nullable Long & @Nullable Cloneable> void methodIntersection3(@Nullable T tLong) {
+        //:: error: (assignment.type.incompatible)
+        long l = tLong;
+    }
+}

--- a/checker/tests/nullness/TypeVarPrimitives.java
+++ b/checker/tests/nullness/TypeVarPrimitives.java
@@ -1,4 +1,4 @@
-// Unannotated version in framework/tests/all-systems/Primitives.java
+// Unannotated version in framework/tests/all-systems/TypeVarPrimitives.java
 import org.checkerframework.checker.nullness.qual.*;
 public class TypeVarPrimitives {
     <T extends @Nullable Long> void method(T tLong) {

--- a/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -557,6 +557,11 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
     }
 
     @Override
+    public Boolean visitIntersection_Primitive(AnnotatedIntersectionType subtype, AnnotatedPrimitiveType supertype, VisitHistory visited) {
+        return visitIntersectionSubtype(subtype, supertype, visited);
+    }
+
+    @Override
     public Boolean visitIntersection_Intersection(AnnotatedIntersectionType subtype, AnnotatedIntersectionType supertype, VisitHistory visited) {
         return visitIntersectionSubtype(subtype, supertype, visited);
     }
@@ -660,6 +665,11 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
     public Boolean visitTypevar_Intersection(AnnotatedTypeVariable subtype, AnnotatedIntersectionType supertype, VisitHistory visited) {
         //this can happen when checking type param bounds
         return visitIntersectionSupertype(subtype, supertype, visited);
+    }
+
+    @Override
+    public Boolean visitTypevar_Primitive(AnnotatedTypeVariable subtype, AnnotatedPrimitiveType supertype, VisitHistory visited) {
+        return visitTypevarSubtype(subtype, supertype, visited);
     }
 
     @Override
@@ -785,8 +795,13 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
      * this method and visitTypevarSupertype will combine to isValid the subtypes upper bound against the supertypes
      * lower bound.
      */
-    protected boolean visitTypevarSubtype( AnnotatedTypeVariable subtype, AnnotatedTypeMirror supertype, VisitHistory visited ) {
-        return checkAndSubtype(subtype.getUpperBound(), supertype, visited);
+    protected boolean visitTypevarSubtype(AnnotatedTypeVariable subtype, AnnotatedTypeMirror supertype, VisitHistory visited) {
+        AnnotatedTypeMirror upperBound = subtype.getUpperBound();
+        if (TypesUtils.isBoxedPrimitive(upperBound.getUnderlyingType())
+            && supertype instanceof AnnotatedPrimitiveType) {
+            upperBound = supertype.atypeFactory.getUnboxedType((AnnotatedDeclaredType) upperBound);
+        }
+        return checkAndSubtype(upperBound, supertype, visited);
     }
 
     /**

--- a/framework/tests/all-systems/ConditionalExpressions.java
+++ b/framework/tests/all-systems/ConditionalExpressions.java
@@ -2,7 +2,6 @@
 // ArrayTypes.foo3() and TypeVarTypeVar.foo5() crash
 // See Issue 643
 // https://github.com/typetools/checker-framework/issues/643
-// @skip-test
 
 import java.io.Serializable;
 import java.util.List;
@@ -28,7 +27,6 @@ public class ConditionalExpressions {
         }
 
         <T extends Long, S extends Integer> void foo5(T tExtendsLong, S sExtendsInt) {
-            // causes crash
             Number o = flag ? tExtendsLong : sExtendsInt;
         }
     }
@@ -43,7 +41,6 @@ public class ConditionalExpressions {
         }
 
         <T extends Cloneable & Serializable> void foo3(T ts, Number[] numbers) {
-            // causes crash
             Cloneable o = flag ? ts : numbers;
         }
 

--- a/framework/tests/all-systems/TypeVarPrimitives.java
+++ b/framework/tests/all-systems/TypeVarPrimitives.java
@@ -1,0 +1,12 @@
+// Annotated versions in
+// checker/tests/nullness/TypeVarPrimitive.java and
+// checker/tests/interning/TypeVarPrimitives.java
+public class TypeVarPrimitives {
+    <T extends Long> void method(T tLong) {
+        long l = tLong;
+    }
+    <T extends Long & Cloneable> void methodIntersection(T tLong) {
+        long l = tLong;
+    }
+}
+


### PR DESCRIPTION
Example of when these combinations are used:
````
public class TypeVarPrimitives {
    <T extends Long> void method(T tLong) {
        long l = tLong;
    }
    <T extends Long & Cloneable> void methodIntersection(T tLong) {
        long l = tLong;
    }
````
(This covers 2/5 cases in issue #701)