### PR TITLE
The primary annotation on an intersection type is the GLB of the prim…

### DIFF
--- a/checker/tests/nullness/Issue868.java
+++ b/checker/tests/nullness/Issue868.java
@@ -1,6 +1,5 @@
 // Test case for Issue 868
 // https://github.com/typetools/checker-framework/issues/868
-// @skip-test
 
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;


### PR DESCRIPTION
The primary annotation on an intersection type is the GLB of the primary annotations of the bounds (a.k.a direct super types).  Calling addAnnotation on an annotated intersection type adds that annotation to any bound that does not have an annotation in that hierarchy. (Tested on daikon-typecheck)  

(More clean up of intersections is required in the rest of the code, but this must wait until LUB(#643) is corrected.)  

Fixes #868
