### PR TITLE
Changed upperbound manual picture to give an example

### DIFF
--- a/docs/manual/figures/upperbound.svg
+++ b/docs/manual/figures/upperbound.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -161,18 +161,6 @@
        x="210.61656"
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.32192183;stroke-miterlimit:4;stroke-dasharray:none" />
     <text
-       id="text3585"
-       y="56.765598"
-       x="441.76974"
-       style="font-style:normal;font-weight:normal;font-size:15.80440044px;font-family:'courier new';text-anchor:middle;fill:#000000"
-       font-size="15.8044">
-      <tspan
-         id="tspan3587"
-         y="56.765598"
-         x="441.76974"
-         style="font-size:21.16666603px">@LTOMLengthOf({&quot;java.lang.String&quot;})</tspan>
-    </text>
-    <text
        font-size="15.8044"
        style="font-style:normal;font-weight:normal;font-size:15.80440044px;font-family:'courier new';text-anchor:middle;fill:#000000"
        x="441.76974"
@@ -182,7 +170,7 @@
          style="font-size:21.16666603px"
          x="441.76974"
          y="56.765598"
-         id="tspan3678">@LTOMLengthOf({&quot;java.lang.String&quot;})</tspan>
+         id="tspan3678">@LTOMLengthOf(&quot;myArray&quot;)</tspan>
     </text>
   </g>
   <g
@@ -230,7 +218,7 @@
          x="469.17535"
          y="56.765598"
          id="tspan4850"
-         style="font-size:21.16666603px">@LTLengthOf({&quot;java.lang.String&quot;})</tspan>
+         style="font-size:21.16666603px">@LTLengthOf(&quot;myArray&quot;)</tspan>
     </text>
   </g>
   <g
@@ -291,7 +279,7 @@
          style="font-size:21.16666603px"
          x="441.76974"
          y="56.765598"
-         id="tspan3710">@LTEqLengthOf({&quot;java.lang.String&quot;})</tspan>
+         id="tspan3710">@LTEqLengthOf(&quot;myArray&quot;)</tspan>
     </text>
   </g>
 </svg>

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -168,7 +168,8 @@ qualifiers:
     Checker.  On the left is a type system for lower bounds.  On the right
     is a type system for upper bounds.  Qualifiers written in gray should
     never be written in source code; they are used internally by the type
-    system.}
+    system. ''myArray'' in the Upper Bound qualifiers is an example of
+    an array's name.}
   \label{fig-index-int-types}
 \end{figure}
 


### PR DESCRIPTION
in response to Mike's request. The figure in the upperbound section of the manual no longer says "java.lang.String" and instead says "myArray". I also made what "myArray" means explicit in the caption.