### PR TITLE
Fixes bug in getAnnotationInHierarchy involving @PolyAll

### DIFF
--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -84,7 +84,7 @@ import org.checkerframework.javacutil.TreeUtils;
 public class KeyForAnnotatedTypeFactory
         extends GenericAnnotatedTypeFactory<CFValue, CFStore, KeyForTransfer, KeyForAnalysis> {
 
-    protected final AnnotationMirror UNKNOWNKEYFOR, KEYFOR;
+    protected final AnnotationMirror UNKNOWNKEYFOR, KEYFOR, KEYFORBOTTOM;
 
     private final KeyForPropagator keyForPropagator;
     private final KeyForCanonicalizer keyForCanonicalizer = new KeyForCanonicalizer();
@@ -103,6 +103,7 @@ public class KeyForAnnotatedTypeFactory
 
         KEYFOR = AnnotationUtils.fromClass(elements, KeyFor.class);
         UNKNOWNKEYFOR = AnnotationUtils.fromClass(elements, UnknownKeyFor.class);
+        KEYFORBOTTOM = AnnotationUtils.fromClass(elements, KeyForBottom.class);
         keyForPropagator = new KeyForPropagator(UNKNOWNKEYFOR);
 
         // Add compatibility annotations:
@@ -761,32 +762,7 @@ public class KeyForAnnotatedTypeFactory
     private final class KeyForQualifierHierarchy extends GraphQualifierHierarchy {
 
         public KeyForQualifierHierarchy(MultiGraphFactory factory) {
-            super(factory, null);
-        }
-
-        @Override
-        public AnnotationMirror getPolymorphicAnnotation(AnnotationMirror start) {
-            AnnotationMirror top = getTopAnnotation(start);
-
-            if (AnnotationUtils.areSameIgnoringValues(top, UNKNOWNKEYFOR)) {
-                return null;
-            }
-
-            if (polyQualifiers.containsKey(top)) {
-                return polyQualifiers.get(top);
-            } else if (polyQualifiers.containsKey(polymorphicQualifier)) {
-                return polyQualifiers.get(polymorphicQualifier);
-            } else {
-                // No polymorphic qualifier exists for that hierarchy.
-                ErrorReporter.errorAbort(
-                        "GraphQualifierHierarchy: did not find the polymorphic qualifier corresponding to qualifier "
-                                + start
-                                + "; all polymorphic qualifiers: "
-                                + polyQualifiers
-                                + "; this: "
-                                + this);
-                return null;
-            }
+            super(factory, KEYFORBOTTOM);
         }
 
         /*

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -386,7 +386,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
                             !checker.getQualifierHierarchy().isSubtype(aOnVar,
-                                    upper.getAnnotationInHierarchy(aOnVar))) {
+                                    upper.findAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }
                 }
@@ -432,7 +432,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
                             !atypeFactory.getQualifierHierarchy().isSubtype(aOnVar,
-                                    upper.getAnnotationInHierarchy(aOnVar))) {
+                                    upper.findAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }
                 }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -326,8 +326,8 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
             Collection<AnnotationMirror> b) {
         Set<AnnotationMirror> result = AnnotationUtils.createAnnotationSet();
         for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
-            AnnotationMirror aAnno = qualHierarchy.findCorrespondingAnnotation(top, a);
-            AnnotationMirror bAnno = qualHierarchy.findCorrespondingAnnotation(top, b);
+            AnnotationMirror aAnno = qualHierarchy.getCorrespondingAnnotation(a, top);
+            AnnotationMirror bAnno = qualHierarchy.getCorrespondingAnnotation(b, top);
             assert aAnno != null : "Did not find an annotation for '" + top + "' in '" + a + "'.";
             assert bAnno != null : "Did not find an annotation for '" + top + "' in '" + b + "'.";
             if (qualHierarchy.isSubtype(aAnno, bAnno)) {

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -326,8 +326,8 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
             Collection<AnnotationMirror> b) {
         Set<AnnotationMirror> result = AnnotationUtils.createAnnotationSet();
         for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
-            AnnotationMirror aAnno = qualHierarchy.getCorrespondingAnnotation(a, top);
-            AnnotationMirror bAnno = qualHierarchy.getCorrespondingAnnotation(b, top);
+            AnnotationMirror aAnno = qualHierarchy.findAnnotationInSameHierarchy(a, top);
+            AnnotationMirror bAnno = qualHierarchy.findAnnotationInSameHierarchy(b, top);
             assert aAnno != null : "Did not find an annotation for '" + top + "' in '" + a + "'.";
             assert bAnno != null : "Did not find an annotation for '" + top + "' in '" + b + "'.";
             if (qualHierarchy.isSubtype(aAnno, bAnno)) {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -260,7 +260,7 @@ public abstract class AnnotatedTypeMirror {
         }
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
-            AnnotationMirror anno = qualHier.findCorrespondingAnnotation(aliased, annotations);
+            AnnotationMirror anno = qualHier.getCorrespondingAnnotation(annotations, aliased);
             if (anno != null) {
                 return anno;
             }
@@ -287,7 +287,7 @@ public abstract class AnnotatedTypeMirror {
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
             AnnotationMirror anno =
-                    qualHier.findCorrespondingAnnotation(aliased, getEffectiveAnnotations());
+                    qualHier.getCorrespondingAnnotation(getEffectiveAnnotations(), aliased);
             if (anno != null) {
                 return anno;
             }

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -260,7 +260,7 @@ public abstract class AnnotatedTypeMirror {
         }
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
-            AnnotationMirror anno = qualHier.getCorrespondingAnnotation(annotations, aliased);
+            AnnotationMirror anno = qualHier.findAnnotationInSameHierarchy(annotations, aliased);
             if (anno != null) {
                 return anno;
             }
@@ -287,7 +287,7 @@ public abstract class AnnotatedTypeMirror {
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
             AnnotationMirror anno =
-                    qualHier.getCorrespondingAnnotation(getEffectiveAnnotations(), aliased);
+                    qualHier.findAnnotationInSameHierarchy(getEffectiveAnnotations(), aliased);
             if (anno != null) {
                 return anno;
             }

--- a/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
@@ -80,7 +80,7 @@ class GeneralQualifierHierarchy extends MultiGraphQualifierHierarchy {
 
     // Never find a corresponding qualifier.
     @Override
-    public AnnotationMirror getCorrespondingAnnotation(
+    public AnnotationMirror findAnnotationInSameHierarchy(
             Collection<? extends AnnotationMirror> annotations, AnnotationMirror annotationMirror) {
         return null;
     }

--- a/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
@@ -80,8 +80,8 @@ class GeneralQualifierHierarchy extends MultiGraphQualifierHierarchy {
 
     // Never find a corresponding qualifier.
     @Override
-    public AnnotationMirror findCorrespondingAnnotation(
-            AnnotationMirror aliased, Collection<? extends AnnotationMirror> annotations) {
+    public AnnotationMirror getCorrespondingAnnotation(
+            Collection<? extends AnnotationMirror> annotations, AnnotationMirror annotationMirror) {
         return null;
     }
 

--- a/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -592,13 +592,13 @@ public abstract class QualifierHierarchy {
     }
 
     /**
-     * Returns the annotation in annos that is in the hierarchy of which annotationMirror is top
+     * Returns the annotation in annos that is in the hierarchy to which annotationMirror is top.
      *
      * If the annotation in the hierarchy is PolyAll, then the polymorphic qualifier in the
      * hierarchy is returned instead of PolyAll.
      *
      * @param annos set of annotations to search
-     * @param top annotation that is the top of hierarchy of which the returned annotation belongs
+     * @param top annotation that is the top of hierarchy to which the returned annotation belongs
      * @return annotation in the same hierarchy as annotationMirror or null if one is not found
      */
     public AnnotationMirror findAnnotationInHierarchy(

--- a/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -605,16 +605,16 @@ public abstract class QualifierHierarchy {
             Collection<? extends AnnotationMirror> annos, AnnotationMirror top) {
         boolean hasPolyAll = false;
         for (AnnotationMirror anno : annos) {
-            if (!isSubtype(anno, top)) {
-                continue;
-            } else if (!AnnotationUtils.areSameByClass(anno, PolyAll.class)) {
+            boolean isSubtype = isSubtype(anno, top);
+            if (isSubtype && AnnotationUtils.areSameByClass(anno, PolyAll.class)) {
+                // If the set contains @PolyAll, only return the polymorphic qualifier if annos
+                // contains no other annotation in the hierarchy.
+                hasPolyAll = true;
+            } else if (isSubtype) {
                 return anno;
             }
-            hasPolyAll = true;
         }
         if (hasPolyAll) {
-            // If the set contains @PolyAll, only return the polymorphic qualifier if annos
-            // contains no other annotation in the hierarchy.
             return getPolymorphicAnnotation(top);
         }
         return null;

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1140,7 +1140,7 @@ public class AnnotatedTypes {
                     lubAnnotatedType.clearAnnotations();
                     lubAnnotatedType.addAnnotations(type.getAnnotations());
                     for (AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
-                        AnnotationMirror o = otherType.getAnnotationInHierarchy(top);
+                        AnnotationMirror o = otherType.findAnnotationInHierarchy(top);
                         assert o != null : "null should have all annotations.";
                         if (AnnotationUtils.areSame(o,
                                 qualifierHierarchy.getBottomAnnotation(top))) {

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -384,8 +384,8 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
             Collection<? extends AnnotationMirror> rhs,
             Collection<? extends AnnotationMirror> lhs) {
         for (AnnotationMirror top : getTopAnnotations()) {
-            AnnotationMirror rhsForTop = getAnnotationInHierarchy(rhs, top);
-            AnnotationMirror lhsForTop = getAnnotationInHierarchy(lhs, top);
+            AnnotationMirror rhsForTop = findAnnotationInHierarchy(rhs, top);
+            AnnotationMirror lhsForTop = findAnnotationInHierarchy(lhs, top);
             if (!isSubtypeTypeVariable(rhsForTop, lhsForTop)) {
                 return false;
             }

--- a/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
@@ -88,7 +88,7 @@ class QualifierHierarchyAdapter<Q> {
         }
 
         @Override
-        public AnnotationMirror getAnnotationInHierarchy(
+        public AnnotationMirror findAnnotationInHierarchy(
                 Collection<? extends AnnotationMirror> annos, AnnotationMirror top) {
             for (AnnotationMirror anno : annos) {
                 if (converter.isKey(anno)) {

--- a/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
@@ -93,6 +93,8 @@ class QualifierHierarchyAdapter<Q> {
             for (AnnotationMirror anno : annos) {
                 if (converter.isKey(anno)) {
                     return anno;
+                } else if (annotationConverter.isAnnotationSupported(anno)) {
+                    return converter.getAnnotation(annotationConverter.fromAnnotations(annos));
                 }
             }
             return null;


### PR DESCRIPTION
QualifierHierarchy#getAnnotationInHierarchy used to return `@PolyAll` even if another annotation in that hierarchy is in the set.  

Also, renamed find findCorrespondingAnnotation to getCorrespondingAnnotation.  Though maybe getAnnotationInSameHierarchy would be better?

getCorrespondingAnnotation now calls getAnnotationInHierarchy rather than reimplementing the same functionality.  This uncovered a bug in QualifierHierarchyAdapter#getAnnotationInHierarchy which I fixed.