### PR TITLE
Don't require checkers to be in a package (Fixes #854)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@ AnnotatedTypeFactory#createSupportedTypeQualifiers() must now return a mutable
 list.  Checkers that override this method will have to be changed.
 
 Closed issues:
-856, 850, 838, 829, 826, 824, 820, 810, 809, 805, 790, 681, 590, 384.
+856, 850, 845, 838, 829, 826, 824, 820, 810, 809, 805, 790, 681, 590, 384.
 
 ---------------------------------------------------------------------------
 

--- a/framework/jtreg/issue845/checker/NotInPackageChecker.java
+++ b/framework/jtreg/issue845/checker/NotInPackageChecker.java
@@ -1,0 +1,7 @@
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+/**
+ * Checker that is in the default package.  This tests for Issue 845
+ * https://github.com/typetools/checker-framework/issues/845
+ */
+public class NotInPackageChecker extends BaseTypeChecker {}

--- a/framework/jtreg/issue845/checker/qual/NotInPackageTop.java
+++ b/framework/jtreg/issue845/checker/qual/NotInPackageTop.java
@@ -1,0 +1,11 @@
+package qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
+public @interface NotInPackageTop {}

--- a/framework/jtreg/issue845/test/Test.java
+++ b/framework/jtreg/issue845/test/Test.java
@@ -1,0 +1,8 @@
+/*
+ * @test
+ * @summary Testing that a checker isn't required to be in a package. (Issue 845, https://github.com/typetools/checker-framework/issues/845)  The checker java files have to be in a seperate directory otherwise $CHECKERFRAMEWORK/framework/jtreg/checker/qual directory is on the classpath before the qual directory with the compiled classes.
+ *
+ * @compile -XDrawDiagnostics -Xlint:unchecked ../checker/NotInPackageChecker.java ../checker/qual/NotInPackageTop.java
+ * @compile -XDrawDiagnostics -Xlint:unchecked -processor NotInPackageChecker Test.java -proc:only -XDrawDiagnostics
+ */
+class Test {}

--- a/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -105,7 +105,10 @@ public class AnnotationClassLoader {
 
         // package name must use dots, this is later prepended to annotation
         // class names as we load the classes using the class loader
-        packageName = checker.getClass().getPackage().getName() + QUAL_PACKAGE_SUFFIX;
+        packageName =
+                checker.getClass().getPackage() != null
+                        ? checker.getClass().getPackage().getName() + QUAL_PACKAGE_SUFFIX
+                        : QUAL_PACKAGE_SUFFIX.substring(1);
 
         // the package name with dots replaced by slashes will be used to scan
         // file directories


### PR DESCRIPTION
(Fixes #854)