### PR TITLE
Migrate off deprecated javac option 'attrParseOnly'

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/cfg/JavaSource2CFGDOT.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/JavaSource2CFGDOT.java
@@ -11,6 +11,7 @@ import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Options;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -234,8 +235,8 @@ public class JavaSource2CFGDOT {
                 };
 
         Context context = new Context();
+        Options.instance(context).put("compilePolicy", "ATTR_ONLY");
         JavaCompiler javac = new JavaCompiler(context);
-        javac.attrParseOnly = true;
         JavacFileManager fileManager = (JavacFileManager) context.get(JavaFileManager.class);
 
         JavaFileObject l =


### PR DESCRIPTION
The option was removed as part of JDK-8148808 [1][2]. Setting
`-XDcompilePolicy=ATTR_ONLY` provides equivalent behaviour.

[1] https://bugs.openjdk.java.net/browse/JDK-8148808
[2] http://hg.openjdk.java.net/jdk9/dev/langtools/rev/645b5debcb07