### PR TITLE
Release: correct git command

### DIFF
--- a/release/release_utils.py
+++ b/release/release_utils.py
@@ -407,7 +407,7 @@ def push_changes_prompt_if_fail(repo_root):
                 if not prompt_yn("Try again (responding 'n' will skip this push command but will not exit the script) ?"):
                     break
         if is_git(repo_root):
-            cmd = 'git -C %s push' % repo_root
+            cmd = 'git -C %s push origin master' % repo_root
         else:
             cmd = 'hg -R %s push' % repo_root
         result = os.system(cmd)


### PR DESCRIPTION
When pushing from the bare interm git repositories, the follow error is issued (though the release scripts thinks the push succeeds):
````
fatal: The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin master
````
The change in this PR specifies origin master in on of the pushes.  A less confusing alternative would be to set the upstream of master when the repository is cloned.