### PR TITLE
Add type arguments for all raw types (Fixes #988)

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1213,26 +1213,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         AnnotatedTypeMirror result = TypeFromTree.fromTypeTree(this, tree);
 
-        // treat Raw as generic!
-        // TODO: This doesn't handle recursive type parameter
-        // e.g. class Pair<Y extends List<Y>> { ... }
-        // Type argument inference for raw types can be improved. See Issue 635.
-        // https://github.com/typetools/checker-framework/issues/635
-        if (result.getKind() == TypeKind.DECLARED) {
-            AnnotatedDeclaredType dt = (AnnotatedDeclaredType) result;
-            if (dt.wasRaw()) {
-                List<AnnotatedTypeMirror> typeArgs = new ArrayList<AnnotatedTypeMirror>();
-                AnnotatedDeclaredType declaration =
-                        fromElement((TypeElement) dt.getUnderlyingType().asElement());
-                for (AnnotatedTypeMirror typeParam : declaration.getTypeArguments()) {
-                    AnnotatedWildcardType wct =
-                            getUninferredWildcardType((AnnotatedTypeVariable) typeParam);
-                    typeArgs.add(wct);
-                }
-                dt.setTypeArguments(typeArgs);
-            }
-        }
-
         annotateInheritedFromClass(result);
         if (shouldCache) {
             fromTreeCache.put(tree, result.deepCopy());

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -931,7 +931,7 @@ public abstract class AnnotatedTypeMirror {
                 if (wasRaw()) {
                     // TODO: This doesn't handle recursive type parameter
                     // e.g. class Pair<Y extends List<Y>> { ... }
-                    // Type argument inference for raw types can be improved. See Issue 635.
+                    // Type argument inference for raw types can be improved. See Issue #635.
                     // https://github.com/typetools/checker-framework/issues/635
                     AnnotatedDeclaredType declaration =
                             atypeFactory.fromElement((TypeElement) getUnderlyingType().asElement());

--- a/framework/tests/all-systems/Issue988.java
+++ b/framework/tests/all-systems/Issue988.java
@@ -1,8 +1,6 @@
 // Test case for Issue 988:
 // https://github.com/typetools/checker-framework/issues/988
 
-// @skip-test
-
 abstract class Issue988 {
     abstract Class getRawClass();
 

--- a/framework/tests/all-systems/RawTypeAssignment.java
+++ b/framework/tests/all-systems/RawTypeAssignment.java
@@ -3,8 +3,6 @@ import java.util.Calendar;
 
 class Component {}
 
-// If this class inherits from the raw type ArrayList, then we
-// get an error type as the GLB below.
 class Components extends ArrayList {}
 
 // If we include a type parameter in the superclass, then there
@@ -17,9 +15,8 @@ public class RawTypeAssignment {
     }
 
     static void addTimes(Calendar calendar) {
-        // In this method, we compute the greatest lower bound of
-        // ArrayList<Component> and the return type of getComponents.
-        // Currently, this GLB is an error type, which is a bug.
+        // Type systems may issue an error below because of a mismatch between the type arguments..
+        @SuppressWarnings("assignment.type.incompatible")
         //:: warning: [unchecked] unchecked conversion
         ArrayList<Component> clist = getComponents();
         clist.get(0);

--- a/framework/tests/all-systems/RawTypeAssignment.java
+++ b/framework/tests/all-systems/RawTypeAssignment.java
@@ -15,7 +15,7 @@ public class RawTypeAssignment {
     }
 
     static void addTimes(Calendar calendar) {
-        // Type systems may issue an error below because of a mismatch between the type arguments..
+        // Type systems may issue an error below because of a mismatch between the type arguments.
         @SuppressWarnings("assignment.type.incompatible")
         //:: warning: [unchecked] unchecked conversion
         ArrayList<Component> clist = getComponents();


### PR DESCRIPTION
Move code that creates type arguments for raw types to the AnnotatedTypeMirror. (Fixes #988.)