### PR TITLE
Fix lost @GuardedBy refinements

### DIFF
--- a/checker/src/org/checkerframework/checker/lock/LockStore.java
+++ b/checker/src/org/checkerframework/checker/lock/LockStore.java
@@ -113,9 +113,10 @@ public class LockStore extends CFAbstractStore<CFValue, LockStore> {
      */
     private CFValue changeLockAnnoToTop(Receiver r, CFValue currentValue) {
         if (currentValue == null) {
-            currentValue =
-                    analysis.createSingleAnnotationValue(
-                            atypeFactory.GUARDEDBYUNKNOWN, r.getType());
+            Set<AnnotationMirror> set = AnnotationUtils.createAnnotationSet();
+            set.add(atypeFactory.GUARDEDBYUNKNOWN);
+            set.add(atypeFactory.LOCKPOSSIBLYHELD);
+            return analysis.createAbstractValue(set, r.getType());
         }
 
         QualifierHierarchy hierarchy = atypeFactory.getQualifierHierarchy();

--- a/checker/src/org/checkerframework/checker/lock/LockStore.java
+++ b/checker/src/org/checkerframework/checker/lock/LockStore.java
@@ -192,16 +192,10 @@ public class LockStore extends CFAbstractStore<CFValue, LockStore> {
                 fieldValues.put(field, changeLockAnnoToTop(field, fieldValues.get(field)));
             }
 
-            // Local variables could also be unlocked if passed as an argument.
-            for (Node argument : n.getArguments()) {
-                Receiver arg = FlowExpressions.internalReprOf(atypeFactory, argument);
-                if (arg instanceof LocalVariable) {
-                    CFValue localValue = localVariableValues.get(arg);
-                    if (localValue != null) {
-                        localVariableValues.put(
-                                (LocalVariable) arg, changeLockAnnoToTop(arg, localValue));
-                    }
-                }
+            // Local variables could also be unlocked via an alias
+            for (LocalVariable var : new ArrayList<>(localVariableValues.keySet())) {
+                CFValue newValue = changeLockAnnoToTop(var, localVariableValues.get(var));
+                localVariableValues.put(var, newValue);
             }
         }
     }

--- a/checker/tests/lock/ChapterExamples.java
+++ b/checker/tests/lock/ChapterExamples.java
@@ -910,15 +910,9 @@ class ChapterExamples {
                 new ReentrantLock(); // rl2 is reassigned later - it is not effectively final
         rl1.lock();
         rl1.unlock();
-        // TODO: The two method.invocation.invalid errors below are due to the fact
-        // that unlock() called above is a non-side-effect-free method
-        // and is due to this line in LockStore.updateForMethodCall:
-        // localVariableValues.clear();
-        // Fix LockStore.updateForMethodCall so it is less conservative and remove
-        // the expected error.
-        //:: error: (lock.expression.not.final) :: error: (method.invocation.invalid)
+        //:: error: (lock.expression.not.final)
         rl2.lock();
-        //:: error: (lock.expression.not.final) :: error: (method.invocation.invalid)
+        //:: error: (lock.expression.not.final)
         rl2.unlock();
 
         rl2 =

--- a/checker/tests/lock/TestTreeKinds.java
+++ b/checker/tests/lock/TestTreeKinds.java
@@ -391,13 +391,6 @@ public class TestTreeKinds {
             foo.field.toString();
         }
 
-        // An error is raised here because non-side-effect-free method unlockTheLock() is called above,
-        // and is due to this line in LockStore.updateForMethodCall:
-        // localVariableValues.clear();
-        // which clears the value of 'r' in the store to its CLIMB-to-top default of @GuardedByUnknown.
-        // TODO: Fix LockStore.updateForMethodCall so it is less conservative and remove
-        // the expected error.
-        //:: error: (method.invocation.invalid)
         if (r.nextBoolean()) {
             lockTheLock();
             sideEffectFreeMethod();
@@ -409,14 +402,6 @@ public class TestTreeKinds {
             foo.field.toString();
         }
 
-        // An error is raised here because the non-side-effect-free methods unlockTheLock() and nonSideEffectFreeMethod() are called above
-        // (for the method.invocation.invalid error not to be issued, neither of those two methods can be called above),
-        // and is due to this line in LockStore.updateForMethodCall:
-        // localVariableValues.clear();
-        // which clears the value of 'r' in the store to its CLIMB-to-top default of @GuardedByUnknown.
-        // TODO: Fix LockStore.updateForMethodCall so it is less conservative and remove
-        // the expected error.
-        //:: error: (method.invocation.invalid)
         if (r.nextBoolean()) {
             lockTheLock();
             lockingFreeMethod();

--- a/checker/tests/lock/Update.java
+++ b/checker/tests/lock/Update.java
@@ -1,0 +1,12 @@
+import org.checkerframework.checker.lock.qual.GuardedBy;
+
+class Update {
+
+    void test() {
+        Object o1 = new Object();
+        @GuardedBy({}) Object o2 = o1;
+        synchronized (o1) {}
+        // o1 used to loss it refinement because of a bug.
+        @GuardedBy({}) Object o3 = o1;
+    }
+}


### PR DESCRIPTION
Fix Lock Checker bug where expressions lost there refinement in the @GuardedBy hierarchy if they became @LockPossiblyHeld.