### PR TITLE
Makes LBC a subchecker of UBC

### DIFF
--- a/checker/src/org/checkerframework/checker/index/IndexChecker.java
+++ b/checker/src/org/checkerframework/checker/index/IndexChecker.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.index;
 
-import org.checkerframework.checker.index.lowerbound.LowerBoundChecker;
+import org.checkerframework.checker.index.upperbound.UpperBoundChecker;
+import org.checkerframework.framework.source.SuppressWarningsKeys;
 
 /**
  * A type checker for preventing out-of-bounds accesses on arrays. Contains two subcheckers that do
@@ -8,15 +9,14 @@ import org.checkerframework.checker.index.lowerbound.LowerBoundChecker;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-public class IndexChecker extends LowerBoundChecker {
+@SuppressWarningsKeys("index")
+public class IndexChecker extends UpperBoundChecker {
     // Ideally, the Index Checker would be an AggregateChecker that ran the Lower and Upper Bound
     // Checkers.  However, both checkers use annotations from the ValueChecker and the
     // MinLenChecker. So in order for these subcheckers to only be run once, the IndexChecker
-    // is a subclass of the LowerBoundChecker.  If isIndexChecker() returns true, then the
-    // LowerBoundChecker runs the UpperBoundChecker as a subchecker.
+    // is a subclass of the UpperBoundChecker, which runs the LowerBoundChecker as a subchecker
+    // anyway.
 
-    @Override
-    protected boolean isIndexChecker() {
-        return true;
-    }
+    // TODO: we should discuss what's actually going on here, because at this point the Index Checker
+    // now exists only for the name, I think.
 }

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundChecker.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundChecker.java
@@ -2,7 +2,6 @@ package org.checkerframework.checker.index.lowerbound;
 
 import java.util.LinkedHashSet;
 import org.checkerframework.checker.index.minlen.MinLenChecker;
-import org.checkerframework.checker.index.upperbound.UpperBoundChecker;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.framework.source.SuppressWarningsKeys;
@@ -22,15 +21,6 @@ public class LowerBoundChecker extends BaseTypeChecker {
                 super.getImmediateSubcheckerClasses();
         checkers.add(ValueChecker.class);
         checkers.add(MinLenChecker.class);
-        if (isIndexChecker()) {
-            // If running the Index Checker, then run the Upper Bound Checker as a subchecker.
-            // See comment on the Index Checker for more details.
-            checkers.add(UpperBoundChecker.class);
-        }
         return checkers;
-    }
-
-    protected boolean isIndexChecker() {
-        return false;
     }
 }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -2,12 +2,7 @@ package org.checkerframework.checker.index.upperbound;
 
 import static org.checkerframework.javacutil.AnnotationUtils.getElementValueArray;
 
-import com.sun.source.tree.BinaryTree;
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.MemberSelectTree;
-import com.sun.source.tree.MethodInvocationTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.UnaryTree;
+import com.sun.source.tree.*;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,17 +13,11 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexMethodIdentifier;
+import org.checkerframework.checker.index.lowerbound.LowerBoundAnnotatedTypeFactory;
+import org.checkerframework.checker.index.lowerbound.LowerBoundChecker;
 import org.checkerframework.checker.index.minlen.MinLenAnnotatedTypeFactory;
 import org.checkerframework.checker.index.minlen.MinLenChecker;
-import org.checkerframework.checker.index.qual.IndexFor;
-import org.checkerframework.checker.index.qual.IndexOrHigh;
-import org.checkerframework.checker.index.qual.IndexOrLow;
-import org.checkerframework.checker.index.qual.LTEqLengthOf;
-import org.checkerframework.checker.index.qual.LTLengthOf;
-import org.checkerframework.checker.index.qual.LTOMLengthOf;
-import org.checkerframework.checker.index.qual.MinLen;
-import org.checkerframework.checker.index.qual.UpperBoundBottom;
-import org.checkerframework.checker.index.qual.UpperBoundUnknown;
+import org.checkerframework.checker.index.qual.*;
 import org.checkerframework.checker.index.samelen.SameLenAnnotatedTypeFactory;
 import org.checkerframework.checker.index.samelen.SameLenChecker;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
@@ -120,6 +109,15 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     private SameLenAnnotatedTypeFactory getSameLenAnnotatedTypeFactory() {
         return getTypeFactoryOfSubchecker(SameLenChecker.class);
+    }
+
+    /**
+     * Provides a way to query the Lower Bound Checker, which determines whether each integer in the
+     * program is non-negative or not, and checks that no possibly negative integers are used to
+     * access arrays.
+     */
+    private LowerBoundAnnotatedTypeFactory getLowerBoundAnnotatedTypeFactory() {
+        return getTypeFactoryOfSubchecker(LowerBoundChecker.class);
     }
 
     @Override
@@ -307,6 +305,16 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
         builder.setValue("value", names);
         return builder.build();
+    }
+
+    // For use in the refinement rules.
+    public boolean hasLowerBoundTypeByClass(
+            ExpressionTree tree, Class<? extends Annotation> classOfType) {
+        return AnnotationUtils.areSameByClass(
+                getLowerBoundAnnotatedTypeFactory()
+                        .getAnnotatedType(tree)
+                        .getAnnotationInHierarchy(getLowerBoundAnnotatedTypeFactory().UNKNOWN),
+                classOfType);
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundChecker.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundChecker.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.index.upperbound;
 
 import java.util.LinkedHashSet;
+import org.checkerframework.checker.index.lowerbound.LowerBoundChecker;
 import org.checkerframework.checker.index.minlen.MinLenChecker;
 import org.checkerframework.checker.index.samelen.SameLenChecker;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -19,6 +20,7 @@ public class UpperBoundChecker extends BaseTypeChecker {
     protected LinkedHashSet<Class<? extends BaseTypeChecker>> getImmediateSubcheckerClasses() {
         LinkedHashSet<Class<? extends BaseTypeChecker>> checkers =
                 super.getImmediateSubcheckerClasses();
+        checkers.add(LowerBoundChecker.class);
         checkers.add(ValueChecker.class);
         checkers.add(MinLenChecker.class);
         checkers.add(SameLenChecker.class);

--- a/checker/tests/upperbound/CombineFacts.java
+++ b/checker/tests/upperbound/CombineFacts.java
@@ -1,5 +1,6 @@
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
+@SuppressWarnings("lowerbound")
 class CombineFacts {
     void test(int[] a1) {
         @LTLengthOf("a1") int len = a1.length - 1;

--- a/checker/tests/upperbound/Dimension.java
+++ b/checker/tests/upperbound/Dimension.java
@@ -1,3 +1,4 @@
+@SuppressWarnings("lowerbound")
 public class Dimension {
     void test(int expr) {
         int[] array = new int[expr];

--- a/checker/tests/upperbound/IndexForTest.java
+++ b/checker/tests/upperbound/IndexForTest.java
@@ -2,6 +2,7 @@ package index;
 
 import org.checkerframework.checker.index.qual.IndexFor;
 
+@SuppressWarnings("lowerbound")
 public class IndexForTest {
     int[] array = {0};
 

--- a/checker/tests/upperbound/IndexOrLowTests.java
+++ b/checker/tests/upperbound/IndexOrLowTests.java
@@ -2,6 +2,7 @@ import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.IndexOrLow;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
+@SuppressWarnings("lowerbound")
 public class IndexOrLowTests {
     int[] array = {1, 2};
 

--- a/checker/tests/upperbound/LTLDivide.java
+++ b/checker/tests/upperbound/LTLDivide.java
@@ -1,6 +1,7 @@
 import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
+@SuppressWarnings("lowerbound")
 class LTLDivide {
     int[] test(int[] array) {
         //        @LTLengthOf("array") int len = array.length / 2;

--- a/checker/tests/upperbound/MinLenIndexFor.java
+++ b/checker/tests/upperbound/MinLenIndexFor.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.MinLen;
 
+@SuppressWarnings("lowerbound")
 public class MinLenIndexFor {
     int @MinLen(2) [] arrayLen2 = {0, 1, 2};
 

--- a/checker/tests/upperbound/Pilot3ArrayCreation.java
+++ b/checker/tests/upperbound/Pilot3ArrayCreation.java
@@ -1,7 +1,5 @@
 // This test case is for issue 44: https://github.com/kelloggm/checker-framework/issues/44
 
-// @skip-test until the test is fixed
-
 class Pilot3ArrayCreation {
     void test(int[] firstArray, int[] secondArray[]) {
         int[] newArray = new int[firstArray.length + secondArray.length];

--- a/checker/tests/upperbound/RefineLTE2.java
+++ b/checker/tests/upperbound/RefineLTE2.java
@@ -4,6 +4,7 @@
 import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.MinLen;
 
+@SuppressWarnings("lowerbound")
 public class RefineLTE2 {
 
     protected int @MinLen(1) [] values;


### PR DESCRIPTION
To allow the following to be type checked:

```java
int[] newArray = new int[firstArray.length + secondArray.length];
        for (int i = 0; i < firstArray.length; i++) {
            newArray[i] = firstArray[i]; //or newArray[i] = secondArray[i];
        }
```

by checking for a sum of NonNegative integers used in the creation of an array; if one is found, those integers must be LTEL of the new array.