### PR TITLE
Update the Lock Checker to use the expression annotation support.

### DIFF
--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -4,6 +4,8 @@ package org.checkerframework.checker.lock;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 */
 
+import static org.checkerframework.javacutil.TreeUtils.getReceiverTree;
+
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayAccessTree;
@@ -22,7 +24,7 @@ import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -41,32 +43,29 @@ import org.checkerframework.checker.lock.qual.EnsuresLockHeldIf;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.lock.qual.GuardedBy;
 import org.checkerframework.checker.lock.qual.GuardedByBottom;
+import org.checkerframework.checker.lock.qual.GuardedByUnknown;
 import org.checkerframework.checker.lock.qual.Holding;
+import org.checkerframework.checker.lock.qual.LockHeld;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
-import org.checkerframework.dataflow.analysis.FlowExpressions.ClassName;
-import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
-import org.checkerframework.dataflow.analysis.FlowExpressions.LocalVariable;
-import org.checkerframework.dataflow.analysis.FlowExpressions.MethodCall;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
-import org.checkerframework.dataflow.analysis.FlowExpressions.ThisReference;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.ImplicitThisLiteralNode;
-import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.qual.Deterministic;
 import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.util.PurityUtils;
+import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotatedTypes;
-import org.checkerframework.framework.util.ContractsUtils.Precondition;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionContext;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionParseException;
+import org.checkerframework.framework.util.expressionannotations.ExpressionAnnotationError;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.ErrorReporter;
@@ -85,7 +84,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     private final Class<? extends Annotation> checkerGuardedByClass = GuardedBy.class;
     private final Class<? extends Annotation> checkerGuardSatisfiedClass = GuardSatisfied.class;
 
-    private static final Pattern selfReceiverPattern = Pattern.compile("^<self>(\\.(.*))?$");
+    protected static final Pattern selfReceiverPattern = Pattern.compile("^<self>(\\.(.*))?$");
 
     public LockVisitor(BaseTypeChecker checker) {
         super(checker);
@@ -261,7 +260,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
      * skipped. If the receiver actual parameter has type @GuardSatisfied, this method simply
      * returns true without performing any other actions. The method returns false otherwise.
      *
-     * @param node the MethodInvocationTree of the method being called
+     * @param methodInvocationTree the MethodInvocationTree of the method being called
      * @param methodDefinitionReceiver the ATM of the formal receiver parameter of the method being
      *     called
      * @param methodCallReceiver the ATM of the receiver argument of the method call
@@ -269,7 +268,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
      */
     @Override
     protected boolean skipReceiverSubtypeCheck(
-            MethodInvocationTree node,
+            MethodInvocationTree methodInvocationTree,
             AnnotatedTypeMirror methodDefinitionReceiver,
             AnnotatedTypeMirror methodCallReceiver) {
 
@@ -294,18 +293,16 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
         if (AnnotationUtils.areSameByClass(effectiveGb, checkerGuardedByClass)) {
             Set<AnnotationMirror> annos = methodDefinitionReceiver.getAnnotations();
-            for (AnnotationMirror anno : annos) {
-                if (AnnotationUtils.areSameByClass(anno, checkerGuardSatisfiedClass)) {
-                    MethodInvocationNode methodInvocationNode =
-                            (MethodInvocationNode) atypeFactory.getNodeForTree(node);
-                    Node receiverNode = methodInvocationNode.getTarget().getReceiver();
-                    checkPreconditions(
-                            node,
-                            receiverNode,
-                            generatePreconditionsBasedOnGuards(methodCallReceiver));
-
-                    return true;
+            AnnotationMirror guardSatisfied =
+                    AnnotationUtils.getAnnotationByClass(annos, checkerGuardSatisfiedClass);
+            if (guardSatisfied != null) {
+                Tree receiverTree = TreeUtils.getReceiverTree(methodInvocationTree);
+                if (receiverTree == null) {
+                    checkLockOfImplicitThis(methodInvocationTree, effectiveGb);
+                } else {
+                    checkLock(receiverTree, effectiveGb);
                 }
+                return true;
             }
         }
 
@@ -325,40 +322,6 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             }
         }
         return annotationSet;
-    }
-
-    /**
-     * Given an AnnotatedTypeMirror containing a @GuardedBy annotation, returns the set of lock
-     * expression preconditions specified in the @GuardedBy annotation. Returns an empty set if no
-     * such expressions are found.
-     *
-     * @param atm the AnnotatedTypeMirror containing the @GuardedBy annotation with the lock
-     *     expression preconditions.
-     * @return a set of lock expression preconditions that can be processed by checkPreconditions
-     */
-    private Set<Precondition> generatePreconditionsBasedOnGuards(AnnotatedTypeMirror atm) {
-        Set<AnnotationMirror> amList = atm.getAnnotations();
-        Set<Precondition> preconditions = new LinkedHashSet<>();
-
-        if (amList != null) {
-            for (AnnotationMirror annotationMirror : amList) {
-
-                if (AnnotationUtils.areSameByClass(annotationMirror, checkerGuardedByClass)) {
-                    if (AnnotationUtils.hasElementValue(annotationMirror, "value")) {
-                        List<String> guardedByValue =
-                                AnnotationUtils.getElementValueArray(
-                                        annotationMirror, "value", String.class, false);
-
-                        for (String lockExpression : guardedByValue) {
-                            preconditions.add(
-                                    new Precondition(lockExpression, atypeFactory.LOCKHELD));
-                        }
-                    }
-                }
-            }
-        }
-
-        return preconditions;
     }
 
     @Override
@@ -404,9 +367,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
         if (varType.hasAnnotation(GuardSatisfied.class)) {
             if (valueType.hasAnnotation(GuardedBy.class)) {
-                checkPreconditions(
-                        (ExpressionTree) valueTree, generatePreconditionsBasedOnGuards(valueType));
-
+                checkLock(valueTree, valueType.getAnnotation(GuardedBy.class));
                 return;
             } else if (valueType.hasAnnotation(GuardSatisfied.class)) {
                 // TODO: Find a cleaner, non-abstraction-breaking way to know whether method actual parameters are being assigned to formal parameters.
@@ -453,9 +414,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     @Override
     public Void visitMemberSelect(MemberSelectTree tree, Void p) {
         if (atypeFactory.getNodeForTree(tree) instanceof FieldAccessNode) {
-            Tree treeOfExpression = tree.getExpression();
-            Node nodeOfExpression = atypeFactory.getNodeForTree(treeOfExpression);
-            checkFieldOrArrayAccess(tree, treeOfExpression, nodeOfExpression);
+            AnnotatedTypeMirror atmOfReceiver = atypeFactory.getAnnotatedType(tree.getExpression());
+            AnnotationMirror gb =
+                    atmOfReceiver.getEffectiveAnnotationInHierarchy(atypeFactory.GUARDEDBYUNKNOWN);
+            checkLock(tree.getExpression(), gb);
         }
 
         return super.visitMemberSelect(tree, p);
@@ -535,46 +497,12 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
                 && isValid;
     }
 
-    /**
-     * Checks that the field or array access is legal by checking that the locks in the access's
-     * expression are held.
-     *
-     * @param accessTree field or array access tree to check (may be an identifier tree of a field)
-     * @param treeToReportErrorAt tree whose location is used to report the error
-     * @param expressionNode node of the field or array access's expression
-     */
-    private void checkFieldOrArrayAccess(
-            ExpressionTree accessTree, Tree treeToReportErrorAt, Node expressionNode) {
-        AnnotatedTypeMirror atmOfReceiver = atypeFactory.getReceiverType(accessTree);
-        if (treeToReportErrorAt != null && atmOfReceiver != null) {
-            AnnotationMirror gb =
-                    atmOfReceiver.getEffectiveAnnotationInHierarchy(atypeFactory.GUARDEDBYUNKNOWN);
-            if (gb == null) {
-                ErrorReporter.errorAbort("LockVisitor.checkFieldOrArrayAccess: gb cannot be null");
-            }
-
-            if (AnnotationUtils.areSameByClass(gb, checkerGuardedByClass)) {
-                Set<Precondition> preconditions = generatePreconditionsBasedOnGuards(atmOfReceiver);
-                checkPreconditions(treeToReportErrorAt, expressionNode, preconditions);
-            } else if (AnnotationUtils.areSameByClass(gb, checkerGuardSatisfiedClass)) {
-                // Can always dereference if type is @GuardSatisfied
-            } else {
-                // Can never dereference for any other types in the @GuardedBy hierarchy
-                checker.report(
-                        Result.failure(
-                                "cannot.dereference",
-                                accessTree.toString(),
-                                AnnotationUtils.annotationSimpleName(gb)),
-                        accessTree);
-            }
-        }
-    }
-
     @Override
     public Void visitArrayAccess(ArrayAccessTree tree, Void p) {
-        Tree treeOfExpression = tree.getExpression();
-        Node nodeOfExpression = atypeFactory.getNodeForTree(treeOfExpression);
-        checkFieldOrArrayAccess(tree, treeOfExpression, nodeOfExpression);
+        AnnotatedTypeMirror atmOfReceiver = atypeFactory.getAnnotatedType(tree.getExpression());
+        AnnotationMirror gb =
+                atmOfReceiver.getEffectiveAnnotationInHierarchy(atypeFactory.GUARDEDBYUNKNOWN);
+        checkLock(tree.getExpression(), gb);
         return super.visitArrayAccess(tree, p);
     }
 
@@ -637,7 +565,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
         if (methodElement != null) {
             // Handle releasing of explicit locks. Verify that the lock expression is effectively final.
-            ExpressionTree recvTree = TreeUtils.getReceiverTree(node);
+            ExpressionTree recvTree = getReceiverTree(node);
 
             ensureReceiverOfExplicitUnlockCallIsEffectivelyFinal(node, methodElement, recvTree);
 
@@ -979,62 +907,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             final Receiver lockExpr,
             String expressionForErrorReporting,
             Tree treeForErrorReporting) {
-        // Keep the 'lockExpr' parameter intact for debugging purposes, and traverse the overall expression using 'expr' instead.
-        Receiver expr = lockExpr;
-
-        while (true) {
-            if (expr instanceof FieldAccess) {
-                FieldAccess fieldAccess = (FieldAccess) expr;
-                Receiver recv = fieldAccess.getReceiver();
-
-                // Do NOT call fieldAccess.isUnmodifiableByOtherCode if the receiver is a method call, since it also checks if the receiver
-                // is unmodifiable and does so incorrectly in that case. The present
-                // method will determine whether or not a method call receiver is effectively final
-                // (see the "if (expr instanceof MethodCall)" block below).
-                if (!(fieldAccess.isUnmodifiableByOtherCode()
-                        || (fieldAccess.isFinal() && recv instanceof MethodCall))) {
-                    checker.report(
-                            Result.failure(
-                                    "lock.expression.not.final", expressionForErrorReporting),
-                            treeForErrorReporting);
-                    return;
-                }
-                expr = recv;
-            } else if (expr instanceof LocalVariable) {
-                if (!ElementUtils.isEffectivelyFinal(((LocalVariable) expr).getElement())) {
-                    checker.report(
-                            Result.failure(
-                                    "lock.expression.not.final", expressionForErrorReporting),
-                            treeForErrorReporting);
-                }
-                return;
-            } else if (expr instanceof MethodCall) {
-                MethodCall methodCall = (MethodCall) expr;
-                for (Receiver param : methodCall.getParameters()) {
-                    ensureExpressionIsEffectivelyFinal(
-                            param, expressionForErrorReporting, treeForErrorReporting);
-                }
-                if (!PurityUtils.isDeterministic(atypeFactory, methodCall.getElement())) {
-                    checker.report(
-                            Result.failure(
-                                    "lock.expression.not.final", expressionForErrorReporting),
-                            treeForErrorReporting);
-                    return;
-                }
-                expr = methodCall.getReceiver();
-            } else if (expr instanceof ThisReference
-                    || // The current object is always final.
-                    expr instanceof ClassName) { // Class names are always final.
-                // Neither ThisReference nor ClassName instances have a receiver,
-                // so exit the loop.
-                return;
-            } else { // type of 'expr' is not supported in @GuardedBy(...) lock expressions
-                checker.report(
-                        Result.failure(
-                                "lock.expression.possibly.not.final", expressionForErrorReporting),
-                        treeForErrorReporting);
-                return;
-            }
+        if (!atypeFactory.isExpressionEffectivelyFinal(lockExpr)) {
+            checker.report(
+                    Result.failure("lock.expression.not.final", expressionForErrorReporting),
+                    treeForErrorReporting);
         }
     }
 
@@ -1047,83 +923,13 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
         if (amList != null) {
             for (AnnotationMirror annotationMirror : amList) {
-                if (AnnotationUtils.areSameByClass(annotationMirror, checkerGuardedByClass)) {
-                    checkLockExpressionInGuardedByAnnotation(tree, annotationMirror);
-                } else if (AnnotationUtils.areSameByClass(
-                        annotationMirror, checkerGuardSatisfiedClass)) {
+                if (AnnotationUtils.areSameByClass(annotationMirror, checkerGuardSatisfiedClass)) {
                     issueErrorIfGuardSatisfiedAnnotationInUnsupportedLocation(tree);
                 }
             }
         }
 
         return super.visitAnnotation(tree, p);
-    }
-
-    /**
-     * Check that the lock expression in a GuardedBy annotation is a valid flow expression and is
-     * effectively final
-     *
-     * @param tree AnnotationTree used for context and error reporting
-     * @param guardedByAnnotation GuardedBy AnnotationMirror
-     */
-    private void checkLockExpressionInGuardedByAnnotation(
-            AnnotationTree tree, AnnotationMirror guardedByAnnotation) {
-        List<String> guardedByValue =
-                AnnotationUtils.getElementValueArray(
-                        guardedByAnnotation, "value", String.class, true);
-        if (guardedByValue.isEmpty()) {
-            // getting the FlowExpressionContext could be costly,
-            // so don't do it if there isn't a lock expression to check
-            return;
-        }
-
-        TreePath path = getCurrentPath();
-        MethodTree enclMethod = TreeUtils.enclosingMethod(path);
-        FlowExpressionContext flowExprContext;
-        if (enclMethod != null) {
-            flowExprContext =
-                    FlowExpressionContext.buildContextForMethodDeclaration(
-                            enclMethod, path, checker.getContext());
-        } else {
-            ClassTree enclosingClass = TreeUtils.enclosingClass(path);
-            flowExprContext =
-                    FlowExpressionContext.buildContextForClassDeclaration(
-                            enclosingClass, checker.getContext());
-        }
-
-        // Adapted from BaseTypeVisitor.checkPreconditions
-
-        if (flowExprContext == null) {
-            // The expressions cannot be parsed. Issue an error for the whole list of @GuardedBy expressions.
-            checker.report(
-                    Result.failure("lock.expression.possibly.not.final", guardedByValue), tree);
-            return;
-        }
-
-        TreePath pathForLocalVariableRetrieval = getPathForLocalVariableRetrieval(path);
-
-        if (pathForLocalVariableRetrieval == null) {
-            // The expressions cannot be parsed. Issue an error for the whole list of @GuardedBy expressions.
-            checker.report(
-                    Result.failure("lock.expression.possibly.not.final", guardedByValue), tree);
-            return;
-        }
-
-        for (String lockExpression : guardedByValue) {
-            try {
-                // Attempt to parse the lock expression.
-                // This will also issue errors if the lock expressions are not final
-                parseExpressionString(
-                        lockExpression,
-                        flowExprContext,
-                        pathForLocalVariableRetrieval,
-                        null,
-                        tree,
-                        true);
-            } catch (FlowExpressionParseException e) {
-                checker.report(e.getResult(), tree);
-            }
-        }
     }
 
     /**
@@ -1260,73 +1066,14 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             Node receiverNode = ((FieldAccessNode) node).getReceiver();
             if (receiverNode instanceof ImplicitThisLiteralNode) {
                 // All other field access are handle via visitMemberSelect
-                checkFieldOrArrayAccess(tree, tree, receiverNode);
+                AnnotationMirror guardedBy =
+                        atypeFactory
+                                .getSelfType(tree)
+                                .getAnnotationInHierarchy(atypeFactory.GUARDEDBY);
+                checkLockOfImplicitThis(tree, guardedBy);
             }
         }
         return super.visitIdentifier(tree, p);
-    }
-
-    /**
-     * If expression is {@code "<self>"}, a flow expression receiver for {@code node} is returned,
-     * unless {@code node} is null, in which case null is returned. Also checks that the flow
-     * expression is effectively final and issues an error if it is not.
-     *
-     * <p>Returns the result of the super implementation otherwise.
-     */
-    @Override
-    protected FlowExpressions.Receiver parseExpressionString(
-            String expression,
-            FlowExpressionContext flowExprContext,
-            TreePath path,
-            Node node,
-            Tree treeForErrorReporting,
-            boolean use)
-            throws FlowExpressionParseException {
-        FlowExpressions.Receiver expr = null;
-        expression = expression.trim();
-
-        Matcher selfReceiverMatcher = selfReceiverPattern.matcher(expression);
-
-        if (selfReceiverMatcher.matches()) {
-            if (node == null) {
-                // node is definitely null if this method was called by LockVisitor.visitAnnotation.
-                // In this case, we skip the check to ensure that the "<self>" expression is
-                // effectively final at the site of the @GuardedBy("<self>") annotation.
-
-                return null;
-            }
-
-            String remainingExpression = selfReceiverMatcher.group(2);
-
-            if (remainingExpression == null || remainingExpression.isEmpty()) {
-                expr = FlowExpressions.internalReprOf(atypeFactory, node);
-            } else {
-                // TODO: The proper way to do this is to call flowExprContext.copyChangeToParsingMemberOfReceiver to set the
-                // receiver to the <self> expression, and then call FlowExpressionParseUtil.parse on the
-                // remaining expression string with the new flow expression context. However, this currently
-                // results in a FlowExpressions.Receiver that has a different hash code than if
-                // the following flow expression is parsed directly, which results in our inability
-                // to check that a lock expression is held as it does not match anything in the store
-                // due to the hash code mismatch.
-                // For now, convert the "<self>" portion to the node's string representation, and parse
-                // the entire string:
-
-                expr =
-                        FlowExpressionParseUtil.parse(
-                                node.toString() + "." + remainingExpression,
-                                flowExprContext,
-                                path,
-                                true);
-            }
-        } else {
-            expr =
-                    super.parseExpressionString(
-                            expression, flowExprContext, path, node, treeForErrorReporting, true);
-        }
-
-        ensureExpressionIsEffectivelyFinal(expr, expression, treeForErrorReporting);
-
-        return expr;
     }
 
     /**
@@ -1356,30 +1103,28 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     }
 
     @Override
-    public Void visitBinary(BinaryTree node, Void p) {
-        if (node.getKind() == Tree.Kind.PLUS) {
-            Tree leftTree = node.getLeftOperand();
-            Tree rightTree = node.getRightOperand();
+    public Void visitBinary(BinaryTree binaryTree, Void p) {
+        if (TreeUtils.isStringConcatenation(binaryTree)) {
+            Tree leftTree = binaryTree.getLeftOperand();
+            Tree rightTree = binaryTree.getRightOperand();
 
             boolean lhsIsString = TypesUtils.isString(InternalUtils.typeOf(leftTree));
             boolean rhsIsString = TypesUtils.isString(InternalUtils.typeOf(rightTree));
-            if (!lhsIsString && rhsIsString) {
+            if (!lhsIsString) {
                 checkPreconditionsForImplicitToStringCall(leftTree);
-            } else if (lhsIsString && !rhsIsString) {
+            } else if (!rhsIsString) {
                 checkPreconditionsForImplicitToStringCall(rightTree);
             }
         }
 
-        return super.visitBinary(node, p);
+        return super.visitBinary(binaryTree, p);
     }
 
     @Override
     public Void visitCompoundAssignment(CompoundAssignmentTree node, Void p) {
-        if (node.getKind() == Tree.Kind.PLUS_ASSIGNMENT) {
+        if (TreeUtils.isStringCompoundConcatenation(node)) {
             ExpressionTree rightTree = node.getExpression();
-
-            if (TypesUtils.isString(InternalUtils.typeOf(node.getVariable()))
-                    && !TypesUtils.isString(InternalUtils.typeOf(rightTree))) {
+            if (!TypesUtils.isString(InternalUtils.typeOf(rightTree))) {
                 checkPreconditionsForImplicitToStringCall(rightTree);
             }
         }
@@ -1404,7 +1149,178 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     // contracts.precondition.not.satisfied.field, so it would be clear that
     // the error refers to an implicit method call, not a dereference (field access).
     private void checkPreconditionsForImplicitToStringCall(Tree tree) {
-        checkPreconditions(
-                tree, generatePreconditionsBasedOnGuards(atypeFactory.getAnnotatedType(tree)));
+        AnnotationMirror gbAnno =
+                atypeFactory
+                        .getAnnotatedType(tree)
+                        .getEffectiveAnnotationInHierarchy(atypeFactory.GUARDEDBY);
+        checkLock(tree, gbAnno);
+    }
+
+    private void checkLockOfImplicitThis(Tree tree, AnnotationMirror gbAnno) {
+        checkLockOfThisOrTree(tree, true, gbAnno);
+    }
+
+    private void checkLock(Tree tree, AnnotationMirror gbAnno) {
+        checkLockOfThisOrTree(tree, false, gbAnno);
+    }
+
+    private void checkLockOfThisOrTree(Tree tree, boolean implicitThis, AnnotationMirror gbAnno) {
+        if (gbAnno == null) {
+            ErrorReporter.errorAbort("LockVisitor.checkLock: gbAnno cannot be null");
+        }
+        if (AnnotationUtils.areSameByClass(gbAnno, GuardedByUnknown.class)
+                || AnnotationUtils.areSameByClass(gbAnno, GuardedByBottom.class)) {
+            checker.report(Result.failure("lock.not.held", "unknown lock"), tree);
+            return;
+        } else if (AnnotationUtils.areSameByClass(gbAnno, GuardSatisfied.class)) {
+            return;
+        }
+
+        Node node = atypeFactory.getNodeForTree(tree);
+
+        List<LockExpression> expressions = getLockExpressions(implicitThis, gbAnno, node);
+        if (expressions.isEmpty()) {
+            return;
+        }
+
+        LockStore store = atypeFactory.getStoreBefore(node);
+        for (LockExpression expression : expressions) {
+            if (expression.error != null) {
+                checker.report(
+                        Result.failure(
+                                "expression.unparsable.type.invalid", expression.error.toString()),
+                        tree);
+            } else if (expression.lockExpression == null) {
+                checker.report(
+                        Result.failure(
+                                "expression.unparsable.type.invalid", expression.expressionString),
+                        tree);
+            } else if (!isLockHeld(expression.lockExpression, store)) {
+                checker.report(
+                        Result.failure("lock.not.held", expression.lockExpression.toString()),
+                        tree);
+            }
+
+            if (expression.error != null && expression.lockExpression != null) {
+                ensureExpressionIsEffectivelyFinal(
+                        expression.lockExpression, expression.expressionString, tree);
+            }
+        }
+    }
+
+    private boolean isLockHeld(Receiver lock, LockStore store) {
+        if (store == null) {
+            return false;
+        }
+        CFAbstractValue<?> value = store.getValue(lock);
+        if (value == null) {
+            return false;
+        }
+        Set<AnnotationMirror> annos = value.getAnnotations();
+        QualifierHierarchy hierarchy = atypeFactory.getQualifierHierarchy();
+        AnnotationMirror lockAnno =
+                hierarchy.findAnnotationInSameHierarchy(annos, atypeFactory.LOCKHELD);
+        return lockAnno != null && AnnotationUtils.areSameByClass(lockAnno, LockHeld.class);
+    }
+
+    private List<LockExpression> getLockExpressions(
+            boolean implicitThis, AnnotationMirror gbAnno, Node node) {
+
+        List<String> expressions =
+                AnnotationUtils.getElementValueArray(gbAnno, "value", String.class, true);
+
+        if (expressions.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        TreePath currentPath = getCurrentPath();
+        List<Receiver> params =
+                FlowExpressions.getParametersOfEnclosingMethod(atypeFactory, currentPath);
+
+        TypeMirror enclosingType = InternalUtils.typeOf(TreeUtils.enclosingClass(currentPath));
+        Receiver pseudoReceiver =
+                FlowExpressions.internalRepOfPseudoReceiver(currentPath, enclosingType);
+        FlowExpressionContext exprContext =
+                new FlowExpressionContext(pseudoReceiver, params, atypeFactory.getContext());
+
+        Receiver self =
+                implicitThis ? pseudoReceiver : FlowExpressions.internalReprOf(atypeFactory, node);
+
+        List<LockExpression> lockExpressions = new ArrayList<>();
+        for (String expression : expressions) {
+            lockExpressions.add(parseExpressionString(expression, exprContext, currentPath, self));
+        }
+        return lockExpressions;
+    }
+
+    private LockExpression parseExpressionString(
+            String expression,
+            FlowExpressionContext flowExprContext,
+            TreePath path,
+            Receiver itself) {
+
+        LockExpression lockExpression = new LockExpression(expression);
+        if (ExpressionAnnotationError.isExpressionError(expression)) {
+            lockExpression.error = new ExpressionAnnotationError(expression);
+            return lockExpression;
+        }
+
+        Matcher selfReceiverMatcher = selfReceiverPattern.matcher(expression);
+        try {
+            if (selfReceiverMatcher.matches()) {
+                String remainingExpression = selfReceiverMatcher.group(2);
+                if (remainingExpression == null || remainingExpression.isEmpty()) {
+                    lockExpression.lockExpression = itself;
+                    if (!atypeFactory.isExpressionEffectivelyFinal(lockExpression.lockExpression)) {
+                        checker.report(
+                                Result.failure(
+                                        "lock.expression.not.final", lockExpression.lockExpression),
+                                path.getLeaf());
+                    }
+                    return lockExpression;
+                } else {
+                    // TODO: The proper way to do this is to call flowExprContext.copyChangeToParsingMemberOfReceiver to set the
+                    // receiver to the <self> expression, and then call FlowExpressionParseUtil.parse on the
+                    // remaining expression string with the new flow expression context. However, this currently
+                    // results in a FlowExpressions.Receiver that has a different hash code than if
+                    // the following flow expression is parsed directly, which results in our inability
+                    // to check that a lock expression is held as it does not match anything in the store
+                    // due to the hash code mismatch.
+                    // For now, convert the "<self>" portion to the node's string representation, and parse
+                    // the entire string:
+
+                    lockExpression.lockExpression =
+                            FlowExpressionParseUtil.parse(
+                                    itself.toString() + "." + remainingExpression,
+                                    flowExprContext,
+                                    path,
+                                    true);
+                    if (!atypeFactory.isExpressionEffectivelyFinal(lockExpression.lockExpression)) {
+                        checker.report(
+                                Result.failure(
+                                        "lock.expression.not.final", lockExpression.lockExpression),
+                                path.getLeaf());
+                    }
+                    return lockExpression;
+                }
+            } else {
+                lockExpression.lockExpression =
+                        FlowExpressionParseUtil.parse(expression, flowExprContext, path, true);
+                return lockExpression;
+            }
+        } catch (FlowExpressionParseException ex) {
+            lockExpression.error = new ExpressionAnnotationError(expression, ex);
+            return lockExpression;
+        }
+    }
+
+    private class LockExpression {
+        final String expressionString;
+        Receiver lockExpression = null;
+        ExpressionAnnotationError error = null;
+
+        LockExpression(String expression) {
+            this.expressionString = expression;
+        }
     }
 }

--- a/checker/src/org/checkerframework/checker/lock/messages.properties
+++ b/checker/src/org/checkerframework/checker/lock/messages.properties
@@ -1,6 +1,5 @@
 ### Error messages for the Lock Checker
 contracts.precondition.not.satisfied=unguarded call to method '%s' requiring '%s' to be held
-contracts.precondition.not.satisfied.field=unguarded access to field, variable or parameter '%s' guarded by '%s'
 override.sideeffect.invalid=%s in %s cannot override %s in %s; the side-effect annotation on an overrider method must be at least as strong as that one the overridden method
 multiple.sideeffect.annotations=method is annotated with multiple side effect annotations
 multiple.lock.precondition.annotations=only one @Holding, @net.jcip.annotations.GuardedBy or @javax.annotation.concurrent.GuardedBy annotation is allowed on a method
@@ -19,3 +18,4 @@ synchronized.block.in.lockingfree.method=A synchronized block cannot be written 
 class.declaration.guardedby.annotation.invalid=A class declaration may not be annotated with any qualifier from the @GuardedBy hierarchy other than @GuardedBy({}).
 lock.expression.not.final=lock expression includes a non-final field or a call to a method that is not pure or deterministic.\n lock expression: %s
 lock.expression.possibly.not.final=could not determine that the lock expression(s) include only non-final fields or calls to methods that are pure or deterministic.\n lock expression: %s
+lock.not.held=required lock not held.\nrequired: %s

--- a/checker/tests/lock-safedefaults/BasicTest.java
+++ b/checker/tests/lock-safedefaults/BasicTest.java
@@ -32,7 +32,7 @@ public class BasicTest {
     void testFields() {
         // Test in two ways that return values are @GuardedByUnknown.
         // The first way is more durable as cannot.dereference is tied specifically to @GuardedByUnknown (and @GuardedByBottom, but it is unlikely to become the default for return values on unannotated methods).
-        //:: error: (cannot.dereference)
+        //:: error: (lock.not.held)
         myUnannotatedMethod(o1).field = new Object();
         // The second way is less durable because the default for fields is currently @GuardedBy({}) but
         // could be changed to @GuardedByUnknown.
@@ -44,7 +44,7 @@ public class BasicTest {
         myAnnotatedMethod2();
         m.field = new Object();
         myUnannotatedMethod2();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field = new Object();
     }
 
@@ -68,12 +68,12 @@ public class BasicTest {
         q.field = new Object();
         // Should behave as @MayReleaseLocks, and *should* reset @LockHeld assumption about local variable lock.
         myUnannotatedMethod2();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         q.field = new Object();
         lock.lock();
         // Should behave as @MayReleaseLocks, and *should* reset @LockHeld assumption about local variable lock.
         unannotatedReleaseLock(lock);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         q.field = new Object();
     }
 }

--- a/checker/tests/lock/ChapterExamples.java
+++ b/checker/tests/lock/ChapterExamples.java
@@ -89,12 +89,12 @@ class ChapterExamples {
             m.method();
 
             @GuardedByUnknown MyClass local = new @GuardedByUnknown MyClass();
-            //:: error: (cannot.dereference)
+            //:: error: (lock.not.held)
             local.field = new Object();
             //:: error: (method.invocation.invalid)
             local.method();
 
-            //:: error: (cannot.dereference)
+            //:: error: (lock.not.held)
             m.field = new Object();
         }
     }
@@ -116,7 +116,7 @@ class ChapterExamples {
         final Object myLock = new Object();
 
         void testCallToMethod(@GuardedBy("myLock") MyClass this) {
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held)
             this.method(); // method()'s receiver is annotated as @GuardSatisfied
         }
     }
@@ -134,24 +134,24 @@ class ChapterExamples {
             this.myField = new MyClass();
             this.myField.toString();
         }
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField.toString();
     }
 
     void guardedByThisOnReceiver(@GuardedBy("this") ChapterExamples this) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField.toString();
         synchronized (this) {
             myField = new MyClass();
@@ -163,23 +163,23 @@ class ChapterExamples {
 
     void testDereferenceOfReceiverAndParameter(
             @GuardedBy("lock") ChapterExamples this, @GuardedBy("lock") MyClass m) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         myField.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.myField.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field = new Object();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field.toString();
         // The following error is due to the fact that you cannot access "this.lock" without first having acquired "lock".
         // The right fix in a user scenario would be to not guard "this" with "this.lock". The current object could instead
         // be guarded by "<self>" or by some other lock expression that is not one of its fields. We are keeping this test
         // case here to make sure this scenario issues a warning.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (lock) {
             myField = new MyClass();
             myField.toString();
@@ -202,18 +202,18 @@ class ChapterExamples {
     }
 
     void myMethod8() {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         boolean b4 = compare(p1, myMethod());
 
         // An error is issued indicating that p2 might be dereferenced without
         // "lock" being held. The method call need not be modified, since
         // @GuardedBy({}) <: @GuardedByUnknown and @GuardedBy("lock") <: @GuardedByUnknown,
         // but the lock must be acquired prior to the method call.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         boolean b2 = compare(p1, p2);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         boolean b3 = compare(p1, this.p2);
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         boolean b5 = compare(p1, this.myMethod());
         synchronized (lock) {
             boolean b6 = compare(p1, p2); // OK
@@ -231,13 +231,13 @@ class ChapterExamples {
     // myMethod().method()
 
     void myMethod7() {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         Object f = myObj.field;
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         Object f2 = myMethodReturningMyObj().field;
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         myObj.method(); // method()'s receiver is annotated as @GuardSatisfied
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         myMethodReturningMyObj().method(); // method()'s receiver is annotated as @GuardSatisfied
 
         synchronized (lock) {
@@ -247,9 +247,9 @@ class ChapterExamples {
             myMethodReturningMyObj().method();
         }
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         myMethodReturningMyObj().field = new Object();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         x.field = new Object();
         synchronized (lock) {
             myMethod().field = new Object();
@@ -275,11 +275,11 @@ class ChapterExamples {
     }
 
     void exampleMethod() {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         x.field = new Object(); // ILLEGAL because the lock is not known to be held
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         y.field = new Object(); // ILLEGAL because the lock is not known to be held
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         myMethod().field = new Object(); // ILLEGAL because the lock is not known to be held
         synchronized (lock) {
             x.field = new Object(); // OK: the lock is known to be held
@@ -337,7 +337,7 @@ class ChapterExamples {
     @GuardedBy("ChapterExamples.myLock") MyClass y2 = x2;
 
     void myMethod4() {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         x2.field = new Object(); // ILLEGAL because the lock is not held
         synchronized (ChapterExamples.myLock) {
             y2.field = new Object(); // OK: the lock is held
@@ -345,7 +345,7 @@ class ChapterExamples {
     }
 
     void myMethod5(@GuardedBy("ChapterExamples.myLock") MyClass a) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         a.field = new Object(); // ILLEGAL: the lock is not held
         synchronized (ChapterExamples.myLock) {
             a.field = new Object(); // OK: the lock is held
@@ -366,15 +366,15 @@ class ChapterExamples {
         synchronized (lock) {
             boolean b1 = compare(p1, p2); // OK. No error issued.
         }
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         p2.field = new Object();
         // An error is issued indicating that p2 might be dereferenced without "lock" being held. The method call need not be modified, since @GuardedBy({}) <: @GuardedByUnknown and @GuardedBy("lock") <: @GuardedByUnknown, but the lock must be acquired prior to the method call.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         boolean b2 = compare(p1, p2);
     }
 
     void helper1(@GuardedBy("ChapterExamples.myLock") MyClass a) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         a.field = new Object(); // ILLEGAL: the lock is not held
         synchronized (ChapterExamples.myLock) {
             a.field = new Object(); // OK: the lock is held
@@ -394,7 +394,7 @@ class ChapterExamples {
 
     @LockingFree
     void helper4(@GuardedBy("ChapterExamples.myLock") MyClass d) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         d.field = new Object(); // ILLEGAL: the lock is not held
     }
 
@@ -405,11 +405,11 @@ class ChapterExamples {
 
     void myMethod2(@GuardedBy("ChapterExamples.myLock") MyClass e) {
         helper1(e); // OK to pass to another routine without holding the lock.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         e.field = new Object(); // ILLEGAL: the lock is not held
         //:: error: (contracts.precondition.not.satisfied)
         helper2(e);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         helper3(e);
         synchronized (ChapterExamples.myLock) {
             helper2(e);
@@ -480,9 +480,9 @@ class ChapterExamples {
         d = b.intValue(); // The de-sugared version does not issue an error.
       }
 
-      // TODO re-enable this error (contracts.precondition.not.satisfied.field)
+      // TODO re-enable this error (lock.not.held)
       c = c + b; // Syntactic sugar for c = new Integer(c.intValue() + b.intValue()), hence 'lock' must be held.
-      // TODO re-enable this error (contracts.precondition.not.satisfied.field)
+      // TODO re-enable this error (lock.not.held)
       c = new Integer(c.intValue() + b.intValue()); // The de-sugared version
 
       synchronized(lock) {
@@ -490,7 +490,7 @@ class ChapterExamples {
         c = new Integer(c.intValue() + b.intValue()); // The de-sugared version
       }
 
-      // TODO re-enable this error (contracts.precondition.not.satisfied.field)
+      // TODO re-enable this error (lock.not.held)
       a = b; // TODO: This assignment between two reference types should not require a lock to be held.
     }*/
 
@@ -502,19 +502,19 @@ class ChapterExamples {
     @GuardedBy("lock2") MyClass extension;
 
     void method0() {
-        //:: error: (contracts.precondition.not.satisfied) :: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held) :: error: (lock.not.held)
         filename = filename.append(extension);
     }
 
     void method1() {
         lock1.lock();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         filename = filename.append(extension);
     }
 
     void method2() {
         lock2.lock();
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         filename = filename.append(extension);
     }
 

--- a/checker/tests/lock/Constructors.java
+++ b/checker/tests/lock/Constructors.java
@@ -17,31 +17,31 @@ public @GuardedBy({}) class Constructors {
     static final MyClass unlockedStatic = new MyClass();
 
     @GuardedBy("unlockedStatic") MyClass nonstaticGuardedByStatic = new MyClass();
-
+    //:: error: (expression.unparsable.type.invalid)
     static @GuardedBy("unlocked") MyClass staticGuardedByNonStatic = new MyClass();
     static @GuardedBy("unlockedStatic") MyClass staticGuardedByStatic = new MyClass();
 
     Object initializedObject1 = unlocked.field;
     Object initializedObject2 = guardedThis.field;
-    //:: error: (contracts.precondition.not.satisfied.field)
+    //:: error: (lock.not.held)
     Object initializedObject3 = guardedOther.field;
-    //:: error: (contracts.precondition.not.satisfied.field)
+    //:: error: (expression.unparsable.type.invalid)
     Object initializedObject4 = staticGuardedByNonStatic.field;
-    //:: error: (contracts.precondition.not.satisfied.field)
+    //:: error: (lock.not.held)
     Object initializedObject5 = nonstaticGuardedByStatic.field;
-    //:: error: (contracts.precondition.not.satisfied.field)
+    //:: error: (lock.not.held)
     Object initializedObject6 = staticGuardedByStatic.field;
 
     Constructors() {
         unlocked.field.toString();
         guardedThis.field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         guardedOther.field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (expression.unparsable.type.invalid)
         staticGuardedByNonStatic.field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         nonstaticGuardedByStatic.field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         staticGuardedByStatic.field.toString();
     }
 }

--- a/checker/tests/lock/Fields.java
+++ b/checker/tests/lock/Fields.java
@@ -17,14 +17,14 @@ public class Fields {
 
     synchronized void wrongLock1() {
         // locking over wrong lock
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         locked.field = new Object(); // error
     }
 
     synchronized void wrongLock2() {
         // locking over wrong lock
         synchronized (this) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             locked.field = new Object(); // error
         }
     }
@@ -35,7 +35,7 @@ public class Fields {
         }
 
         // accessing after the synchronized object
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         locked.field = new Object(); // error
     }
 
@@ -48,11 +48,11 @@ public class Fields {
 
     void wrongLocksb() {
         // without locking
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         lockedByThis.field = new Object(); // error
 
         synchronized (Fields.class) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             lockedByThis.field = new Object(); // error
         }
     }
@@ -63,7 +63,7 @@ public class Fields {
         }
 
         // accessing after the synchronized object
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         lockedByThis.field = new Object(); // error
     }
 
@@ -78,24 +78,24 @@ public class Fields {
 
         synchronized (this) {
             lockedByThis.field = new Object();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             a.lockedByThis.field = new Object(); // error
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             b.lockedByThis.field = new Object(); // error
         }
 
         synchronized (a) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             lockedByThis.field = new Object(); // error
             a.lockedByThis.field = new Object();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             b.lockedByThis.field = new Object(); // error
         }
 
         synchronized (b) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             lockedByThis.field = new Object(); // error
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             a.lockedByThis.field = new Object(); // error
             b.lockedByThis.field = new Object();
         }

--- a/checker/tests/lock/FlowExpressions.java
+++ b/checker/tests/lock/FlowExpressions.java
@@ -14,9 +14,9 @@ class FlowExpressions {
     }
 
     public void method() {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         getm().field = new Object();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field = new Object();
         // TODO: fix the Lock Checker code so that a flowexpr.parse.error is issued (due to the guard of "nonexistentfield" on m2)
         // m2.field = new Object();

--- a/checker/tests/lock/GuardSatisfiedTest.java
+++ b/checker/tests/lock/GuardSatisfiedTest.java
@@ -32,16 +32,16 @@ public class GuardSatisfiedTest {
             @GuardSatisfied Object q) {
         // Test matching parameters
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         methodToCall1(o, o);
-        //:: error: (contracts.precondition.not.satisfied.field) :: error: (guardsatisfied.parameters.must.match)
+        //:: error: (lock.not.held) :: error: (guardsatisfied.parameters.must.match)
         methodToCall1(o, p);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         methodToCall1(p, p);
         synchronized (lock2) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             methodToCall1(o, o);
-            //:: error: (guardsatisfied.parameters.must.match) :: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (guardsatisfied.parameters.must.match) :: error: (lock.not.held)
             methodToCall1(o, p);
             methodToCall1(p, p);
             synchronized (lock1) {
@@ -54,20 +54,20 @@ public class GuardSatisfiedTest {
 
         // Test a return type matching a parameter.
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         o = methodToCall2(o);
-        //:: error: (contracts.precondition.not.satisfied.field) :: error: (assignment.type.incompatible)
+        //:: error: (lock.not.held) :: error: (assignment.type.incompatible)
         p = methodToCall2(o);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         methodToCall2(o);
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         methodToCall2(p);
         synchronized (lock2) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             o = methodToCall2(o);
-            //:: error: (contracts.precondition.not.satisfied.field) :: error: (assignment.type.incompatible)
+            //:: error: (lock.not.held) :: error: (assignment.type.incompatible)
             p = methodToCall2(o);
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             methodToCall2(o);
             methodToCall2(p);
         }
@@ -76,7 +76,7 @@ public class GuardSatisfiedTest {
             //:: error: (assignment.type.incompatible)
             p = methodToCall2(o);
             methodToCall2(o);
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             methodToCall2(p);
         }
 
@@ -86,13 +86,13 @@ public class GuardSatisfiedTest {
         //:: error: (guardsatisfied.parameters.must.match)
         methodToCall3(q);
 
-        //:: error: (guardsatisfied.parameters.must.match) :: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (guardsatisfied.parameters.must.match) :: error: (lock.not.held)
         methodToCall3(p);
         synchronized (lock1) {
             // Two @GS parameters with no index are incomparable (as is the case for 'this' and 'q')
             //:: error: (guardsatisfied.parameters.must.match)
             methodToCall3(q);
-            //:: error: (guardsatisfied.parameters.must.match) :: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (guardsatisfied.parameters.must.match) :: error: (lock.not.held)
             methodToCall3(p);
             synchronized (lock2) {
                 // Two @GS parameters with no index are incomparable (as is the case for 'this' and 'q')
@@ -111,21 +111,21 @@ public class GuardSatisfiedTest {
     // Test the return type NOT matching the receiver type
     void testMethodCall(@GuardedBy("lock1") GuardSatisfiedTest this) {
         @GuardedBy("lock2") Object g;
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         methodToCall4();
-        // TODO: contracts.precondition.not.satisfied is getting swallowed below
-        //  error (assignment.type.incompatible) error (contracts.precondition.not.satisfied)
+        // TODO: lock.not.held is getting swallowed below
+        //  error (assignment.type.incompatible) error (lock.not.held)
         // g = methodToCall4();
 
         // Separate the above test case into two for now
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         methodToCall4();
 
         // The following error is due to the fact that you cannot access "this.lock1" without first having acquired "lock1".
         // The right fix in a user scenario would be to not guard "this" with "this.lock1". The current object could instead
         // be guarded by "<self>" or by some other lock expression that is not one of its fields. We are keeping this test
         // case here to make sure this scenario issues a warning.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (lock1) {
             //:: error: (assignment.type.incompatible)
             g = methodToCall4();
@@ -190,10 +190,10 @@ public class GuardSatisfiedTest {
 
     void testAssignment(@GuardSatisfied Object o) {
         @GuardedBy({"lock1", "lock2"}) Object p = new Object();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         o = p;
         synchronized (lock1) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             o = p;
             synchronized (lock2) {
                 o = p;

--- a/checker/tests/lock/Issue152.java
+++ b/checker/tests/lock/Issue152.java
@@ -1,8 +1,6 @@
-// @skip-test
-
 // Test case for Issue 152:
 // https://github.com/typetools/checker-framework/issues/152
-
+// @skip-test
 import org.checkerframework.checker.lock.qual.GuardedBy;
 
 public class Issue152 {
@@ -20,6 +18,18 @@ public class Issue152 {
         void method() {
             //:: error: (assignment.type.incompatible)
             this.locked = super.locked;
+        }
+    }
+
+    class OuterClass {
+        private final Object lock = new Object();
+
+        @GuardedBy("this.lock") Object field;
+
+        class InnerClass {
+            private final Object lock = new Object();
+            //:: error: (assignment.type.incompatible)
+            @GuardedBy("this.lock") Object field2 = field;
         }
     }
 }

--- a/checker/tests/lock/Issue524.java
+++ b/checker/tests/lock/Issue524.java
@@ -29,7 +29,7 @@ class Issue524 {
             @GuardedBy("localLock") MyClass q = new MyClass();
             localLock.lock();
             localLock.lock();
-            // Without a fix for issue 524 in place, the error contracts.precondition.not.satisfied.field
+            // Without a fix for issue 524 in place, the error lock.not.held
             // (unguarded access to field, variable or parameter 'q' guarded by 'localLock') is issued for the following line.
             q.field.toString();
         }

--- a/checker/tests/lock/ItselfExpressionCases.java
+++ b/checker/tests/lock/ItselfExpressionCases.java
@@ -15,18 +15,18 @@ class ItselfExpressionCases {
     @Pure
     private @GuardedBy({"<self>"}) MyClass getm2(@GuardedBy("<self>") ItselfExpressionCases this) {
         // The following error is due to the precondition of the this.m field dereference not being satisfied.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         return m;
     }
 
     @Pure
     private Object getmfield() {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         return getm().field;
     }
 
     public void arrayTest(final Object @GuardedBy("<self>") [] a1) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         Object a = a1[0];
         synchronized (a1) {
             a = a1[0];
@@ -41,7 +41,7 @@ class ItselfExpressionCases {
     }
 
     public void arrayTest() {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         Object a = geta2()[0];
         synchronized (geta2()) {
             a = geta2()[0];
@@ -52,37 +52,37 @@ class ItselfExpressionCases {
             final @GuardedBy("<self>") MyClass o,
             @GuardSatisfied Object gs,
             @GuardSatisfied MyClass gsMyClass) {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         getm().field = new Object();
         synchronized (getm()) {
             getm().field = new Object();
         }
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field = new Object();
         synchronized (m) {
             m.field = new Object();
         }
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         gs = m.field;
         synchronized (m) {
             gs = m.field;
         }
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         gs = getm().field;
         synchronized (getm()) {
             gs = getm().field;
         }
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         gsMyClass = getm();
         synchronized (getm()) {
             gsMyClass = getm();
         }
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held) :: error: (contracts.precondition.not.satisfied)
         o.foo();
         synchronized (o) {
             //:: error: (contracts.precondition.not.satisfied)
@@ -92,7 +92,7 @@ class ItselfExpressionCases {
             }
         }
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         o.foo2();
         synchronized (o) {
             o.foo2();
@@ -108,14 +108,15 @@ class ItselfExpressionCases {
         void foo2(@GuardSatisfied MyClass this) {}
 
         void method(@GuardedBy("<self>") MyClass this) {
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held) :: error: (contracts.precondition.not.satisfied)
             this.foo();
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held):: error: (contracts.precondition.not.satisfied)
             foo();
+            //:: error: (lock.not.held)
             synchronized (somelock) {
-                //:: error: (contracts.precondition.not.satisfied)
+                //:: error: (lock.not.held)
                 this.foo();
-                //:: error: (contracts.precondition.not.satisfied)
+                //:: error: (lock.not.held)
                 foo();
                 synchronized (this) {
                     this.foo();
@@ -123,9 +124,9 @@ class ItselfExpressionCases {
                 }
             }
 
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held)
             this.foo2();
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held)
             foo2();
             synchronized (this) {
                 this.foo2();

--- a/checker/tests/lock/JCIPAnnotations.java
+++ b/checker/tests/lock/JCIPAnnotations.java
@@ -31,19 +31,19 @@ public class JCIPAnnotations {
         //:: error: (method.invocation.invalid)
         jcipGuardedField.methodWithUnguardedReceiver();
         jcipGuardedField.methodWithGuardedReceiver();
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         jcipGuardedField.methodWithGuardSatisfiedReceiver();
         //:: error: (method.invocation.invalid)
         javaxGuardedField.methodWithUnguardedReceiver();
         javaxGuardedField.methodWithGuardedReceiver();
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         javaxGuardedField.methodWithGuardSatisfiedReceiver();
     }
 
     void testDereferences() {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.jcipGuardedField.field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.javaxGuardedField.field.toString();
         synchronized (lock) {
             this.jcipGuardedField.field.toString();

--- a/checker/tests/lock/LockEffectAnnotations.java
+++ b/checker/tests/lock/LockEffectAnnotations.java
@@ -59,13 +59,13 @@ public class LockEffectAnnotations {
             x3.field =
                     new Object(); // OK: the lock is still held since mySideEffectFreeMethod is side-effect-free
             myUnlockingMethod();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             x3.field = new Object(); // ILLEGAL: myLockingMethod is not locking-free
         }
         if (myLock2.tryLock()) {
             x3.field = new Object(); // OK: the lock is held
             myReleaseLocksEmptyMethod();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             x3.field =
                     new Object(); // ILLEGAL: even though myUnannotatedEmptyMethod is empty, since
             // myReleaseLocksEmptyMethod() is annotated with @MayReleaseLocks and the Lock Checker no longer knows
@@ -141,7 +141,7 @@ public class LockEffectAnnotations {
 
     //:: error: (class.declaration.guardedby.annotation.invalid)
     @GuardedByUnknown class MyClass2 {}
-    //:: error: (class.declaration.guardedby.annotation.invalid) :: error: (lock.expression.possibly.not.final)
+    //:: error: (class.declaration.guardedby.annotation.invalid)
     @GuardedBy("lock") class MyClass3 {}
 
     @GuardedBy({}) class MyClass4 {}

--- a/checker/tests/lock/NestedSynchronizedBlocks.java
+++ b/checker/tests/lock/NestedSynchronizedBlocks.java
@@ -30,13 +30,13 @@ public class NestedSynchronizedBlocks {
 
         // Test that the locks are known to have been released.
 
-        //:: error:(contracts.precondition.not.satisfied.field)
+        //:: error:(lock.not.held)
         m1.field = new Object();
-        //:: error:(contracts.precondition.not.satisfied.field)
+        //:: error:(lock.not.held)
         m2.field = new Object();
-        //:: error:(contracts.precondition.not.satisfied.field)
+        //:: error:(lock.not.held)
         m3.field = new Object();
-        //:: error:(contracts.precondition.not.satisfied.field)
+        //:: error:(lock.not.held)
         m4.field = new Object();
     }
 }

--- a/checker/tests/lock/Primitives.java
+++ b/checker/tests/lock/Primitives.java
@@ -17,145 +17,145 @@ class Primitives {
         //@GuardedByName("lock")
         boolean b;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = i >>> primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive >>> i;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i >>>= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         primitive >>>= i;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i %= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = 4 % primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive % 4;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         primitive++;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         primitive--;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         ++primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         --primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         if (primitive != 5) {}
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive >> i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive << i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = i >> primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = i << primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i <<= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i >>= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         primitive <<= i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         primitive >>= i;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         assert (primitiveBoolean);
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitive >= i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitive <= i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitive > i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitive < i;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = i >= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = i <= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = i > primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = i < primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i += primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i -= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i *= primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i /= primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = 4 + primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = 4 - primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = 4 * primitive;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = 4 / primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive + 4;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive - 4;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive * 4;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive / 4;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         if (primitiveBoolean) {}
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = ~primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitiveBoolean || false;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitiveBoolean | false;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitiveBoolean ^ true;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b &= primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b |= primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b ^= primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = !primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         i = primitive;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = true && primitiveBoolean;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = true & primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = false || primitiveBoolean;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = false | primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = false ^ primitiveBoolean;
 
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitiveBoolean && true;
-        // TODO reenable this error: (contracts.precondition.not.satisfied.field)
+        // TODO reenable this error: (lock.not.held)
         b = primitiveBoolean & true;
     }
 }

--- a/checker/tests/lock/Simple.java
+++ b/checker/tests/lock/Simple.java
@@ -4,21 +4,21 @@ public class Simple {
     final Object lock1 = new Object(), lock2 = new Object();
 
     void testMethodCall(@GuardedBy("lock1") Simple this) {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (lock1) {
         }
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (this.lock1) {
         }
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (lock2) {
         }
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (this.lock2) {
         }
 
         final @GuardedBy("myClass.field") MyClass myClass = new MyClass();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         synchronized (myClass.field) {
         }
         synchronized (myClass) {

--- a/checker/tests/lock/Strings.java
+++ b/checker/tests/lock/Strings.java
@@ -1,6 +1,5 @@
 package chapter;
 
-import chapter.ChapterExamples.MyClass;
 import org.checkerframework.checker.lock.qual.GuardSatisfied;
 import org.checkerframework.checker.lock.qual.GuardedBy;
 import org.checkerframework.checker.lock.qual.GuardedByBottom;
@@ -30,20 +29,20 @@ public class Strings {
     void StringConcat(@GuardedBy("lock") MyClass param) {
         {
             String s1a = "a" + "a";
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             String s1b = "a" + param;
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             String s1c = param + "a";
-            //:: error: (contracts.precondition.not.satisfied)
+            //:: error: (lock.not.held)
             String s1d = param.toString();
 
             String s2 = "a";
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             s2 += param;
 
             String s3 = "a";
             // In addition to testing whether "lock" is held, tests that the result of a string concatenation has type @GuardedBy({}).
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             String s4 = s3 += param;
         }
         synchronized (lock) {
@@ -59,5 +58,9 @@ public class Strings {
             // In addition to testing whether "lock" is held, tests that the result of a string concatenation has type @GuardedBy({}).
             String s4 = s3 += param;
         }
+    }
+
+    class MyClass {
+        Object field = new Object();
     }
 }

--- a/checker/tests/lock/TestConcurrentSemantics1.java
+++ b/checker/tests/lock/TestConcurrentSemantics1.java
@@ -1,11 +1,9 @@
 package chapter;
 
-import chapter.ChapterExamples.MyClass;
 import java.util.concurrent.locks.ReentrantLock;
 import org.checkerframework.checker.lock.qual.GuardedBy;
 import org.checkerframework.checker.lock.qual.GuardedByUnknown;
 
-/** Created by smillst on 11/17/16. */
 class TestConcurrentSemantics1 {
     /* This class tests the following critical scenario.
      *
@@ -42,7 +40,7 @@ class TestConcurrentSemantics1 {
         @GuardedBy("lock1") MyClass local = new MyClass();
         m = local;
         lock1.lock();
-        //:: error: (cannot.dereference)
+        //:: error: (lock.not.held)
         m.field = new Object();
     }
 

--- a/checker/tests/lock/TestTreeKinds.java
+++ b/checker/tests/lock/TestTreeKinds.java
@@ -19,7 +19,7 @@ public class TestTreeKinds {
 
     {
         // In constructor/initializer, it's OK not to hold the lock on 'this', but other locks must be respected.
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         m.field = new Object();
     }
 
@@ -136,7 +136,7 @@ public class TestTreeKinds {
         if (Thread.holdsLock(intrinsicLock)) {
             m.field.toString();
         } else {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             m.field.toString();
         }
     }
@@ -151,7 +151,7 @@ public class TestTreeKinds {
 
         // TODO: File a bug for the dataflow issue mentioned in the line below.
         // TODO: uncomment: Hits a bug in dataflow:    do { break; } while (foo.field != null); // access to guarded object in while condition of do/while loop
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         for (foo = new MyClass(); foo.field != null; foo = new MyClass()) {
             break;
         } // access to guarded object in condition of for loop
@@ -160,33 +160,33 @@ public class TestTreeKinds {
         // A simple method call to a guarded object is not considered a dereference (only field accesses are considered dereferences).
         unguardedFoo.method2();
         // Same as above, but the guard must be satisfied if the receiver is @GuardSatisfied.
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         foo.method2();
         // attempt to use guarded object in a switch statement
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         switch (foo.field.hashCode()) {
         }
         // attempt to use guarded object inside a try with resources
         // try(foo = new MyClass()) { foo.field.toString(); }
 
         // Retrieving an element from a guarded array is a dereference
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         MyClass m = fooArray[0];
 
         // method call on dereference of unguarded element of *guarded* array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         fooArray[0].field.toString();
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = fooArray.length; // dereference of guarded array itself
 
         // method call on dereference of guarded array element
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         fooArray2[0].field.toString();
         // method call on dereference of unguarded array - TODO: currently preconditions are not retrieved correctly from array types. This is not unique to the Lock Checker.
         // fooArray2.field.toString();
 
         // method call on dereference of guarded array element of multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         fooArray3[0][0].field.toString();
         // method call on dereference of unguarded single-dimensional array element of unguarded multidimensional array - TODO: currently preconditions are not retrieved correctly from array types. This is not unique to the Lock Checker.
         // fooArray3[0].field.toString();
@@ -194,35 +194,35 @@ public class TestTreeKinds {
         // fooArray3.field.toString();
 
         // method call on dereference of unguarded array element of *guarded* multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         fooArray4[0][0].field.toString();
         // dereference of unguarded single-dimensional array element of *guarded* multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = fooArray4[0].length;
         // dereference of guarded multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = fooArray4.length;
 
         // method call on dereference of unguarded array element of *guarded subarray* of multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         fooArray5[0][0].field.toString();
         // dereference of guarded single-dimensional array element of multidimensional array
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = fooArray5[0].length;
         // dereference of unguarded multidimensional array
         l = fooArray5.length;
 
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         l = getFooArray().length; // dereference of guarded array returned by a method
 
         // method call on dereference of guarded array element returned by a method
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         getFooArray2()[0].field.toString();
         // dereference of unguarded array returned by a method
         l = getFooArray2().length;
 
         // method call on dereference of guarded array element of multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         getFooArray3()[0][0].field.toString();
         // dereference of unguarded single-dimensional array element of multidimensional array returned by a method
         l = getFooArray3()[0].length;
@@ -230,30 +230,30 @@ public class TestTreeKinds {
         l = getFooArray3().length;
 
         // method call on dereference of unguarded array element of *guarded* multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         getFooArray4()[0][0].field.toString();
         // dereference of unguarded single-dimensional array element of *guarded* multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         l = getFooArray4()[0].length;
         // dereference of guarded multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         l = getFooArray4().length;
 
         // method call on dereference of unguarded array element of *guarded subarray* of multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         getFooArray5()[0][0].field.toString();
         // dereference of guarded single-dimensional array element of multidimensional array returned by a method
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = getFooArray5()[0].length;
         // dereference of unguarded multidimensional array returned by a method
         l = getFooArray5().length;
 
         // Test different @GuardedBy(...) present on the element and array locations.
         @GuardedBy("lock") MyClass @GuardedBy("lock2") [] array = new MyClass[3];
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         array[0].field = new Object();
         if (lock.isHeldByCurrentThread()) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             array[0].field = new Object();
             if (lock2.isHeldByCurrentThread()) {
                 array[0].field = new Object();
@@ -261,17 +261,17 @@ public class TestTreeKinds {
         }
 
         // method call on guarded object within parenthesized expression
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         String s = (foo.field.toString());
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         foo.field.toString(); // method call on guarded object
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         getFoo().field.toString(); // method call on guarded object returned by a method
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         this.foo.field.toString(); // method call on guarded object using 'this' literal
         // dereference of guarded object in labeled statement
         label:
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         foo.field.toString();
         // access to guarded object in instanceof expression (OK)
         if (foo instanceof MyClass) {}
@@ -286,18 +286,18 @@ public class TestTreeKinds {
         // access to guarded object in a lambda expression
         Runnable rn =
                 () -> {
-                    //:: error: (contracts.precondition.not.satisfied.field)
+                    //:: error: (lock.not.held)
                     foo.field.toString();
                 };
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         i = myClassInstance.i; // access to member field of guarded object
         // MemberReferenceTrees? how do they work
         fooArray = new MyClass[3]; // second allocation of guarded array (OK)
         // dereference of guarded object in conditional expression tree
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         s = i == 5 ? foo.field.toString() : f.field.toString();
         // dereference of guarded object in conditional expression tree
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         s = i == 5 ? f.field.toString() : foo.field.toString();
         // Testing of 'return' is done in getFooWithWrongReturnType()
         // throwing a guarded object - when throwing an exception, it must be @GuardedBy({}). Even @GuardedByUnknown is not allowed.
@@ -311,7 +311,7 @@ public class TestTreeKinds {
         @GuardedBy({}) Object e1 = (Object) exception;
         // OK, since the local variable's type gets refined to @GuardedBy("lock")
         Object e2 = (Object) exception;
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         l = myParametrizedType.l; // dereference of guarded object having a parameterized type
 
         // We need to support locking on local variables and protecting local variables because these locals may contain references to fields. Somehow we need to pass along the information of which field it was.
@@ -325,8 +325,8 @@ public class TestTreeKinds {
             // there is an attempt to dereference an expression whose type has been refined to @GuardedByBottom
             // (due to the comparison to null). However, with -AconcurrentSemantics turned on, foo may no longer
             // be null by now, the refinement to @GuardedByBottom is lost and the refined type of foo is now the
-            // declared type ( @GuardedBy("lock") ), resulting in the contracts.precondition.not.satisfied.field error.
-            //:: error: (contracts.precondition.not.satisfied.field)
+            // declared type ( @GuardedBy("lock") ), resulting in the lock.not.held error.
+            //:: error: (lock.not.held)
             foo.field.toString();
         }
 
@@ -343,12 +343,12 @@ public class TestTreeKinds {
 
         @GuardedBy("localLock") MyClass guardedByLocalLock = new MyClass();
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         guardedByLocalLock.field.toString();
 
         @GuardedBy("lock") MyClass local = new MyClass();
 
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         local.field.toString();
 
         lockTheLock();
@@ -376,17 +376,17 @@ public class TestTreeKinds {
 
             unlockTheLock();
 
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             foo.field.toString();
         } else {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             foo.field.toString();
         }
 
         if (tryToLockTheLock()) {
             foo.field.toString();
         } else {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             foo.field.toString();
         }
 
@@ -397,7 +397,7 @@ public class TestTreeKinds {
         } else {
             lockTheLock();
             nonSideEffectFreeMethod();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             foo.field.toString();
         }
 
@@ -408,7 +408,7 @@ public class TestTreeKinds {
         } else {
             lockTheLock();
             nonSideEffectFreeMethod();
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             foo.field.toString();
         }
     }
@@ -423,7 +423,7 @@ public class TestTreeKinds {
     }
 
     void testReceiverGuardedByItself(@GuardedBy("<self>") TestTreeKinds this) {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         method();
         synchronized (this) {
             method();
@@ -433,7 +433,7 @@ public class TestTreeKinds {
     void method(@GuardSatisfied TestTreeKinds this) {}
 
     void testOtherClassReceiverGuardedByItself(final @GuardedBy("<self>") OtherClass o) {
-        //:: error: (contracts.precondition.not.satisfied)
+        //:: error: (lock.not.held)
         o.foo();
         synchronized (o) {
             o.foo();

--- a/checker/tests/lock/ThisPostCondition.java
+++ b/checker/tests/lock/ThisPostCondition.java
@@ -49,7 +49,7 @@ class ThisPostCondition {
     }
 
     void doNotLock() {
-        //:: error: (contracts.precondition.not.satisfied.field)
+        //:: error: (lock.not.held)
         bar.field.toString();
     }
 
@@ -57,7 +57,7 @@ class ThisPostCondition {
         if (myLock.tryLock()) {
             bar.field.toString();
         } else {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             bar.field.toString();
         }
     }

--- a/checker/tests/lock/ThisSuper.java
+++ b/checker/tests/lock/ThisSuper.java
@@ -1,0 +1,90 @@
+// Test case for Issue #152
+// https://github.com/typetools/checker-framework/issues/152
+
+// @skip-test
+import org.checkerframework.checker.lock.qual.GuardedBy;
+
+public class ThisSuper {
+
+    class MyClass {
+        Object field;
+    }
+
+    class LockExample {
+        protected final Object myLock = new Object();
+
+        protected @GuardedBy("myLock") MyClass locked;
+
+        @GuardedBy("this.myLock") MyClass m1;
+
+        protected @GuardedBy("this.myLock") MyClass locked2;
+
+        public void accessLock() {
+            synchronized (myLock) {
+                this.locked.field = new Object();
+            }
+        }
+    }
+
+    class LockExampleSubclass extends LockExample {
+        private final Object myLock = new Object();
+
+        private @GuardedBy("this.myLock") MyClass locked;
+
+        @GuardedBy("this.myLock") MyClass m2;
+
+        public LockExampleSubclass() {
+            final LockExampleSubclass les1 = new LockExampleSubclass();
+            final LockExampleSubclass les2 = new LockExampleSubclass();
+            final LockExampleSubclass les3 = les2;
+            LockExample le1 = new LockExample();
+
+            synchronized (super.myLock) {
+                super.locked.toString();
+                super.locked2.toString();
+                //:: error: (contracts.precondition.not.satisfied)
+                locked.toString();
+            }
+            synchronized (myLock) {
+                //:: error: (contracts.precondition.not.satisfied)
+                super.locked.toString();
+                //:: error: (contracts.precondition.not.satisfied)
+                super.locked2.toString();
+                locked.toString();
+            }
+
+            //:: error: (assignment.type.incompatible)
+            les1.locked = le1.locked;
+            //:: error: (assignment.type.incompatible)
+            les1.locked = le1.locked2;
+
+            //:: error: (assignment.type.incompatible)
+            les1.locked = les2.locked;
+
+            //:: error: (assignment.type.incompatible)
+            this.locked = super.locked;
+            //:: error: (assignment.type.incompatible)
+            this.locked = super.locked2;
+
+            //:: error: (assignment.type.incompatible)
+            m1 = m2;
+        }
+
+        @Override
+        public void accessLock() {
+            synchronized (myLock) {
+                this.locked.field = new Object();
+                //:: error: (lock.not.held)
+                super.locked.field = new Object();
+                System.out.println(
+                        this.locked.field
+                                + " "
+                                +
+                                //:: error: (lock.not.held)
+                                super.locked.field);
+                System.out.println(
+                        "Are locks equal? " + (super.locked == this.locked ? "yes" : "no"));
+            }
+        }
+    }
+}

--- a/checker/tests/lock/ViewpointAdaptation.java
+++ b/checker/tests/lock/ViewpointAdaptation.java
@@ -1,10 +1,9 @@
 // Test case for Issue #770
 // https://github.com/typetools/checker-framework/issues/770
-// @skip-test
 import org.checkerframework.checker.lock.qual.GuardedBy;
 
 public class ViewpointAdaptation {
-    //:: error: (flowexpr.parse.error)
+    //:: error: (expression.unparsable.type.invalid)
     @GuardedBy("a") private final ViewpointAdaptation f = new ViewpointAdaptation();
 
     @GuardedBy("this.lock") private ViewpointAdaptation g = new ViewpointAdaptation();
@@ -17,7 +16,7 @@ public class ViewpointAdaptation {
         synchronized (a) {
             // The expression "a" from the @GuardedBy annotation
             // on f is not valid at the declaration site of f.
-            //:: error: (flowexpr.parse.error)
+            //:: error: (expression.unparsable.type.invalid)
             f.counter++;
         }
     }
@@ -29,7 +28,7 @@ public class ViewpointAdaptation {
         t.g = g; // "t.lock" != "this.lock"
 
         synchronized (t.lock) {
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             g.counter++;
         }
     }
@@ -44,7 +43,7 @@ public class ViewpointAdaptation {
         synchronized (l) {
             // Aliasing of lock expressions is not tracked by the Lock Checker.
             // The Lock Checker does not know that l == t.lock
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             g.counter++;
         }
     }

--- a/checker/tests/lock/ViewpointAdaptation2.java
+++ b/checker/tests/lock/ViewpointAdaptation2.java
@@ -1,20 +1,8 @@
 // Test case for Issue #770
 // https://github.com/typetools/checker-framework/issues/770
-// @skip-test
 import org.checkerframework.checker.lock.qual.GuardedBy;
 
 public class ViewpointAdaptation2 {
-    class OuterClass {
-        private final Object lock = new Object();
-
-        @GuardedBy("this.lock") Object field;
-
-        class InnerClass {
-            private final Object lock = new Object();
-            //:: error: (assignment.type.incompatible)
-            @GuardedBy("this.lock") Object field2 = field;
-        }
-    }
 
     class LockExample {
         protected final Object myLock = new Object();

--- a/checker/tests/lock/ViewpointAdaptation3.java
+++ b/checker/tests/lock/ViewpointAdaptation3.java
@@ -1,6 +1,5 @@
 // Test case for Issue #770
 // https://github.com/typetools/checker-framework/issues/770
-// @skip-test
 import org.checkerframework.checker.lock.qual.GuardedBy;
 
 public class ViewpointAdaptation3 {
@@ -38,20 +37,6 @@ public class ViewpointAdaptation3 {
             final LockExampleSubclass les3 = les2;
             LockExample le1 = new LockExample();
 
-            synchronized (super.myLock) {
-                super.locked.toString();
-                super.locked2.toString();
-                //:: error: (contracts.precondition.not.satisfied)
-                locked.toString();
-            }
-            synchronized (myLock) {
-                //:: error: (contracts.precondition.not.satisfied)
-                super.locked.toString();
-                //:: error: (contracts.precondition.not.satisfied)
-                super.locked2.toString();
-                locked.toString();
-            }
-
             //:: error: (assignment.type.incompatible)
             les1.locked = le1.locked;
             //:: error: (assignment.type.incompatible)
@@ -59,31 +44,6 @@ public class ViewpointAdaptation3 {
 
             //:: error: (assignment.type.incompatible)
             les1.locked = les2.locked;
-
-            //:: error: (assignment.type.incompatible)
-            this.locked = super.locked;
-            //:: error: (assignment.type.incompatible)
-            this.locked = super.locked2;
-
-            //:: error: (assignment.type.incompatible)
-            m1 = m2;
-        }
-
-        @Override
-        public void accessLock() {
-            synchronized (myLock) {
-                this.locked.field = new Object();
-                //:: error: (contracts.precondition.not.satisfied.field)
-                super.locked.field = new Object();
-                System.out.println(
-                        this.locked.field
-                                + " "
-                                +
-                                //:: error: (contracts.precondition.not.satisfied.field)
-                                super.locked.field);
-                System.out.println(
-                        "Are locks equal? " + (super.locked == this.locked ? "yes" : "no"));
-            }
         }
     }
 
@@ -105,15 +65,15 @@ public class ViewpointAdaptation3 {
             //:: error: (assignment.type.incompatible)
             local = m;
 
-            //:: error: (contracts.precondition.not.satisfied.field)
+            //:: error: (lock.not.held)
             local.field = new Object();
 
             synchronized (lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 a.m.field = new Object();
             }
             synchronized (this.lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 a.m.field = new Object();
             }
             synchronized (a.lock) {
@@ -124,18 +84,18 @@ public class ViewpointAdaptation3 {
                 local.field = new Object();
             }
             synchronized (this.lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 local.field = new Object();
             }
             synchronized (a.lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 local.field = new Object();
             }
 
             synchronized (lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 this.m.field = new Object();
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 m.field = new Object();
             }
             synchronized (this.lock) {
@@ -143,9 +103,9 @@ public class ViewpointAdaptation3 {
                 m.field = new Object();
             }
             synchronized (a.lock) {
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 this.m.field = new Object();
-                //:: error: (contracts.precondition.not.satisfied.field)
+                //:: error: (lock.not.held)
                 m.field = new Object();
             }
         }

--- a/framework/src/org/checkerframework/framework/util/ContractsUtils.java
+++ b/framework/src/org/checkerframework/framework/util/ContractsUtils.java
@@ -177,6 +177,7 @@ public class ContractsUtils {
         contracts.addAll(getConditionalPostconditions(element));
         return contracts;
     }
+
     /** Returns the set of preconditions on the element {@code element}. */
     public Set<Precondition> getPreconditions(Element element) {
         Set<Precondition> result = new LinkedHashSet<>();

--- a/framework/src/org/checkerframework/framework/util/expressionannotations/ExpressionAnnotationError.java
+++ b/framework/src/org/checkerframework/framework/util/expressionannotations/ExpressionAnnotationError.java
@@ -9,6 +9,7 @@ import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressio
 /** Helper class for creating expression annotation error strings. */
 public class ExpressionAnnotationError {
     private static final String formatString = "[error for expression: %s error: %s]";
+
     private static final Pattern errorPattern =
             Pattern.compile("\\[error for expression: (.*) error: (.*)\\]");
 

--- a/framework/src/org/checkerframework/framework/util/expressionannotations/ExpressionAnnotationHelper.java
+++ b/framework/src/org/checkerframework/framework/util/expressionannotations/ExpressionAnnotationHelper.java
@@ -70,6 +70,7 @@ import org.checkerframework.javacutil.TreeUtils;
  */
 public class ExpressionAnnotationHelper {
     protected final AnnotatedTypeFactory factory;
+
     /** A list of annotations that are expression annotations. */
     protected final List<Class<? extends Annotation>> expressionAnnos;
 
@@ -190,7 +191,6 @@ public class ExpressionAnnotationHelper {
         // list.get(0)
         // If the type of List.get is viewpoint adapted for the invocation "list.get(0)", then
         // typeFromUse would be @KeyFor("map") String get(int).
-
         // Instead, use the type for the method (viewpointAdaptedType) and viewpoint adapt that
         // type.
         // Then copy annotations from the viewpoint adapted type to typeFromUse, if that annotation


### PR DESCRIPTION
The Lock Checker hacked BaseTypeVisitor's precondition code to issue a contracts.precondition.not.satisfied.field error when a lock was not held. This commit removes that hack from BaseTypeVisitor and a "lock.not.held" error is issued instead.

(Daikon type-checks with this change and takes about the same amount of time.)