### PR TITLE
(Correctly) Fixes #672

### DIFF
--- a/checker/tests/nullness/Issue672.java
+++ b/checker/tests/nullness/Issue672.java
@@ -1,0 +1,23 @@
+// Testcase for Issue 672
+// https://github.com/typetools/checker-framework/issues/672
+
+final class Issue672 extends Throwable {
+    final Throwable ex;
+
+    Issue672(Throwable x) { ex = x; }
+
+    static Issue672 test1(Throwable x, boolean flag) {
+        return new Issue672(x instanceof Exception ? x
+                : ((flag ? x :new Issue672(x))));
+    }
+
+    static Issue672 test2(Throwable x, boolean flag) {
+        return (new Issue672(x instanceof Exception ? x
+                : ((flag ? x :new Issue672(x)))));
+    }
+
+    static Issue672 test3(Throwable x) {
+        return test1(x instanceof Exception ? x
+                : new Issue672(x), false);
+    }
+}

--- a/checker/tests/nullness/java8/Issue557.java
+++ b/checker/tests/nullness/java8/Issue557.java
@@ -33,6 +33,15 @@ class Issue557a {
     MyOpt<String> opt2() {
       return MyOpt.empty();
     }
+
+    MyOpt<String> opt3(boolean flag) {
+      return flag ? MyOpt.of("Hello") : (flag ? MyOpt.empty() : MyOpt.empty());
+    }
+    void foo(MyOpt<String> param) {
+    }
+    void callFoo(boolean flag) {
+      foo(flag ? MyOpt.of("Hello") : (flag ? MyOpt.empty() : MyOpt.empty()));
+    }
 }
 
 class Issue557b {

--- a/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
@@ -330,31 +330,39 @@ public final class TreeUtils {
      *   <li>VariableTree</li>
      * </ul>
      *
-     * If the leaf is a ConditionalExpressionTree, then recur on the leaf.
+     * If the leaf is a ConditionalExpressionTree or ParenthesizedTree, then recur on the leaf.
      *
      * Otherwise, null is returned.
      *
      * @return  the assignment context as described
      */
     public static Tree getAssignmentContext(final TreePath treePath) {
-        TreePath path = treePath.getParentPath();
+        TreePath parentPath = treePath.getParentPath();
 
-        if (path == null) {
+        if (parentPath == null) {
             return null;
         }
-        Tree node = path.getLeaf();
-        if ((node instanceof AssignmentTree) ||
-                (node instanceof CompoundAssignmentTree) ||
-                (node instanceof MethodInvocationTree) ||
-                (node instanceof NewArrayTree) ||
-                (node instanceof NewClassTree) ||
-                (node instanceof ReturnTree) ||
-                (node instanceof VariableTree)) {
-            return node;
-        } else if (node instanceof ConditionalExpressionTree) {
-            return getAssignmentContext(path);
+
+        Tree parent = parentPath.getLeaf();
+        switch (parent.getKind()) {
+        case PARENTHESIZED:
+        case CONDITIONAL_EXPRESSION:
+            return getAssignmentContext(parentPath);
+        case ASSIGNMENT:
+        case METHOD_INVOCATION:
+        case NEW_ARRAY:
+        case NEW_CLASS:
+        case RETURN:
+        case VARIABLE:
+            return parent;
+        default:
+            // 11 Tree.Kinds are CompoundAssignmentTrees,
+            // so use instanceof rather than listing all 11.
+            if (parent instanceof CompoundAssignmentTree) {
+                return parent;
+            }
+            return null;
         }
-        return null;
     }
 
     /**


### PR DESCRIPTION
Improves type agr inference for nested conditionals.  This is a rebased version
of the code reviewed in pull request #675. Plus addtional changes to fix bug
that made plume-lib-typecheck crash.  (This is the correction to f010477deb460a496d66c963593e42ac3e1e181f which was reverted in 4fb2074207cb698be9127b86d7f9fc8733f7fa91)