### PR TITLE
AnnotatedArrayType should override clearAnnotations()

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1456,6 +1456,12 @@ public abstract class AnnotatedTypeMirror {
             return at;
 
         }
+
+        @Override
+        public void clearAnnotations() {
+            super.clearAnnotations();
+            componentType.clearAnnotations();
+        }
     }
 
     /**


### PR DESCRIPTION
clearAnnotations() doesn't work correctly for AnnotatedArrayType because it fails to clear annotations on the component type. The result is that when we try to extract annotations from an Element, we get extra (and incorrect) annotations on the resulting type.

To see a test case, look at the MethodTypeParameters test case (tests/glacier/MethodTypeParameters.java) in the Glacier repository (https://github.com/mcoblenz/Glacier). Without this change, the parameter to `asImmutableList` is inferred to be of an invalid type.

The same bug may exist for other subclasses of AnnotatedTypeMirror. For example, AnnotatedTypeVariable, which has lowerBound and upperBound fields, may also need to override clearAnnotations(). But I'm not confident enough to include those changes in this patch.