### PR TITLE
Correct handling of uninferred type arguments

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -332,8 +332,8 @@ public class AnnotatedTypeCopier
                                 original.getUnderlyingType(),
                                 original.atypeFactory,
                                 original.isDeclaration());
-        if (original.isTypeArgHack()) {
-            copy.setTypeArgHack();
+        if (original.isUninferredTypeArgument()) {
+            copy.setUninferredTypeArgument();
         }
 
         maybeCopyPrimaryAnnotations(original, copy);

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3029,11 +3029,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * This method is a hack to use when a method type argument could not be inferred automatically
-     * or if a raw type is used. The only use should be:
+     * Returns a wildcard type to be used as a type argument when the correct type could not be
+     * inferred. The wildcard will be marked as an uninferred wildcard so that {@link
+     * AnnotatedWildcardType#isUninferredTypeArgument()} returns true.
+     *
+     * <p>This method should only be used for type argument inference or raw types:
      * org.checkerframework.framework.util.AnnotatedTypes.inferTypeArguments(ProcessingEnvironment,
      * AnnotatedTypeFactory, ExpressionTree, ExecutableElement)
      * org.checkerframework.framework.type.AnnotatedTypeFactory.fromTypeTree(Tree)
+     *
+     * @param typeVar TypeVariable which could not be inferred
+     * @return a wildcard that is marked as an uninferred type argument
      */
     public AnnotatedWildcardType getUninferredWildcardType(AnnotatedTypeVariable typeVar) {
         final boolean intersectionType;
@@ -3057,7 +3063,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         }
         wctype.setSuperBound(typeVar.getLowerBound().deepCopy());
         wctype.addAnnotations(typeVar.getAnnotations());
-        wctype.setTypeArgHack();
+        wctype.setUninferredTypeArgument();
         return wctype;
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3033,7 +3033,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * inferred. The wildcard will be marked as an uninferred wildcard so that {@link
      * AnnotatedWildcardType#isUninferredTypeArgument()} returns true.
      *
-     * <p>This method should only be used for type argument inference or raw types:
+     * <p>This method should only be used by type argument inference or for type arguments to raw
+     * types:
      * org.checkerframework.framework.util.AnnotatedTypes.inferTypeArguments(ProcessingEnvironment,
      * AnnotatedTypeFactory, ExpressionTree, ExecutableElement)
      * org.checkerframework.framework.type.AnnotatedTypeFactory.fromTypeTree(Tree)

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1990,7 +1990,7 @@ public abstract class AnnotatedTypeMirror {
                 type.addAnnotations(this.getAnnotationsField());
             }
 
-            type.typeArgHack = typeArgHack;
+            type.uninferredTypeArgument = uninferredTypeArgument;
 
             return type;
         }
@@ -2010,16 +2010,23 @@ public abstract class AnnotatedTypeMirror {
             return getExtendsBound().getErased();
         }
 
-        // Remove the typeArgHack once method type
+        // Remove the uninferredTypeArgument once method type
         // argument inference and raw type handling is improved.
-        private boolean typeArgHack = false;
+        private boolean uninferredTypeArgument = false;
 
-        /* package-scope */ void setTypeArgHack() {
-            typeArgHack = true;
+        /* package-scope */ void setUninferredTypeArgument() {
+            uninferredTypeArgument = true;
         }
 
-        /* package-scope */ boolean isTypeArgHack() {
-            return typeArgHack;
+        /**
+         * Returns whether or not this wildcard is a type argument for which inference failed to
+         * infer a type.
+         *
+         * @return Returns whether or not this wildcard is a type argument for which inference
+         *     failed
+         */
+        public boolean isUninferredTypeArgument() {
+            return uninferredTypeArgument;
         }
     }
 

--- a/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -31,8 +31,8 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     private final Types types;
     private final AnnotatedTypeFactory annotatedTypeFactory;
     /**
-     * If the type being visited is an uniferred type argument, then the underlying type may not
-     * have the correct relationship with the super type.*
+     * Whether or not the type being visited is an uninferred type argument. If true, then the
+     * underlying type may not have the correct relationship with the supertype.
      */
     private boolean isUninferredTypeAgrument = false;
 

--- a/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -30,6 +30,11 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
 
     private final Types types;
     private final AnnotatedTypeFactory annotatedTypeFactory;
+    /**
+     * If the type being visited is an uniferred type argument, then the underlying type may not
+     * have the correct relationship with the super type.*
+     */
+    private boolean isUninferredTypeAgrument = false;
 
     public AsSuperVisitor(AnnotatedTypeFactory annotatedTypeFactory) {
         this.annotatedTypeFactory = annotatedTypeFactory;
@@ -59,6 +64,7 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
         // parameters to asSuper are not changed and a copy is returned.
         AnnotatedTypeMirror copyType = type.deepCopy();
         AnnotatedTypeMirror copySuperType = superType.deepCopy();
+        reset();
         AnnotatedTypeMirror result = visit(copyType, copySuperType, null);
 
         if (result == null) {
@@ -67,6 +73,10 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
         }
 
         return (T) result;
+    }
+
+    private void reset() {
+        isUninferredTypeAgrument = false;
     }
 
     @Override
@@ -138,6 +148,9 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
         if (TypesUtils.isString(superType.getUnderlyingType())) {
             // Any type can be converted to a String
             return visit(annotatedTypeFactory.getStringType(type), superType, p);
+        }
+        if (isUninferredTypeAgrument) {
+            return copyPrimaryAnnos(type, superType);
         }
         ErrorReporter.errorAbort(
                 "AsSuperVisitor: type is not an erased subtype of supertype."
@@ -695,7 +708,12 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
 
     private AnnotatedTypeMirror visitWildcard_NotTypvarNorWildcard(
             AnnotatedWildcardType type, AnnotatedTypeMirror superType, Void p) {
+        boolean oldIsUninferredTypeArgument = isUninferredTypeAgrument;
+        if (type.isUninferredTypeArgument()) {
+            isUninferredTypeAgrument = true;
+        }
         AnnotatedTypeMirror asSuper = visit(type.getExtendsBound(), superType, p);
+        isUninferredTypeAgrument = oldIsUninferredTypeArgument;
         return copyPrimaryAnnos(type, asSuper);
     }
 
@@ -720,6 +738,10 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     @Override
     public AnnotatedTypeMirror visitWildcard_Typevar(
             AnnotatedWildcardType type, AnnotatedTypeVariable superType, Void p) {
+        boolean oldIsUninferredTypeArgument = isUninferredTypeAgrument;
+        if (type.isUninferredTypeArgument()) {
+            isUninferredTypeAgrument = true;
+        }
         AnnotatedTypeMirror upperBound =
                 visit(type.getExtendsBound(), superType.getUpperBound(), p);
         superType.setUpperBound(upperBound);
@@ -734,6 +756,7 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             lowerBound = asSuperTypevarLowerBound(type.getSuperBound(), superType, p);
         }
         superType.setLowerBound(lowerBound);
+        isUninferredTypeAgrument = oldIsUninferredTypeArgument;
 
         return copyPrimaryAnnos(type, superType);
     }
@@ -747,6 +770,10 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     @Override
     public AnnotatedTypeMirror visitWildcard_Wildcard(
             AnnotatedWildcardType type, AnnotatedWildcardType superType, Void p) {
+        boolean oldIsUninferredTypeArgument = isUninferredTypeAgrument;
+        if (type.isUninferredTypeArgument()) {
+            isUninferredTypeAgrument = true;
+        }
         AnnotatedTypeMirror upperBound =
                 visit(type.getExtendsBound(), superType.getExtendsBound(), p);
         superType.setExtendsBound(upperBound);
@@ -761,6 +788,7 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             lowerBound = asSuperWildcardLowerBound(type.getSuperBound(), superType, p);
         }
         superType.setSuperBound(lowerBound);
+        isUninferredTypeAgrument = oldIsUninferredTypeArgument;
 
         return copyPrimaryAnnos(type, superType);
     }

--- a/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -983,7 +983,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Visit
 
     protected boolean visitWildcardSupertype(
             AnnotatedTypeMirror subtype, AnnotatedWildcardType supertype, VisitHistory visited) {
-        if (supertype.isTypeArgHack()) { //TODO: REMOVE WHEN WE FIX TYPE ARG INFERENCE
+        if (supertype.isUninferredTypeArgument()) { //TODO: REMOVE WHEN WE FIX TYPE ARG INFERENCE
             return isSubtype(subtype, supertype.getExtendsBound());
         }
         return isSubtype(subtype, supertype.getSuperBound(), visited);

--- a/framework/src/org/checkerframework/framework/type/EqualityAtmComparer.java
+++ b/framework/src/org/checkerframework/framework/type/EqualityAtmComparer.java
@@ -6,8 +6,9 @@ import org.checkerframework.javacutil.AnnotationUtils;
 /**
  * Compares two annotated type mirrors for structural equality using only the primary annotations
  * and underlying types of the two input types and their component types. Note, this leaves out
- * other fields specific to some AnnotatedTypeMirrors (like directSuperTypes, wasRaw, isTypeArgHack
- * etc...). Ideally, both EqualityAtmComparer and HashcodeAtmVisitor would visit relevant fields.
+ * other fields specific to some AnnotatedTypeMirrors (like directSuperTypes, wasRaw,
+ * isUninferredTypeArgument etc...). Ideally, both EqualityAtmComparer and HashcodeAtmVisitor would
+ * visit relevant fields.
  *
  * <p>This class is used by AnnotatedTypeMirror#equals
  *

--- a/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
+++ b/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
@@ -622,6 +622,9 @@ public class QualifierPolymorphism {
         public Map<AnnotationMirror, Set<? extends AnnotationMirror>> visitWildcard(
                 AnnotatedWildcardType type, AnnotatedTypeMirror actualType) {
             AnnotatedTypeMirror typeSuper = AnnotatedTypes.asSuper(atypeFactory, type, actualType);
+            if (type.isUninferredTypeArgument()) {
+                return Collections.emptyMap();
+            }
             if (typeSuper.getKind() != TypeKind.WILDCARD) {
                 return visit(typeSuper, actualType);
             }

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -118,7 +118,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
         handleNullTypeArguments(
                 typeFactory, methodElem, methodType, argTypes, assignedTo, targets, inferredArgs);
 
-        handleUninferredTypeVariables(methodType, targets, inferredArgs);
+        handleUninferredTypeVariables(typeFactory, methodType, targets, inferredArgs);
 
         return inferredArgs;
     }
@@ -162,7 +162,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
                 if (withoutNullResult == null) {
                     // withoutNullResult is null when the only constraint on a type argument is
                     // where a method argument is null.
-                    withoutNullResult = atv.getUpperBound().deepCopy();
+                    withoutNullResult = typeFactory.getUninferredWildcardType(atv);
                 }
                 AnnotatedTypeMirror lub =
                         AnnotatedTypes.leastUpperBound(typeFactory, withoutNullResult, result);
@@ -710,6 +710,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
      * parameter.
      */
     private void handleUninferredTypeVariables(
+            AnnotatedTypeFactory typeFactory,
             AnnotatedExecutableType methodType,
             Set<TypeVariable> targets,
             Map<TypeVariable, AnnotatedTypeMirror> inferredArgs) {
@@ -719,8 +720,8 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             if (targets.contains(typeVar)) {
                 final AnnotatedTypeMirror inferredType = inferredArgs.get(typeVar);
                 if (inferredType == null) {
-                    AnnotatedTypeMirror dummy = atv.getUpperBound().deepCopy();
-                    inferredArgs.put(typeVar, dummy);
+                    AnnotatedTypeMirror dummy = typeFactory.getUninferredWildcardType(atv);
+                    inferredArgs.put(atv.getUnderlyingType(), dummy);
                 }
             }
         }

--- a/framework/tests/all-systems/Issue953.java
+++ b/framework/tests/all-systems/Issue953.java
@@ -13,6 +13,8 @@ class Issue953 {
     }
 
     public static void test(MyStream<Integer> y) {
+        // Type argument inference fails, so a checker may report a type checking error.
+        @SuppressWarnings("")
         List<Integer> counts = y.collect(toList());
     }
 

--- a/framework/tests/all-systems/Issue953.java
+++ b/framework/tests/all-systems/Issue953.java
@@ -1,6 +1,5 @@
 // Test case for issue 953
 // https://github.com/typetools/checker-framework/issues/953
-// @skip-test
 
 import java.util.List;
 


### PR DESCRIPTION
This pull request renames the field typeArgHack in AnnotatedWildcardType to isUninferredTypeArgument and documents it.  Also, it adds handling of uninferred type arguments to asSuper.  This fixes the first crash reported in #953.