### PR TITLE
Fields in methods whose receiver is not fully initialized

### DIFF
--- a/checker/tests/nullness/Initializer.java
+++ b/checker/tests/nullness/Initializer.java
@@ -63,8 +63,7 @@ class Initializer {
 
     String f = "";
     void t1(@UnknownInitialization @Raw Initializer this) {
-        // this is potentially uninitialized, but the static type of f, as well as
-        // the initializer guarantee that it is initialized.
+        //:: error: (dereference.of.nullable)
         this.f.toString();
     }
 

--- a/checker/tests/nullness/Initializer.java
+++ b/checker/tests/nullness/Initializer.java
@@ -66,5 +66,24 @@ class Initializer {
         //:: error: (dereference.of.nullable)
         this.f.toString();
     }
+    String fieldF = "";
 
+}
+class SubInitializer extends Initializer {
+
+    String f = "";
+    void subt1(@UnknownInitialization(Initializer.class) @Raw(Initializer.class) SubInitializer this) {
+        fieldF.toString();
+        super.f.toString();
+        //:: error: (dereference.of.nullable)
+        this.f.toString();
+    }
+    void subt2(@UnknownInitialization @Raw SubInitializer this) {
+        //:: error: (dereference.of.nullable)
+        fieldF.toString();
+        //:: error: (dereference.of.nullable)
+        super.f.toString();
+        //:: error: (dereference.of.nullable)
+        this.f.toString();
+    }
 }

--- a/checker/tests/nullness/init/Issue779.java
+++ b/checker/tests/nullness/init/Issue779.java
@@ -1,0 +1,31 @@
+// Test case for Issue #779
+// https://github.com/typetools/checker-framework/issues/779
+import org.checkerframework.checker.initialization.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+class A {
+    Object g = new Object();
+
+    A() {
+        foo();
+    }
+
+    void foo(@Raw(A.class) @UnderInitialization(A.class) A this) {
+        System.out.println("foo A " + g.toString());
+    }
+}
+
+class B extends A {
+    Object f = new Object();
+
+    void foo(@Raw(A.class) @UnderInitialization(A.class) B this) {
+        //:: error: (dereference.of.nullable)
+        System.out.println("foo B " + this.f.toString());
+    }
+}
+
+public class Issue779{
+    public static void main(String[] args) {
+        new B();
+    }
+}

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -395,6 +395,11 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
 
         // add properties about fields (static information from type)
         boolean isNotFullyInitializedReceiver = isNotFullyInitializedReceiver(methodTree);
+        if (isNotFullyInitializedReceiver &&  !TreeUtils.isConstructor(methodTree)) {
+            // cannot add information about fields if the receiver isn't initialized
+            // and the method isn't a constructor
+            return;
+        }
         for (Tree member : classTree.getMembers()) {
             if (member instanceof VariableTree) {
                 VariableTree vt = (VariableTree) member;
@@ -409,9 +414,8 @@ public abstract class CFAbstractTransfer<V extends CFAbstractValue<V>,
                 }
                 V value = analysis.createAbstractValue(type);
                 if (value == null) continue;
-                if (isNotFullyInitializedReceiver) {
-                    // if we are in a constructor (or another method where
-                    // the receiver might not yet be fully initialized),
+                if (TreeUtils.isConstructor(methodTree)) {
+                    // if we are in a constructor,
                     // then we can still use the static type, but only
                     // if there is also an initializer that already does
                     // some initialization.


### PR DESCRIPTION
Fixes #779 

(I'm currently testing this with daikon and plume-lib.  This change could cause new errors in those code bases.)