### PR TITLE
Only support PolyAll by default if a polymorphic qualifier exists

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -805,13 +805,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *         none
      */
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return getBundledTypeQualifiersWithoutPolyAll();
+        return getBundledTypeQualifiersWithPolyAll();
     }
 
     /**
      * Loads all annotations contained in the qual directory of a checker via
-     * reflection, and adds {@link PolyAll} and an explicit array of annotations
-     * to the set of annotation classes.
+     * reflection, and adds {@link PolyAll}, if a polymorphic type qualifier exists,
+     * and an explicit array of annotations to the set of annotation classes.
      * <p>
      * This method can be called in the overridden versions of
      * {@link #createSupportedTypeQualifiers()} in each checker.
@@ -828,7 +828,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             Class<? extends Annotation>... explicitlyListedAnnotations) {
         Set<Class<? extends Annotation>> annotations =
                 loadTypeAnnotationsFromQualDir(explicitlyListedAnnotations);
-        annotations.add(PolyAll.class);
+        for (Class<? extends Annotation> annotationClass : annotations) {
+            if (annotationClass.getAnnotation(PolymorphicQualifier.class) != null) {
+                annotations.add(PolyAll.class);
+            }
+        }
         return annotations;
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -828,10 +828,15 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             Class<? extends Annotation>... explicitlyListedAnnotations) {
         Set<Class<? extends Annotation>> annotations =
                 loadTypeAnnotationsFromQualDir(explicitlyListedAnnotations);
+        boolean addPolyAll = false;
         for (Class<? extends Annotation> annotationClass : annotations) {
             if (annotationClass.getAnnotation(PolymorphicQualifier.class) != null) {
-                annotations.add(PolyAll.class);
+                addPolyAll = true;
+                break;
             }
+        }
+        if (addPolyAll) {
+            annotations.add(PolyAll.class);
         }
         return annotations;
     }

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -805,8 +805,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      *         none
      */
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        // by default support PolyAll
-        return getBundledTypeQualifiersWithPolyAll();
+        return getBundledTypeQualifiersWithoutPolyAll();
     }
 
     /**


### PR DESCRIPTION
This is consistent with document of `@PolyAll`
Fixes #883 