### PR TITLE
It's unsound to refine the operand of an instanceof.

### DIFF
--- a/checker/src/org/checkerframework/checker/nullness/NullnessTransfer.java
+++ b/checker/src/org/checkerframework/checker/nullness/NullnessTransfer.java
@@ -15,6 +15,7 @@ import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.ArrayAccessNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
+import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
 import org.checkerframework.dataflow.cfg.node.MethodAccessNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -170,6 +171,16 @@ public class NullnessTransfer extends
                 .visitArrayAccess(n, p);
         makeNonNull(result, n.getArray());
         return result;
+    }
+
+    @Override
+    public TransferResult<NullnessValue, NullnessStore> visitInstanceOf(
+            InstanceOfNode n, TransferInput<NullnessValue, NullnessStore> p) {
+        TransferResult<NullnessValue, NullnessStore> result = super.visitInstanceOf(n, p);
+        NullnessStore thenStore = result.getThenStore();
+        NullnessStore elseStore = result.getElseStore();
+        makeNonNull(thenStore, n.getOperand());
+        return new ConditionalTransferResult<>(result.getResultValue(), thenStore, elseStore);
     }
 
     @Override

--- a/checker/tests/nullness/init/InstanceOf.java
+++ b/checker/tests/nullness/init/InstanceOf.java
@@ -1,0 +1,17 @@
+import org.checkerframework.checker.nullness.qual.*;
+import org.checkerframework.checker.initialization.qual.*;
+class PptTopLevel {
+   class Ppt {
+     Object method() { return ""; }
+   }
+   class OtherPpt extends Ppt {}
+}
+class InstanceOf {
+    void foo( PptTopLevel.@UnknownInitialization(PptTopLevel.class) Ppt ppt) {
+        ppt.method();
+        if (ppt instanceof PptTopLevel.OtherPpt) {
+            PptTopLevel.OtherPpt pslice = (PptTopLevel.OtherPpt) ppt;
+ String     samp_str = " s" + pslice.method();
+        }
+    }
+}

--- a/checker/tests/nullness/init/InstanceOf.java
+++ b/checker/tests/nullness/init/InstanceOf.java
@@ -1,17 +1,25 @@
-import org.checkerframework.checker.nullness.qual.*;
-import org.checkerframework.checker.initialization.qual.*;
+// Test case for pull request 735
+// https://github.com/typetools/checker-framework/pull/735
+
+import org.checkerframework.checker.initialization.UnknownInitialization;
+
 class PptTopLevel {
-   class Ppt {
-     Object method() { return ""; }
-   }
-   class OtherPpt extends Ppt {}
+    class Ppt {
+        Object method() {
+            return "";
+        }
+    }
+
+    class OtherPpt extends Ppt {
+    }
 }
+
 class InstanceOf {
-    void foo( PptTopLevel.@UnknownInitialization(PptTopLevel.class) Ppt ppt) {
+    void foo(PptTopLevel.@UnknownInitialization(PptTopLevel.class) Ppt ppt) {
         ppt.method();
         if (ppt instanceof PptTopLevel.OtherPpt) {
             PptTopLevel.OtherPpt pslice = (PptTopLevel.OtherPpt) ppt;
- String     samp_str = " s" + pslice.method();
+            String samp_str = " s" + pslice.method();
         }
     }
 }

--- a/checker/tests/nullness/init/InstanceOf.java
+++ b/checker/tests/nullness/init/InstanceOf.java
@@ -16,9 +16,11 @@ class PptTopLevel {
 
 class InstanceOf {
     void foo(PptTopLevel.@UnknownInitialization(PptTopLevel.class) Ppt ppt) {
+        //:: error: (method.invocation.invalid)
         ppt.method();
         if (ppt instanceof PptTopLevel.OtherPpt) {
             PptTopLevel.OtherPpt pslice = (PptTopLevel.OtherPpt) ppt;
+            //:: error: (method.invocation.invalid)
             String samp_str = " s" + pslice.method();
         }
     }

--- a/checker/tests/nullness/init/InstanceOf.java
+++ b/checker/tests/nullness/init/InstanceOf.java
@@ -1,7 +1,7 @@
 // Test case for pull request 735
 // https://github.com/typetools/checker-framework/pull/735
 
-import org.checkerframework.checker.initialization.UnknownInitialization;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 
 class PptTopLevel {
     class Ppt {

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1113,39 +1113,6 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
     // }
 
     /**
-     * Refine the operand of an instanceof check with more specific annotations
-     * if possible.
-     */
-    @Override
-    public TransferResult<V, S> visitInstanceOf(InstanceOfNode n,
-            TransferInput<V, S> p) {
-        TransferResult<V, S> result = super.visitInstanceOf(n, p);
-
-        // Look at the annotations from the type of the instanceof check
-        // (provided by the factory)
-        V factoryValue = getValueFromFactory(n.getTree().getType(), null);
-
-        // Look at the value from the operand.
-        V operandValue = p.getValueOfSubNode(n.getOperand());
-
-        // Combine the two.
-        V mostPreciseValue = moreSpecificValue(operandValue, factoryValue);
-
-        // Insert into the store if possible.
-        Receiver operandInternal = FlowExpressions.internalReprOf(
-                analysis.getTypeFactory(), n.getOperand());
-        if (CFAbstractStore.canInsertReceiver(operandInternal)) {
-            S thenStore = result.getThenStore();
-            S elseStore = result.getElseStore();
-            thenStore.insertValue(operandInternal, mostPreciseValue);
-            return new ConditionalTransferResult<>(result.getResultValue(),
-                    thenStore, elseStore);
-        }
-
-        return result;
-    }
-
-    /**
      * Returns the abstract value of {@code (value1, value2)} that is more
      * specific. If the two are incomparable, then {@code value1} is returned.
      */


### PR DESCRIPTION
However, the operand of an instance of is non-null if the instanceof is true.

This changes cause a new (legitimate) Daikon type-checking error at [this line](https://github.com/codespecs/daikon/blob/master/java/daikon/Debug.java#L530). It's a method.invocation.invaild error on `pslice.num_samples();`.