### PR TITLE
Revert "Fixes bug in getAnnotationInHierarchy involving @PolyAll"

### DIFF
--- a/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -84,7 +84,7 @@ import org.checkerframework.javacutil.TreeUtils;
 public class KeyForAnnotatedTypeFactory
         extends GenericAnnotatedTypeFactory<CFValue, CFStore, KeyForTransfer, KeyForAnalysis> {
 
-    protected final AnnotationMirror UNKNOWNKEYFOR, KEYFOR, KEYFORBOTTOM;
+    protected final AnnotationMirror UNKNOWNKEYFOR, KEYFOR;
 
     private final KeyForPropagator keyForPropagator;
     private final KeyForCanonicalizer keyForCanonicalizer = new KeyForCanonicalizer();
@@ -103,7 +103,6 @@ public class KeyForAnnotatedTypeFactory
 
         KEYFOR = AnnotationUtils.fromClass(elements, KeyFor.class);
         UNKNOWNKEYFOR = AnnotationUtils.fromClass(elements, UnknownKeyFor.class);
-        KEYFORBOTTOM = AnnotationUtils.fromClass(elements, KeyForBottom.class);
         keyForPropagator = new KeyForPropagator(UNKNOWNKEYFOR);
 
         // Add compatibility annotations:
@@ -762,7 +761,32 @@ public class KeyForAnnotatedTypeFactory
     private final class KeyForQualifierHierarchy extends GraphQualifierHierarchy {
 
         public KeyForQualifierHierarchy(MultiGraphFactory factory) {
-            super(factory, KEYFORBOTTOM);
+            super(factory, null);
+        }
+
+        @Override
+        public AnnotationMirror getPolymorphicAnnotation(AnnotationMirror start) {
+            AnnotationMirror top = getTopAnnotation(start);
+
+            if (AnnotationUtils.areSameIgnoringValues(top, UNKNOWNKEYFOR)) {
+                return null;
+            }
+
+            if (polyQualifiers.containsKey(top)) {
+                return polyQualifiers.get(top);
+            } else if (polyQualifiers.containsKey(polymorphicQualifier)) {
+                return polyQualifiers.get(polymorphicQualifier);
+            } else {
+                // No polymorphic qualifier exists for that hierarchy.
+                ErrorReporter.errorAbort(
+                        "GraphQualifierHierarchy: did not find the polymorphic qualifier corresponding to qualifier "
+                                + start
+                                + "; all polymorphic qualifiers: "
+                                + polyQualifiers
+                                + "; this: "
+                                + this);
+                return null;
+            }
         }
 
         /*

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeValidator.java
@@ -386,7 +386,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
                             !checker.getQualifierHierarchy().isSubtype(aOnVar,
-                                    upper.findAnnotationInHierarchy(aOnVar))) {
+                                    upper.getAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }
                 }
@@ -432,7 +432,7 @@ public class BaseTypeValidator extends AnnotatedTypeScanner<Void, Tree> implemen
                 for (AnnotationMirror aOnVar : onVar) {
                     if (upper.isAnnotatedInHierarchy(aOnVar) &&
                             !atypeFactory.getQualifierHierarchy().isSubtype(aOnVar,
-                                    upper.findAnnotationInHierarchy(aOnVar))) {
+                                    upper.getAnnotationInHierarchy(aOnVar))) {
                         this.reportError(type, tree);
                     }
                 }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -326,8 +326,8 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
             Collection<AnnotationMirror> b) {
         Set<AnnotationMirror> result = AnnotationUtils.createAnnotationSet();
         for (AnnotationMirror top : qualHierarchy.getTopAnnotations()) {
-            AnnotationMirror aAnno = qualHierarchy.findAnnotationInSameHierarchy(a, top);
-            AnnotationMirror bAnno = qualHierarchy.findAnnotationInSameHierarchy(b, top);
+            AnnotationMirror aAnno = qualHierarchy.findCorrespondingAnnotation(top, a);
+            AnnotationMirror bAnno = qualHierarchy.findCorrespondingAnnotation(top, b);
             assert aAnno != null : "Did not find an annotation for '" + top + "' in '" + a + "'.";
             assert bAnno != null : "Did not find an annotation for '" + top + "' in '" + b + "'.";
             if (qualHierarchy.isSubtype(aAnno, bAnno)) {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -260,7 +260,7 @@ public abstract class AnnotatedTypeMirror {
         }
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
-            AnnotationMirror anno = qualHier.findAnnotationInSameHierarchy(annotations, aliased);
+            AnnotationMirror anno = qualHier.findCorrespondingAnnotation(aliased, annotations);
             if (anno != null) {
                 return anno;
             }
@@ -287,7 +287,7 @@ public abstract class AnnotatedTypeMirror {
         if (atypeFactory.isSupportedQualifier(aliased)) {
             QualifierHierarchy qualHier = this.atypeFactory.getQualifierHierarchy();
             AnnotationMirror anno =
-                    qualHier.findAnnotationInSameHierarchy(getEffectiveAnnotations(), aliased);
+                    qualHier.findCorrespondingAnnotation(aliased, getEffectiveAnnotations());
             if (anno != null) {
                 return anno;
             }

--- a/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GeneralAnnotatedTypeFactory.java
@@ -80,8 +80,8 @@ class GeneralQualifierHierarchy extends MultiGraphQualifierHierarchy {
 
     // Never find a corresponding qualifier.
     @Override
-    public AnnotationMirror findAnnotationInSameHierarchy(
-            Collection<? extends AnnotationMirror> annotations, AnnotationMirror annotationMirror) {
+    public AnnotationMirror findCorrespondingAnnotation(
+            AnnotationMirror aliased, Collection<? extends AnnotationMirror> annotations) {
         return null;
     }
 

--- a/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/QualifierHierarchy.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
-import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ErrorReporter;
 
@@ -565,59 +564,35 @@ public abstract class QualifierHierarchy {
         }
     }
 
-    /**
-     *
-     * @deprecated use {@link #findAnnotationInSameHierarchy(Collection, AnnotationMirror)} instead
-     */
-    @Deprecated
     public AnnotationMirror findCorrespondingAnnotation(
             AnnotationMirror aliased, Collection<? extends AnnotationMirror> a) {
-        return findAnnotationInSameHierarchy(a, aliased);
-    }
-
-    /**
-     * Returns the annotation in annos that is in the same hierarchy as annotationMirror
-     *
-     * If the annotation in the hierarchy is PolyAll, then the polymorphic qualifier in the
-     * hierarchy is returned instead of PolyAll.
-     *
-     * @param annos set of annotations to search
-     * @param annotationMirror annotation that is in same hierarchy as the returned annotation
-     * @return annotation in the same hierarchy as annotationMirror or null if one is not found
-     */
-    public AnnotationMirror findAnnotationInSameHierarchy(
-            Collection<? extends AnnotationMirror> annos, AnnotationMirror annotationMirror) {
-        AnnotationMirror top = this.getTopAnnotation(annotationMirror);
-        return findAnnotationInHierarchy(annos, top);
-    }
-
-    /**
-     * Returns the annotation in annos that is in the hierarchy to which annotationMirror is top.
-     *
-     * If the annotation in the hierarchy is PolyAll, then the polymorphic qualifier in the
-     * hierarchy is returned instead of PolyAll.
-     *
-     * @param annos set of annotations to search
-     * @param top annotation that is the top of hierarchy to which the returned annotation belongs
-     * @return annotation in the same hierarchy as annotationMirror or null if one is not found
-     */
-    public AnnotationMirror findAnnotationInHierarchy(
-            Collection<? extends AnnotationMirror> annos, AnnotationMirror top) {
-        boolean hasPolyAll = false;
-        for (AnnotationMirror anno : annos) {
-            boolean isSubtype = isSubtype(anno, top);
-            if (isSubtype && AnnotationUtils.areSameByClass(anno, PolyAll.class)) {
-                // If the set contains @PolyAll, only return the polymorphic qualifier if annos
-                // contains no other annotation in the hierarchy.
-                hasPolyAll = true;
-            } else if (isSubtype) {
+        AnnotationMirror top = this.getTopAnnotation(aliased);
+        for (AnnotationMirror anno : a) {
+            if (this.isSubtype(anno, top)) {
                 return anno;
             }
         }
-        if (hasPolyAll) {
-            return getPolymorphicAnnotation(top);
-        }
         return null;
+    }
+
+    /**
+     * Returns the annotation from the hierarchy identified by its 'top' annotation
+     * from a set of annotations, using this QualifierHierarchy for subtype tests.
+     *
+     * @param annos
+     *            The set of annotations.
+     * @param top
+     *            The top annotation of the hierarchy to consider.
+     */
+    public AnnotationMirror getAnnotationInHierarchy(
+            Collection<? extends AnnotationMirror> annos, AnnotationMirror top) {
+        AnnotationMirror annoInHierarchy = null;
+        for (AnnotationMirror rhsAnno : annos) {
+            if (isSubtype(rhsAnno, top)) {
+                annoInHierarchy = rhsAnno;
+            }
+        }
+        return annoInHierarchy;
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1140,7 +1140,7 @@ public class AnnotatedTypes {
                     lubAnnotatedType.clearAnnotations();
                     lubAnnotatedType.addAnnotations(type.getAnnotations());
                     for (AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
-                        AnnotationMirror o = otherType.findAnnotationInHierarchy(top);
+                        AnnotationMirror o = otherType.getAnnotationInHierarchy(top);
                         assert o != null : "null should have all annotations.";
                         if (AnnotationUtils.areSame(o,
                                 qualifierHierarchy.getBottomAnnotation(top))) {

--- a/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -384,8 +384,8 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
             Collection<? extends AnnotationMirror> rhs,
             Collection<? extends AnnotationMirror> lhs) {
         for (AnnotationMirror top : getTopAnnotations()) {
-            AnnotationMirror rhsForTop = findAnnotationInHierarchy(rhs, top);
-            AnnotationMirror lhsForTop = findAnnotationInHierarchy(lhs, top);
+            AnnotationMirror rhsForTop = getAnnotationInHierarchy(rhs, top);
+            AnnotationMirror lhsForTop = getAnnotationInHierarchy(lhs, top);
             if (!isSubtypeTypeVariable(rhsForTop, lhsForTop)) {
                 return false;
             }

--- a/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
+++ b/framework/src/org/checkerframework/qualframework/base/QualifierHierarchyAdapter.java
@@ -88,13 +88,11 @@ class QualifierHierarchyAdapter<Q> {
         }
 
         @Override
-        public AnnotationMirror findAnnotationInHierarchy(
+        public AnnotationMirror getAnnotationInHierarchy(
                 Collection<? extends AnnotationMirror> annos, AnnotationMirror top) {
             for (AnnotationMirror anno : annos) {
                 if (converter.isKey(anno)) {
                     return anno;
-                } else if (annotationConverter.isAnnotationSupported(anno)) {
-                    return converter.getAnnotation(annotationConverter.fromAnnotations(annos));
                 }
             }
             return null;


### PR DESCRIPTION
Reverts typetools/checker-framework#869

(Caused daikon-typecheck failures http://tern.cs.washington.edu:8080/job/daikon-typecheck/jdk=JDK_7/1092/console) 