### PR TITLE
Revert "enable storing extends/implements in TypesIntoElements#store()"

### DIFF
--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -60,6 +60,12 @@ public class TypesIntoElements {
 
         storeTypeParameters(processingEnv, types, atypeFactory, tree.getTypeParameters(), csym);
 
+        /* TODO: storing extends/implements types results in
+         * a strange error e.g. from the Nullness Checker.
+         * I think somewhere we take the annotations on extends/implements as
+         * the receiver annotation on a constructor, breaking logic there.
+         * I assume that the problem is the default that we use for these locations.
+         * Once we've decided the defaulting, enable this.
         storeClassExtends(processingEnv, types, atypeFactory, tree.getExtendsClause(), csym, -1);
         {
             int implidx = 0;
@@ -68,6 +74,7 @@ public class TypesIntoElements {
                 ++implidx;
             }
         }
+        */
 
         for (Tree mem : tree.getMembers()) {
             if (mem.getKind() == Tree.Kind.METHOD) {
@@ -162,17 +169,7 @@ public class TypesIntoElements {
         addUniqueTypeCompounds(types, sym, tcs);
     }
 
-    /**
-     * Given a class symbol {@code cysm}, and the extendsClause/implementsClause tree {@code ext}
-     * of the corresponding class tree, store the type compounds on {@code ext} into {@code csym}.
-     * @param processingEnv
-     * @param types
-     * @param atypeFactory
-     * @param ext
-     * @param csym the given class symbol
-     * @param implidx the type index of extends/implements, see jsr308 specification:
-     *      http://types.cs.washington.edu/jsr308/specification/java-annotation-design.html#class-file%3Aext%3Ari%3Aextends
-     */
+    @SuppressWarnings("unused") // TODO: see usage in comments above
     private static void storeClassExtends(
             ProcessingEnvironment processingEnv,
             Types types,
@@ -184,15 +181,9 @@ public class TypesIntoElements {
         AnnotatedTypeMirror type;
         int pos;
         if (ext == null) {
-            Type superClass = csym.getSuperclass();
-            if (superClass.getKind() == TypeKind.NONE) {
-                // if superclass is NONE, then this class symbol is either
-                // an interface or it is java.lang.Object class itself.
-                // do nothing in both cases
-                return;
-            } else {
-                type = atypeFactory.fromElement(superClass.asElement());
-            }
+            // The implicit superclass is always java.lang.Object.
+            // TODO: is this a good way to get the type?
+            type = atypeFactory.fromElement(csym.getSuperclass().asElement());
             pos = -1;
         } else {
             type = atypeFactory.getAnnotatedTypeFromTypeTree(ext);

--- a/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -5,6 +5,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import java.util.List;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
 /**
@@ -23,14 +24,13 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
             List<AnnotatedTypeMirror.AnnotatedDeclaredType> supertypes,
             TypeElement subtypeElement) {
 
+        final boolean isInterface = subtypeElement.getSuperclass().getKind() == TypeKind.NONE;
+
+        final int typeOffset = isInterface ? 0 : -1;
+
         for (int i = 0; i < supertypes.size(); i++) {
             final AnnotatedTypeMirror supertype = supertypes.get(i);
-            // offset i by -1 since typeIndex should start from -1.
-            // -1 represents the supertype on (implicit) extends clause
-            // 0 or greater represents the supertype on (implicit) impelments clause
-            // details see jsr308 specification:
-            // http://types.cs.washington.edu/jsr308/specification/java-annotation-design.html#class-file%3Aext%3Ari%3Aextends
-            final int typeIndex = i - 1;
+            final int typeIndex = i + typeOffset;
 
             (new SuperTypeApplier(supertype, subtypeElement, typeIndex)).extractAndApply();
         }
@@ -81,11 +81,7 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
      */
     @Override
     public int getTypeCompoundIndex(Attribute.TypeCompound anno) {
-        int type_index = anno.getPosition().type_index;
-        // TODO: this is a temporary workaround of a bug in langtools
-        // https://bugs.openjdk.java.net/browse/JDK-8164519
-        // This workaround should be removed when the corresponding langtools bug is fixed.
-        return type_index == 0xffff ? -1 : type_index;
+        return anno.getPosition().type_index;
     }
 
     /**


### PR DESCRIPTION
Reverts typetools/checker-framework#876

Caused daikon-typecheck to fail with the Nullness Checker.   Here's a minimized example. 

````
import java.io.Serializable;
class Test implements Serializable {
}
````
````
class Other {
    void foo() {
        Test other = null;
    }
}
````
````
 javacheck -processor nullness Test.java Other.java
Other.java:3: error: [assignment.type.incompatible] incompatible types in assignment.
        Test other = null;
                     ^
  found   : null
  required: @Initialized @NonNull Test
1 error
````