### PR TITLE
Fix issue 698

### DIFF
--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
@@ -58,9 +58,10 @@ public interface WholeProgramInference {
     /**
      * Updates the parameter types of the method {@code methodTree} based on the
      * parameter types of the overridden method {@code overriddenMethod}.
-     * @param methodTree the tree of the method that contains the parameter.
+     * @param methodTree the tree of the method that contains the parameter(s).
      * @param methodElt the element of the method.
-     * @param overriddenMethod the overridden method.
+     * @param overriddenMethod the AnnotatedExecutableType of the overridden
+     * method.
      * @param atf the annotated type factory of a given type system, whose
      * type hierarchy will be used to update the parameter type.
      */
@@ -73,9 +74,10 @@ public interface WholeProgramInference {
      * receiver type of the overridden method {@code overriddenMethod}.
      * @param methodTree the tree of the method that contains the receiver.
      * @param methodElt the element of the method.
-     * @param overriddenMethod the overridden method.
+     * @param overriddenMethod the AnnotatedExecutableType of the overridden
+     * method.
      * @param atf the annotated type factory of a given type system, whose
-     * type hierarchy will be used to update the parameter type.
+     * type hierarchy will be used to update the receiver type.
      */
     void updateInferredMethodReceiverType(
             MethodTree methodTree, ExecutableElement methodElt,

--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
@@ -9,6 +9,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
@@ -55,7 +56,33 @@ public interface WholeProgramInference {
             ExecutableElement methodElt, AnnotatedTypeFactory atf);
 
     /**
-     * Updates the type of {@code parameter} base on an assignment of
+     * Updates the parameter types of the method {@code methodTree} based on the
+     * parameter types of the overridden method {@code overriddenMethod}.
+     * @param methodTree the tree of the method that contains the parameter.
+     * @param methodElt the element of the method.
+     * @param overriddenMethod the overridden method.
+     * @param atf the annotated type factory of a given type system, whose
+     * type hierarchy will be used to update the parameter type.
+     */
+    void updateInferredMethodParameterTypes(
+            MethodTree methodTree, ExecutableElement methodElt,
+            AnnotatedExecutableType overriddenMethod, AnnotatedTypeFactory atf);
+
+    /**
+     * Updates the receiver type of the method {@code methodElt} based on the
+     * receiver type of the overridden method {@code overriddenMethod}.
+     * @param methodTree the tree of the method that contains the receiver.
+     * @param methodElt the element of the method.
+     * @param overriddenMethod the overridden method.
+     * @param atf the annotated type factory of a given type system, whose
+     * type hierarchy will be used to update the parameter type.
+     */
+    void updateInferredMethodReceiverType(
+            MethodTree methodTree, ExecutableElement methodElt,
+            AnnotatedExecutableType overriddenMethod, AnnotatedTypeFactory atf);
+
+    /**
+     * Updates the type of {@code parameter} based on an assignment of
      * {@code rhs} to {@code parameter}.
      * @param parameter the node representing the parameter.
      * @param rhs the node being assigned to the parameter in the method body.

--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -19,6 +19,8 @@ import org.checkerframework.framework.qual.IgnoreInWholeProgramInference;
 import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 
@@ -141,6 +143,51 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
         List<Node> arguments = objectCreationNode.getArguments();
         updateInferredExecutableParameterTypes(constructorElt, atf, jaifPath, method, arguments);
 
+    }
+
+    /**
+     * Updates the parameter types of the method {@code methodElt} in the Scene
+     * of the method's enclosing class based on the overridden method
+     * {@code overriddenMethod} parameter types.
+     * <p>
+     * For each method parameter in methodElt:
+     *   <ul>
+     *     <li>If the Scene does not contain an annotated type for that
+     *     parameter, then the type of the respective parameter on the
+     *     overridden method will be added to the parameter in the Scene.</li>
+     *     <li>If the Scene previously contained an annotated type for that
+     *     parameter, then its new type will be the LUB between the previous
+     *     type and the type of the respective parameter on the overridden
+     *     method.</li>
+     *   </ul>
+     * <p>
+     * @param methodTree the tree of the method that contains the parameter.
+     * @param methodElt the element of the method.
+     * @param overriddenMethod the overridden method.
+     * @param atf the annotated type factory of a given type system, whose
+     * type hierarchy will be used to update the parameter type.
+     */
+    @Override
+    public void updateInferredMethodParameterTypes(
+            MethodTree methodTree, ExecutableElement methodElt,
+            AnnotatedExecutableType overriddenMethod, AnnotatedTypeFactory atf) {
+        ClassSymbol classSymbol = getEnclosingClassSymbol(methodTree);
+        String className = classSymbol.flatname.toString();
+        String jaifPath = helper.getJaifPath(className);
+        AClass clazz = helper.getAClass(className, jaifPath);
+        String methodName = JVMNames.getJVMMethodName(methodElt);
+        AMethod method = clazz.methods.vivify(methodName);
+
+        for (int i = 0; i < overriddenMethod.getParameterTypes().size(); i++) {
+            VariableElement ve = methodElt.getParameters().get(i);
+            AnnotatedTypeMirror paramATM = atf.getAnnotatedType(ve);
+
+            AnnotatedTypeMirror argATM = overriddenMethod.getParameterTypes().get(i);
+            AField param = method.parameters.vivify(i);
+            helper.updateAnnotationSetInScene(
+                    param.type, atf, jaifPath, argATM, paramATM,
+                    TypeUseLocation.PARAMETER);
+        }
     }
 
     /**
@@ -290,6 +337,50 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
                         param.type, atf, jaifPath, argATM, paramATM,
                         TypeUseLocation.PARAMETER);
                 break;
+            }
+        }
+    }
+
+    /**
+     * Updates the receiver type of the method {@code methodElt} in the Scene
+     * of the method's enclosing class based on the overridden method
+     * {@code overriddenMethod} receiver type.
+     * <p>
+     * For each method parameter in methodElt:
+     *   <ul>
+     *     <li>If the Scene does not contain an annotated type for the
+     *     receiver, then the type of the receiver on the overridden method will
+     *     be added to the receiver in the Scene.</li>
+     *     <li>If the Scene previously contained an annotated type for the
+     *     receiver, then its new type will be the LUB between the previous
+     *     type and the type of the receiver on the overridden method.</li>
+     *   </ul>
+     * <p>
+     * @param methodTree the tree of the method that contains the receiver.
+     * @param methodElt the element of the method.
+     * @param overriddenMethod the overridden method.
+     * @param atf the annotated type factory of a given type system, whose
+     * type hierarchy will be used to update the parameter type.
+     */
+    @Override
+    public void updateInferredMethodReceiverType(
+            MethodTree methodTree, ExecutableElement methodElt,
+            AnnotatedExecutableType overriddenMethod, AnnotatedTypeFactory atf) {
+        ClassSymbol classSymbol = getEnclosingClassSymbol(methodTree);
+        String className = classSymbol.flatname.toString();
+        String jaifPath = helper.getJaifPath(className);
+        AClass clazz = helper.getAClass(className, jaifPath);
+        String methodName = JVMNames.getJVMMethodName(methodElt);
+        AMethod method = clazz.methods.vivify(methodName);
+
+        AnnotatedDeclaredType argADT = overriddenMethod.getReceiverType();
+        if (argADT != null) {
+            AnnotatedTypeMirror paramATM = atf.getAnnotatedType(methodTree).getReceiverType();
+            if (paramATM != null) {
+                AField receiver = method.receiver;
+                helper.updateAnnotationSetInScene(
+                        receiver.type, atf, jaifPath, argADT, paramATM,
+                        TypeUseLocation.RECEIVER);
             }
         }
     }

--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -163,7 +163,8 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
      * <p>
      * @param methodTree the tree of the method that contains the parameter.
      * @param methodElt the element of the method.
-     * @param overriddenMethod the overridden method.
+     * @param overriddenMethod the AnnotatedExecutableType of the overridden
+     * method.
      * @param atf the annotated type factory of a given type system, whose
      * type hierarchy will be used to update the parameter type.
      */
@@ -346,7 +347,7 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
      * of the method's enclosing class based on the overridden method
      * {@code overriddenMethod} receiver type.
      * <p>
-     * For each method parameter in methodElt:
+     * For the receiver in methodElt:
      *   <ul>
      *     <li>If the Scene does not contain an annotated type for the
      *     receiver, then the type of the receiver on the overridden method will
@@ -360,7 +361,7 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
      * @param methodElt the element of the method.
      * @param overriddenMethod the overridden method.
      * @param atf the annotated type factory of a given type system, whose
-     * type hierarchy will be used to update the parameter type.
+     * type hierarchy will be used to update the receiver type.
      */
     @Override
     public void updateInferredMethodReceiverType(

--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
@@ -228,6 +228,9 @@ public class WholeProgramInferenceScenesHelper {
                 // Return type
                 removeIgnoredAnnosFromATypeElement(
                         method.returnType, TypeUseLocation.RETURN);
+                // Receiver type
+                removeIgnoredAnnosFromATypeElement(
+                        method.receiver.type, TypeUseLocation.RECEIVER);
                 // Parameter type
                 for (AField param : method.parameters.values()) {
                     removeIgnoredAnnosFromATypeElement(

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -274,7 +274,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
 
             addFinalLocalValues(info, methodElem);
 
-            if (infer) {
+            if (shouldPerformWholeProgramInference(methodTree, methodElem)) {
                 Map<AnnotatedDeclaredType, ExecutableElement> overriddenMethods =
                         AnnotatedTypes.overriddenMethods(
                                 analysis.atypeFactory.getElementUtils(),

--- a/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
@@ -2,6 +2,7 @@ import tests.wholeprograminference.qual.*;
 class Parent {
     public void foo(@Sibling1 Object obj, @Sibling2 Object obj2) {}
     public void bar(@Sibling1 Parent this, @Sibling2 Object obj) {}
+    public void barz(@Sibling1 Parent this, @Sibling2 Object obj) {}
 }
 
 class Child extends Parent {
@@ -20,4 +21,8 @@ class Child extends Parent {
         //:: error: (assignment.type.incompatible)
         @Sibling2 Object o = obj;
     }
+
+    @SuppressWarnings("")
+    @Override
+    public void barz(Object obj) {}
 }

--- a/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
@@ -2,6 +2,7 @@ import tests.wholeprograminference.qual.*;
 class Parent {
     public void foo(@Sibling1 Object obj, @Sibling2 Object obj2) {}
     public void bar(@Sibling1 Parent this, @Sibling2 Object obj) {}
+    public void barz(@Sibling1 Parent this, @Sibling2 Object obj) {}
 }
 
 class Child extends Parent {
@@ -19,5 +20,17 @@ class Child extends Parent {
         @Sibling1 Child child = this;
         //:: error: (assignment.type.incompatible)
         @Sibling2 Object o = obj;
+    }
+
+    @SuppressWarnings("")
+    @Override
+    public void barz(Object obj) {}
+
+    public void callbarz(Object obj) {
+        // If the @SuppressWarnings("") on the overridden version of barz above is not
+        // respected, and the annotations on the receiver and parameter of barz are
+        // inferred, then the following call to barz will result in a method.invocation.invalid
+        // and an argument.type.incompatible type checking errors.
+        barz(obj);
     }
 }

--- a/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
@@ -2,7 +2,6 @@ import tests.wholeprograminference.qual.*;
 class Parent {
     public void foo(@Sibling1 Object obj, @Sibling2 Object obj2) {}
     public void bar(@Sibling1 Parent this, @Sibling2 Object obj) {}
-    public void barz(@Sibling1 Parent this, @Sibling2 Object obj) {}
 }
 
 class Child extends Parent {
@@ -21,8 +20,4 @@ class Child extends Parent {
         //:: error: (assignment.type.incompatible)
         @Sibling2 Object o = obj;
     }
-
-    @SuppressWarnings("")
-    @Override
-    public void barz(Object obj) {}
 }

--- a/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
@@ -1,0 +1,19 @@
+import tests.wholeprograminference.qual.*;
+class Parent {
+    public void foo(@Sibling1 Object obj) {}
+    public void bar(@Sibling1 Parent this) {}
+}
+
+class Child extends Parent {
+    @Override
+    public void foo(Object obj) {
+        //:: error: (assignment.type.incompatible)
+        @Sibling1 Object obj2 = obj;
+    }
+
+    @Override
+    public void bar() {
+        //:: error: (assignment.type.incompatible)
+        @Sibling1 Child child = this;
+    }
+}

--- a/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/OverriddenMethodsTest.java
@@ -1,19 +1,23 @@
 import tests.wholeprograminference.qual.*;
 class Parent {
-    public void foo(@Sibling1 Object obj) {}
-    public void bar(@Sibling1 Parent this) {}
+    public void foo(@Sibling1 Object obj, @Sibling2 Object obj2) {}
+    public void bar(@Sibling1 Parent this, @Sibling2 Object obj) {}
 }
 
 class Child extends Parent {
     @Override
-    public void foo(Object obj) {
+    public void foo(Object obj, Object obj2) {
         //:: error: (assignment.type.incompatible)
-        @Sibling1 Object obj2 = obj;
+        @Sibling1 Object o = obj;
+        //:: error: (assignment.type.incompatible)
+        @Sibling2 Object o2 = obj2;
     }
 
     @Override
-    public void bar() {
+    public void bar(Object obj) {
         //:: error: (assignment.type.incompatible)
         @Sibling1 Child child = this;
+        //:: error: (assignment.type.incompatible)
+        @Sibling2 Object o = obj;
     }
 }


### PR DESCRIPTION
This is a fix for issue #698.

Whole-program inference now infers annotations on the receiver and parameters of overridder methods. This branch was built based on #703.
