### PR TITLE
using AppClassLoader to load Annotation classes of a checker.

### DIFF
--- a/checker/examples/fenum-extension/Makefile
+++ b/checker/examples/fenum-extension/Makefile
@@ -13,7 +13,7 @@ all: compile-for-test named-quals-test qual-folder-test clean
 demo:
 	$(JAVAC) $(JAVAOPTS) $(FILES)
 	@echo "***** This command is expected to produce 21 errors:"
-	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -AqualDirs=$(PROJECTDIR) Demo.java
+	$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -AqualDirs=$(PROJECTDIR) Demo.java
 
 # compile qualifiers
 compile-for-test:
@@ -21,13 +21,13 @@ compile-for-test:
 
 # test case for using externally defined qualifiers by explicitly naming them using the -Aquals option
 named-quals-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -Aquals=qual.MyFenum Demo.java > Out.txt 2>&1
+	-$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -Aquals=qual.MyFenum Demo.java > Out.txt 2>&1
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 
 # test case for using externally defined qualifiers by loading them from a directory using the -AqualDirs option
 qual-folder-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -AqualDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1
+	-$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.fenum.FenumChecker -AqualDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 

--- a/checker/examples/subtyping-extension/Makefile
+++ b/checker/examples/subtyping-extension/Makefile
@@ -14,7 +14,7 @@ all: compile-for-test named-quals-test qual-folder-test clean
 demo:
 	$(JAVAC) $(JAVAOPTS) $(FILES)
 	@echo "***** This command is expected to produce a warning on line 12 and an error on line 35:"
-	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -AqualDirs=$(PROJECTDIR) Demo.java
+	$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -AqualDirs=$(PROJECTDIR) Demo.java
 
 # compile qualifiers
 compile-for-test:
@@ -22,13 +22,13 @@ compile-for-test:
 
 # test case for using externally defined qualifiers by explicitly naming them using the -Aquals option
 named-quals-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -Aquals=qual.Encrypted,qual.PossiblyUnencrypted Demo.java > Out.txt 2>&1
+	-$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -Aquals=qual.Encrypted,qual.PossiblyUnencrypted Demo.java > Out.txt 2>&1
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 
 # test case for using externally defined qualifiers by loading them from a directory using the -AqualDirs option
 qual-folder-test:
-	-$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -AqualDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1
+	-$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.common.subtyping.SubtypingChecker -AqualDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 

--- a/checker/examples/units-extension/Makefile
+++ b/checker/examples/units-extension/Makefile
@@ -16,7 +16,7 @@ all: compile-for-test named-quals-test qual-folder-test clean
 demo:
 	$(JAVAC) $(JAVAOPTS) $(FILES)
 	@echo "***** This command is expected to produce errors on line 15 & 66:"
-	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java
+	$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java
 
 # compile qualifiers
 compile-for-test:
@@ -24,13 +24,13 @@ compile-for-test:
 
 # test case for using externally defined units by explicitly naming them using the -Aunits option
 named-quals-test:
-	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -Aunits=qual.Hz,qual.kHz,qual.Frequency Demo.java > Out.txt 2>&1 || true
+	$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -Aunits=qual.Hz,qual.kHz,qual.Frequency Demo.java > Out.txt 2>&1 || true
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 
 # test case for using externally defined units by loading them from a directory using the -AunitsDirs option
 qual-folder-test:
-	$(JAVAC) -Xbootclasspath/p:$(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1 || true
+	$(JAVAC) -classpath $(PROJECTDIR) -AprintErrorStack -processor org.checkerframework.checker.units.UnitsChecker -AunitsDirs=$(PROJECTDIR) Demo.java > Out.txt 2>&1 || true
 	diff -u Expected.txt Out.txt
 	-rm Out.txt
 

--- a/checker/manual/fenum-checker.tex
+++ b/checker/manual/fenum-checker.tex
@@ -123,23 +123,17 @@ If you define your own annotation(s), provide the name(s) of the annotation(s)
 through the \code{-Aquals} option, using a comma-no-space-separated notation:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.checker.fenum.FenumChecker \ttbs
         -Aquals=\textit{myModule.qual.MyFenum} MyFile.java ...
 \end{alltt}
-
-The annotations listed in \code{-Aquals} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac bootclasspath)
-before you run the Fenum Checker with \code{javac}.  It
-is not sufficient to supply their source files on the command line.
 
 You can also provide the fully-qualified paths to a set of directories
 that contain the annotations through the \code{-AqualDirs} option,
 using a colon-no-space-separated notation. For example:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.checker.fenum.FenumChecker \ttbs
         -AqualDirs=\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} MyFile.java ...
 \end{alltt}

--- a/checker/manual/fenum-checker.tex
+++ b/checker/manual/fenum-checker.tex
@@ -128,7 +128,11 @@ through the \code{-Aquals} option, using a comma-no-space-separated notation:
         -Aquals=\textit{myModule.qual.MyFenum} MyFile.java ...
 \end{alltt}
 
-The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+The annotations listed in \code{-Aquals} must be accessible to
+the compiler during compilation in the classpath.  In other words, they must
+already be compiled (and, typically, be on the javac classpath)
+before you run the Subtyping Checker with \code{javac}.  It
+is not sufficient to supply their source files on the command line.
 
 You can also provide the fully-qualified paths to a set of directories
 that contain the annotations through the \code{-AqualDirs} option,

--- a/checker/manual/fenum-checker.tex
+++ b/checker/manual/fenum-checker.tex
@@ -131,7 +131,7 @@ through the \code{-Aquals} option, using a comma-no-space-separated notation:
 The annotations listed in \code{-Aquals} must be accessible to
 the compiler during compilation in the classpath.  In other words, they must
 already be compiled (and, typically, be on the javac classpath)
-before you run the Subtyping Checker with \code{javac}.  It
+before you run the Fenum Checker with \code{javac}.  It
 is not sufficient to supply their source files on the command line.
 
 You can also provide the fully-qualified paths to a set of directories

--- a/checker/manual/fenum-checker.tex
+++ b/checker/manual/fenum-checker.tex
@@ -128,6 +128,8 @@ through the \code{-Aquals} option, using a comma-no-space-separated notation:
         -Aquals=\textit{myModule.qual.MyFenum} MyFile.java ...
 \end{alltt}
 
+The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+
 You can also provide the fully-qualified paths to a set of directories
 that contain the annotations through the \code{-AqualDirs} option,
 using a colon-no-space-separated notation. For example:

--- a/checker/manual/subtyping-checker.tex
+++ b/checker/manual/subtyping-checker.tex
@@ -53,6 +53,8 @@ notation:
         -Aquals=\textit{myModule.qual.MyQual},\textit{myModule.qual.OtherQual} MyFile.java ...
 \end{alltt}
 
+The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+
 \item
 Provide the fully-qualified paths to a set of directories that contain the
 annotations in the custom type system through the \code{-AqualDirs} option,

--- a/checker/manual/subtyping-checker.tex
+++ b/checker/manual/subtyping-checker.tex
@@ -53,7 +53,11 @@ notation:
         -Aquals=\textit{myModule.qual.MyQual},\textit{myModule.qual.OtherQual} MyFile.java ...
 \end{alltt}
 
-The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+The annotations listed in \code{-Aquals} must be accessible to
+the compiler during compilation in the classpath.  In other words, they must
+already be compiled (and, typically, be on the javac classpath)
+before you run the Subtyping Checker with \code{javac}.  It
+is not sufficient to supply their source files on the command line.
 
 \item
 Provide the fully-qualified paths to a set of directories that contain the

--- a/checker/manual/subtyping-checker.tex
+++ b/checker/manual/subtyping-checker.tex
@@ -206,7 +206,7 @@ that contain the qualifiers using the \code{-AqualDirs} option, and add
 the directories to the boot classpath, for example:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.common.subtyping.SubtypingChecker \ttbs
         -AqualDirs=\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} YourProgram.java
 \end{alltt}

--- a/checker/manual/subtyping-checker.tex
+++ b/checker/manual/subtyping-checker.tex
@@ -48,16 +48,10 @@ type system through the \code{-Aquals} option, using a comma-no-space-separated
 notation:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.common.subtyping.SubtypingChecker \ttbs
         -Aquals=\textit{myModule.qual.MyQual},\textit{myModule.qual.OtherQual} MyFile.java ...
 \end{alltt}
-
-The annotations listed in \code{-Aquals} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac bootclasspath)
-before you run the Subtyping Checker with \code{javac}.  It
-is not sufficient to supply their source files on the command line.
 
 \item
 Provide the fully-qualified paths to a set of directories that contain the
@@ -65,7 +59,7 @@ annotations in the custom type system through the \code{-AqualDirs} option,
 using a colon-no-space-separated notation. For example:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.common.subtyping.SubtypingChecker \ttbs
         -AqualDirs=\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} MyFile.java
 \end{alltt}

--- a/checker/manual/units-checker.tex
+++ b/checker/manual/units-checker.tex
@@ -260,7 +260,11 @@ notation:
         -Aunits=\textit{myModule.qual.MyUnit},\textit{myModule.qual.MyOtherUnit} MyFile.java ...
 \end{alltt}
 
-The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+The annotations listed in \code{-Aquals} must be accessible to
+the compiler during compilation in the classpath.  In other words, they must
+already be compiled (and, typically, be on the javac classpath)
+before you run the Subtyping Checker with \code{javac}.  It
+is not sufficient to supply their source files on the command line.
 
 \item
 You can also provide the fully-qualified paths to a set of directories

--- a/checker/manual/units-checker.tex
+++ b/checker/manual/units-checker.tex
@@ -255,16 +255,10 @@ annotations through the \code{-Aunits} option, using a comma-no-space-separated
 notation:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.checker.units.UnitsChecker \ttbs
         -Aunits=\textit{myModule.qual.MyUnit},\textit{myModule.qual.MyOtherUnit} MyFile.java ...
 \end{alltt}
-
-The annotations listed in \code{-Aunits} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac bootclasspath)
-before you run the Units Checker with \code{javac}.  It
-is not sufficient to supply their source files on the command line.
 
 \item
 You can also provide the fully-qualified paths to a set of directories
@@ -272,7 +266,7 @@ that contain units qualifiers through the \code{-AunitsDirs} option,
 using a colon-no-space-separated notation. For example:
 
 \begin{alltt}
-  javac -Xbootclasspath/p:\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
+  javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
         -processor org.checkerframework.checker.units.UnitsChecker \ttbs
         -AunitsDirs=\textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} MyFile.java ...
 \end{alltt}

--- a/checker/manual/units-checker.tex
+++ b/checker/manual/units-checker.tex
@@ -263,7 +263,7 @@ notation:
 The annotations listed in \code{-Aquals} must be accessible to
 the compiler during compilation in the classpath.  In other words, they must
 already be compiled (and, typically, be on the javac classpath)
-before you run the Subtyping Checker with \code{javac}.  It
+before you run the Units Checker with \code{javac}.  It
 is not sufficient to supply their source files on the command line.
 
 \item

--- a/checker/manual/units-checker.tex
+++ b/checker/manual/units-checker.tex
@@ -260,7 +260,7 @@ notation:
         -Aunits=\textit{myModule.qual.MyUnit},\textit{myModule.qual.MyOtherUnit} MyFile.java ...
 \end{alltt}
 
-The annotations listed in \code{-Aquals} must be accessible to
+The annotations listed in \code{-Aunits} must be accessible to
 the compiler during compilation in the classpath.  In other words, they must
 already be compiled (and, typically, be on the javac classpath)
 before you run the Units Checker with \code{javac}.  It

--- a/checker/manual/units-checker.tex
+++ b/checker/manual/units-checker.tex
@@ -260,6 +260,8 @@ notation:
         -Aunits=\textit{myModule.qual.MyUnit},\textit{myModule.qual.MyOtherUnit} MyFile.java ...
 \end{alltt}
 
+The annotations listed in \code{-Aquals} must be accessible to the compiler during compilation in the classpath.  In other words, they must already be compiled (and, typically, be on the javac classpath) before you run the Subtyping Checker with \code{javac}. It is not sufficient to supply their source files on the command line.
+
 \item
 You can also provide the fully-qualified paths to a set of directories
 that contain units qualifiers through the \code{-AunitsDirs} option,

--- a/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -372,8 +372,8 @@ public class AnnotationClassLoader {
      * it has access to
      *
      * The classpaths will be obtained in the order of: 1) extension
-     * paths (from java.ext.dirs) 3) classpaths (set in CLASSPATH, or through
-     * -classpath and -cp) 4) paths accessible and examined by the classloader
+     * paths (from java.ext.dirs) 2) classpaths (set in CLASSPATH, or through
+     * -classpath and -cp) 3) paths accessible and examined by the classloader
      *
      * In each of these paths, the order of the paths as specified in the
      * command line options or environment variables will be the order returned

--- a/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -371,8 +371,7 @@ public class AnnotationClassLoader {
      * environment variables, and by examining the classloader to see what paths
      * it has access to
      *
-     * The classpaths will be obtained in the order of: 1) boot classpaths (set
-     * using -bootclasspath -Xbootclasspath or -J-Xbootclasspath) 2) extension
+     * The classpaths will be obtained in the order of: 1) extension
      * paths (from java.ext.dirs) 3) classpaths (set in CLASSPATH, or through
      * -classpath and -cp) 4) paths accessible and examined by the classloader
      *
@@ -384,9 +383,6 @@ public class AnnotationClassLoader {
      */
     private final Set<String> getClasspaths() {
         Set<String> paths = new LinkedHashSet<String>();
-
-        // add all paths in Xbootclasspath
-        paths.addAll(Arrays.asList(System.getProperty("sun.boot.class.path").split(":")));
 
         // add all extension paths
         paths.addAll(Arrays.asList(System.getProperty("java.ext.dirs").split(":")));

--- a/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -677,7 +677,7 @@ public class AnnotationClassLoader {
 
         try {
             // load the class
-            cls = Class.forName(fullyQualifiedClassName);
+            cls = Class.forName(fullyQualifiedClassName, true, getAppClassLoader());
         } catch (ClassNotFoundException e) {
             // do nothing: projects can have annotation class files and regular
             // source files located within the same directory, and as such when

--- a/framework/tests/annotationclassloader/Makefile
+++ b/framework/tests/annotationclassloader/Makefile
@@ -34,7 +34,8 @@ all: load-from-dir-test load-from-jar-test
 demo1:
 	@echo "***** This command is expected to produce an error on line 7:"
 	$(JAVAC) \
-	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) \
+	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR) \
+	-classpath $(PROJECTDIR) \
 	-processor org.checkerframework.common.aliasing.AliasingChecker \
 	-Anomsgtext \
 	-AprintErrorStack \
@@ -45,8 +46,9 @@ demo1:
 demo2:
 	@echo "***** This command is expected to produce an error on line 7:"
 	$(JAVAC) \
-	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) \
+	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR) \
 	-processor org.checkerframework.common.aliasing.AliasingChecker \
+	-classpath :$(PROJECTDIR) \
 	-Anomsgtext \
 	-AprintErrorStack \
 	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \
@@ -57,7 +59,8 @@ demo2:
 # loads from build directories
 load-from-dir-test:
 	-$(JAVAC) \
-	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR):$(PROJECTDIR) \
+	-J-Xbootclasspath/p:$(DATAFLOWBUILD):$(JAVACUTILBUILD):$(STUBPARSERBUILD):$(FRAMEWORKBUILD):$(JAVACJAR) \
+	-classpath $(PROJECTDIR) \
 	-processor org.checkerframework.common.aliasing.AliasingChecker \
 	-Anomsgtext \
 	-AprintErrorStack \
@@ -69,7 +72,8 @@ load-from-dir-test:
 # loads from framework.jar
 load-from-jar-test:
 	-$(JAVAC) \
-	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR):$(PROJECTDIR) \
+	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR) \
+	-classpath $(PROJECTDIR) \
 	-processor org.checkerframework.common.aliasing.AliasingChecker \
 	-Anomsgtext \
 	-AprintErrorStack \

--- a/framework/tests/annotationclassloader/Makefile
+++ b/framework/tests/annotationclassloader/Makefile
@@ -47,8 +47,8 @@ demo2:
 	@echo "***** This command is expected to produce an error on line 7:"
 	$(JAVAC) \
 	-J-Xbootclasspath/p:$(FRAMEWORKJAR):$(JAVACJAR) \
-	-processor org.checkerframework.common.aliasing.AliasingChecker \
 	-classpath :$(PROJECTDIR) \
+	-processor org.checkerframework.common.aliasing.AliasingChecker \
 	-Anomsgtext \
 	-AprintErrorStack \
 	-Astubs=$(PROJECTDIR)/../aliasing/stubfile.astub \


### PR DESCRIPTION
Previously, the `AnnotationClassLoader` using itself's ClassLoader (which is null, usually means will using the bootstrap class loader) to load annotation Classes, which means the annotation class files need to be set in bootstrap classpath.

This will cause problems when loading an external annotation class outside of CheckerFramework. Even with correct `fullyQualifiedClassName`, the previously code will still throw ClassNotFoundException.

I changed the code to using the class loader returned by `AnnotationClassLoader#getAppClassLoader()`.
( This `getAppClassLoader()` method will return current checker's ClassLoader or return `SystemClassLoader` if checker's ClassLoader is null. )


This change will let the Checker Framework correctly loads external checker's qualifier classes, either by `BaseTypeChecker`'s ClassLoader, or could allow external checker simply put it's class files in environment variable `CLASSPATH` (or `-classpath`), and then let `SystemClassLoader` load those classes.