### PR TITLE
Add comments to flow expression parsing and dataflow

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -629,7 +629,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /**
      * Checks all (non-conditional) postcondition on the method {@code node}
-     * with element {@code methodElement} for consistency.
+     * with element {@code methodElement} for consistency, i.e.
+     * that no formal parameter names are mentioned in the postconditions
+     * (an index such as "#1" should be used instead), and that all
+     * formal parameters referred to by an index in the postconditions are
+     * effectively final.
      */
     protected void checkPostconditionsConsistency(MethodTree node,
             ExecutableElement methodElement, List<String> formalParamNames) {
@@ -760,7 +764,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /**
      * Checks all conditional postcondition on the method with element
-     * {@code methodElement} for consistency.
+     * {@code methodElement} for consistency, i.e. that no formal parameter
+     * names are mentioned in the conditional postconditions (an index such
+     * as "#1" should be used instead), and that all formal parameters
+     * referred to by an index in the conditional postconditions are
+     * effectively final.
      */
     protected void checkConditionalPostconditionsConsistency(MethodTree node,
             ExecutableElement methodElement, List<String> formalParamNames) {
@@ -802,12 +810,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /**
-     * Check that the parameters used in {@code stringExpr} are final for method
+     * Check that the parameters used in {@code stringExpr} are effectively final for method
      * {@code method}.
      */
     protected void checkFlowExprParameters(ExecutableElement method, String stringExpr) {
         // check that all parameters used in the expression are
-        // final, so that they cannot be modified
+        // effectively final, so that they cannot be modified
         List<Integer> parameterIndices = FlowExpressionParseUtil.parameterIndices(stringExpr);
         for (Integer idx : parameterIndices) {
             VariableElement parameter = method.getParameters().get(idx - 1);
@@ -1032,6 +1040,15 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
     }
 
+    /**
+     * Returns a flow expression context corresponding to the given {@code node}.
+     * Only handles the kinds of Nodes for which a precondition check is applicable
+     * and for which values are stored in {@link CFAbstractStore}. Returns null
+     * if the Node kind is not handled.
+     *
+     * @param node the Node to generate the flow expression context for
+     * @return the resulting flow expression context, or null if the Node kind is not handled.
+     */
     private FlowExpressionContext getFlowExpressionContextFromNode(Node node) {
         FlowExpressionContext flowExprContext = null;
 
@@ -1110,7 +1127,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /**
      * Checks all the preconditions of the method with element
-     * {@code methodElement} for consistency.
+     * {@code methodElement} for consistency, i.e. that no formal
+     * parameter names are mentioned in the preconditions
+     * (an index such as "#1" should be used instead), and that all
+     * formal parameters referred to by an index in the preconditions are
+     * effectively final.
      */
     protected void checkPreconditionsConsistency(MethodTree node,
             ExecutableElement methodElement, List<String> formalParamNames) {

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
@@ -4,8 +4,10 @@ package org.checkerframework.framework.flow;
 import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
+import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ArrayAccess;
+import org.checkerframework.dataflow.analysis.FlowExpressions.ClassName;
 import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
 import org.checkerframework.dataflow.analysis.FlowExpressions.LocalVariable;
 import org.checkerframework.dataflow.analysis.FlowExpressions.MethodCall;
@@ -41,6 +43,17 @@ import javax.lang.model.util.Types;
  * A store for the checker framework analysis tracks the annotations of memory
  * locations such as local variables and fields.
  *
+ * When adding a new field to track values for a code construct (similar to
+ * {@code localVariableValues} and {@code thisValue}), it is important
+ * to review all constructors and methods in this class for locations
+ * where the new field must be handled (such as the copy constructor and
+ * {@code clearValue}), as well as all constructors/methods in subclasses
+ * of {code CFAbstractStore}. Note that this includes not only overridden
+ * methods in the subclasses, but new methods in the subclasses as well.
+ * Also check if {@link BaseTypeVisitor#getFlowExpressionContextFromNode(Node)}
+ * needs to be updated. Failing to do so may result in silent failures that are
+ * time consuming to debug.
+ *
  * @author Charlie Garrett
  * @author Stefan Heule
  */
@@ -55,8 +68,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
     protected final CFAbstractAnalysis<V, S, ?> analysis;
 
     /**
-     * Information collected about local variables, which are identified by the
-     * corresponding element.
+     * Information collected about local variables (including method arguments).
      */
     protected final Map<FlowExpressions.LocalVariable, V> localVariableValues;
 
@@ -83,6 +95,10 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      */
     protected Map<FlowExpressions.MethodCall, V> methodValues;
 
+    /**
+     * Information collected about <class name>.class values,
+     * using the internal representation {@link ClassName}.
+     */
     protected Map<FlowExpressions.ClassName, V> classValues;
 
     /**
@@ -562,11 +578,8 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      * Update the information in the store by considering an assignment with
      * target {@code n}, where the target is an array access.
      *
-     * <ol>
-     * <li value="1">Remove any abstract values for field accesses <em>b.g</em>
-     * where {@code n} might alias any expression in the receiver <em>b</em>.
-     * <li value="2">Remove any information about pure method calls.
-     * </ol>
+     * See {@link #removeConflicting(ArrayAccess,V)}, as it is called first
+     * by this method.
      */
     protected void updateForArrayAssignment(ArrayAccess arrayAccess,
             /*@Nullable*/ V val) {
@@ -613,7 +626,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      * <li value="2">Remove any abstract values for field accesses <em>b.g</em>
      * where {@code fieldAccess} might alias any expression in the receiver
      * <em>b</em>.
-     * <li value="3">Remove any information about pure method calls.
+     * <li value="3">Remove any information about method calls.
      * <li value="4">Remove any abstract values an arrary access <em>b[i]</em>
      * where {@code fieldAccess} might alias any expression in the receiver
      * <em>a</em> or index <em>i</em>.
@@ -684,7 +697,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      * <li value="2">Remove any abstract values for field accesses <em>b.g</em>
      * where <em>a[i]</em> might alias any expression in the receiver <em>b</em>
      * and there is an array expression somewhere in the receiver.
-     * <li value="3">Remove any information about pure method calls.
+     * <li value="3">Remove any information about method calls.
      * </ol>
      *
      * @param val
@@ -742,7 +755,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      * <em>b</em>.
      * <li value="2">Remove any abstract values for array accesses <em>a[i]</em>
      * where {@code localVar} might alias the receiver <em>a</em>.
-     * <li value="3">Remove any information about pure method calls where the
+     * <li value="3">Remove any information about method calls where the
      * receiver or any of the parameters contains {@code localVar}.
      * </ol>
      */

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractStore.java
@@ -96,7 +96,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
     protected Map<FlowExpressions.MethodCall, V> methodValues;
 
     /**
-     * Information collected about <class name>.class values,
+     * Information collected about &lt;class name&gt;.class values,
      * using the internal representation {@link ClassName}.
      */
     protected Map<FlowExpressions.ClassName, V> classValues;
@@ -578,7 +578,7 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
      * Update the information in the store by considering an assignment with
      * target {@code n}, where the target is an array access.
      *
-     * See {@link #removeConflicting(ArrayAccess,V)}, as it is called first
+     * See {@link CFAbstractStore#removeConflicting(ArrayAccess,CFAbstractValue)}, as it is called first
      * by this method.
      */
     protected void updateForArrayAssignment(ArrayAccess arrayAccess,

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -441,7 +441,7 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
 
             Element elem = e.getKey();
 
-            // There is a design flaw where the values of final local values leaks
+            // TODO: There is a design flaw where the values of final local values leaks
             // into other methods of the same class. For example, in
             // class a { void b() {...} void c() {...} }
             // final local values from b() would be visible in the store for c(),

--- a/framework/src/org/checkerframework/framework/qual/TargetLocations.java
+++ b/framework/src/org/checkerframework/framework/qual/TargetLocations.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
  * implemented if a more fine-grained control is necessary.
  *
  */
+// TODO: Verify this meta-annotation (step 3 in https://github.com/typetools/checker-framework/issues/515).
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)

--- a/framework/src/org/checkerframework/framework/qual/TargetLocations.java
+++ b/framework/src/org/checkerframework/framework/qual/TargetLocations.java
@@ -26,7 +26,6 @@ import java.lang.annotation.Target;
  * implemented if a more fine-grained control is necessary.
  *
  */
-// TODO: Verify this meta-annotation (step 3 in https://github.com/typetools/checker-framework/issues/515).
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)


### PR DESCRIPTION
Add comments to code that handles parsing of flow expressions and storage/retrieval of their refined values as determined by dataflow analysis.

In addition to these comments, there is a summary [in this document](https://docs.google.com/document/d/10tYe0D60hDHdyLT2q9mIPmWHIzZaCU2UHS2lP-grNiQ/edit#bookmark=id.mzn7kztlxn7b) of how `BaseTypeVisitor.checkPreconditions` together with `FlowExpressionParseUtil.parse` perform viewpoint adaptation for member accesses. Please let me know if you would like me to include that text as a comment in FlowExpressionParseUtil.java.