### PR TITLE
Refactor GenericAnnotatedTypeFactory methods to be more finegrained.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -425,7 +425,11 @@ public abstract class GenericAnnotatedTypeFactory<
     protected final QualifierDefaults createQualifierDefaults() {
         QualifierDefaults defs = new QualifierDefaults(elements, this);
         addCheckedCodeDefaults(defs);
+        addCheckedStandardDefaults(defs);
         addUncheckedCodeDefaults(defs);
+        addUncheckedStandardDefaults(defs);
+        checkForDefaultQualifierInHierarchy(defs);
+
         return defs;
     }
 
@@ -509,17 +513,15 @@ public abstract class GenericAnnotatedTypeFactory<
         AnnotationMirror unqualified = AnnotationUtils.fromClass(elements, Unqualified.class);
         if (!foundOtherwise && this.isSupportedQualifier(unqualified)) {
             defs.addCheckedCodeDefault(unqualified, TypeUseLocation.OTHERWISE);
-            foundOtherwise = true;
         }
+    }
 
-        if (!foundOtherwise) {
-            ErrorReporter.errorAbort(
-                    "GenericAnnotatedTypeFactory.createQualifierDefaults: "
-                            + "@DefaultQualifierInHierarchy or @DefaultFor(TypeUseLocation.OTHERWISE) not found. "
-                            + "Every checker must specify a default qualifier. "
-                            + getSortedQualifierNames());
-        }
-
+    /**
+     * Adds the standard CLIMB defaults that do not conflict with previously added defaults.
+     *
+     * @param defs {@link QualifierDefaults} object to which defaults are added
+     */
+    protected void addCheckedStandardDefaults(QualifierDefaults defs) {
         if (this.everUseFlow) {
             Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
             Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
@@ -564,9 +566,32 @@ public abstract class GenericAnnotatedTypeFactory<
                         AnnotationUtils.fromClass(elements, annotation), TypeUseLocation.OTHERWISE);
             }
         }
+    }
+
+    /**
+     * Adds standard unchecked defaults that do not conflict with previously added defaults.
+     *
+     * @param defs {@link QualifierDefaults} object to which defaults are added
+     */
+    protected void addUncheckedStandardDefaults(QualifierDefaults defs) {
         Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
         Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
         defs.addUncheckedStandardDefaults(tops, bottoms);
+    }
+
+    /**
+     * Check that a default qualifier (in at least one hierarchy) has been set and issue an error if not.
+     *
+     * @param defs {@link QualifierDefaults} object to which defaults are added
+     */
+    protected void checkForDefaultQualifierInHierarchy(QualifierDefaults defs) {
+        if (!defs.hasDefaultsForCheckedCode()) {
+            ErrorReporter.errorAbort(
+                    "GenericAnnotatedTypeFactory.createQualifierDefaults: "
+                            + "@DefaultQualifierInHierarchy or @DefaultFor(TypeUseLocation.OTHERWISE) not found. "
+                            + "Every checker must specify a default qualifier. "
+                            + getSortedQualifierNames());
+        }
 
         // Don't require @DefaultQualifierInHierarchyInUncheckedCode or an
         // unchecked default for TypeUseLocation.OTHERWISE.

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -199,6 +199,20 @@ public class QualifierDefaults {
     }
 
     /**
+     * Check that a default with TypeUseLocation OTHERWISE or ALL is specified.
+     *
+     * @return whether we found a Default with location OTHERWISE or ALL
+     */
+    public boolean hasDefaultsForCheckedCode() {
+        for (Default def : checkedCodeDefaults) {
+            if (def.location == TypeUseLocation.OTHERWISE || def.location == TypeUseLocation.ALL) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Add standard unchecked defaults that do not conflict with previously added defaults.
      * @param tops AnnotationMirrors that are top
      * @param bottoms AnnotationMirrors that are bottom


### PR DESCRIPTION
Also move check for qualifier defaults into separate method. The motivation for this is so that we can override `ensureDefaultsExist` in checker-framework-inference. We run into the error after removing Unqualified as a supported Type Qualifier but when dealing with inference we don't need a default.