### PR TITLE
AnnotatedTypeMirror.toString(true) uses all verbose settings

### DIFF
--- a/checker/tests/nullness-extra/Makefile
+++ b/checker/tests/nullness-extra/Makefile
@@ -2,10 +2,10 @@
 .PHONY: all skipped Bug109 multiple-errors package-anno issue265 issue309 compat shorthand issue502 issue559 issue594 issue607
 
 # Tests that are currently passing
-all: Bug109 compat issue265 issue309 issue502 multiple-errors package-anno shorthand issue607
+all: Bug109 compat issue265 issue309 issue502 multiple-errors package-anno shorthand issue607 issue594
 
 # Tests that are currently not passing
-skipped: issue559 issue594
+skipped: issue559
 
 
 Bug109:

--- a/checker/tests/nullness-extra/issue594/Expected.txt
+++ b/checker/tests/nullness-extra/issue594/Expected.txt
@@ -1,6 +1,6 @@
-Issue594.java:19: error: [return.type.incompatible] incompatible types in return.
+Issue594.java:18: error: [return.type.incompatible] incompatible types in return.
         return result;
                ^
-  found   : T extends @Initialized @Nullable Object super SOMETHING
-  required: T extends @Initialized @Nullable Object super SOMETHING-ELSE
+  found   : T[ extends @Initialized @Nullable Object super @Initialized @Nullable Void]
+  required: T[ extends @Initialized @Nullable Object super @Initialized @NonNull Void]
 1 error

--- a/checker/tests/nullness-extra/issue594/Issue594.java
+++ b/checker/tests/nullness-extra/issue594/Issue594.java
@@ -6,7 +6,6 @@
 //   found   : T extends @Initialized @Nullable Object
 //   required: T extends @Initialized @Nullable Object
 
-// @skip-test temorarily disabled until issue #594 is fixed
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/checker/tests/nullness-extra/issue594/Makefile
+++ b/checker/tests/nullness-extra/issue594/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all
 
 all: clean
-	$(JAVAC) -processor org.checkerframework.checker.nullness.NullnessChecker Issue594.java > Out.txt 2>&1
-	diff -u Expected.txt Out.txt
+	-$(JAVAC) -processor org.checkerframework.checker.nullness.NullnessChecker Issue594.java > Out.txt 2>&1
+	diff  Expected.txt Out.txt
 
 clean:
 	rm -f Issue594.class Out.txt

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1907,10 +1907,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         String valueTypeString = valueType.toString();
         String varTypeString = varType.toString();
 
-        // If both types as strings are the same, try outputting
-        // the type including also invisible qualifiers.
-        // This usually means there is a mistake in type defaulting.
-        // This code is therefore not covered by a test.
+        // If both types as strings are the same, try printing verbosely.
         if (valueTypeString.equals(varTypeString)) {
             valueTypeString = valueType.toString(true);
             varTypeString = varType.toString(true);

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFormatter.java
@@ -21,11 +21,11 @@ public interface AnnotatedTypeFormatter {
     /**
      * Formats type into a String.
      * @param type the type to be converted
-     * @param printInvisibles whether or not to print invisible annotations
+     * @param printVerbose whether or not to print verbosely
      * @see org.checkerframework.framework.qual.InvisibleQualifier
      * @return a string representation of type
      */
     @SideEffectFree
-    public String format(AnnotatedTypeMirror type, boolean printInvisibles);
+    public String format(AnnotatedTypeMirror type, boolean printVerbose);
 
 }

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -727,8 +727,8 @@ public abstract class AnnotatedTypeMirror {
     }
 
     @SideEffectFree
-    public final String toString(boolean printInvisibles) {
-        return formatter.format(this, printInvisibles);
+    public final String toString(boolean verbose) {
+        return formatter.format(this, verbose);
 
     }
 

--- a/framework/src/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -77,7 +77,6 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
     @Override
     public String format(final AnnotatedTypeMirror type, final boolean printVerbose) {
         formattingVisitor.setVerboseSettings(printVerbose);
-        formattingVisitor.setVerboseSettings(printVerbose);
         return formattingVisitor.visit(type);
     }
 

--- a/framework/src/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -70,13 +70,14 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
 
     @Override
     public String format(final AnnotatedTypeMirror type) {
-        formattingVisitor.resetPrintInvisibles();
+        formattingVisitor.resetPrintVerboseSettings();
         return formattingVisitor.visit(type);
     }
 
     @Override
-    public String format(final AnnotatedTypeMirror type, final boolean printInvisibles) {
-        formattingVisitor.setCurrentPrintInvisibleSetting(printInvisibles);
+    public String format(final AnnotatedTypeMirror type, final boolean printVerbose) {
+        formattingVisitor.setVerboseSettings(printVerbose);
+        formattingVisitor.setVerboseSettings(printVerbose);
         return formattingVisitor.visit(type);
     }
 
@@ -104,31 +105,39 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         protected boolean currentPrintInvisibleSetting;
 
         /**
+         * Default value of currentPrintVerboseGenerics
+         */
+        protected final boolean defaultPrintVerboseGenerics;
+
+        /**
          * Prints type variables in a less ambiguous manner using [] to delimit them.
          * Always prints both bounds even if they lower bound is an AnnotatedNull type.
          */
-        protected boolean printVerboseGenerics;
+        protected boolean currentPrintVerboseGenerics;
 
         public FormattingVisitor(AnnotationFormatter annoFormatter, boolean printVerboseGenerics,
                                  boolean defaultInvisiblesSetting) {
             this.annoFormatter = annoFormatter;
-            this.printVerboseGenerics = printVerboseGenerics;
+            this.defaultPrintVerboseGenerics = printVerboseGenerics;
+            this.currentPrintVerboseGenerics = printVerboseGenerics;
             this.defaultInvisiblesSetting = defaultInvisiblesSetting;
             this.currentPrintInvisibleSetting = false;
         }
 
         /**
-         * Set the current print invisible setting to use while printing
+         * Set the current verbose settings to use while printing
          */
-        protected void setCurrentPrintInvisibleSetting(boolean printInvisibleSetting) {
-            this.currentPrintInvisibleSetting = printInvisibleSetting;
+        protected void setVerboseSettings(boolean printVerbose) {
+            this.currentPrintInvisibleSetting = printVerbose;
+            this.currentPrintVerboseGenerics = printVerbose;
         }
 
         /**
-         * Set currentPrintInvisibleSettings to the default
+         * Set verbose settings to the default
          */
-        protected void resetPrintInvisibles() {
+        protected void resetPrintVerboseSettings() {
             this.currentPrintInvisibleSetting = defaultInvisiblesSetting;
+            this.currentPrintVerboseGenerics = defaultPrintVerboseGenerics;
         }
 
         /** print to sb keyWord followed by field.  NULL types are substituted with
@@ -137,7 +146,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         @SideEffectFree
         protected void printBound(final String keyWord, final AnnotatedTypeMirror field,
                                   final Set<AnnotatedTypeMirror> visiting, final StringBuilder sb) {
-            if (!printVerboseGenerics && (field == null || field.getKind() == TypeKind.NULL)) {
+            if (!currentPrintVerboseGenerics && (field == null || field.getKind() == TypeKind.NULL)) {
                 return;
             }
 
@@ -312,12 +321,12 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
 
                 try {
                     visiting.add(type);
-                    if (printVerboseGenerics) {
+                    if (currentPrintVerboseGenerics) {
                         sb.append("[");
                     }
                     printBound("extends", type.getUpperBoundField(), visiting, sb);
                     printBound("super", type.getLowerBoundField(), visiting, sb);
-                    if (printVerboseGenerics) {
+                    if (currentPrintVerboseGenerics) {
                         sb.append("]");
                     }
 
@@ -356,12 +365,12 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
                 try {
                     visiting.add(type);
 
-                    if (printVerboseGenerics) {
+                    if (currentPrintVerboseGenerics) {
                         sb.append("[");
                     }
                     printBound("extends", type.getExtendsBoundField(), visiting, sb);
                     printBound("super", type.getSuperBoundField(), visiting, sb);
-                    if (printVerboseGenerics) {
+                    if (currentPrintVerboseGenerics) {
                         sb.append("]");
                     }
 

--- a/framework/src/org/checkerframework/qualframework/base/CheckerAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/CheckerAdapter.java
@@ -123,8 +123,8 @@ public class CheckerAdapter<Q> extends BaseTypeChecker {
         }
 
         @Override
-        public String format(AnnotatedTypeMirror type, boolean printInvisibles) {
-            return qualifiedTypeFormatter.format(getTypeMirrorConverter().getQualifiedType(type), printInvisibles);
+        public String format(AnnotatedTypeMirror type, boolean printVerbose) {
+            return qualifiedTypeFormatter.format(getTypeMirrorConverter().getQualifiedType(type), printVerbose);
         }
 
         @Override


### PR DESCRIPTION
Including printAllQualifiers and printVerboseGenerics.  This means that the
full generics information will be printed at assignment types incompatible when
the shorter toString does not differ between types. (This implements so of the
functionality discussed in #594, but not all.  In particular, https://github.com/typetools/checker-framework/issues/594#issuecomment-183120237 is not addressed.)