### PR TITLE
asMemberOf should substitute type variables declared in outer classes too

### DIFF
--- a/checker/tests/nullness/Issue577.java
+++ b/checker/tests/nullness/Issue577.java
@@ -1,0 +1,82 @@
+// Test case for issue #577 with expected errors:
+// Also see test case in framework/tests/all-systems/Issue577.java
+// https://github.com/typetools/checker-framework/issues/577
+
+import org.checkerframework.checker.nullness.qual.*;
+
+class Banana<T extends Number> extends Apple<int[]> {
+    @Override
+    void fooOuter(int[] array) {}
+    class InnerBanana extends InnerApple<long[]> {
+        @Override
+        //:: error: (override.param.invalid)
+        <F2 extends Object> void foo(int[] array, long[] array2, F2 param3) {
+        }
+    }
+}
+
+class Apple<T> {
+    void fooOuter(T param) {}
+    class InnerApple<E> {
+        <F> void foo(T param, E param2, F param3) {
+        }
+    }
+}
+
+class Pineapple<E extends Object> extends Apple<E> {
+   @Override
+   void fooOuter(E array) {}
+   class InnerPineapple extends InnerApple<@Nullable String> {
+        @Override
+        //:: error: (override.param.invalid)
+        <F3> void foo(E array, String array2, F3 param3) {
+        }
+    }
+}
+
+class IntersectionAsMemberOf {
+    interface MyGenericInterface<F> {
+        F getF();
+    }
+
+    <T extends Object & MyGenericInterface<@NonNull String>> void foo(T param) {
+      //TODO: this error is due to a bug in asSuper
+      // See Issue 717
+      // https://github.com/typetools/checker-framework/issues/717
+       //:: error: (assignment.type.incompatible)
+       @NonNull String s = param.getF();
+    }
+}
+
+class UnionAsMemberOf {
+    interface MyInterface<T> {
+        T getT();
+    }
+
+    class MyExceptionA extends Throwable implements Cloneable, MyInterface<@NonNull String> {
+        public String getT() {
+            return "t";
+        }
+    }
+
+    class MyExceptionB extends Throwable implements Cloneable, MyInterface<String> {
+        public String getT() {
+            return "t";
+        }
+
+    }
+
+    void bar() throws MyExceptionA, MyExceptionB {}
+
+    void foo1(MyInterface<Throwable> param) throws Throwable {
+        try {
+            bar();
+        } catch (MyExceptionA | MyExceptionB ex1) {
+            //TODO: this error is due to a bug in asSuper
+            // See Issue 717
+            // https://github.com/typetools/checker-framework/issues/717
+            //:: error: (assignment.type.incompatible)
+            @NonNull String s = ex1.getT();
+        }
+    }
+}

--- a/framework/tests/all-systems/Issue577.java
+++ b/framework/tests/all-systems/Issue577.java
@@ -1,17 +1,81 @@
-// @skip-test
-
-// Test case for issue #577: https://github.com/typetools/checker-framework/issues/577
-class Banana extends Apple<int[]> {
-    class InnerBanana extends InnerApple {
+// Test case for issue #577:
+// Test with expected errors: checker/tests/nullness/Issue577.java
+// https://github.com/typetools/checker-framework/issues/577
+class Banana<T extends Number> extends Apple<int[]> {
+    @Override
+    void fooOuter(int[] array) {}
+    class InnerBanana extends InnerApple<long[]> {
         @Override
-        void foo(int[] array) {
+        <F2> void foo(int[] array, long[] array2, F2 param3) {
         }
     }
 }
 
 class Apple<T> {
-    class InnerApple {
-        void foo(T param) {
+    void fooOuter(T param) {}
+    class InnerApple<E> {
+        <F> void foo(T param, E param2, F param3) {
         }
     }
+}
+
+class Pineapple<E> extends Apple<E> {
+   @Override
+   void fooOuter(E array) {}
+}
+
+class IntersectionAsMemberOf {
+    interface MyGenericInterface<F> {
+        F getF();
+    }
+
+    <T extends Object & MyGenericInterface<String>> void foo(T param) {
+        String s = param.getF();
+    }
+}
+
+class UnionAsMemberOf {
+    interface MyInterface<T> {
+        T getT();
+    }
+
+    class MyExceptionA extends Throwable implements Cloneable, MyInterface<String> {
+        public String getT() {
+            return "t";
+        }
+    }
+
+    class MyExceptionB extends Throwable implements Cloneable, MyInterface<String> {
+        public String getT() {
+            return "t";
+        }
+
+    }
+
+    void bar() throws MyExceptionA, MyExceptionB {}
+
+    void foo1(MyInterface<Throwable> param) throws Throwable {
+        try {
+            bar();
+        } catch (MyExceptionA | MyExceptionB ex1) {
+            String s = ex1.getT();
+        }
+    }
+}
+
+final class Outer<K extends Object> {
+    // TODO: See Issue 724
+    // https://github.com/typetools/checker-framework/issues/724
+    @SuppressWarnings({"regex:argument.type.incompatible", "tainting:argument.type.incompatible"})
+    private Inner createInner(ReferenceQueue<? super K> q) {
+        return new Inner(q);
+    }
+
+    private final class Inner {
+        private Inner(ReferenceQueue<? super K> q) {
+        }
+    }
+}
+
+class ReferenceQueue<T> {
 }


### PR DESCRIPTION
Fixes #577

AnnotatedDeclaredType#getEnclosingType is missing annotations and the qualifier framework does not implement QualifiedDeclaredType#getEnclosingType (see #724).   Because of this, this pull request causes the Regex and Tainting Checker to issue (new) false positive warnings.