### PR TITLE
Put checker.jar on processorpath, not classpath

### DIFF
--- a/checker/examples/units-extension/Makefile
+++ b/checker/examples/units-extension/Makefile
@@ -3,7 +3,7 @@ FILES=qual/Frequency.java \
   qual/Hz.java \
   qual/kHz.java
 
-JAVAOPTS=-source 7 -target 7
+JAVAOPTS=-source 7 -target 7  -classpath .:../../dist/checker.jar
 
 JAVAC?=../../bin/javac
 
@@ -24,13 +24,13 @@ compile-for-test:
 
 # test case for using externally defined units by explicitly naming them using the -Aunits option
 named-quals-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -Aunits=qual.Hz,qual.kHz,qual.Frequency Demo.java > Out.txt 2>&1
+	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -Aunits=qual.Hz,qual.kHz,qual.Frequency Demo.java > Out.txt 2>&1 || true
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 
 # test case for using externally defined units by loading them from a directory using the -AunitsDirs option
 qual-folder-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1
+	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1 || true
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 

--- a/framework/src/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerMain.java
@@ -51,7 +51,11 @@ public class CheckerMain {
     /**
      * The path to the jar containing CheckerMain.class (i.e. checker.jar)
      */
-    protected final File checkersJar;
+    protected final File checkerJar;
+    /**
+     * The path to checker-qual.jar
+     */
+    protected final File checkerQualJar;
 
 
     private final List<String> compilationBootclasspath;
@@ -62,6 +66,8 @@ public class CheckerMain {
 
     private final List<String> cpOpts;
 
+    private final List<String> ppOpts;
+
     private final List<String> toolOpts;
 
     private final List<File> argListFiles;
@@ -70,10 +76,11 @@ public class CheckerMain {
      * Construct all the relevant file locations and Java version given the path to this jar and
      * a set of directories in which to search for jars.
      */
-    public CheckerMain(final File checkersJar, final String [] args) {
+    public CheckerMain(final File checkerJar, final String [] args) {
 
-        this.checkersJar   = checkersJar;
-        final File searchPath = checkersJar.getParentFile();
+        this.checkerJar   = checkerJar;
+        final File searchPath = checkerJar.getParentFile();
+        this.checkerQualJar   = new File(searchPath, "checker-qual.jar");
 
         final List<String> argsList = new ArrayList<String>(args.length);
         for (String arg : args) {
@@ -93,17 +100,22 @@ public class CheckerMain {
         this.jvmOpts       = extractJvmOpts(argsList);
 
         this.cpOpts        = createCpOpts(argsList);
+        this.ppOpts        = createPpOpts(argsList);
         this.toolOpts      = argsList;
 
         assertValidState();
     }
 
     protected void assertValidState() {
-        assertFilesExist(Arrays.asList(javacJar, jdkJar, checkersJar));
+        assertFilesExist(Arrays.asList(javacJar, jdkJar, checkerJar, checkerQualJar));
     }
 
     public void addToClasspath(List<String> cpOpts) {
         this.cpOpts.addAll(cpOpts);
+    }
+
+    public void addToProcessorpath(List<String> ppOpts) {
+        this.ppOpts.addAll(ppOpts);
     }
 
     public void addToRuntimeBootclasspath(List<String> runtimeBootClasspathOpts) {
@@ -123,7 +135,20 @@ public class CheckerMain {
 
     protected List<String> createCpOpts(final List<String> argsList) {
         final List<String> extractedOps = extractCpOpts(argsList);
-        extractedOps.add(0, this.checkersJar.getAbsolutePath());
+        extractedOps.add(0, this.checkerQualJar.getAbsolutePath());
+        return extractedOps;
+    }
+
+    // Assumes that createCpOpts has already been run.
+    protected List<String> createPpOpts(final List<String> argsList) {
+        final List<String> extractedOps = extractPpOpts(argsList);
+        if (extractedOps.isEmpty()) {
+            // If processorpath is not provided, then javac uses the classpath.
+            // CheckerMain always supplies a processorpath, so if the user
+            // didn't specify a processorpath, then use the classpath.
+            extractedOps.addAll(this.cpOpts);
+        }
+        extractedOps.add(0, this.checkerJar.getAbsolutePath());
         return extractedOps;
     }
 
@@ -257,16 +282,13 @@ public class CheckerMain {
 
         String path = null;
 
-        int i = 0;
-        while (i < args.size()) {
-
-            if (args.get(i).equals("-cp") || args.get(i).equals("-classpath")) {
-                if (args.size() > i) {
+        for (int i=0; i<args.size(); i++) {
+            if ((args.get(i).equals("-cp") || args.get(i).equals("-classpath"))
+                && (i + 1 < args.size())) {
                     args.remove(i);
                     path = args.remove(i);
-                } // else loop ends and we have a dangling -cp.  javac will issue a warning.
-            } else {
-                i++;
+                // re-process whatever is currently at element i
+                i--;
             }
         }
 
@@ -287,6 +309,35 @@ public class CheckerMain {
         return actualArgs;
     }
 
+    /**
+     * Remove the -processorpath options and their arguments from args.
+     * Return the last argument.
+     *
+     * @param args a list of arguments to extract from
+     * @return the arguments that should be put on the processorpath when calling javac.jar
+     */
+    protected static List<String> extractPpOpts(final List<String> args) {
+        List<String> actualArgs = new ArrayList<String>();
+
+        String path = null;
+
+        for (int i=0; i<args.size(); i++) {
+            if (args.get(i).equals("-processorpath")
+                && (i + 1 < args.size())) {
+                args.remove(i);
+                path = args.remove(i);
+                // re-process whatever is currently at element i
+                i--;
+            }
+        }
+
+        if (path != null) {
+            actualArgs.add(path);
+        }
+
+        return actualArgs;
+    }
+
     protected void addMainArgs(final List<String> args) {
         args.add("com.sun.tools.javac.Main");
     }
@@ -295,7 +346,7 @@ public class CheckerMain {
      * Invoke the JSR308 Type Annotations Compiler with all relevant jars on its classpath or boot classpath
      */
     public List<String> getExecArguments() {
-        List<String> args = new ArrayList<String>(jvmOpts.size() + cpOpts.size() + toolOpts.size() + 5);
+        List<String> args = new ArrayList<String>(jvmOpts.size() + cpOpts.size() + toolOpts.size() + 7);
 
         final String java = PluginUtil.getJavaCommand(System.getProperty("java.home"), System.out);
         args.add(java);
@@ -314,6 +365,10 @@ public class CheckerMain {
         if (!argsListHasClassPath(argListFiles)) {
             args.add("-classpath");
             args.add(quote(PluginUtil.join(File.pathSeparator, cpOpts)));
+        }
+        if (!argsListHasProcessorPath(argListFiles)) {
+            args.add("-processorpath");
+            args.add(quote(PluginUtil.join(File.pathSeparator, ppOpts)));
         }
 
         args.addAll(toolOpts);
@@ -390,6 +445,20 @@ public class CheckerMain {
     private static boolean argsListHasClassPath(final List<File> argListFiles) {
         for (final String arg : expandArgFiles(argListFiles)) {
             if (arg.contains("-classpath") || arg.contains("-cp")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns true if some @arglist file sets the processorpath.
+     * @param argListFiles command-line argument files (specified with @ on the command line)
+     */
+    private static boolean argsListHasProcessorPath(final List<File> argListFiles) {
+        for (final String arg : expandArgFiles(argListFiles)) {
+            if (arg.contains("-processorpath")) {
                 return true;
             }
         }
@@ -557,7 +626,7 @@ public class CheckerMain {
     private List<String> getAllCheckerClassNames() {
         ArrayList<String> checkerClassNames = new ArrayList<String>();
         try {
-            final JarInputStream checkerJarIs = new JarInputStream(new FileInputStream(checkersJar));
+            final JarInputStream checkerJarIs = new JarInputStream(new FileInputStream(checkerJar));
             ZipEntry entry;
             while ((entry = checkerJarIs.getNextEntry()) != null) {
                 final String name = entry.getName();
@@ -568,7 +637,7 @@ public class CheckerMain {
             }
             checkerJarIs.close();
         } catch (IOException e) {
-            throw new RuntimeException("Could not read " + checkersJar, e);
+            throw new RuntimeException("Could not read " + checkerJar, e);
         }
 
         return checkerClassNames;


### PR DESCRIPTION
Fixes issue #700, "Too many classes on the bootclasspath".