### PR TITLE
Fix checker/bin-devel/javac by adding a processor path option.

### DIFF
--- a/checker/bin-devel/javac
+++ b/checker/bin-devel/javac
@@ -48,10 +48,15 @@ for i in "$@" ; do
    IFS="$saveIFS"
 done
 
+# TODO: pass only the qualifiers in .cp
+
 eval "java" \
-     "-DCheckerDevelMain.cp=${buildDirs} " \
+     "-DCheckerDevelMain.cp= " \
+     "-DCheckerDevelMain.pp=${buildDirs} " \
      "-DCheckerDevelMain.compile.bcp=${jdkPaths} " \
      "-DCheckerDevelMain.runtime.bcp=${ltBinDir} " \
      "-DCheckerDevelMain.binary=${binaryDir}" \
      "-classpath ${buildDirs} " \
-     "org.checkerframework.framework.util.CheckerDevelMain" "-AprintErrorStack" ${args}
+     "org.checkerframework.framework.util.CheckerDevelMain" \
+     "-AprintErrorStack" \
+     ${args}

--- a/framework/src/org/checkerframework/framework/util/CheckerDevelMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerDevelMain.java
@@ -10,6 +10,7 @@ public class CheckerDevelMain extends CheckerMain {
     private static final String PROP_PREFIX = "CheckerDevelMain";
     private static final String BINARY_PROP = PROP_PREFIX + ".binary";
     private static final String CP_PROP = PROP_PREFIX + ".cp";
+    private static final String PP_PROP = PROP_PREFIX + ".pp";
     private static final String COMPILE_BCP_PROP = PROP_PREFIX + ".compile.bcp";
     private static final String RUNTIME_BCP_PROP = PROP_PREFIX + ".runtime.bcp";
     private static final String VERBOSE_PROP = PROP_PREFIX + ".verbose";
@@ -17,6 +18,7 @@ public class CheckerDevelMain extends CheckerMain {
     public static void main(final String[] args) {
 
         final String cp = System.getProperty(CP_PROP);
+        final String pp = System.getProperty(PP_PROP);
         final String runtimeBcp = System.getProperty(RUNTIME_BCP_PROP);
         final String compileBcp = System.getProperty(COMPILE_BCP_PROP);
         final String binDir = System.getProperty(BINARY_PROP);
@@ -27,6 +29,8 @@ public class CheckerDevelMain extends CheckerMain {
                     "CheckerDevelMain:\n"
                             + "Prepended to classpath:     "
                             + cp
+                            + "Prepended to processor classpath:     "
+                            + pp
                             + "\n"
                             + "Prepended to compile bootclasspath: "
                             + compileBcp
@@ -45,6 +49,9 @@ public class CheckerDevelMain extends CheckerMain {
                         + "checker.jar, javac.jar, etc... are usually built";
 
         assert (cp != null) : CP_PROP + " must specify a path entry to prepend to the CLASSPATH";
+        assert (pp != null)
+                : PP_PROP + " must specify a path entry to prepend to the processor path";
+
         assert (runtimeBcp != null)
                 : RUNTIME_BCP_PROP
                         + " must specify a path entry to prepend to the Java bootclasspath when running Javac"; //TODO: Fix the assert messages
@@ -54,7 +61,9 @@ public class CheckerDevelMain extends CheckerMain {
 
         // The location that checker.jar would be in if we have built it
         final File checkersLoc = new File(binDir, "checker.jar");
-        final CheckerDevelMain program = new CheckerDevelMain(checkersLoc, args);
+        ArrayList<String> alargs = new ArrayList<>(args.length);
+        alargs.addAll(Arrays.asList(args));
+        final CheckerDevelMain program = new CheckerDevelMain(checkersLoc, alargs);
         final int exitStatus = program.invokeCompiler();
         System.exit(exitStatus);
     }
@@ -63,7 +72,7 @@ public class CheckerDevelMain extends CheckerMain {
      * Construct all the relevant file locations and java version given the path to this jar and
      * a set of directories in which to search for jars
      */
-    public CheckerDevelMain(File searchPath, String[] args) {
+    public CheckerDevelMain(File searchPath, List<String> args) {
         super(searchPath, args);
     }
 
@@ -76,11 +85,6 @@ public class CheckerDevelMain extends CheckerMain {
     }
 
     @Override
-    public void addMainToArgs(final List<String> args) {
-        args.add("com.sun.tools.javac.Main");
-    }
-
-    @Override
     protected List<String> createCompilationBootclasspath(final List<String> argsList) {
         return prependPathOpts(COMPILE_BCP_PROP, super.createCompilationBootclasspath(argsList));
     }
@@ -88,6 +92,11 @@ public class CheckerDevelMain extends CheckerMain {
     @Override
     protected List<String> createCpOpts(final List<String> argsList) {
         return prependPathOpts(CP_PROP, super.createCpOpts(argsList));
+    }
+
+    @Override
+    protected List<String> createPpOpts(final List<String> argsList) {
+        return prependPathOpts(PP_PROP, super.createPpOpts(argsList));
     }
 
     private static List<String> prependPathOpts(

--- a/framework/src/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/org/checkerframework/framework/util/CheckerMain.java
@@ -56,7 +56,9 @@ public class CheckerMain {
      */
     public static void main(String[] args) {
         final File pathToThisJar = new File(findPathTo(CheckerMain.class, false));
-        final CheckerMain program = new CheckerMain(pathToThisJar, args);
+        ArrayList<String> alargs = new ArrayList<>(args.length);
+        alargs.addAll(Arrays.asList(args));
+        final CheckerMain program = new CheckerMain(pathToThisJar, alargs);
         final int exitStatus = program.invokeCompiler();
         System.exit(exitStatus);
     }
@@ -98,35 +100,29 @@ public class CheckerMain {
      * Construct all the relevant file locations and Java version given the path to this jar and
      * a set of directories in which to search for jars.
      */
-    public CheckerMain(final File checkerJar, final String[] args) {
+    public CheckerMain(final File checkerJar, final List<String> args) {
 
         this.checkerJar = checkerJar;
         final File searchPath = checkerJar.getParentFile();
         this.checkerQualJar = new File(searchPath, "checker-qual.jar");
 
-        final List<String> argsList = new ArrayList<String>(args.length);
-        for (String arg : args) {
-            argsList.add(arg.trim());
-        }
-
-        replaceShorthandProcessor(argsList);
-        argListFiles = collectArgFiles(argsList);
+        replaceShorthandProcessor(args);
+        argListFiles = collectArgFiles(args);
 
         this.javacJar =
-                extractFileArg(
-                        PluginUtil.JAVAC_PATH_OPT, new File(searchPath, "javac.jar"), argsList);
+                extractFileArg(PluginUtil.JAVAC_PATH_OPT, new File(searchPath, "javac.jar"), args);
 
         final String jdkJarName = PluginUtil.getJdkJarName();
         this.jdkJar =
-                extractFileArg(PluginUtil.JDK_PATH_OPT, new File(searchPath, jdkJarName), argsList);
+                extractFileArg(PluginUtil.JDK_PATH_OPT, new File(searchPath, jdkJarName), args);
 
-        this.compilationBootclasspath = createCompilationBootclasspath(argsList);
-        this.runtimeBootClasspath = createRuntimeBootclasspath(argsList);
-        this.jvmOpts = extractJvmOpts(argsList);
+        this.compilationBootclasspath = createCompilationBootclasspath(args);
+        this.runtimeBootClasspath = createRuntimeBootclasspath(args);
+        this.jvmOpts = extractJvmOpts(args);
 
-        this.cpOpts = createCpOpts(argsList);
-        this.ppOpts = createPpOpts(argsList);
-        this.toolOpts = argsList;
+        this.cpOpts = createCpOpts(args);
+        this.ppOpts = createPpOpts(args);
+        this.toolOpts = args;
 
         assertValidState();
     }


### PR DESCRIPTION
Small refactorings to use Lists instead of arrays.

 fixes the bin-devel/javac script by @wmdietl 