### PR TITLE
Always pass -AprintErrorStack to test class.

### DIFF
--- a/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
+++ b/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
@@ -3,7 +3,6 @@ package org.checkerframework.framework.test;
 import static org.checkerframework.framework.test.TestConfigurationBuilder.buildDefaultConfiguration;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +59,10 @@ public abstract class CheckerFrameworkPerDirectoryTest {
     /**
      * Creates a new checker test.
      *
+     * <p>{@link TestConfigurationBuilder#getDefaultConfigurationBuilder(String, File, String,
+     * Iterable, Iterable, List, boolean)} adds additional checker options such as
+     * -AprintErrorStack.
+     *
      * @param checker the class for the checker to use
      * @param testDir the path to the directory of test inputs
      * @param checkerOptions options to pass to the compiler when running tests
@@ -72,9 +75,7 @@ public abstract class CheckerFrameworkPerDirectoryTest {
         this.testFiles = testFiles;
         this.checkerName = checker.getName();
         this.testDir = "tests" + File.separator + testDir;
-        this.checkerOptions = new ArrayList<>();
-        this.checkerOptions.addAll(Arrays.asList(checkerOptions));
-        this.checkerOptions.add("-AprintErrorStack");
+        this.checkerOptions = Arrays.asList(checkerOptions);
     }
 
     @Test

--- a/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
+++ b/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerDirectoryTest.java
@@ -3,6 +3,7 @@ package org.checkerframework.framework.test;
 import static org.checkerframework.framework.test.TestConfigurationBuilder.buildDefaultConfiguration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -71,7 +72,9 @@ public abstract class CheckerFrameworkPerDirectoryTest {
         this.testFiles = testFiles;
         this.checkerName = checker.getName();
         this.testDir = "tests" + File.separator + testDir;
-        this.checkerOptions = Arrays.asList(checkerOptions);
+        this.checkerOptions = new ArrayList<>();
+        this.checkerOptions.addAll(Arrays.asList(checkerOptions));
+        this.checkerOptions.add("-AprintErrorStack");
     }
 
     @Test

--- a/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerFileTest.java
+++ b/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerFileTest.java
@@ -3,6 +3,7 @@ package org.checkerframework.framework.test;
 import static org.checkerframework.framework.test.TestConfigurationBuilder.buildDefaultConfiguration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -75,7 +76,9 @@ public abstract class CheckerFrameworkPerFileTest {
         this.testFile = testFile;
         this.checkerName = checker.getName();
         this.testDir = "tests" + File.separator + testDir;
-        this.checkerOptions = Arrays.asList(checkerOptions);
+        this.checkerOptions = new ArrayList<>();
+        this.checkerOptions.addAll(Arrays.asList(checkerOptions));
+        this.checkerOptions.add("-AprintErrorStack");
     }
 
     @Test

--- a/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerFileTest.java
+++ b/framework/src/org/checkerframework/framework/test/CheckerFrameworkPerFileTest.java
@@ -3,7 +3,6 @@ package org.checkerframework.framework.test;
 import static org.checkerframework.framework.test.TestConfigurationBuilder.buildDefaultConfiguration;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -64,6 +63,10 @@ public abstract class CheckerFrameworkPerFileTest {
     /**
      * Creates a new checker test.
      *
+     * <p>{@link TestConfigurationBuilder#getDefaultConfigurationBuilder(String, File, String,
+     * Iterable, Iterable, List, boolean)} adds additional checker options such as
+     * -AprintErrorStack.
+     *
      * @param checker the class for the checker to use
      * @param testDir the path to the directory of test inputs
      * @param checkerOptions options to pass to the compiler when running tests
@@ -76,9 +79,7 @@ public abstract class CheckerFrameworkPerFileTest {
         this.testFile = testFile;
         this.checkerName = checker.getName();
         this.testDir = "tests" + File.separator + testDir;
-        this.checkerOptions = new ArrayList<>();
-        this.checkerOptions.addAll(Arrays.asList(checkerOptions));
-        this.checkerOptions.add("-AprintErrorStack");
+        this.checkerOptions = Arrays.asList(checkerOptions);
     }
 
     @Test

--- a/framework/src/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
+++ b/framework/src/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
@@ -179,7 +179,8 @@ public class TestDiagnosticUtils {
         String trimmed = original;
         String filename = "";
         if (noMsgText) {
-            if (!trimmed.contains("unexpected Throwable")) {
+            if (!trimmed.contains("unexpected Throwable")
+                    && !trimmed.contains("Compilation unit")) {
                 if (trimmed.contains("\n")) {
                     trimmed = trimmed.substring(0, trimmed.indexOf('\n'));
                 }

--- a/framework/src/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
+++ b/framework/src/org/checkerframework/framework/test/diagnostics/TestDiagnosticUtils.java
@@ -179,6 +179,8 @@ public class TestDiagnosticUtils {
         String trimmed = original;
         String filename = "";
         if (noMsgText) {
+            // Only keep the first line of the error or warning, unless it is a thrown exception
+            // "unexpected Throwable" or it is an Checker Error (contains "Compilation unit").
             if (!trimmed.contains("unexpected Throwable")
                     && !trimmed.contains("Compilation unit")) {
                 if (trimmed.contains("\n")) {


### PR DESCRIPTION
Also, print all lines of CheckerErrors, so that the error stack is printed.  For example:
```
 [junit] While type-checking /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Dataflow.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/FinalLocalVariables.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Initialization.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Issue367.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Issue403.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Issue436.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Issue572.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Issue953b.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/LambdaNullness.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Parameters.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/ParametersInBody.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Receivers.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Returns.java, /Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8/lambda/Shadowed.java
    [junit] junit.framework.AssertionFailedError: 47 out of 47 expected diagnostics were found.
    [junit] 1 unexpected diagnostic was found:
    [junit] :-1: other: error: AsSuperVisitor: type is not an erased subtype of supertype.
    [junit]   type: @Initialized @NonNull Object
    [junit]   superType: @Initialized @NonNull List<? extends @Initialized @Nullable Object>
    [junit]   Compilation unit: tests/nullness/java8/lambda/Issue953b.java
    [junit]   Exception: java.lang.Throwable; Stack trace: org.checkerframework.framework.source.SourceChecker.errorAbort(SourceChecker.java:721)
    [junit]   org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:41)
    [junit]   org.checkerframework.framework.type.AsSuperVisitor.errorTypeNotErasedSubtypeOfSuperType(AsSuperVisitor.java:142)
    [junit]   org.checkerframework.framework.type.AsSuperVisitor.visitDeclared_Declared(AsSuperVisitor.java:322)
    [junit]   org.checkerframework.framework.type.AsSuperVisitor.visitDeclared_Declared(AsSuperVisitor.java:29)
    [junit]   org.checkerframework.framework.util.AtmCombo.accept(AtmCombo.java:308)
    [junit]   org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor.visit(AbstractAtmComboVisitor.java:50)
    [junit]   org.checkerframework.framework.type.AsSuperVisitor.visit(AsSuperVisitor.java:76)
    [junit]   org.checkerframework.framework.type.AsSuperVisitor.asSuper(AsSuperVisitor.java:62)
    [junit]   org.checkerframework.framework.util.AnnotatedTypes.asSuper(AnnotatedTypes.java:131)
```
