### PR TITLE
infer-and-annotate.sh receives command-line options to insert-annotations-to-source

### DIFF
--- a/checker/bin/infer-and-annotate.sh
+++ b/checker/bin/infer-and-annotate.sh
@@ -10,12 +10,12 @@
 # be available from the $PATH.
 
 # This script receives as arguments:
-# 0. (Optional) command-line options to insert-annotations-to-source.
+# 0. Any number of cmd-line arguments to insert-annotations-to-source (optional).
 # 1. Processor's name (in any form recognized by CF's javac -processor argument).
 # 2. Classpath (target project's classpath).
 # 3. Any number of extra processor arguments to be passed to the checker.
-# 4. List of paths to .jaif files -- used as input (optional).
-# 5. List of paths to .java files in a program.
+# 4. Any number of paths to .jaif files -- used as input (optional).
+# 5. Any number of paths to .java files in a program.
 
 # Example of usage:
 # ./infer-and-annotate.sh "LockChecker,NullnessChecker" \
@@ -60,15 +60,14 @@ interactive=
 # such as -processorpath and -source, which are followed by a value.
 read_input() {
 
-    infer_and_annotate_args=""
+    # Collect command-line arguments that come before the preprocessor.
+    # Assumes that every command line argument starts with a hyphen.
+    insert_to_source_args=""
     for i in "$@"
     do
-        # Parsing command-line arguments that may come before the preprocessor.
-        # This function makes the assumption that every command line argument
-        # starts with a hyphen.
         case "$1" in
             -*)
-                infer_and_annotate_args="$infer_and_annotate_args $1"
+                insert_to_source_args="$insert_to_source_args $1"
                 shift
             ;;
             *)
@@ -146,7 +145,7 @@ infer_and_annotate() {
         if [ ! `find $WHOLE_PROGRAM_INFERENCE_DIR -prune -empty` ]
         then
             # Only insert annotations if there is at least one .jaif file.
-            insert-annotations-to-source $infer_and_annotate_args -i `find $WHOLE_PROGRAM_INFERENCE_DIR -name "*.jaif"` $java_files
+            insert-annotations-to-source $insert_to_source_args -i `find $WHOLE_PROGRAM_INFERENCE_DIR -name "*.jaif"` $java_files
         fi
         # Updates DIFF_JAIF variable.
         # diff returns exit-value 1 when there are differences between files.

--- a/checker/bin/infer-and-annotate.sh
+++ b/checker/bin/infer-and-annotate.sh
@@ -10,6 +10,7 @@
 # be available from the $PATH.
 
 # This script receives as arguments:
+# 0. (Optional) command-line options to insert-annotations-to-source.
 # 1. Processor's name (in any form recognized by CF's javac -processor argument).
 # 2. Classpath (target project's classpath).
 # 3. Any number of extra processor arguments to be passed to the checker.
@@ -58,6 +59,24 @@ interactive=
 # that every argument starts with a hyphen. It means one cannot pass arguments
 # such as -processorpath and -source, which are followed by a value.
 read_input() {
+
+    infer_and_annotate_args=""
+    for i in "$@"
+    do
+        # Parsing command-line arguments that may come before the preprocessor.
+        # This function makes the assumption that every command line argument
+        # starts with a hyphen.
+        case "$1" in
+            -*)
+                infer_and_annotate_args="$infer_and_annotate_args $1"
+                shift
+            ;;
+            *)
+                break
+            ;;
+        esac
+    done
+
     # First two arguments are processor and cp.
     processor=$1
     cp=$2
@@ -127,7 +146,7 @@ infer_and_annotate() {
         if [ ! `find $WHOLE_PROGRAM_INFERENCE_DIR -prune -empty` ]
         then
             # Only insert annotations if there is at least one .jaif file.
-            insert-annotations-to-source -i `find $WHOLE_PROGRAM_INFERENCE_DIR -name "*.jaif"` $java_files
+            insert-annotations-to-source $infer_and_annotate_args -i `find $WHOLE_PROGRAM_INFERENCE_DIR -name "*.jaif"` $java_files
         fi
         # Updates DIFF_JAIF variable.
         # diff returns exit-value 1 when there are differences between files.

--- a/checker/manual/inference.tex
+++ b/checker/manual/inference.tex
@@ -144,16 +144,17 @@ Its command-line arguments are:
 \end{sloppypar}
 
 \begin{enumerate}
-\item Optional: Command-line options to insert-annotations-to-source.
+\item Optional: Command-line arguments to
+  \href{https://types.cs.washington.edu/annotation-file-utilities/#insert-annotations-to-source}{\<insert-annotations-to-source>}.
 \item Processor's name.
 \item Target program's classpath.  This argument is required; pass "" if it
   is empty.
 \item Extra processor arguments which will be passed to the checker, if any.
   You may supply any number of such arguments, or none.  Each such argument
   must start with a hyphen.
-\item Optional: List of paths to \<.jaif> files used as input in the inference
+\item Optional: Paths to \<.jaif> files used as input in the inference
     process.
-\item List of paths to \<.java> files in the program.
+\item Paths to \<.java> files in the program.
 \end{enumerate}
 
 For example, to add annotations to the \<plume-lib> project:

--- a/checker/manual/inference.tex
+++ b/checker/manual/inference.tex
@@ -144,6 +144,7 @@ Its command-line arguments are:
 \end{sloppypar}
 
 \begin{enumerate}
+\item Optional: Command-line options to insert-annotations-to-source.
 \item Processor's name.
 \item Target program's classpath.  This argument is required; pass "" if it
   is empty.


### PR DESCRIPTION
This change allows the `infer-and-annotate.sh` to receive as argument flags that will be used when calling `insert-annotations-to-source`. One example of such flag is `-c`, which will insert annotations in comments. These flags are optional, and must come before the preprocessor when calling `infer-and-annotate.sh`. The manual and documentation of the script were updated to explain that.

Tests:
Manual verification running `infer-and-annotate.sh` using the NullnessChecker on plume-lib, with and without the `-c` argument.