### PR TITLE
Add util method for obtaining class loader

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -28,6 +28,7 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AnnotationBuilder;
 import org.checkerframework.javacutil.ErrorReporter;
+import org.checkerframework.javacutil.InternalUtils;
 
 /*>>>
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -424,19 +425,7 @@ public class AnnotationClassLoader {
      *         classloader, or null if both are unavailable
      */
     private final /*@Nullable*/ ClassLoader getAppClassLoader() {
-        ClassLoader applicationClassLoader = checker.getClass().getClassLoader();
-
-        // see if we can access the application classloader
-        if (applicationClassLoader == null) {
-            // if the application classloader for the checker isn't available,
-            // then try to obtain the System application classloader
-            applicationClassLoader = ClassLoader.getSystemClassLoader();
-
-            // Debug use:
-            // processingEnv.getMessager().printMessage(Kind.NOTE, "Using System application class loader!");
-        }
-
-        return applicationClassLoader;
+        return InternalUtils.getClassLoaderForClass(checker.getClass());
     }
 
     /**
@@ -589,7 +578,7 @@ public class AnnotationClassLoader {
             final String annoName) {
         try {
             final Class<? extends Annotation> annoClass =
-                    Class.forName(annoName).asSubclass(Annotation.class);
+                    Class.forName(annoName, true, getAppClassLoader()).asSubclass(Annotation.class);
             return annoClass;
         } catch (ClassNotFoundException e) {
             checker.userErrorAbort(

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -576,7 +576,8 @@ public class AnnotationUtils {
             AnnotationMirror anno, CharSequence name, boolean useDefaults) {
         Name cn = getElementValueClassName(anno, name, useDefaults);
         try {
-            Class<?> cls = Class.forName(cn.toString());
+            ClassLoader classLoader = InternalUtils.getClassLoaderForClass(AnnotationUtils.class);
+            Class<?> cls = Class.forName(cn.toString(), true, classLoader);
             return cls;
         } catch (ClassNotFoundException e) {
             ErrorReporter.errorAbort(

--- a/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
@@ -416,4 +416,16 @@ public class InternalUtils {
     public static TypeElement getTypeElement(TypeMirror type) {
         return (TypeElement) ((Type) type).tsym;
     }
+
+    /**
+     * Obtain the class loader for {@code clazz}, if that is not available then the system class loader
+     * will be returned
+     * @param clazz
+     * @return the class loader used to {@code clazz}, or the system
+     *         class loader, or null if both are unavailable
+     */
+    public static ClassLoader getClassLoaderForClass(Class<? extends Object> clazz) {
+        ClassLoader classLoader = clazz.getClassLoader();
+        return classLoader == null ? ClassLoader.getSystemClassLoader() : classLoader;
+    }
 }


### PR DESCRIPTION
Add an util method for obtaining class loader for a class in `javacutil.InternalUtils`.

The logic is borrowed from `AnnotationClassLoader#getAppClassLoader()`:

"it will first try to obtain the class loader of the target class, if that is not available then it will try to obtain the system class loader."

Move this logic to `javacutil` could benefit checker-framework to have a unify mechanism of obtaining the class loader --- all place that might need support loading external classes should first get the `classloader` by calling this util method and then use `Class.forname(name, ..., classloader)` to load class.

We currently put this util method in `javacutil.InternalUtils` as it seems other place would be even more not suitable for this util method.

