### PR TITLE
fix bug in DOTCFGVisualizer: visualise same store twice when input only have a regular store

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -353,7 +353,7 @@ public class DOTCFGVisualizer<A extends AbstractValue<A>,
         // split input representation to two lines
         this.sbStore.append("Before:");
         S thenStore = input.getThenStore();
-        if (thenStore == null) {
+        if (!input.containsTwoStores()) {
             S regularStore = input.getRegularStore();
             this.sbStore.append('[');
             visualizeStore(regularStore);


### PR DESCRIPTION
in `DOTCFGVisualizer#visualizeBlockTransferInput()`, when a transfer-input only have a regular store, the visualizer should visualise the regular store by the then-branch from line 356 to line 361 in file [DOTCFGVisualizer.java](https://github.com/typetools/checker-framework/blob/master/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java#L356).

However, in line 355, the variable `thenStore` never be null because [TransferInput#getThenStore()](https://github.com/typetools/checker-framework/blob/master/dataflow/src/org/checkerframework/dataflow/analysis/TransferInput.java#L185) always returns a non-null value. Thus, current code actually always using the else-branch to visualise stores of a transfer-input, which will cause the visualizer visualize the same store twice when the given input only have one regular store.

The correct if-condition in line 356 should use [TransferInput#containsTwoStores()](https://github.com/typetools/checker-framework/blob/master/dataflow/src/org/checkerframework/dataflow/analysis/TransferInput.java#L216).