### PR TITLE
Fix for #765 (Failed assert in dataflow) 

### DIFF
--- a/checker/tests/nullness/Issue765.java
+++ b/checker/tests/nullness/Issue765.java
@@ -1,0 +1,15 @@
+// Test case for Issue 765
+// https://github.com/typetools/checker-framework/issues/765
+class Issue765 {
+  Thread thread = new Thread() {
+  };
+
+  void execute() {
+    thread = new Thread() {
+      @Override
+      public void run() {
+      }
+    };
+    thread.start();
+  }
+}

--- a/dataflow/src/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/Analysis.java
@@ -621,13 +621,12 @@ public class Analysis<A extends AbstractValue<A>, S extends Store<S>, T extends 
     public /*@Nullable*/ A getValue(Node n) {
         if (isRunning) {
             // we do not yet have a org.checkerframework.dataflow fact about the current node
-            if (currentNode == n
+            if (currentNode == null || currentNode == n
                     || (currentTree != null && currentTree == n.getTree())) {
                 return null;
             }
             // check that 'n' is a subnode of 'node'. Check immediate operands
             // first for efficiency.
-            assert currentNode != null;
             assert !n.isLValue() : "Did not expect an lvalue, but got " + n;
             if (!(currentNode != n && (currentNode.getOperands().contains(n) || currentNode
                     .getTransitiveOperands().contains(n)))) {


### PR DESCRIPTION
Only the Nullness and Nullness Rawness Checkers trip the assert.  I can't figure out why that's the case, but it seems safe to remove the assert and return null instead.  (I tested this change on daikon with my other asSuper changes and it typechecked.)