### PR TITLE
Revert "Run some downstream tests in Travis, so they are tested for pull requests"

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,18 +1,7 @@
 #!/bin/bash
 
-# Optional argument $1 is one of:
-#   all, junit, nonjunit, downstream, plume-lib-typecheck, misc
+# Optional argument $1 is one of:  junit, nonjunit, misc, downstream
 # If it is omitted, this script does everything.
-
-export GROUP=$1
-if [[ "${GROUP}" == "" ]]; then
-  export GROUP=all
-fi
-
-if [[ "${GROUP}" != "all" && "${GROUP}" != "misc" && "${GROUP}" != "junit" && "${GROUP}" != "nonjunit" && "${GROUP}" != "downstream" && "${GROUP}" != "plume-lib-typecheck" ]]; then
-  echo "Bad argument '${GROUP}'; should be omitted or one of: all, misc, junit, nonjunit, downstream, plume-lib-typecheck."
-  exit 1
-fi
 
 
 # Fail the whole script if any command fails
@@ -34,47 +23,7 @@ export SHELLOPTS
 # The above command builds the JDK, so there is no need for a subsequent
 # command to rebuild it again.
 
-if [[ "${GROUP}" == "junit" || "${GROUP}" == "all" ]]; then
-  (cd checker && ant junit-tests-nojtreg-nobuild)
-fi
-
-if [[ "${GROUP}" == "nonjunit" || "${GROUP}" == "all" ]]; then
-  (cd checker && ant nonjunit-tests-nojtreg-nobuild jtreg-tests)
-
-  # It's cheaper to run the demos test here than to trigger the
-  # checker-framework-demos job, which has to build the whole Checker Framework.
-  (cd checker && ant check-demos)
-fi
-
-if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
-  ## downstream tests:  projects that depend on the the Checker Framework.
-  ## These are here so they can be run by pull requests.  (Pull requests
-  ## currently don't trigger downstream jobs.)
-  ## Not done in the main "downstream" job:
-  ##  * plume-lib-typecheck (takes 30 minutes)
-  ## Not done in the Travis build, but triggered as a separate Travis project:
-  ##  * daikon-typecheck: (takes 2 hours)
-
-  # checker-framework-demos: 15 minutes
-  (cd .. && git clone --depth 1 https://github.com/typetools/checker-framework.demos.git)
-  (cd ../checker-framework.demos && ant -Djsr308.home=$ROOT)
-
-  # checker-framework-inference: 18 minutes
-  (cd .. && git clone --depth 1 https://github.com/typetools/checker-framework-inference.git)
-  (cd ../checker-framework-inference && gradle dist && gradle copytest && ant -f tests.xml run-tests)
-
-  # sparta: 1 minute, but the command is "true"!
-  (cd .. && git clone --depth 1 https://github.com/typetools/sparta.git)
-  (cd ../sparta && ant jar all-tests)
-fi
-
-if [[ "${GROUP}" == "plume-lib-typecheck" || "${GROUP}" == "all" ]]; then
-  (cd .. && git clone https://github.com/mernst/plume-lib.git)
-  export CHECKERFRAMEWORK=`pwd`
-  (cd ../plume-lib/java && make check-types)
-fi
-
-if [[ "${GROUP}" == "misc" || "${GROUP}" == "all" ]]; then
+if [[ "$1" != "junit" && "$1" != "nonjunit" && "$1" != "downstream" ]]; then
   ## jdkany tests: miscellaneous tests that shouldn't depend on JDK version.
   ## (Maybe they don't even need the full ./.travis-build-without-test.sh ;
   ## for example they currently don't need the annotated JDK.)
@@ -86,4 +35,30 @@ if [[ "${GROUP}" == "misc" || "${GROUP}" == "all" ]]; then
   # Documentation
   ant javadoc-private
   make -C checker/manual all
+fi
+
+if [[ "$1" != "nonjunit" && "$1" != "misc" && "$1" != "downstream" ]]; then
+  (cd checker && ant junit-tests-nojtreg-nobuild)
+fi
+
+if [[ "$1" != "junit" && "$1" != "misc" && "$1" != "downstream" ]]; then
+  (cd checker && ant nonjunit-tests-nojtreg-nobuild jtreg-tests)
+
+  # It's cheaper to run the demos test here than to trigger the
+  # checker-framework-demos job, which has to build the whole Checker Framework.
+  (cd checker && ant check-demos)
+fi
+
+if [[ "$1" != "junit" && "$1" != "nonjunit" && "$1" != "misc" ]]; then
+  ## downstream tests:  projects that depend on the the Checker Framework.
+  ## These are here so they can be run by pull requests.  (Pull requests
+  ## currently don't trigger downstream jobs.)
+
+  # TODO
+  # checker-framework-demos: 15 minutes
+  # checker-framework-inference: 18 minutes
+  # daikon-typecheck: a long time, already split into multiple jobs
+  # plume-lib-typecheck: 30 minutes
+  # sparta: 1 minute, but the command is "true"!
+
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 
-# So the "node" program is installed
-language: javascript
+language: generic
 
 services:
   - docker
@@ -10,19 +9,15 @@ services:
 env:
   - JDKVER=jdk7 GROUP=junit
   - JDKVER=jdk7 GROUP=nonjunit
-  - JDKVER=jdk7 GROUP=downstream
-  - JDKVER=jdk7 GROUP=plume-lib-typecheck
   - JDKVER=jdk8 GROUP=junit
   - JDKVER=jdk8 GROUP=nonjunit
-  - JDKVER=jdk8 GROUP=downstream
-  - JDKVER=jdk8 GROUP=plume-lib-typecheck
   - JDKVER=jdkany GROUP=misc
 
 before_script:
 - docker pull mdernst/ubuntu-for-cf-$JDKVER
 
 script:
-- travis_wait 60 docker run mdernst/ubuntu-for-cf-$JDKVER /bin/sh -c "export JAVA_HOME=\`which javac|xargs readlink -f|xargs dirname|xargs dirname\` && git clone --quiet -b $TRAVIS_BRANCH --depth 3 https://github.com/$TRAVIS_REPO_SLUG.git checker-framework && cd checker-framework && java -version && javac -version && ./.travis-build.sh $GROUP"
+- docker run mdernst/ubuntu-for-cf-$JDKVER /bin/sh -c "export JAVA_HOME=\`which javac|xargs readlink -f|xargs dirname|xargs dirname\` && git clone --quiet -b $TRAVIS_BRANCH --depth 3 https://github.com/$TRAVIS_REPO_SLUG.git checker-framework && cd checker-framework && java -version && javac -version && ./.travis-build.sh $GROUP"
 
 after_script:
   - |

--- a/checker/bin-devel/Dockerfile-README
+++ b/checker/bin-devel/Dockerfile-README
@@ -16,25 +16,14 @@ or you can just remove some of them.
 # Create the Docker image, in an empty directory, and upload to Docker Hub.
 # Takes about 12 minutes for jdk7 or jdk8, about 1 hour for jdkany.
 alias create_upload_docker_image=' \
-  rm -rf dockerdir && \
   mkdir -p dockerdir && \
-  (cd dockerdir && \
+  cd dockerdir && \
   \cp -pf ../Dockerfile-$OS-$JDKVER Dockerfile && \
   docker build -t mdernst/$OS-for-$PROJECT-$JDKVER . && \
-  docker push mdernst/$OS-for-$PROJECT-$JDKVER) && \
+  docker push mdernst/$OS-for-$PROJECT-$JDKVER && \
+  cd .. && \
   rm -rf dockerdir'
 
-export OS=ubuntu   
-export JDKVER=jdk7   
-export PROJECT=cf 
-create_upload_docker_image
-
-export OS=ubuntu   
-export JDKVER=jdk8   
-export PROJECT=cf 
-create_upload_docker_image
-
-export OS=ubuntu   
-export JDKVER=jdkany 
-export PROJECT=cf 
-create_upload_docker_image
+OS=ubuntu   && JDKVER=jdk7   && PROJECT=cf && create_upload_docker_image
+OS=ubuntu   && JDKVER=jdk8   && PROJECT=cf && create_upload_docker_image
+OS=ubuntu   && JDKVER=jdkany && PROJECT=cf && create_upload_docker_image

--- a/checker/bin-devel/Dockerfile-jdk7
+++ b/checker/bin-devel/Dockerfile-jdk7
@@ -1,5 +1,5 @@
 # Create a Docker image that is ready to run the main Checker Framework tests,
-# using JDK 8.
+# using JDK 7.
 
 FROM ubuntu
 MAINTAINER Michael Ernst <mernst@cs.washington.edu>
@@ -9,12 +9,15 @@ MAINTAINER Michael Ernst <mernst@cs.washington.edu>
 #  * Put "apt-get update" and "apt-get install" in the same RUN command.
 #  * Do not run "apt-get upgrade"; instead get upstream to update.
 RUN apt-get -qqy update && apt-get -qqy install \
+  software-properties-common \
+&& add-apt-repository ppa:openjdk-r/ppa \
+&& apt-get -qqy update && apt-get -qqy install \
   ant \
   git \
-  gradle \
   make \
   mercurial \
   unzip \
-  default-jdk \
+  openjdk-7-jdk \
+&& apt-get -qqy remove openjdk-8-jre-headless:amd64 \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

--- a/checker/bin-devel/Dockerfile-jdk8
+++ b/checker/bin-devel/Dockerfile-jdk8
@@ -1,5 +1,5 @@
 # Create a Docker image that is ready to run the main Checker Framework tests,
-# using JDK 7.
+# using JDK 8.
 
 FROM ubuntu
 MAINTAINER Michael Ernst <mernst@cs.washington.edu>
@@ -9,16 +9,11 @@ MAINTAINER Michael Ernst <mernst@cs.washington.edu>
 #  * Put "apt-get update" and "apt-get install" in the same RUN command.
 #  * Do not run "apt-get upgrade"; instead get upstream to update.
 RUN apt-get -qqy update && apt-get -qqy install \
-  software-properties-common \
-&& add-apt-repository ppa:openjdk-r/ppa \
-&& apt-get -qqy update && apt-get -qqy install \
   ant \
   git \
-  gradle \
   make \
   mercurial \
   unzip \
-  openjdk-7-jdk \
-&& apt-get -qqy remove openjdk-8-jre-headless:amd64 \
+  default-jdk \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

--- a/checker/bin-devel/Dockerfile-jdkany
+++ b/checker/bin-devel/Dockerfile-jdkany
@@ -16,7 +16,6 @@ RUN apt-get -qqy update && apt-get -qqy install \
 && apt-get -qqy update && apt-get -qqy install \
   ant \
   git \
-  gradle \
   make \
   mercurial \
   unzip \

--- a/checker/jdk/Makefile
+++ b/checker/jdk/Makefile
@@ -23,7 +23,7 @@ jdk.jar:
 # Helper
 
 # All class files that contain an annotation, by directory
-ANNOTATED_CLASSES_BY_DIR = $(shell find $(CHECKER_DIRS) -name '*.class' | sort)
+ANNOTATED_CLASSES_BY_DIR = $(shell find $(CHECKER_DIRS) -name '*.class')
 # All class files that contain some annotation, possibly with duplicates.
 # These, and only these, need to be extracted from $(CTSYM).
 ANNOTATED_CLASSES = \

--- a/checker/jdk/Makefile.jdk
+++ b/checker/jdk/Makefile.jdk
@@ -30,8 +30,8 @@ build: classes
 
 ############## Validate annotated jdk against missing methods ##############
 
-SOURCES = $(shell find src/java src/javax src/org -name '*.java' | sort)
-# CLASSES = $(shell find src/java src/javax src/org -name '*.class' | sort)
+SOURCES = $(shell find src/java src/javax src/org -name '*.java')
+# CLASSES = $(shell find src/java src/javax src/org -name '*.class')
 DIFFS = $(patsubst src/%.java,build/%.diff, $(SOURCES))
 
 .PHONY: classes
@@ -62,7 +62,7 @@ validate: classes $(DIFFS)
 # does not exist.  So long as the variables are not used on such a make
 # invocation, this doesn't cause a problem, but it is irritating (and a bit
 # sloppy).
-BUILD_CLASSES = $(shell find build/java build/javax build/org -name '*.class' | sort)
+BUILD_CLASSES = $(shell find build/java build/javax build/org -name '*.class')
 JAIFS = $(patsubst build/%.class,build/%.jaif, $(BUILD_CLASSES))
 ANNOTATED = $(patsubst build/%.class,annotated/%.class, $(BUILD_CLASSES))
 


### PR DESCRIPTION
Reverts typetools/checker-framework#859

The test don't seem to actually be running.  For example the JDK7 JUnit test only took 1 min 4 sec.  Also, the tests in pull request #754 [fail](https://travis-ci.org/typetools/checker-framework/builds/147208752) on the branch, but [pass](https://travis-ci.org/typetools/checker-framework/builds/147208769) when merged to master.  Revert this change until we can fix this.