### PR TITLE
IndexOrLow tests

### DIFF
--- a/checker/tests/lowerbound/IndexOrLowTests.java
+++ b/checker/tests/lowerbound/IndexOrLowTests.java
@@ -1,4 +1,5 @@
 import org.checkerframework.checker.index.qual.GTENegativeOne;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.IndexOrLow;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
@@ -12,8 +13,11 @@ public class IndexOrLowTests {
         //:: error: (array.access.unsafe.low)
         array[index] = 1;
 
-        int y = index + 1;
-        array[y] = 1;
+        if (index > -1) {
+            array[index] = 1;
+        }
+
+        @IndexOrHigh("array") int y = index + 1;
         if (y < array.length) {
             array[y] = 1;
         }
@@ -25,5 +29,11 @@ public class IndexOrLowTests {
         index = array.length - 1;
         @LTLengthOf("array") @GTENegativeOne int x = index;
         index = param;
+    }
+
+    void test3(int[] a, int b) {
+        //:: error: (assignment.type.incompatible)
+        @IndexOrLow("a")
+        int k = a.length - b;
     }
 }

--- a/checker/tests/lowerbound/IndexOrLowTests.java
+++ b/checker/tests/lowerbound/IndexOrLowTests.java
@@ -32,8 +32,9 @@ public class IndexOrLowTests {
     }
 
     void test3(int[] a, int b) {
-        //:: error: (assignment.type.incompatible)
         @IndexOrLow("a")
-        int k = a.length - b;
+        int k;
+        //:: error: (assignment.type.incompatible)
+        k = a.length - b;
     }
 }

--- a/checker/tests/upperbound/IndexOrLowTests.java
+++ b/checker/tests/upperbound/IndexOrLowTests.java
@@ -1,4 +1,5 @@
 import org.checkerframework.checker.index.qual.GTENegativeOne;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.IndexOrLow;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
@@ -9,9 +10,12 @@ public class IndexOrLowTests {
     int index = -1;
 
     void test() {
-        array[index] = 1;
 
-        int y = index + 1;
+        if (index != -1) {
+            array[index] = 1;
+        }
+
+        @IndexOrHigh("array") int y = index + 1;
         //:: error: (array.access.unsafe.high)
         array[y] = 1;
         if (y < array.length) {


### PR DESCRIPTION
This pull request cleans up the tests for the IndexOrLow qualifier. In particular, it:
- removes any line that would issue a warning if the other checker was run (i.e. the upperbound test now no longer issues an `array.index.unsafe.low` warning if the lowerbound checker is run on it)
- makes types explicit where possible (note esp. the inclusion of @IndexOrHigh in both tests)
- adds some additional test cases