### PR TITLE
Candidate for #689

### DIFF
--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -156,7 +156,9 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
         }
 
         Effect callerEffect = atypeFactory.getDeclaredEffect(callerElt);
-        assert (callerEffect.equals(effStack.peek()));
+        // Field initializers inside anonymous inner classes show up with a null current-method ---
+        // the traversal goes straight from the class to the initializer.
+        assert (currentMethods.peek() == null || callerEffect.equals(effStack.peek()));
 
         if (!Effect.LE(targetEffect, callerEffect)) {
             checker.report(Result.failure("call.invalid.ui", targetEffect, callerEffect), node);

--- a/framework/tests/all-systems/Issue689.java
+++ b/framework/tests/all-systems/Issue689.java
@@ -1,0 +1,19 @@
+// Test case for issue 689
+// https://github.com/typetools/checker-framework/issues/689
+public class Issue689 {
+
+    public int initializerFodder() { return 3; }
+
+    public Runnable trigger() {
+        return new Runnable() {
+            // Issue 689 triggers when examining a method invocation inside a field initializer of
+            // an anonymous inner class
+            public final int val = initializerFodder();
+
+            public void run() {
+                // do nothing
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
This is a candidate fix for #689.  It appears the assertion was too strong, because apparently none of the work on the ECOOP paper encountered anonymous inner classes with non-trivial (i.e., method-invoking) field initializers, which don't get visited in the context of an enclosing method structure.

A test for this is necessary as well before I close the issue, but I want this to go through CI to maybe unstick things for Monday.