### PR TITLE
Release fix: Use --mirror

### DIFF
--- a/release/release_utils.py
+++ b/release/release_utils.py
@@ -489,7 +489,7 @@ def clone(src_repo, dst_repo, bareflag):
     if isGitRepo:
         flags = ""
         if bareflag:
-            flags = "--bare"
+            flags = "--mirror"
         execute('git clone --quiet %s %s %s' % (flags, src_repo, dst_repo))
     else:
         execute('hg clone --quiet %s %s' % (src_repo, dst_repo))


### PR DESCRIPTION
When pushing from the bare interm git repositories, the follow error is issued (though the release scripts thinks the push succeeds):
````
fatal: The current branch master has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin master
````

Use --mirror so that branches track origin branches correctly and git push works with out specifying a remote branch to push to.