### PR TITLE
Annotate Optional.orElse with @PolyNull (fixes #1000)

### DIFF
--- a/checker/jdk/lock/src/com/sun/javadoc/ClassDoc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/ClassDoc.java
@@ -2,7 +2,6 @@ package com.sun.javadoc;
 
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public interface ClassDoc extends ProgramElementDoc, Type {
      boolean isAbstract(@GuardSatisfied ClassDoc this);

--- a/checker/jdk/lock/src/com/sun/javadoc/ClassDoc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/ClassDoc.java
@@ -1,6 +1,6 @@
 package com.sun.javadoc;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.checkerframework.checker.lock.qual.*;
 import org.checkerframework.dataflow.qual.Pure;
 

--- a/checker/jdk/lock/src/com/sun/javadoc/Doc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/Doc.java
@@ -1,7 +1,6 @@
 package com.sun.javadoc;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public interface Doc extends java.lang.Comparable<java.lang.Object> {
   public abstract java.lang.String commentText();

--- a/checker/jdk/lock/src/com/sun/javadoc/FieldDoc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/FieldDoc.java
@@ -1,7 +1,6 @@
 package com.sun.javadoc;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public interface FieldDoc extends MemberDoc {
   public abstract com.sun.javadoc.Type type();

--- a/checker/jdk/lock/src/com/sun/javadoc/MemberDoc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/MemberDoc.java
@@ -1,7 +1,6 @@
 package com.sun.javadoc;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public interface MemberDoc extends ProgramElementDoc {
    public abstract boolean isSynthetic(@GuardSatisfied MemberDoc this);

--- a/checker/jdk/lock/src/com/sun/javadoc/ProgramElementDoc.java
+++ b/checker/jdk/lock/src/com/sun/javadoc/ProgramElementDoc.java
@@ -1,7 +1,6 @@
 package com.sun.javadoc;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public interface ProgramElementDoc extends Doc {
   public abstract com.sun.javadoc. ClassDoc containingClass();

--- a/checker/jdk/lock/src/java/io/BufferedReader.java
+++ b/checker/jdk/lock/src/java/io/BufferedReader.java
@@ -1,6 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.*;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/BufferedReader.java
+++ b/checker/jdk/lock/src/java/io/BufferedReader.java
@@ -1,7 +1,6 @@
 package java.io;
 
 import org.checkerframework.dataflow.qual.*;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.lock.qual.*;
 
 
@@ -15,7 +14,7 @@ public class BufferedReader extends Reader {
   public String readLine() throws IOException { throw new RuntimeException("skeleton method"); }
   public long skip(long a1) throws IOException { throw new RuntimeException("skeleton method"); }
 
-   public boolean ready(@GuardSatisfied BufferedReader this) throws IOException { throw new RuntimeException("skeleton method"); }
+  public boolean ready(@GuardSatisfied BufferedReader this) throws IOException { throw new RuntimeException("skeleton method"); }
   public boolean markSupported() { throw new RuntimeException("skeleton method"); }
   public void mark(int a1) throws IOException { throw new RuntimeException("skeleton method"); }
   public void reset() throws IOException { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/io/ByteArrayOutputStream.java
+++ b/checker/jdk/lock/src/java/io/ByteArrayOutputStream.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/CharArrayWriter.java
+++ b/checker/jdk/lock/src/java/io/CharArrayWriter.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/DataOutputStream.java
+++ b/checker/jdk/lock/src/java/io/DataOutputStream.java
@@ -1,6 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/File.java
+++ b/checker/jdk/lock/src/java/io/File.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/io/FilePermission.java
+++ b/checker/jdk/lock/src/java/io/FilePermission.java
@@ -1,6 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/ObjectStreamClass.java
+++ b/checker/jdk/lock/src/java/io/ObjectStreamClass.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/ObjectStreamField.java
+++ b/checker/jdk/lock/src/java/io/ObjectStreamField.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/StreamTokenizer.java
+++ b/checker/jdk/lock/src/java/io/StreamTokenizer.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/io/StringWriter.java
+++ b/checker/jdk/lock/src/java/io/StringWriter.java
@@ -1,7 +1,5 @@
 package java.io;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/AbstractStringBuilder.java
+++ b/checker/jdk/lock/src/java/lang/AbstractStringBuilder.java
@@ -29,8 +29,6 @@ package java.lang;
 import java.util.Arrays;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 /**
  * A mutable sequence of characters.

--- a/checker/jdk/lock/src/java/lang/Class.java
+++ b/checker/jdk/lock/src/java/lang/Class.java
@@ -1,9 +1,9 @@
 package java.lang;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
+
+
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 

--- a/checker/jdk/lock/src/java/lang/Class.java
+++ b/checker/jdk/lock/src/java/lang/Class.java
@@ -4,8 +4,6 @@ import org.checkerframework.checker.lock.qual.*;
 
 
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 public final class Class<T extends Object> extends Object implements java.io.Serializable, java.lang.reflect.GenericDeclaration, java.lang.reflect.Type, java.lang.reflect.AnnotatedElement {
   private static final long serialVersionUID = 0;

--- a/checker/jdk/lock/src/java/lang/Comparable.java
+++ b/checker/jdk/lock/src/java/lang/Comparable.java
@@ -1,7 +1,6 @@
 package java.lang;
 
 
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public interface Comparable<T extends Object> {

--- a/checker/jdk/lock/src/java/lang/Comparable.java
+++ b/checker/jdk/lock/src/java/lang/Comparable.java
@@ -1,6 +1,6 @@
 package java.lang;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/lang/Enum.java
+++ b/checker/jdk/lock/src/java/lang/Enum.java
@@ -31,8 +31,6 @@ import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 /**

--- a/checker/jdk/lock/src/java/lang/Error.java
+++ b/checker/jdk/lock/src/java/lang/Error.java
@@ -26,7 +26,6 @@
 package java.lang;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 /**
  * An {@code Error} is a subclass of {@code Throwable}

--- a/checker/jdk/lock/src/java/lang/Math.java
+++ b/checker/jdk/lock/src/java/lang/Math.java
@@ -1,6 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Math {

--- a/checker/jdk/lock/src/java/lang/Number.java
+++ b/checker/jdk/lock/src/java/lang/Number.java
@@ -1,6 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public abstract class Number implements java.io.Serializable {

--- a/checker/jdk/lock/src/java/lang/Object.java
+++ b/checker/jdk/lock/src/java/lang/Object.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 import org.checkerframework.checker.initialization.qual.*;

--- a/checker/jdk/lock/src/java/lang/Package.java
+++ b/checker/jdk/lock/src/java/lang/Package.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/lang/StackTraceElement.java
+++ b/checker/jdk/lock/src/java/lang/StackTraceElement.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/StringBuffer.java
+++ b/checker/jdk/lock/src/java/lang/StringBuffer.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/StringBuilder.java
+++ b/checker/jdk/lock/src/java/lang/StringBuilder.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/System.java
+++ b/checker/jdk/lock/src/java/lang/System.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/System.java
+++ b/checker/jdk/lock/src/java/lang/System.java
@@ -3,7 +3,7 @@ package java.lang;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 import java.io.*;
 import java.util.Properties;

--- a/checker/jdk/lock/src/java/lang/Thread.java
+++ b/checker/jdk/lock/src/java/lang/Thread.java
@@ -2,7 +2,7 @@ package java.lang;
 
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.Raw;
+
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 

--- a/checker/jdk/lock/src/java/lang/Thread.java
+++ b/checker/jdk/lock/src/java/lang/Thread.java
@@ -3,8 +3,6 @@ package java.lang;
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.lock.qual.*;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 public class Thread implements Runnable {

--- a/checker/jdk/lock/src/java/lang/ThreadGroup.java
+++ b/checker/jdk/lock/src/java/lang/ThreadGroup.java
@@ -1,7 +1,5 @@
 package java.lang;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/Throwable.java
+++ b/checker/jdk/lock/src/java/lang/Throwable.java
@@ -31,7 +31,7 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.Raw;
+
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 
 /**

--- a/checker/jdk/lock/src/java/lang/Throwable.java
+++ b/checker/jdk/lock/src/java/lang/Throwable.java
@@ -27,8 +27,6 @@ package java.lang;
 import  java.io.*;
 import  java.util.*;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/lang/ref/PhantomReference.java
+++ b/checker/jdk/lock/src/java/lang/ref/PhantomReference.java
@@ -25,7 +25,6 @@
 
 package java.lang.ref;
 
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/lang/ref/Reference.java
+++ b/checker/jdk/lock/src/java/lang/ref/Reference.java
@@ -27,7 +27,6 @@ package java.lang.ref;
 
 import sun.misc.Cleaner;
 
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 /**

--- a/checker/jdk/lock/src/java/lang/ref/SoftReference.java
+++ b/checker/jdk/lock/src/java/lang/ref/SoftReference.java
@@ -25,7 +25,6 @@
 
 package java.lang.ref;
 
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 /**

--- a/checker/jdk/lock/src/java/lang/reflect/AnnotatedElement.java
+++ b/checker/jdk/lock/src/java/lang/reflect/AnnotatedElement.java
@@ -1,7 +1,6 @@
 package java.lang.reflect;
 
 import java.lang.annotation.Annotation;
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public interface AnnotatedElement {

--- a/checker/jdk/lock/src/java/lang/reflect/Constructor.java
+++ b/checker/jdk/lock/src/java/lang/reflect/Constructor.java
@@ -1,8 +1,6 @@
 package java.lang.reflect;
 
 import java.lang.annotation.Annotation;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/lang/reflect/Constructor.java
+++ b/checker/jdk/lock/src/java/lang/reflect/Constructor.java
@@ -3,7 +3,7 @@ package java.lang.reflect;
 import java.lang.annotation.Annotation;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Constructor<T> extends AccessibleObject implements GenericDeclaration, Member {

--- a/checker/jdk/lock/src/java/lang/reflect/Field.java
+++ b/checker/jdk/lock/src/java/lang/reflect/Field.java
@@ -2,9 +2,9 @@ package java.lang.reflect;
 
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.Raw;
+
 import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 
 public final class Field extends AccessibleObject implements Member {

--- a/checker/jdk/lock/src/java/lang/reflect/Field.java
+++ b/checker/jdk/lock/src/java/lang/reflect/Field.java
@@ -1,7 +1,5 @@
 package java.lang.reflect;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/lang/reflect/Method.java
+++ b/checker/jdk/lock/src/java/lang/reflect/Method.java
@@ -5,8 +5,6 @@ import java.lang.annotation.AnnotationFormatError;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 @SuppressWarnings("rawtypes")

--- a/checker/jdk/lock/src/java/util/AbstractCollection.java
+++ b/checker/jdk/lock/src/java/util/AbstractCollection.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 

--- a/checker/jdk/lock/src/java/util/AbstractCollection.java
+++ b/checker/jdk/lock/src/java/util/AbstractCollection.java
@@ -1,8 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import java.util.Collection;
 import java.util.stream.Stream;

--- a/checker/jdk/lock/src/java/util/AbstractList.java
+++ b/checker/jdk/lock/src/java/util/AbstractList.java
@@ -1,7 +1,5 @@
 package java.util;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/AbstractMap.java
+++ b/checker/jdk/lock/src/java/util/AbstractMap.java
@@ -2,7 +2,6 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements.

--- a/checker/jdk/lock/src/java/util/AbstractMap.java
+++ b/checker/jdk/lock/src/java/util/AbstractMap.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/AbstractQueue.java
+++ b/checker/jdk/lock/src/java/util/AbstractQueue.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+
 import org.checkerframework.checker.lock.qual.*;
 
 public abstract class AbstractQueue<E extends Object> extends AbstractCollection<E> implements Queue<E> {

--- a/checker/jdk/lock/src/java/util/AbstractQueue.java
+++ b/checker/jdk/lock/src/java/util/AbstractQueue.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/AbstractSequentialList.java
+++ b/checker/jdk/lock/src/java/util/AbstractSequentialList.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/AbstractSet.java
+++ b/checker/jdk/lock/src/java/util/AbstractSet.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/ArrayDeque.java
+++ b/checker/jdk/lock/src/java/util/ArrayDeque.java
@@ -1,9 +1,9 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 public class ArrayDeque<E extends Object> extends AbstractCollection<E> implements Deque<E>, Cloneable, java.io.Serializable {
   private static final long serialVersionUID = 0;

--- a/checker/jdk/lock/src/java/util/ArrayDeque.java
+++ b/checker/jdk/lock/src/java/util/ArrayDeque.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/ArrayList.java
+++ b/checker/jdk/lock/src/java/util/ArrayList.java
@@ -3,7 +3,7 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 // permits null elements
 public class ArrayList<E extends Object> extends AbstractList<E> implements List<E>, RandomAccess, Cloneable, java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/ArrayList.java
+++ b/checker/jdk/lock/src/java/util/ArrayList.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Arrays.java
+++ b/checker/jdk/lock/src/java/util/Arrays.java
@@ -3,7 +3,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 public class Arrays {
   protected Arrays() {}

--- a/checker/jdk/lock/src/java/util/Arrays.java
+++ b/checker/jdk/lock/src/java/util/Arrays.java
@@ -1,7 +1,5 @@
 package java.util;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 

--- a/checker/jdk/lock/src/java/util/BitSet.java
+++ b/checker/jdk/lock/src/java/util/BitSet.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Calendar.java
+++ b/checker/jdk/lock/src/java/util/Calendar.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Collection.java
+++ b/checker/jdk/lock/src/java/util/Collection.java
@@ -1,7 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
 
-import org.checkerframework.dataflow.qual.Pure;
 
 import java.util.stream.Stream;
 

--- a/checker/jdk/lock/src/java/util/Collection.java
+++ b/checker/jdk/lock/src/java/util/Collection.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 import org.checkerframework.dataflow.qual.Pure;
 
 import java.util.stream.Stream;

--- a/checker/jdk/lock/src/java/util/Collections.java
+++ b/checker/jdk/lock/src/java/util/Collections.java
@@ -1,6 +1,5 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 public class Collections {
   protected Collections() {}

--- a/checker/jdk/lock/src/java/util/Comparator.java
+++ b/checker/jdk/lock/src/java/util/Comparator.java
@@ -1,7 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
 
-import org.checkerframework.dataflow.qual.Pure;
 
 import java.util.Comparator;
 import java.util.function.Function;

--- a/checker/jdk/lock/src/java/util/Comparator.java
+++ b/checker/jdk/lock/src/java/util/Comparator.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.NonNull;
+
 import org.checkerframework.dataflow.qual.Pure;
 
 import java.util.Comparator;

--- a/checker/jdk/lock/src/java/util/Currency.java
+++ b/checker/jdk/lock/src/java/util/Currency.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Currency implements java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/Date.java
+++ b/checker/jdk/lock/src/java/util/Date.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class Date implements java.io.Serializable, Cloneable, Comparable<Date> {

--- a/checker/jdk/lock/src/java/util/Deque.java
+++ b/checker/jdk/lock/src/java/util/Deque.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit

--- a/checker/jdk/lock/src/java/util/Deque.java
+++ b/checker/jdk/lock/src/java/util/Deque.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Dictionary.java
+++ b/checker/jdk/lock/src/java/util/Dictionary.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Enumeration.java
+++ b/checker/jdk/lock/src/java/util/Enumeration.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Enumeration<E extends Object> {
   public abstract boolean hasMoreElements();

--- a/checker/jdk/lock/src/java/util/EventListener.java
+++ b/checker/jdk/lock/src/java/util/EventListener.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-public interface EventListener{
+public interface EventListener {
 }

--- a/checker/jdk/lock/src/java/util/EventListenerProxy.java
+++ b/checker/jdk/lock/src/java/util/EventListenerProxy.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class EventListenerProxy implements EventListener {
   public EventListenerProxy(EventListener a1) { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/EventObject.java
+++ b/checker/jdk/lock/src/java/util/EventObject.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class EventObject implements java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/Formattable.java
+++ b/checker/jdk/lock/src/java/util/Formattable.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface Formattable{
   public abstract void formatTo(Formatter a1, int a2, int a3, int a4);

--- a/checker/jdk/lock/src/java/util/FormattableFlags.java
+++ b/checker/jdk/lock/src/java/util/FormattableFlags.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public class FormattableFlags{
   protected FormattableFlags() {}

--- a/checker/jdk/lock/src/java/util/Formatter.java
+++ b/checker/jdk/lock/src/java/util/Formatter.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Formatter implements java.io.Closeable, java.io.Flushable {

--- a/checker/jdk/lock/src/java/util/GregorianCalendar.java
+++ b/checker/jdk/lock/src/java/util/GregorianCalendar.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class GregorianCalendar extends Calendar {

--- a/checker/jdk/lock/src/java/util/HashMap.java
+++ b/checker/jdk/lock/src/java/util/HashMap.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 import org.checkerframework.checker.lock.qual.*;

--- a/checker/jdk/lock/src/java/util/HashMap.java
+++ b/checker/jdk/lock/src/java/util/HashMap.java
@@ -2,7 +2,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
 import org.checkerframework.checker.lock.qual.*;
 
 public class HashMap<K extends Object, V extends Object> extends AbstractMap<K, V> implements Map<K, V>, Cloneable, java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/HashSet.java
+++ b/checker/jdk/lock/src/java/util/HashSet.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class HashSet<E extends Object> extends AbstractSet<E> implements Set<E>, Cloneable, java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/Hashtable.java
+++ b/checker/jdk/lock/src/java/util/Hashtable.java
@@ -2,8 +2,8 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
-import org.checkerframework.checker.nullness.qual.NonNull;
+
+
 import org.checkerframework.checker.lock.qual.*;
 
 // This collection can only contain nonnull values

--- a/checker/jdk/lock/src/java/util/Hashtable.java
+++ b/checker/jdk/lock/src/java/util/Hashtable.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 

--- a/checker/jdk/lock/src/java/util/IdentityHashMap.java
+++ b/checker/jdk/lock/src/java/util/IdentityHashMap.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 import org.checkerframework.checker.lock.qual.*;

--- a/checker/jdk/lock/src/java/util/IdentityHashMap.java
+++ b/checker/jdk/lock/src/java/util/IdentityHashMap.java
@@ -2,7 +2,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
 import org.checkerframework.checker.lock.qual.*;
 
 // This class allows null elements

--- a/checker/jdk/lock/src/java/util/Iterator.java
+++ b/checker/jdk/lock/src/java/util/Iterator.java
@@ -1,11 +1,5 @@
 package java.util;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.checker.nullness.qual.Covariant;
-
-// This @Covariant annotation is sound, but it would not be sound on
-// ListIterator (a subclass of Iterator), which supports a set operation.
-@Covariant(0)
 public interface Iterator<E extends Object> {
   public abstract boolean hasNext();
   public abstract E next();

--- a/checker/jdk/lock/src/java/util/LinkedHashMap.java
+++ b/checker/jdk/lock/src/java/util/LinkedHashMap.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.dataflow.qual.Pure;
 
 
 import org.checkerframework.checker.lock.qual.*;

--- a/checker/jdk/lock/src/java/util/LinkedHashMap.java
+++ b/checker/jdk/lock/src/java/util/LinkedHashMap.java
@@ -2,7 +2,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.dataflow.qual.Pure;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
 import org.checkerframework.checker.lock.qual.*;
 
 public class LinkedHashMap<K extends Object, V extends Object> extends HashMap<K, V> implements Map<K, V> {

--- a/checker/jdk/lock/src/java/util/LinkedHashSet.java
+++ b/checker/jdk/lock/src/java/util/LinkedHashSet.java
@@ -1,8 +1,8 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 // This class permits null elements
-public class LinkedHashSet<E extends @Nullable Object> extends HashSet<E> implements Set<E>, Cloneable, java.io.Serializable {
+public class LinkedHashSet<E extends Object> extends HashSet<E> implements Set<E>, Cloneable, java.io.Serializable {
   private static final long serialVersionUID = 0;
   public LinkedHashSet(int a1, float a2) { throw new RuntimeException("skeleton method"); }
   public LinkedHashSet(int a1) { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/LinkedList.java
+++ b/checker/jdk/lock/src/java/util/LinkedList.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/LinkedList.java
+++ b/checker/jdk/lock/src/java/util/LinkedList.java
@@ -2,9 +2,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 // This class permits null elements
 public class LinkedList<E extends Object> extends AbstractSequentialList<E> implements List<E>, Deque<E>, Cloneable, java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/List.java
+++ b/checker/jdk/lock/src/java/util/List.java
@@ -25,8 +25,6 @@
 
 package java.util;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/List.java
+++ b/checker/jdk/lock/src/java/util/List.java
@@ -29,7 +29,6 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 /**
  * An ordered collection (also known as a <i>sequence</i>).  The user of this
@@ -175,9 +174,6 @@ public interface List<E extends Object> extends Collection<E> {
      *         sequence
      * @see Arrays#asList(Object[])
      */
-    // Element annotation should be the same as that on the type parameter E.
-    // It's @Nullable here because that is most lenient.
-    // Eventually, figure out how to express this, or hard-code in the checker.
     Object[] toArray();
 
     /**
@@ -218,8 +214,6 @@ public interface List<E extends Object> extends Collection<E> {
      *         this list
      * @throws NullPointerException if the specified array is null
      */
-    // @Nullable because, if there is room in the argument a1, the method
-    // puts null after the elements of this.
     <T extends Object> T [] toArray(T [] a);
 
 

--- a/checker/jdk/lock/src/java/util/ListIterator.java
+++ b/checker/jdk/lock/src/java/util/ListIterator.java
@@ -1,7 +1,7 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-public interface ListIterator<E extends @Nullable Object> extends Iterator<E> {
+
+public interface ListIterator<E extends Object> extends Iterator<E> {
   public abstract boolean hasNext();
   public abstract E next();
   public abstract boolean hasPrevious();

--- a/checker/jdk/lock/src/java/util/ListResourceBundle.java
+++ b/checker/jdk/lock/src/java/util/ListResourceBundle.java
@@ -1,8 +1,7 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public abstract class ListResourceBundle extends ResourceBundle {
   public ListResourceBundle() { throw new RuntimeException("skeleton method"); }
-  public final @Nullable Object handleGetObject(@Nullable String a1) { throw new RuntimeException("skeleton method"); }
-    public Enumeration<String> getKeys() { throw new RuntimeException("skeleton method"); }
+  public final Object handleGetObject(String a1) { throw new RuntimeException("skeleton method"); }
+  public Enumeration<String> getKeys() { throw new RuntimeException("skeleton method"); }
 }

--- a/checker/jdk/lock/src/java/util/Locale.java
+++ b/checker/jdk/lock/src/java/util/Locale.java
@@ -59,8 +59,6 @@ import sun.util.locale.LocaleSyntaxException;
 import sun.util.locale.LocaleUtils;
 import sun.util.locale.ParseStatus;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Locale.java
+++ b/checker/jdk/lock/src/java/util/Locale.java
@@ -61,7 +61,7 @@ import sun.util.locale.ParseStatus;
 
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
 import org.checkerframework.checker.lock.qual.*;
 
 /**

--- a/checker/jdk/lock/src/java/util/Map.java
+++ b/checker/jdk/lock/src/java/util/Map.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.*;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Map.java
+++ b/checker/jdk/lock/src/java/util/Map.java
@@ -1,8 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.*;
 
-import org.checkerframework.checker.nullness.qual.Covariant;
-import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/NavigableMap.java
+++ b/checker/jdk/lock/src/java/util/NavigableMap.java
@@ -1,6 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/NavigableMap.java
+++ b/checker/jdk/lock/src/java/util/NavigableMap.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/NavigableSet.java
+++ b/checker/jdk/lock/src/java/util/NavigableSet.java
@@ -1,7 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/NavigableSet.java
+++ b/checker/jdk/lock/src/java/util/NavigableSet.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/Objects.java
+++ b/checker/jdk/lock/src/java/util/Objects.java
@@ -29,7 +29,6 @@ package java.util;
 // import java.util.function.Supplier;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.*;
 
 /**
  * This class consists of {@code static} utility methods for operating

--- a/checker/jdk/lock/src/java/util/Observable.java
+++ b/checker/jdk/lock/src/java/util/Observable.java
@@ -1,12 +1,12 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public class Observable{
   public Observable() { throw new RuntimeException("skeleton method"); }
   public synchronized void addObserver(Observer a1) { throw new RuntimeException("skeleton method"); }
-  public synchronized void deleteObserver(@Nullable Observer a1) { throw new RuntimeException("skeleton method"); }
+  public synchronized void deleteObserver(Observer a1) { throw new RuntimeException("skeleton method"); }
   public void notifyObservers() { throw new RuntimeException("skeleton method"); }
-  public void notifyObservers(@Nullable Object a1) { throw new RuntimeException("skeleton method"); }
+  public void notifyObservers(Object a1) { throw new RuntimeException("skeleton method"); }
   public synchronized void deleteObservers() { throw new RuntimeException("skeleton method"); }
   public synchronized boolean hasChanged() { throw new RuntimeException("skeleton method"); }
   public synchronized int countObservers() { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/Observer.java
+++ b/checker/jdk/lock/src/java/util/Observer.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public interface Observer {
   public abstract void update(Observable a1, Object a2);

--- a/checker/jdk/lock/src/java/util/Optional.java
+++ b/checker/jdk/lock/src/java/util/Optional.java
@@ -24,8 +24,8 @@
  */
 package java.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
+
 
 // Note: Methods with references to java 8 classes have been commented out
 // because it breaks the annotated jdk build when running java 7.
@@ -118,7 +118,7 @@ public final class Optional<T> {
      * @return an {@code Optional} with a present value if the specified value
      * is non-null, otherwise an empty {@code Optional}
      */
-    public static <T> Optional<@NonNull T> ofNullable(@Nullable T value) {
+    public static <T> Optional<T> ofNullable(T value) {
         return value == null ? empty() : of(value);
     }
 
@@ -250,7 +250,7 @@ public final class Optional<T> {
      * be null
      * @return the value, if present, otherwise {@code other}
      */
-    public @Nullable T orElse(@Nullable T other) {
+    public T orElse(T other) {
         return value != null ? value : other;
     }
 

--- a/checker/jdk/lock/src/java/util/PriorityQueue.java
+++ b/checker/jdk/lock/src/java/util/PriorityQueue.java
@@ -1,10 +1,10 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
-import org.checkerframework.checker.nullness.qual.NonNull;
+
+
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 // doesn't permit null element
 public class PriorityQueue<E extends Object> extends AbstractQueue<E> implements java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/PriorityQueue.java
+++ b/checker/jdk/lock/src/java/util/PriorityQueue.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 import org.checkerframework.checker.lock.qual.*;

--- a/checker/jdk/lock/src/java/util/Properties.java
+++ b/checker/jdk/lock/src/java/util/Properties.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public class Properties extends Hashtable<Object, Object> {

--- a/checker/jdk/lock/src/java/util/Properties.java
+++ b/checker/jdk/lock/src/java/util/Properties.java
@@ -1,7 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 public class Properties extends Hashtable<Object, Object> {
   private static final long serialVersionUID = 0;

--- a/checker/jdk/lock/src/java/util/PropertyPermission.java
+++ b/checker/jdk/lock/src/java/util/PropertyPermission.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class PropertyPermission extends java.security.BasicPermission {

--- a/checker/jdk/lock/src/java/util/PropertyResourceBundle.java
+++ b/checker/jdk/lock/src/java/util/PropertyResourceBundle.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public class PropertyResourceBundle extends ResourceBundle {
   public PropertyResourceBundle(java.io.InputStream a1) throws java.io.IOException { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/Queue.java
+++ b/checker/jdk/lock/src/java/util/Queue.java
@@ -1,7 +1,6 @@
 package java.util;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
 
 // Subclasses of this interface/class may opt to prohibit null elements
 public interface Queue<E extends Object> extends Collection<E> {

--- a/checker/jdk/lock/src/java/util/Queue.java
+++ b/checker/jdk/lock/src/java/util/Queue.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+
 import org.checkerframework.checker.lock.qual.*;
 import org.checkerframework.dataflow.qual.Pure;
 

--- a/checker/jdk/lock/src/java/util/Random.java
+++ b/checker/jdk/lock/src/java/util/Random.java
@@ -1,8 +1,7 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class Random implements java.io.Serializable {
-    private static final long serialVersionUID = 0L;
+  private static final long serialVersionUID = 0L;
   public Random() { throw new RuntimeException("skeleton method"); }
   public Random(long a1) { throw new RuntimeException("skeleton method"); }
   public synchronized void setSeed(long a1) { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/RandomAccess.java
+++ b/checker/jdk/lock/src/java/util/RandomAccess.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public interface RandomAccess{
 }

--- a/checker/jdk/lock/src/java/util/ResourceBundle.java
+++ b/checker/jdk/lock/src/java/util/ResourceBundle.java
@@ -1,7 +1,7 @@
 package java.util;
 
 import org.checkerframework.dataflow.qual.*;
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
 import org.checkerframework.checker.lock.qual.*;
 
 public abstract class ResourceBundle{

--- a/checker/jdk/lock/src/java/util/ResourceBundle.java
+++ b/checker/jdk/lock/src/java/util/ResourceBundle.java
@@ -1,6 +1,5 @@
 package java.util;
 
-import org.checkerframework.dataflow.qual.*;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/Scanner.java
+++ b/checker/jdk/lock/src/java/util/Scanner.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Scanner implements Iterator<String> {

--- a/checker/jdk/lock/src/java/util/ServiceLoader.java
+++ b/checker/jdk/lock/src/java/util/ServiceLoader.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class ServiceLoader<S> implements Iterable<S> {

--- a/checker/jdk/lock/src/java/util/Set.java
+++ b/checker/jdk/lock/src/java/util/Set.java
@@ -1,23 +1,22 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
 
 // Subclasses of this interface/class may opt to prohibit null elements
 public interface Set<E extends Object> extends Collection<E> {
-   public abstract int size(@GuardSatisfied Set<E> this);
-   public abstract boolean isEmpty(@GuardSatisfied Set<E> this);
-   public abstract boolean contains(@GuardSatisfied Set<E> this,@GuardSatisfied Object a1);
+  public abstract int size(@GuardSatisfied Set<E> this);
+  public abstract boolean isEmpty(@GuardSatisfied Set<E> this);
+  public abstract boolean contains(@GuardSatisfied Set<E> this, @GuardSatisfied Object a1);
   public abstract Iterator<E> iterator();
   public abstract Object [] toArray();
   public abstract <T> T [] toArray(T [] a1);
   public abstract boolean add(E a1);
   public abstract boolean remove(Object a1);
-   public abstract boolean containsAll(@GuardSatisfied Set<E> this,@GuardSatisfied Collection<?> a1);
+  public abstract boolean containsAll(@GuardSatisfied Set<E> this, @GuardSatisfied Collection<?> a1);
   public abstract boolean addAll(Collection<? extends E> a1);
   public abstract boolean retainAll(Collection<?> a1);
   public abstract boolean removeAll(Collection<?> a1);
   public abstract void clear();
-   public abstract boolean equals(@GuardSatisfied Set<E> this,@GuardSatisfied Object a1);
-   public abstract int hashCode(@GuardSatisfied Set<E> this);
+  public abstract boolean equals(@GuardSatisfied Set<E> this, @GuardSatisfied Object a1);
+  public abstract int hashCode(@GuardSatisfied Set<E> this);
 }

--- a/checker/jdk/lock/src/java/util/Set.java
+++ b/checker/jdk/lock/src/java/util/Set.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/SimpleTimeZone.java
+++ b/checker/jdk/lock/src/java/util/SimpleTimeZone.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class SimpleTimeZone extends TimeZone {

--- a/checker/jdk/lock/src/java/util/SortedMap.java
+++ b/checker/jdk/lock/src/java/util/SortedMap.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.*;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/SortedMap.java
+++ b/checker/jdk/lock/src/java/util/SortedMap.java
@@ -1,6 +1,5 @@
 package java.util;
 import org.checkerframework.dataflow.qual.*;
-import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/SortedSet.java
+++ b/checker/jdk/lock/src/java/util/SortedSet.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/Stack.java
+++ b/checker/jdk/lock/src/java/util/Stack.java
@@ -1,8 +1,8 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 // permits null elements
-public class Stack<E extends @Nullable Object> extends Vector<E> {
+public class Stack<E> extends Vector<E> {
   private static final long serialVersionUID = 0;
   public Stack() { throw new RuntimeException("skeleton method"); }
   public E push(E a1) { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/StringTokenizer.java
+++ b/checker/jdk/lock/src/java/util/StringTokenizer.java
@@ -1,10 +1,8 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-public class StringTokenizer implements Enumeration<@NonNull Object> {
-  public StringTokenizer(String a1, @Nullable String a2, boolean a3) { throw new RuntimeException("skeleton method"); }
-  public StringTokenizer(String a1, @Nullable String a2) { throw new RuntimeException("skeleton method"); }
+public class StringTokenizer implements Enumeration<Object> {
+  public StringTokenizer(String a1, String a2, boolean a3) { throw new RuntimeException("skeleton method"); }
+  public StringTokenizer(String a1, String a2) { throw new RuntimeException("skeleton method"); }
   public StringTokenizer(String a1) { throw new RuntimeException("skeleton method"); }
   public boolean hasMoreTokens() { throw new RuntimeException("skeleton method"); }
   public String nextToken() { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/TimeZone.java
+++ b/checker/jdk/lock/src/java/util/TimeZone.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public abstract class TimeZone implements java.io.Serializable, Cloneable{

--- a/checker/jdk/lock/src/java/util/Timer.java
+++ b/checker/jdk/lock/src/java/util/Timer.java
@@ -1,5 +1,4 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class Timer{
   public Timer() { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/lock/src/java/util/TimerTask.java
+++ b/checker/jdk/lock/src/java/util/TimerTask.java
@@ -1,5 +1,5 @@
 package java.util;
-import org.checkerframework.checker.nullness.qual.Nullable;
+
 
 public abstract class TimerTask implements Runnable{
   protected TimerTask() {}

--- a/checker/jdk/lock/src/java/util/TreeMap.java
+++ b/checker/jdk/lock/src/java/util/TreeMap.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 

--- a/checker/jdk/lock/src/java/util/TreeMap.java
+++ b/checker/jdk/lock/src/java/util/TreeMap.java
@@ -2,8 +2,8 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
+
 import org.checkerframework.checker.lock.qual.*;
 
 // This permits null element when using a custom comparator which allows null

--- a/checker/jdk/lock/src/java/util/TreeSet.java
+++ b/checker/jdk/lock/src/java/util/TreeSet.java
@@ -1,7 +1,6 @@
 package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
-import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/TreeSet.java
+++ b/checker/jdk/lock/src/java/util/TreeSet.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 // Subclasses of this interface/class may opt to prohibit null elements

--- a/checker/jdk/lock/src/java/util/UUID.java
+++ b/checker/jdk/lock/src/java/util/UUID.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class UUID implements java.io.Serializable, Comparable<UUID> {

--- a/checker/jdk/lock/src/java/util/Vector.java
+++ b/checker/jdk/lock/src/java/util/Vector.java
@@ -3,7 +3,7 @@ import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.checker.nullness.qual.PolyNull;
+
 
 // permits nullable object
 public class Vector<E extends Object> extends AbstractList<E> implements List<E>, RandomAccess, Cloneable, java.io.Serializable {

--- a/checker/jdk/lock/src/java/util/Vector.java
+++ b/checker/jdk/lock/src/java/util/Vector.java
@@ -1,6 +1,4 @@
 package java.util;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 import org.checkerframework.checker.lock.qual.*;
 

--- a/checker/jdk/lock/src/java/util/WeakHashMap.java
+++ b/checker/jdk/lock/src/java/util/WeakHashMap.java
@@ -3,7 +3,7 @@ package java.util;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 
-import org.checkerframework.checker.nullness.qual.KeyFor;
+
 import org.checkerframework.checker.lock.qual.*;
 
 // permits null keys and values

--- a/checker/jdk/lock/src/java/util/WeakHashMap.java
+++ b/checker/jdk/lock/src/java/util/WeakHashMap.java
@@ -1,7 +1,5 @@
 package java.util;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 
 import org.checkerframework.checker.lock.qual.*;

--- a/checker/jdk/lock/src/java/util/logging/Logger.java
+++ b/checker/jdk/lock/src/java/util/logging/Logger.java
@@ -40,7 +40,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 // import sun.reflect.CallerSensitive;
 import sun.reflect.Reflection;
 
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 /**

--- a/checker/jdk/lock/src/java/util/regex/Matcher.java
+++ b/checker/jdk/lock/src/java/util/regex/Matcher.java
@@ -1,7 +1,5 @@
 package java.util.regex;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public final class Matcher implements MatchResult {

--- a/checker/jdk/lock/src/java/util/regex/Pattern.java
+++ b/checker/jdk/lock/src/java/util/regex/Pattern.java
@@ -1,8 +1,6 @@
 package java.util.regex;
 
 import org.checkerframework.checker.lock.qual.*;
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 
 public final class Pattern implements java.io.Serializable{
     private static final long serialVersionUID = 0L;

--- a/checker/jdk/lock/src/java/util/regex/PatternSyntaxException.java
+++ b/checker/jdk/lock/src/java/util/regex/PatternSyntaxException.java
@@ -1,7 +1,5 @@
 package java.util.regex;
 
-import org.checkerframework.dataflow.qual.Pure;
-import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.checker.lock.qual.*;
 
 public class PatternSyntaxException extends IllegalArgumentException {

--- a/checker/jdk/nullness/src/java/util/Optional.java
+++ b/checker/jdk/nullness/src/java/util/Optional.java
@@ -49,7 +49,7 @@ import org.checkerframework.checker.nullness.qual.PolyNull;
  *
  * @since 1.8
  */
-public final class Optional<@NonNull T extends @NonNull Object> {
+public final class Optional<T extends @NonNull Object> {
     /**
      * Common instance for {@code empty()}.
      */

--- a/checker/jdk/nullness/src/java/util/Optional.java
+++ b/checker/jdk/nullness/src/java/util/Optional.java
@@ -26,6 +26,7 @@ package java.util;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.PolyNull;
 
 // Note: Methods with references to java 8 classes have been commented out
 // because it breaks the annotated jdk build when running java 7.
@@ -48,7 +49,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @since 1.8
  */
-public final class Optional<T> {
+public final class Optional<@NonNull T extends @NonNull Object> {
     /**
      * Common instance for {@code empty()}.
      */
@@ -250,7 +251,7 @@ public final class Optional<T> {
      * be null
      * @return the value, if present, otherwise {@code other}
      */
-    public @Nullable T orElse(@Nullable T other) {
+    public @PolyNull T orElse(@PolyNull T other) {
         return value != null ? value : other;
     }
 

--- a/checker/tests/nullness/java8/Issue1000.java
+++ b/checker/tests/nullness/java8/Issue1000.java
@@ -2,7 +2,7 @@ import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class Issue1000 {
-    //:: error: illegal.instantiation
+    //:: error: (type.argument.type.incompatible
     void illegalInstantiation(Optional<@Nullable String> arg) {}
 
     String foo1(Optional<String> opt) {
@@ -10,7 +10,7 @@ class Issue1000 {
     }
 
     String foo2(Optional<String> opt) {
-        //:: error: invalid.return.type
+        //:: error: (return.type.incompatible)
         return opt.orElse(null);
     }
 }

--- a/checker/tests/nullness/java8/Issue1000.java
+++ b/checker/tests/nullness/java8/Issue1000.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 class Issue1000 {
-    //:: error: (type.argument.type.incompatible
+    //:: error: (type.argument.type.incompatible)
     void illegalInstantiation(Optional<@Nullable String> arg) {}
 
     String orElseAppliedToNonNull(Optional<String> opt) {

--- a/checker/tests/nullness/java8/Issue1000.java
+++ b/checker/tests/nullness/java8/Issue1000.java
@@ -1,0 +1,16 @@
+import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Issue1000 {
+    //:: error: illegal.instantiation
+    void illegalInstantiation(Optional<@Nullable String> arg) {}
+
+    String foo1(Optional<String> opt) {
+        return opt.orElse("");
+    }
+
+    String foo2(Optional<String> opt) {
+        //:: error: invalid.return.type
+        return opt.orElse(null);
+    }
+}

--- a/checker/tests/nullness/java8/Issue1000.java
+++ b/checker/tests/nullness/java8/Issue1000.java
@@ -5,11 +5,11 @@ class Issue1000 {
     //:: error: (type.argument.type.incompatible
     void illegalInstantiation(Optional<@Nullable String> arg) {}
 
-    String foo1(Optional<String> opt) {
+    String orElseAppliedToNonNull(Optional<String> opt) {
         return opt.orElse("");
     }
 
-    String foo2(Optional<String> opt) {
+    String orElseAppliedToNullable(Optional<String> opt) {
         //:: error: (return.type.incompatible)
         return opt.orElse(null);
     }

--- a/checker/tests/nullness/java8/Issue1000.java
+++ b/checker/tests/nullness/java8/Issue1000.java
@@ -1,3 +1,7 @@
+// Test case for issue #1000:
+// https://github.com/typetools/checker-framework/issues/1000
+// @below-java8-jdk-skip-test
+
 import java.util.Optional;
 import org.checkerframework.checker.nullness.qual.Nullable;
 


### PR DESCRIPTION
This makes the annotated JDK more precise.
The changeset also restricts the type argument to `Optional` to be `@NonNull`, and it removes redundant, conflicting nullness annotations from the lock-annotated JDK.
