### PR TITLE
Only report the Constant Value Checker evaluation warns if command line option is used.

### DIFF
--- a/checker/manual/constant-value-checker.tex
+++ b/checker/manual/constant-value-checker.tex
@@ -150,7 +150,7 @@ would look similar to:
 
 \section{Warnings\label{value-checker-warnings}}
 
-The Constant Value Checker issues a warning if it cannot load and run, at
+If the option \code{-AreportEvalWarns} options is used, the Constant Value Checker issues a warning if it cannot load and run, at
 compile time, a method marked as \<@StaticallyExecutable>.  If it issues
 such a warning, then the return value of the method will be \<@UnknownVal>
 instead of being able to be resolved to a specific value annotation.

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -9,7 +9,6 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TypeCastTree;
-import com.sun.source.tree.UnaryTree;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,8 +31,6 @@ import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.common.value.qual.StaticallyExecutable;
 import org.checkerframework.common.value.qual.StringVal;
 import org.checkerframework.common.value.qual.UnknownVal;
-import org.checkerframework.common.value.util.NumberMath;
-import org.checkerframework.common.value.util.NumberUtils;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
@@ -73,11 +70,10 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     protected Set<String> coveredClassStrings;
 
     /** should this type factory report warnings? **/
-    private boolean reportWarnings = true;
+    private final boolean reportEvalWarnings;
 
     /** Helper class that evaluates statically executable methods, constructor, and fields.*/
-    private final ReflectiveEvalutator evalutator =
-            new ReflectiveEvalutator(checker, this, reportWarnings);
+    private final ReflectiveEvalutator evalutator;
 
     public ValueAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
@@ -104,18 +100,12 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         coveredClassStrings.add("short");
         coveredClassStrings.add("java.lang.Short");
         coveredClassStrings.add("byte[]");
+        reportEvalWarnings = checker.hasOption(ValueChecker.REPORT_EVAL_WARNS);
+        evalutator = new ReflectiveEvalutator(checker, this, reportEvalWarnings);
 
         if (this.getClass().equals(ValueAnnotatedTypeFactory.class)) {
             this.postInit();
         }
-    }
-
-    public void disableWarnings() {
-        reportWarnings = false;
-    }
-
-    public void enableWarnings() {
-        reportWarnings = true;
     }
 
     @Override

--- a/framework/src/org/checkerframework/common/value/ValueChecker.java
+++ b/framework/src/org/checkerframework/common/value/ValueChecker.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashSet;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.qual.StubFiles;
+import org.checkerframework.framework.source.SupportedOptions;
 
 /**
  * @author plvines
@@ -11,7 +12,9 @@ import org.checkerframework.framework.qual.StubFiles;
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
 @StubFiles("statically-executable.astub")
+@SupportedOptions(ValueChecker.REPORT_EVAL_WARNS)
 public class ValueChecker extends BaseTypeChecker {
+    public static final String REPORT_EVAL_WARNS = "reportEvalWarns";
 
     @Override
     protected BaseTypeVisitor<?> createSourceVisitor() {

--- a/framework/tests/src/tests/ValueTest.java
+++ b/framework/tests/src/tests/ValueTest.java
@@ -2,6 +2,7 @@ package tests;
 
 import java.io.File;
 import java.util.List;
+import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
 import org.junit.runners.Parameterized.Parameters;
 
@@ -23,7 +24,8 @@ public class ValueTest extends CheckerFrameworkPerDirectoryTest {
                 org.checkerframework.common.value.ValueChecker.class,
                 "value",
                 "-Anomsgtext",
-                "-Astubs=statically-executable.astub");
+                "-Astubs=statically-executable.astub",
+                "-A" + ValueChecker.REPORT_EVAL_WARNS);
     }
 
     @Parameters


### PR DESCRIPTION

Fixes #902