### PR TITLE
Use AnnotationMirror sets and maps that don't use the equals method.

### DIFF
--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
@@ -59,10 +59,10 @@ public class AnnotationMirrorMap<V> implements Map<AnnotationMirror, V> {
     @Override
     public V get(Object key) {
         if (key instanceof AnnotationMirror) {
-            for (AnnotationMirror k : shadowMap.keySet()) {
-                if (AnnotationUtils.areSame(k, (AnnotationMirror) key)) {
-                    return shadowMap.get(k);
-                }
+            AnnotationMirror keyAnno =
+                    AnnotationUtils.getSame(shadowMap.keySet(), (AnnotationMirror) key);
+            if (keyAnno != null) {
+                return shadowMap.get(keyAnno);
             }
         }
         return null;
@@ -79,10 +79,10 @@ public class AnnotationMirrorMap<V> implements Map<AnnotationMirror, V> {
     @Override
     public V remove(Object key) {
         if (key instanceof AnnotationMirror) {
-            for (AnnotationMirror k : shadowMap.keySet()) {
-                if (AnnotationUtils.areSame(k, (AnnotationMirror) key)) {
-                    return shadowMap.remove(k);
-                }
+            AnnotationMirror keyAnno =
+                    AnnotationUtils.getSame(shadowMap.keySet(), (AnnotationMirror) key);
+            if (keyAnno != null) {
+                return shadowMap.remove(keyAnno);
             }
         }
         return null;

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
@@ -11,13 +11,13 @@ import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * The Map interface defines some of its methods with respect to the equals method. This
- * implementation of Map violates those specifications, but fulfills the same property using
- * AnnotationUtils.areSame.
+ * implementation of Map violates those specifications, but fulfills the same property using {@link
+ * AnnotationUtils#areSame}.
  *
  * <p>For example, the specification for the containsKey(Object key) method says: "returns true if
  * and only if this map contains a mapping for a key k such that (key == null ? k == null :
- * key.equals(k))." The specification for AnnotationMirrorMap is "returns true if and only if this
- * map contains a mapping for a key k such that (key == null ? k == null :
+ * key.equals(k))." The specification for {@link AnnotationMirrorMap#containsKey} is "returns true
+ * if and only if this map contains a mapping for a key k such that (key == null ? k == null :
  * AnnotationUtils.areSame(key, k))."
  *
  * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorMap.java
@@ -10,12 +10,18 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
- * Implements the Map interface where the keys to the map are AnnotationMirrors. This classes uses
- * {@link AnnotationUtils#areSame(AnnotationMirror, AnnotationMirror)} instead of {@link
- * AnnotationMirror#equals(Object)}.
+ * The Map interface defines some of its methods with respect to the equals method. This
+ * implementation of Map violates those specifications, but fulfills the same property using
+ * AnnotationUtils.areSame.
+ *
+ * <p>For example, the specification for the containsKey(Object key) method says: "returns true if
+ * and only if this map contains a mapping for a key k such that (key == null ? k == null :
+ * key.equals(k))." The specification for AnnotationMirrorMap is "returns true if and only if this
+ * map contains a mapping for a key k such that (key == null ? k == null :
+ * AnnotationUtils.areSame(key, k))."
  *
  * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
- * method; therefore, the existing implementations of Set cannot be used.
+ * method; therefore, existing implementations of Map cannot be used.
  */
 public class AnnotationMirrorMap<V> implements Map<AnnotationMirror, V> {
     private final Map<AnnotationMirror, V> shadowMap = new TreeMap<>(annotationOrdering());

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
@@ -11,17 +11,14 @@ import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * The Set interface defines many methods with respect to the equals method. This implementation of
- * Set violates those specifications, but fulfills the same property using AnnotationUtils.areSame
- * rather than equals.
+ * Set violates those specifications, but fulfills the same property using {@link
+ * AnnotationUtils#areSame} rather than equals.
  *
  * <p>For example, the specification for the contains(Object o) method says: "returns true if and
  * only if this collection contains at least one element e such that (o == null ? e == null : o
- * .equals(e))." The specification for AnnotationMirrorSet is returns true if and only if this
- * collection contains at least one element e such that (o == null ? e == null :
+ * .equals(e))." The specification for {@link AnnotationMirrorSet#contains} is "returns true if and
+ * only if this collection contains at least one element e such that (o == null ? e == null :
  * AnnotationUtils.areSame(o, e))".
- *
- * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
- * method; therefore, existing implementations of Map cannot be used.
  *
  * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
  * method; therefore, the existing implementations of Set cannot be used.

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
@@ -1,0 +1,139 @@
+package org.checkerframework.framework.util;
+
+import static org.checkerframework.javacutil.AnnotationUtils.annotationOrdering;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.javacutil.AnnotationUtils;
+
+/**
+ * Implements the Set interface for AnnotationMirrors that uses {@link
+ * AnnotationUtils#areSame(AnnotationMirror, AnnotationMirror)} instead of {@link
+ * AnnotationMirror#equals(Object)}.
+ *
+ * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
+ * method; therefore, the existing implementations of Set cannot be used.
+ */
+public class AnnotationMirrorSet implements Set<AnnotationMirror> {
+    private Set<AnnotationMirror> shadowSet = new TreeSet<>(annotationOrdering());
+
+    public AnnotationMirrorSet() {}
+
+    public AnnotationMirrorSet(Collection<? extends AnnotationMirror> values) {
+        this();
+        this.addAll(values);
+    }
+
+    @Override
+    public int size() {
+        return shadowSet.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return shadowSet.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return o instanceof AnnotationMirror
+                && AnnotationUtils.containsSame(shadowSet, (AnnotationMirror) o);
+    }
+
+    @Override
+    public Iterator<AnnotationMirror> iterator() {
+        return shadowSet.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return shadowSet.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return shadowSet.toArray(a);
+    }
+
+    @Override
+    public boolean add(AnnotationMirror annotationMirror) {
+        if (contains(annotationMirror)) {
+            return false;
+        }
+        shadowSet.add(annotationMirror);
+        return true;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        if (o instanceof AnnotationMirror) {
+            AnnotationMirror found = null;
+            for (AnnotationMirror am : shadowSet) {
+                if (AnnotationUtils.areSame(am, (AnnotationMirror) o)) {
+                    found = (AnnotationMirror) o;
+                }
+            }
+            return found != null && shadowSet.remove(found);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        for (Object a : c) {
+            if (a instanceof AnnotationMirror) {
+                if (!AnnotationUtils.containsSame(shadowSet, (AnnotationMirror) a)) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends AnnotationMirror> c) {
+        boolean result = true;
+        for (AnnotationMirror a : c) {
+            if (!add(a)) {
+                result = false;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        Set<AnnotationMirror> newSet = new TreeSet<>(annotationOrdering());
+        for (Object o : c) {
+            if (contains(o)) {
+                newSet.add((AnnotationMirror) o);
+            }
+        }
+        if (newSet.size() != shadowSet.size()) {
+            shadowSet = newSet;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean result = true;
+        for (Object a : c) {
+            if (!remove(a)) {
+                result = false;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void clear() {
+        shadowSet.clear();
+    }
+}

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
@@ -10,9 +10,18 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
- * Implements the Set interface for AnnotationMirrors that uses {@link
- * AnnotationUtils#areSame(AnnotationMirror, AnnotationMirror)} instead of {@link
- * AnnotationMirror#equals(Object)}.
+ * The Set interface defines many methods with respect to the equals method. This implementation of
+ * Set violates those specifications, but fulfills the same property using AnnotationUtils.areSame
+ * rather than equals.
+ *
+ * <p>For example, the specification for the contains(Object o) method says: "returns true if and
+ * only if this collection contains at least one element e such that (o == null ? e == null : o
+ * .equals(e))." The specification for AnnotationMirrorSet is returns true if and only if this
+ * collection contains at least one element e such that (o == null ? e == null :
+ * AnnotationUtils.areSame(o, e))".
+ *
+ * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
+ * method; therefore, existing implementations of Map cannot be used.
  *
  * <p>AnnotationMirror is an interface and not all implementing classes provide a correct equals
  * method; therefore, the existing implementations of Set cannot be used.

--- a/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotationMirrorSet.java
@@ -76,12 +76,7 @@ public class AnnotationMirrorSet implements Set<AnnotationMirror> {
     @Override
     public boolean remove(Object o) {
         if (o instanceof AnnotationMirror) {
-            AnnotationMirror found = null;
-            for (AnnotationMirror am : shadowSet) {
-                if (AnnotationUtils.areSame(am, (AnnotationMirror) o)) {
-                    found = (AnnotationMirror) o;
-                }
-            }
+            AnnotationMirror found = AnnotationUtils.getSame(shadowSet, (AnnotationMirror) o);
             return found != null && shadowSet.remove(found);
         }
         return false;
@@ -89,12 +84,8 @@ public class AnnotationMirrorSet implements Set<AnnotationMirror> {
 
     @Override
     public boolean containsAll(Collection<?> c) {
-        for (Object a : c) {
-            if (a instanceof AnnotationMirror) {
-                if (!AnnotationUtils.containsSame(shadowSet, (AnnotationMirror) a)) {
-                    return false;
-                }
-            } else {
+        for (Object o : c) {
+            if (!contains(o)) {
                 return false;
             }
         }

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -26,6 +26,7 @@ import org.checkerframework.framework.type.GeneralAnnotatedTypeFactory;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.TypeHierarchy;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.PluginUtil;
 import org.checkerframework.framework.util.typeinference.constraint.A2F;
 import org.checkerframework.framework.util.typeinference.constraint.A2FReducer;
@@ -418,7 +419,8 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             List<AnnotatedTypeVariable> targetDeclarations,
             AnnotatedTypeFactory typeFactory) {
         final QualifierHierarchy qualifierHierarchy = typeFactory.getQualifierHierarchy();
-        final Set<? extends AnnotationMirror> tops = qualifierHierarchy.getTopAnnotations();
+        final AnnotationMirrorSet tops =
+                new AnnotationMirrorSet(qualifierHierarchy.getTopAnnotations());
 
         for (AnnotatedTypeVariable targetDecl : targetDeclarations) {
             InferredValue inferred = fromArgSupertypes.get(targetDecl.getUnderlyingType());

--- a/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/GlbUtil.java
@@ -3,7 +3,6 @@ package org.checkerframework.framework.util.typeinference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -17,6 +16,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedNullType;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.TypeHierarchy;
+import org.checkerframework.framework.util.AnnotationMirrorMap;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
@@ -31,7 +32,7 @@ public class GlbUtil {
      *     annotations of typeMirrors
      */
     public static AnnotatedTypeMirror glbAll(
-            final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> typeMirrors,
+            final Map<AnnotatedTypeMirror, AnnotationMirrorSet> typeMirrors,
             final AnnotatedTypeFactory typeFactory) {
         final QualifierHierarchy qualifierHierarchy = typeFactory.getQualifierHierarchy();
         if (typeMirrors.isEmpty()) {
@@ -39,10 +40,9 @@ public class GlbUtil {
         }
 
         // dtermine the greatest lower bounds for the primary annotations
-        Map<AnnotationMirror, AnnotationMirror> glbPrimaries =
-                AnnotationUtils.createAnnotationMap();
-        for (Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> tmEntry : typeMirrors.entrySet()) {
-            final Set<AnnotationMirror> typeAnnoHierarchies = tmEntry.getValue();
+        AnnotationMirrorMap<AnnotationMirror> glbPrimaries = new AnnotationMirrorMap<>();
+        for (Entry<AnnotatedTypeMirror, AnnotationMirrorSet> tmEntry : typeMirrors.entrySet()) {
+            final AnnotationMirrorSet typeAnnoHierarchies = tmEntry.getValue();
             final AnnotatedTypeMirror type = tmEntry.getKey();
 
             for (AnnotationMirror top : typeAnnoHierarchies) {
@@ -63,7 +63,7 @@ public class GlbUtil {
         final List<AnnotatedTypeMirror> glbTypes = new ArrayList<>();
 
         // create a copy of all of the types and apply the glb primary annotation
-        final Set<AnnotationMirror> values = new HashSet<>(glbPrimaries.values());
+        final AnnotationMirrorSet values = new AnnotationMirrorSet(glbPrimaries.values());
         for (AnnotatedTypeMirror type : typeMirrors.keySet()) {
             if (type.getKind() != TypeKind.TYPEVAR
                     || !qualifierHierarchy.isSubtype(type.getEffectiveAnnotations(), values)) {

--- a/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -38,7 +38,8 @@ import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.TypeVariableSubstitutor;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
-import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.framework.util.AnnotationMirrorMap;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.TreeUtils;
@@ -311,9 +312,9 @@ public class TypeArgInferenceUtil {
      * Take a set of annotations and separate them into a mapping of ({@code hierarchy top &rArr;
      * annotations in hierarchy})
      */
-    public static Map<AnnotationMirror, AnnotationMirror> createHierarchyMap(
-            final Set<AnnotationMirror> annos, final QualifierHierarchy qualifierHierarchy) {
-        Map<AnnotationMirror, AnnotationMirror> result = AnnotationUtils.createAnnotationMap();
+    public static AnnotationMirrorMap<AnnotationMirror> createHierarchyMap(
+            final AnnotationMirrorSet annos, final QualifierHierarchy qualifierHierarchy) {
+        AnnotationMirrorMap<AnnotationMirror> result = new AnnotationMirrorMap<>();
 
         for (AnnotationMirror anno : annos) {
             result.put(qualifierHierarchy.getTopAnnotation(anno), anno);

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMap.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMap.java
@@ -1,18 +1,16 @@
 package org.checkerframework.framework.util.typeinference.solver;
 
-import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.typeinference.solver.TargetConstraints.Equalities;
 import org.checkerframework.framework.util.typeinference.solver.TargetConstraints.Subtypes;
 import org.checkerframework.framework.util.typeinference.solver.TargetConstraints.Supertypes;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * ConstraintMap holds simplified versions of the TUConstraints for ALL type variable for which we
@@ -64,11 +62,11 @@ public class ConstraintMap {
     public void addTargetEquality(
             final TypeVariable target,
             final TypeVariable equivalent,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         final Equalities equalities = targetToRecords.get(target).equalities;
-        final Set<AnnotationMirror> equivalentTops = equalities.targets.get(equivalent);
+        final AnnotationMirrorSet equivalentTops = equalities.targets.get(equivalent);
         if (equivalentTops == null) {
-            equalities.targets.put(equivalent, new HashSet<>(hierarchies));
+            equalities.targets.put(equivalent, new AnnotationMirrorSet(hierarchies));
         } else {
             equivalentTops.addAll(hierarchies);
         }
@@ -81,12 +79,12 @@ public class ConstraintMap {
     public void addPrimaryEqualities(
             final TypeVariable target,
             QualifierHierarchy qualHierarchy,
-            final Set<AnnotationMirror> annos) {
+            final AnnotationMirrorSet annos) {
         final Equalities equalities = targetToRecords.get(target).equalities;
 
         for (final AnnotationMirror anno : annos) {
             final AnnotationMirror top = qualHierarchy.getTopAnnotation(anno);
-            if (!AnnotationUtils.containsSame(equalities.primaries.keySet(), top)) {
+            if (!equalities.primaries.containsKey(top)) {
                 equalities.primaries.put(top, anno);
             }
         }
@@ -101,11 +99,11 @@ public class ConstraintMap {
     public void addTargetSupertype(
             final TypeVariable target,
             final TypeVariable subtype,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         final Supertypes supertypes = targetToRecords.get(target).supertypes;
-        final Set<AnnotationMirror> supertypeTops = supertypes.targets.get(subtype);
+        final AnnotationMirrorSet supertypeTops = supertypes.targets.get(subtype);
         if (supertypeTops == null) {
-            supertypes.targets.put(subtype, new HashSet<>(hierarchies));
+            supertypes.targets.put(subtype, new AnnotationMirrorSet(hierarchies));
         } else {
             supertypeTops.addAll(hierarchies);
         }
@@ -120,11 +118,11 @@ public class ConstraintMap {
     public void addTypeSupertype(
             final TypeVariable target,
             final AnnotatedTypeMirror subtype,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         final Supertypes supertypes = targetToRecords.get(target).supertypes;
-        final Set<AnnotationMirror> supertypeTops = supertypes.types.get(subtype);
+        final AnnotationMirrorSet supertypeTops = supertypes.types.get(subtype);
         if (supertypeTops == null) {
-            supertypes.types.put(subtype, new HashSet<>(hierarchies));
+            supertypes.types.put(subtype, new AnnotationMirrorSet(hierarchies));
         } else {
             supertypeTops.addAll(hierarchies);
         }
@@ -137,13 +135,13 @@ public class ConstraintMap {
     public void addPrimarySupertype(
             final TypeVariable target,
             QualifierHierarchy qualifierHierarchy,
-            final Set<AnnotationMirror> annos) {
+            final AnnotationMirrorSet annos) {
         final Supertypes supertypes = targetToRecords.get(target).supertypes;
         for (final AnnotationMirror anno : annos) {
             final AnnotationMirror top = qualifierHierarchy.getTopAnnotation(anno);
-            Set<AnnotationMirror> entries = supertypes.primaries.get(top);
+            AnnotationMirrorSet entries = supertypes.primaries.get(top);
             if (entries == null) {
-                entries = new LinkedHashSet<>();
+                entries = new AnnotationMirrorSet();
                 supertypes.primaries.put(top, entries);
             }
             entries.add(anno);
@@ -159,11 +157,11 @@ public class ConstraintMap {
     public void addTargetSubtype(
             final TypeVariable target,
             final TypeVariable supertype,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         final Subtypes subtypes = targetToRecords.get(target).subtypes;
-        final Set<AnnotationMirror> subtypesTops = subtypes.targets.get(supertype);
+        final AnnotationMirrorSet subtypesTops = subtypes.targets.get(supertype);
         if (subtypesTops == null) {
-            subtypes.targets.put(supertype, new HashSet<>(hierarchies));
+            subtypes.targets.put(supertype, new AnnotationMirrorSet(hierarchies));
         } else {
             subtypesTops.addAll(hierarchies);
         }
@@ -178,11 +176,11 @@ public class ConstraintMap {
     public void addTypeSubtype(
             final TypeVariable target,
             final AnnotatedTypeMirror supertype,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         final Subtypes subtypes = targetToRecords.get(target).subtypes;
-        final Set<AnnotationMirror> subtypesTops = subtypes.targets.get(supertype);
+        final AnnotationMirrorSet subtypesTops = subtypes.targets.get(supertype);
         if (subtypesTops == null) {
-            subtypes.types.put(supertype, new HashSet<>(hierarchies));
+            subtypes.types.put(supertype, new AnnotationMirrorSet(hierarchies));
         } else {
             subtypesTops.addAll(hierarchies);
         }
@@ -195,13 +193,13 @@ public class ConstraintMap {
     public void addPrimarySubtypes(
             final TypeVariable target,
             QualifierHierarchy qualifierHierarchy,
-            final Set<AnnotationMirror> annos) {
+            final AnnotationMirrorSet annos) {
         final Subtypes subtypes = targetToRecords.get(target).subtypes;
         for (final AnnotationMirror anno : annos) {
             final AnnotationMirror top = qualifierHierarchy.getTopAnnotation(anno);
-            Set<AnnotationMirror> entries = subtypes.primaries.get(top);
+            AnnotationMirrorSet entries = subtypes.primaries.get(top);
             if (entries == null) {
-                entries = new LinkedHashSet<>();
+                entries = new AnnotationMirrorSet();
                 subtypes.primaries.put(top, entries);
             }
             entries.add(anno);
@@ -214,11 +212,11 @@ public class ConstraintMap {
      * @param hierarchies a set of TOP annotations
      */
     public void addTypeEqualities(
-            TypeVariable target, AnnotatedTypeMirror type, Set<AnnotationMirror> hierarchies) {
+            TypeVariable target, AnnotatedTypeMirror type, AnnotationMirrorSet hierarchies) {
         final Equalities equalities = targetToRecords.get(target).equalities;
-        final Set<AnnotationMirror> equalityTops = equalities.types.get(type);
+        final AnnotationMirrorSet equalityTops = equalities.types.get(type);
         if (equalityTops == null) {
-            equalities.types.put(type, new HashSet<>(hierarchies));
+            equalities.types.put(type, new AnnotationMirrorSet(hierarchies));
         } else {
             equalityTops.addAll(hierarchies);
         }

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMapBuilder.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMapBuilder.java
@@ -1,6 +1,5 @@
 package org.checkerframework.framework.util.typeinference.solver;
 
-import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
@@ -9,6 +8,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.typeinference.constraint.TIsU;
 import org.checkerframework.framework.util.typeinference.constraint.TSuperU;
 import org.checkerframework.framework.util.typeinference.constraint.TUConstraint;
@@ -51,12 +51,13 @@ public class ConstraintMapBuilder {
             AnnotatedTypeFactory typeFactory) {
 
         final QualifierHierarchy qualifierHierarchy = typeFactory.getQualifierHierarchy();
-        final Set<? extends AnnotationMirror> tops = qualifierHierarchy.getTopAnnotations();
+        final AnnotationMirrorSet tops =
+                new AnnotationMirrorSet(qualifierHierarchy.getTopAnnotations());
         final ConstraintMap result = new ConstraintMap(targets);
 
-        final Set<AnnotationMirror> tAnnos = new LinkedHashSet<>();
-        final Set<AnnotationMirror> uAnnos = new LinkedHashSet<>();
-        final Set<AnnotationMirror> hierarchiesInRelation = new LinkedHashSet<>();
+        final AnnotationMirrorSet tAnnos = new AnnotationMirrorSet();
+        final AnnotationMirrorSet uAnnos = new AnnotationMirrorSet();
+        final AnnotationMirrorSet hierarchiesInRelation = new AnnotationMirrorSet();
 
         for (TUConstraint constraint : constraints) {
             tAnnos.clear();
@@ -153,7 +154,7 @@ public class ConstraintMapBuilder {
             TypeVariable typeU,
             ConstraintMap result,
             TUConstraint constraint,
-            Set<AnnotationMirror> hierarchiesInRelation) {
+            AnnotationMirrorSet hierarchiesInRelation) {
         if (constraint instanceof TIsU) {
             result.addTargetEquality(typeT, typeU, hierarchiesInRelation);
         } else if (constraint instanceof TSuperU) {
@@ -167,7 +168,7 @@ public class ConstraintMapBuilder {
             TypeVariable typeVariable,
             TUConstraint constraint,
             ConstraintMap result,
-            Set<AnnotationMirror> annotationMirrors,
+            AnnotationMirrorSet annotationMirrors,
             QualifierHierarchy qualifierHierarchy) {
         if (constraint instanceof TIsU) {
             result.addPrimaryEqualities(typeVariable, qualifierHierarchy, annotationMirrors);
@@ -183,7 +184,7 @@ public class ConstraintMapBuilder {
             AnnotatedTypeMirror type,
             ConstraintMap result,
             TUConstraint constraint,
-            Set<AnnotationMirror> hierarchies) {
+            AnnotationMirrorSet hierarchies) {
         if (constraint instanceof TIsU) {
             result.addTypeEqualities(target, type, hierarchies);
         } else if (constraint instanceof TSuperU) {

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/InferenceResult.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/InferenceResult.java
@@ -138,7 +138,7 @@ public class InferenceResult extends LinkedHashMap<TypeVariable, InferredValue> 
                 final InferredValue subValue = subordinate.get(target);
                 if (subValue != null && subValue instanceof InferredType) {
                     this.put(target, subValue);
-                    return newType;
+                    return null;
                 }
             } else {
                 if (newType.type.getKind() == TypeKind.NULL) {

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/InferredValue.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/InferredValue.java
@@ -1,11 +1,10 @@
 package org.checkerframework.framework.util.typeinference.solver;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 
 /**
  * When one of the constraint solvers infers that a the target has a given type/target in ALL
@@ -43,13 +42,13 @@ public class InferredValue {
          * Indicates that the inferred type should have these primary annotations and the remainder
          * should come from the annotations inferred for target.
          */
-        public final Set<AnnotationMirror> additionalAnnotations;
+        public final AnnotationMirrorSet additionalAnnotations;
 
         public InferredTarget(
                 final TypeVariable target,
                 final Collection<? extends AnnotationMirror> additionalAnnotations) {
             this.target = target;
-            this.additionalAnnotations = new HashSet<>(additionalAnnotations);
+            this.additionalAnnotations = new AnnotationMirrorSet(additionalAnnotations);
         }
     }
 }

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/SubtypesSolver.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/SubtypesSolver.java
@@ -14,6 +14,8 @@ import javax.lang.model.util.Types;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
+import org.checkerframework.framework.util.AnnotationMirrorMap;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.typeinference.GlbUtil;
 import org.checkerframework.framework.util.typeinference.solver.InferredValue.InferredType;
 import org.checkerframework.framework.util.typeinference.solver.TargetConstraints.Subtypes;
@@ -79,14 +81,14 @@ public class SubtypesSolver {
 
             // if the subtypes size is only 1 then we need not do any GLBing on the underlying types
             // but we may have primary annotations that need to be GLBed
-            Map<AnnotationMirror, Set<AnnotationMirror>> primaries = subtypes.primaries;
+            AnnotationMirrorMap<AnnotationMirrorSet> primaries = subtypes.primaries;
             if (subtypes.types.size() == 1) {
-                final Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> entry =
+                final Entry<AnnotatedTypeMirror, AnnotationMirrorSet> entry =
                         subtypes.types.entrySet().iterator().next();
                 AnnotatedTypeMirror supertype = entry.getKey().deepCopy();
 
                 for (AnnotationMirror top : entry.getValue()) {
-                    final Set<AnnotationMirror> superAnnos = primaries.get(top);
+                    final AnnotationMirrorSet superAnnos = primaries.get(top);
                     // if it is null we're just going to use the anno already on supertype
                     if (superAnnos != null) {
                         final AnnotationMirror supertypeAnno =
@@ -143,16 +145,16 @@ public class SubtypesSolver {
     protected static void propagatePreviousGlbs(
             final Subtypes targetSubtypes,
             InferenceResult solution,
-            final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> subtypesOfTarget) {
+            final Map<AnnotatedTypeMirror, AnnotationMirrorSet> subtypesOfTarget) {
 
-        for (final Entry<TypeVariable, Set<AnnotationMirror>> subtypeTarget :
+        for (final Entry<TypeVariable, AnnotationMirrorSet> subtypeTarget :
                 targetSubtypes.targets.entrySet()) {
             final InferredValue subtargetInferredGlb = solution.get(subtypeTarget.getKey());
 
             if (subtargetInferredGlb != null) {
                 final AnnotatedTypeMirror subtargetGlbType =
                         ((InferredType) subtargetInferredGlb).type;
-                Set<AnnotationMirror> subtargetAnnos = subtypesOfTarget.get(subtargetGlbType);
+                AnnotationMirrorSet subtargetAnnos = subtypesOfTarget.get(subtargetGlbType);
                 if (subtargetAnnos != null) {
                     // there is already an equivalent type in the list of subtypes, just add
                     // any hierarchies that are not in its list but are in the supertarget's list

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/SupertypesSolver.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/SupertypesSolver.java
@@ -3,10 +3,8 @@ package org.checkerframework.framework.util.typeinference.solver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -21,6 +19,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiv
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.framework.util.AnnotationMirrorMap;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.typeinference.TypeArgInferenceUtil;
 import org.checkerframework.framework.util.typeinference.solver.InferredValue.InferredType;
 import org.checkerframework.framework.util.typeinference.solver.TargetConstraints.Equalities;
@@ -52,7 +52,7 @@ public class SupertypesSolver {
         final InferenceResult solution = new InferenceResult();
         for (final TypeVariable target : remainingTargets) {
             final AnnotatedTypeMirror lub = lubs.getType(target);
-            Map<AnnotationMirror, AnnotationMirror> lubAnnos = lubs.getPrimaries(target);
+            AnnotationMirrorMap<AnnotationMirror> lubAnnos = lubs.getPrimaries(target);
 
             // we may have a partial solution present in the equality constraints, override
             // any annotations found in the lub with annotations from the equality constraints
@@ -88,19 +88,19 @@ public class SupertypesSolver {
             final ConstraintMap constraintMap,
             final AnnotatedTypeFactory typeFactory) {
         final Equalities equalities = constraintMap.getConstraints(target).equalities;
-        final Set<? extends AnnotationMirror> tops =
-                typeFactory.getQualifierHierarchy().getTopAnnotations();
+        final AnnotationMirrorSet tops =
+                new AnnotationMirrorSet(typeFactory.getQualifierHierarchy().getTopAnnotations());
 
         if (!equalities.types.isEmpty()) {
             // there should be only one equality type if any at this point
-            final Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> eqEntry =
+            final Entry<AnnotatedTypeMirror, AnnotationMirrorSet> eqEntry =
                     equalities.types.entrySet().iterator().next();
             final AnnotatedTypeMirror equalityType = eqEntry.getKey();
-            final Set<AnnotationMirror> equalityAnnos = eqEntry.getValue();
+            final AnnotationMirrorSet equalityAnnos = eqEntry.getValue();
 
             boolean failed = false;
             for (final AnnotationMirror top : tops) {
-                if (!AnnotationUtils.containsSame(equalityAnnos, top)) {
+                if (!equalityAnnos.contains(top)) {
                     final AnnotationMirror lubAnno = lub.getAnnotationInHierarchy(top);
                     if (lubAnno == null) {
                         // If the LUB and the Equality were the SAME typevar, and the lub was unannotated
@@ -139,23 +139,23 @@ public class SupertypesSolver {
      */
     protected InferredType mergeLubAnnosWithEqualities(
             final TypeVariable target,
-            final Map<AnnotationMirror, AnnotationMirror> lubAnnos,
+            final AnnotationMirrorMap<AnnotationMirror> lubAnnos,
             final ConstraintMap constraintMap,
             final AnnotatedTypeFactory typeFactory) {
         final Equalities equalities = constraintMap.getConstraints(target).equalities;
-        final Set<? extends AnnotationMirror> tops =
-                typeFactory.getQualifierHierarchy().getTopAnnotations();
+        final AnnotationMirrorSet tops =
+                new AnnotationMirrorSet(typeFactory.getQualifierHierarchy().getTopAnnotations());
 
         if (!equalities.types.isEmpty()) {
             // there should be only equality type if any at this point
-            final Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> eqEntry =
+            final Entry<AnnotatedTypeMirror, AnnotationMirrorSet> eqEntry =
                     equalities.types.entrySet().iterator().next();
             final AnnotatedTypeMirror equalityType = eqEntry.getKey();
-            final Set<AnnotationMirror> equalityAnnos = eqEntry.getValue();
+            final AnnotationMirrorSet equalityAnnos = eqEntry.getValue();
 
             boolean failed = false;
             for (final AnnotationMirror top : tops) {
-                if (!AnnotationUtils.containsSame(equalityAnnos, top)) {
+                if (!equalityAnnos.contains(top)) {
                     final AnnotationMirror lubAnno = lubAnnos.get(top);
                     if (lubAnno == null) {
                         failed = true;
@@ -178,19 +178,19 @@ public class SupertypesSolver {
     /** Holds the least upper bounds for every target type parameter. */
     class Lubs {
         public final Map<TypeVariable, AnnotatedTypeMirror> types = new LinkedHashMap<>();
-        public final Map<TypeVariable, Map<AnnotationMirror, AnnotationMirror>> primaries =
+        public final Map<TypeVariable, AnnotationMirrorMap<AnnotationMirror>> primaries =
                 new LinkedHashMap<>();
 
         public void addPrimaries(
-                final TypeVariable target, Map<AnnotationMirror, AnnotationMirror> primaries) {
-            this.primaries.put(target, new LinkedHashMap<>(primaries));
+                final TypeVariable target, AnnotationMirrorMap<AnnotationMirror> primaries) {
+            this.primaries.put(target, new AnnotationMirrorMap<>(primaries));
         }
 
         public void addType(final TypeVariable target, final AnnotatedTypeMirror type) {
             types.put(target, type);
         }
 
-        public Map<AnnotationMirror, AnnotationMirror> getPrimaries(final TypeVariable target) {
+        public AnnotationMirrorMap<AnnotationMirror> getPrimaries(final TypeVariable target) {
             return primaries.get(target);
         }
 
@@ -212,11 +212,12 @@ public class SupertypesSolver {
             ConstraintMap constraintMap,
             AnnotatedTypeFactory typeFactory) {
         final QualifierHierarchy qualifierHierarchy = typeFactory.getQualifierHierarchy();
-        final Set<? extends AnnotationMirror> tops = qualifierHierarchy.getTopAnnotations();
+        final AnnotationMirrorSet tops =
+                new AnnotationMirrorSet(qualifierHierarchy.getTopAnnotations());
 
         Lubs solution = new Lubs();
 
-        Map<AnnotationMirror, AnnotationMirror> lubOfPrimaries = new HashMap<>(tops.size());
+        AnnotationMirrorMap<AnnotationMirror> lubOfPrimaries = new AnnotationMirrorMap<>();
 
         List<TypeVariable> targetsSupertypesLast = new ArrayList<>(remainingTargets);
 
@@ -241,9 +242,9 @@ public class SupertypesSolver {
 
         for (final TypeVariable target : targetsSupertypesLast) {
             TargetConstraints targetRecord = constraintMap.getConstraints(target);
-            final Map<AnnotationMirror, Set<AnnotationMirror>> subtypeAnnos =
+            final AnnotationMirrorMap<AnnotationMirrorSet> subtypeAnnos =
                     targetRecord.supertypes.primaries;
-            final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> subtypesOfTarget =
+            final Map<AnnotatedTypeMirror, AnnotationMirrorSet> subtypesOfTarget =
                     targetRecord.supertypes.types;
 
             // if this target is a supertype of other targets and those targets have already been lubbed
@@ -257,7 +258,8 @@ public class SupertypesSolver {
             if (subtypesOfTarget.keySet().size() > 0) {
                 final AnnotatedTypeMirror lub =
                         leastUpperBound(target, typeFactory, subtypesOfTarget);
-                final Set<AnnotationMirror> effectiveLubAnnos = lub.getEffectiveAnnotations();
+                final AnnotationMirrorSet effectiveLubAnnos =
+                        new AnnotationMirrorSet(lub.getEffectiveAnnotations());
 
                 for (AnnotationMirror lubAnno : effectiveLubAnnos) {
                     final AnnotationMirror hierarchy = qualifierHierarchy.getTopAnnotation(lubAnno);
@@ -285,13 +287,13 @@ public class SupertypesSolver {
     protected static void propagatePreviousLubs(
             final TargetConstraints targetRecord,
             Lubs solution,
-            final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> subtypesOfTarget) {
+            final Map<AnnotatedTypeMirror, AnnotationMirrorSet> subtypesOfTarget) {
 
-        for (final Entry<TypeVariable, Set<AnnotationMirror>> supertypeTarget :
+        for (final Entry<TypeVariable, AnnotationMirrorSet> supertypeTarget :
                 targetRecord.supertypes.targets.entrySet()) {
             final AnnotatedTypeMirror supertargetLub = solution.getType(supertypeTarget.getKey());
             if (supertargetLub != null) {
-                Set<AnnotationMirror> supertargetTypeAnnos = subtypesOfTarget.get(supertargetLub);
+                AnnotationMirrorSet supertargetTypeAnnos = subtypesOfTarget.get(supertargetLub);
                 if (supertargetTypeAnnos != null) {
                     // there is already an equivalent type in the list of subtypes, just add
                     // any hierarchies that are not in its list but are in the supertarget's list
@@ -308,14 +310,14 @@ public class SupertypesSolver {
      * correspond to that hierarchy place the lub in lubOfPrimaries
      */
     protected static void lubPrimaries(
-            Map<AnnotationMirror, AnnotationMirror> lubOfPrimaries,
-            Map<AnnotationMirror, Set<AnnotationMirror>> subtypeAnnos,
-            Set<? extends AnnotationMirror> tops,
+            AnnotationMirrorMap<AnnotationMirror> lubOfPrimaries,
+            AnnotationMirrorMap<AnnotationMirrorSet> subtypeAnnos,
+            AnnotationMirrorSet tops,
             QualifierHierarchy qualifierHierarchy) {
 
         lubOfPrimaries.clear();
         for (final AnnotationMirror top : tops) {
-            final Set<AnnotationMirror> annosInHierarchy = subtypeAnnos.get(top);
+            final AnnotationMirrorSet annosInHierarchy = subtypeAnnos.get(top);
             if (annosInHierarchy != null && !annosInHierarchy.isEmpty()) {
                 lubOfPrimaries.put(top, leastUpperBound(annosInHierarchy, qualifierHierarchy));
             }
@@ -327,12 +329,12 @@ public class SupertypesSolver {
      * a given hierarchy replace it with the corresponding value in lowerBoundAnnos
      */
     public static AnnotatedTypeMirror groundMissingHierarchies(
-            final Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> typeToHierarchies,
-            final Map<AnnotationMirror, AnnotationMirror> lowerBoundAnnos) {
-        final Set<AnnotationMirror> presentHierarchies = typeToHierarchies.getValue();
-        final Set<AnnotationMirror> missingAnnos = new LinkedHashSet<>();
+            final Entry<AnnotatedTypeMirror, AnnotationMirrorSet> typeToHierarchies,
+            final AnnotationMirrorMap<AnnotationMirror> lowerBoundAnnos) {
+        final AnnotationMirrorSet presentHierarchies = typeToHierarchies.getValue();
+        final AnnotationMirrorSet missingAnnos = new AnnotationMirrorSet();
         for (AnnotationMirror top : lowerBoundAnnos.keySet()) {
-            if (!AnnotationUtils.containsSame(presentHierarchies, top)) {
+            if (!presentHierarchies.contains(top)) {
                 missingAnnos.add(lowerBoundAnnos.get(top));
             }
         }
@@ -354,17 +356,18 @@ public class SupertypesSolver {
     public static AnnotatedTypeMirror leastUpperBound(
             final TypeVariable target,
             final AnnotatedTypeFactory typeFactory,
-            final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> types) {
+            final Map<AnnotatedTypeMirror, AnnotationMirrorSet> types) {
 
         QualifierHierarchy qualifierHierarchy = typeFactory.getQualifierHierarchy();
         AnnotatedTypeVariable targetsDeclaredType =
                 (AnnotatedTypeVariable) typeFactory.getAnnotatedType(target.asElement());
-        final Map<AnnotationMirror, AnnotationMirror> lowerBoundAnnos =
+        final AnnotationMirrorMap<AnnotationMirror> lowerBoundAnnos =
                 TypeArgInferenceUtil.createHierarchyMap(
-                        targetsDeclaredType.getLowerBound().getEffectiveAnnotations(),
+                        new AnnotationMirrorSet(
+                                targetsDeclaredType.getLowerBound().getEffectiveAnnotations()),
                         qualifierHierarchy);
 
-        final Iterator<Entry<AnnotatedTypeMirror, Set<AnnotationMirror>>> typesIter =
+        final Iterator<Entry<AnnotatedTypeMirror, AnnotationMirrorSet>> typesIter =
                 types.entrySet().iterator();
         if (!typesIter.hasNext()) {
             ErrorReporter.errorAbort("Calling LUB on empty list!");
@@ -378,7 +381,7 @@ public class SupertypesSolver {
          * constraints imply the bottom annotation is the LUB). Note: Even if we choose bottom as
          * the lub here, the assignment context may raise this annotation.
          */
-        final Entry<AnnotatedTypeMirror, Set<AnnotationMirror>> head = typesIter.next();
+        final Entry<AnnotatedTypeMirror, AnnotationMirrorSet> head = typesIter.next();
 
         AnnotatedTypeMirror lubType = groundMissingHierarchies(head, lowerBoundAnnos);
         AnnotatedTypeMirror nextType = null;

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/TargetConstraints.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/TargetConstraints.java
@@ -2,10 +2,11 @@ package org.checkerframework.framework.util.typeinference.solver;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.AnnotationMirrorMap;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 
 /**
  * TargetConstraints represents the set of all TUConstraints for which target was the type
@@ -44,15 +45,15 @@ public class TargetConstraints {
 
     protected static class Equalities {
         // Map( hierarchy top -> exact annotation in hierarchy)
-        public Map<AnnotationMirror, AnnotationMirror> primaries = new LinkedHashMap<>();
+        public AnnotationMirrorMap<AnnotationMirror> primaries = new AnnotationMirrorMap<>();
 
         // Map( type -> hierarchy top for which the primary annotation of type is equal to the primary annotation of the target)
         // note all components and underlying types are EXACTLY equal to the key to this map
-        public final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> types = new LinkedHashMap<>();
+        public final Map<AnnotatedTypeMirror, AnnotationMirrorSet> types = new LinkedHashMap<>();
 
         // Map( type -> hierarchy top for which the primary annotation of target is equal to the primary annotaiton of the target)
         // note all components and underlying types are EXACTLY equal to the key to this map
-        public final Map<TypeVariable, Set<AnnotationMirror>> targets = new LinkedHashMap<>();
+        public final Map<TypeVariable, AnnotationMirrorSet> targets = new LinkedHashMap<>();
 
         public void clear() {
             primaries.clear();
@@ -64,15 +65,15 @@ public class TargetConstraints {
     // remember these are constraint in which target is the supertype
     protected static class Supertypes {
         // Map( hierarchy top -> annotations that are subtypes to target in hierarchy)
-        public Map<AnnotationMirror, Set<AnnotationMirror>> primaries = new LinkedHashMap<>();
+        public AnnotationMirrorMap<AnnotationMirrorSet> primaries = new AnnotationMirrorMap<>();
 
         // Map( type -> hierarchy tops for which the primary annotations of type are subtypes of the primary annotations of the target)
         // note all components and underlying types must uphold the supertype relationship in all hierarchies
-        public final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> types = new LinkedHashMap<>();
+        public final Map<AnnotatedTypeMirror, AnnotationMirrorSet> types = new LinkedHashMap<>();
 
         // Map( otherTarget -> hierarchy tops for which the primary annotations of otherTarget are subtypes of the primary annotations of the target)
         // note all components and underlying types must uphold the subtype relationship in all hierarchies
-        public final Map<TypeVariable, Set<AnnotationMirror>> targets = new LinkedHashMap<>();
+        public final Map<TypeVariable, AnnotationMirrorSet> targets = new LinkedHashMap<>();
 
         public void clear() {
             primaries.clear();
@@ -84,15 +85,15 @@ public class TargetConstraints {
     // remember these are constraint in which target is the subtype
     protected static class Subtypes {
         // Map( hierarchy top -> annotations that are supertypes to target in hierarchy)
-        public Map<AnnotationMirror, Set<AnnotationMirror>> primaries = new LinkedHashMap<>();
+        public AnnotationMirrorMap<AnnotationMirrorSet> primaries = new AnnotationMirrorMap<>();
 
         // Map( type -> hierarchy tops for which the primary annotations of type are supertypes of the primary annotations of the target)
         // note all components and underlying types must uphold the supertype relationship in all hierarchies
-        public final Map<AnnotatedTypeMirror, Set<AnnotationMirror>> types = new LinkedHashMap<>();
+        public final Map<AnnotatedTypeMirror, AnnotationMirrorSet> types = new LinkedHashMap<>();
 
         // Map( otherTarget -> hierarchy tops for which the primary annotations of otherTarget are supertypes of the primary annotations of the target)
         // note all components and underlying types must uphold the subtype relationship in all hierarchies
-        public final Map<TypeVariable, Set<AnnotationMirror>> targets = new LinkedHashMap<>();
+        public final Map<TypeVariable, AnnotationMirrorSet> targets = new LinkedHashMap<>();
 
         public void clear() {
             primaries.clear();

--- a/framework/tests/all-systems/Issue953.java
+++ b/framework/tests/all-systems/Issue953.java
@@ -1,6 +1,6 @@
 // Test case for issue 953
 // https://github.com/typetools/checker-framework/issues/953
-
+// @skip-test Crash will be fixed once both pull request #978 and #977 are merged.
 import java.util.List;
 
 class Issue953 {

--- a/framework/tests/all-systems/Issue953b.java
+++ b/framework/tests/all-systems/Issue953b.java
@@ -1,7 +1,7 @@
 // Test case for issue 953
 // https://github.com/typetools/checker-framework/issues/953
 // The signture of MyStream#collect is slightly different than the one in Issue953.java
-// @skip-test Crash will be fixed once both pull request #978 and #977 are merged.
+
 import java.util.List;
 
 public class Issue953b {

--- a/framework/tests/all-systems/Issue953b.java
+++ b/framework/tests/all-systems/Issue953b.java
@@ -1,7 +1,7 @@
 // Test case for issue 953
 // https://github.com/typetools/checker-framework/issues/953
 // The signture of MyStream#collect is slightly different than the one in Issue953.java
-
+// @skip-test Crash will be fixed once both pull request #978 and #977 are merged.
 import java.util.List;
 
 public class Issue953b {

--- a/framework/tests/all-systems/Issue953b.java
+++ b/framework/tests/all-systems/Issue953b.java
@@ -1,13 +1,14 @@
 // Test case for issue 953
 // https://github.com/typetools/checker-framework/issues/953
+// The signture of MyStream#collect is slightly different than the one in Issue953.java
 
 import java.util.List;
 
-class Issue953 {
+public class Issue953b {
     class MyCollector<A, B, C> {}
 
     class MyStream<E> {
-        <F, G> F collect(MyCollector<? super E, G, F> param) {
+        <F, G> F collect(MyCollector<? extends E, G, F> param) {
             throw new RuntimeException();
         }
     }

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -286,12 +286,23 @@ public class AnnotationUtils {
      */
     public static boolean containsSame(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
+        return getSame(c, anno) != null;
+    }
+
+    /**
+     * Returns the AnnotationMirror in {@code c} that is the same annotation as {@code anno}.
+     *
+     * @return AnnotationMirror with the same class as {@code anno} iff c contains anno, according
+     *     to areSame; otherwise, {@code null}
+     */
+    public static AnnotationMirror getSame(
+            Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
         for (AnnotationMirror an : c) {
             if (AnnotationUtils.areSame(an, anno)) {
-                return true;
+                return an;
             }
         }
-        return false;
+        return null;
     }
 
     /**
@@ -329,12 +340,24 @@ public class AnnotationUtils {
      */
     public static boolean containsSameIgnoringValues(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
+        return getSameIgnoringValues(c, anno) != null;
+    }
+
+    /**
+     * Returns the AnnotationMirror in {@code c} that is the same annotation as {@code anno}
+     * ignoring values.
+     *
+     * @return AnnotationMirror with the same class as {@code anno} iff c contains anno, according
+     *     to areSameIgnoringValues; otherwise, {@code null}
+     */
+    public static AnnotationMirror getSameIgnoringValues(
+            Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
         for (AnnotationMirror an : c) {
             if (AnnotationUtils.areSameIgnoringValues(an, anno)) {
-                return true;
+                return an;
             }
         }
-        return false;
+        return null;
     }
 
     private static final Comparator<AnnotationMirror> ANNOTATION_ORDERING =


### PR DESCRIPTION
This pull request only updates the classes in org.checkerframework.framework.util.typeinference.* to use the new classes.  We could update the rest of the classes if desired.  I updated type argument inference first because it using annotation mirror sets and maps caused a crash.