### PR TITLE
Makes samelen symmetric in most cases

### DIFF
--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -94,14 +94,20 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * For the use of the transfer function; generates a SameLen that includes a and b, as well as
      * everything in sl1 and sl2, if they are SameLen annotations.
      *
-     * @param a the name of the first array
-     * @param b the name of the second array
+     * @param aRec receiver representing the first array
+     * @param bRec receiver representing the second array
      * @param sl1 the current annotation of the first array
      * @param sl2 the current annotation of the second array
      * @return a combined SameLen annotation
      */
     public AnnotationMirror createCombinedSameLen(
-            String a, String b, AnnotationMirror sl1, AnnotationMirror sl2) {
+            FlowExpressions.Receiver aRec,
+            FlowExpressions.Receiver bRec,
+            AnnotationMirror sl1,
+            AnnotationMirror sl2) {
+
+        String a = aRec.toString();
+        String b = bRec.toString();
 
         List<String> aValues = new ArrayList<String>();
         aValues.add(a);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.index.samelen;
 
-import com.sun.source.util.TreePath;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -9,7 +8,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.checker.index.qual.SameLenBottom;
 import org.checkerframework.checker.index.qual.SameLenUnknown;
@@ -18,12 +16,9 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotationBuilder;
-import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy.MultiGraphFactory;
 import org.checkerframework.javacutil.AnnotationUtils;
-import org.checkerframework.javacutil.InternalUtils;
-import org.checkerframework.javacutil.TreeUtils;
 
 /**
  * The SameLen Checker is used to determine whether there are multiple arrays in a program that
@@ -122,28 +117,6 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         AnnotationMirror res = getCombinedSameLen(aValues, bValues);
         return res;
-    }
-
-    public FlowExpressions.Receiver arrayReceiverFromString(
-            String arrayExpression, TreePath currentPath) {
-        TypeMirror enclosingClass = InternalUtils.typeOf(TreeUtils.enclosingClass(currentPath));
-
-        FlowExpressions.Receiver r =
-                FlowExpressions.internalRepOfPseudoReceiver(currentPath, enclosingClass);
-        FlowExpressionParseUtil.FlowExpressionContext context =
-                new FlowExpressionParseUtil.FlowExpressionContext(
-                        r,
-                        FlowExpressions.getParametersOfEnclosingMethod(this, currentPath),
-                        this.getContext());
-
-        FlowExpressions.Receiver array;
-        try {
-            array = FlowExpressionParseUtil.parse(arrayExpression, context, currentPath, true);
-        } catch (FlowExpressionParseUtil.FlowExpressionParseException ex) {
-            // ignore parse errors.
-            return null;
-        }
-        return array;
     }
 
     /**

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -113,7 +113,8 @@ public class SameLenTransfer extends CFTransfer {
             AnnotationMirror combinedSameLen, Node node, CFStore store) {
         for (String s : SameLenUtils.getValue(combinedSameLen)) {
             Receiver recS =
-                    aTypeFactory.arrayReceiverFromString(s, aTypeFactory.getPath(node.getTree()));
+                    aTypeFactory.getReceiverFromJavaExpressionString(
+                            s, aTypeFactory.getPath(node.getTree()));
             if (recS != null) {
                 store.clearValue(recS);
                 store.insertValue(recS, combinedSameLen);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -16,6 +16,7 @@ import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
+import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
@@ -112,9 +113,14 @@ public class SameLenTransfer extends CFTransfer {
     private void propagateCombinedSameLen(
             AnnotationMirror combinedSameLen, Node node, CFStore store) {
         for (String s : SameLenUtils.getValue(combinedSameLen)) {
-            Receiver recS =
-                    aTypeFactory.getReceiverFromJavaExpressionString(
-                            s, aTypeFactory.getPath(node.getTree()));
+            Receiver recS;
+            try {
+                recS =
+                        aTypeFactory.getReceiverFromJavaExpressionString(
+                                s, aTypeFactory.getPath(node.getTree()));
+            } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
+                recS = null;
+            }
             if (recS != null) {
                 store.clearValue(recS);
                 store.insertValue(recS, combinedSameLen);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -70,10 +70,7 @@ public class SameLenTransfer extends CFTransfer {
 
                 AnnotationMirror combinedSameLen =
                         aTypeFactory.createCombinedSameLen(
-                                targetRec.toString(),
-                                otherRec.toString(),
-                                UNKNOWN,
-                                arrayLengthNodeAnnotation);
+                                targetRec, otherRec, UNKNOWN, arrayLengthNodeAnnotation);
 
                 propagateCombinedSameLen(combinedSameLen, node, result.getRegularStore());
             }
@@ -90,8 +87,10 @@ public class SameLenTransfer extends CFTransfer {
 
             AnnotationMirror combinedSameLen =
                     aTypeFactory.createCombinedSameLen(
-                            node.getTarget().toString(),
-                            node.getExpression().toString(),
+                            FlowExpressions.internalReprOf(
+                                    analysis.getTypeFactory(), node.getTarget()),
+                            FlowExpressions.internalReprOf(
+                                    analysis.getTypeFactory(), node.getExpression()),
                             UNKNOWN,
                             leftAnno);
 
@@ -101,10 +100,17 @@ public class SameLenTransfer extends CFTransfer {
         return result;
     }
 
+    /**
+     * Insert combinedSameLen into the store as the SameLen type of each array listed in
+     * combinedSameLen.
+     *
+     * @param combinedSameLen A Samelen annotation. Not just an annotation in the SameLen hierarchy;
+     *     this annotation MUST be @SameLen().
+     * @param node The node in the tree where the combination is happening. Used for context.
+     * @param store The store to modify
+     */
     private void propagateCombinedSameLen(
             AnnotationMirror combinedSameLen, Node node, CFStore store) {
-        // Get the value of the combined samelen type, and then
-        // insert that combined SameLen into the receiver for each.
         for (String s : SameLenUtils.getValue(combinedSameLen)) {
             Receiver recS =
                     aTypeFactory.arrayReceiverFromString(s, aTypeFactory.getPath(node.getTree()));
@@ -141,10 +147,7 @@ public class SameLenTransfer extends CFTransfer {
             AnnotationMirror rightReceiverAnno = getAnno(rightReceiverNode);
             AnnotationMirror combinedSameLen =
                     aTypeFactory.createCombinedSameLen(
-                            leftRec.toString(),
-                            rightRec.toString(),
-                            leftReceiverAnno,
-                            rightReceiverAnno);
+                            leftRec, rightRec, leftReceiverAnno, rightReceiverAnno);
 
             propagateCombinedSameLen(combinedSameLen, left, store);
         }

--- a/checker/tests/index/SameLenAssignmentTransfer.java
+++ b/checker/tests/index/SameLenAssignmentTransfer.java
@@ -1,0 +1,10 @@
+import org.checkerframework.checker.index.qual.*;
+
+class SameLenAssignmentTransfer {
+    void transfer5(int @SameLen("#2") [] a, int[] b) {
+        int[] c = a;
+        for (int i = 0; i < c.length; i++) { // i's type is @LTL("c")
+            b[i] = 1;
+        }
+    }
+}

--- a/checker/tests/index/SameLenManyArrays.java
+++ b/checker/tests/index/SameLenManyArrays.java
@@ -1,0 +1,37 @@
+import org.checkerframework.checker.index.qual.*;
+
+class SameLenManyArrays {
+    void transfer1(int @SameLen("#2") [] a, int[] b) {
+        int[] c = new int[a.length];
+        for (int i = 0; i < c.length; i++) { // i's type is @LTL("c")
+            b[i] = 1;
+            int @SameLen({"a", "b", "c"}) [] d = c;
+        }
+    }
+
+    void transfer2(int @SameLen("#2") [] a, int[] b) {
+        for (int i = 0; i < b.length; i++) { // i's type is @LTL("b")
+            a[i] = 1;
+        }
+    }
+
+    void transfer3(int @SameLen("#2") [] a, int[] b, int[] c) {
+        if (a.length == c.length) {
+            for (int i = 0; i < c.length; i++) { // i's type is @LTL("c")
+                b[i] = 1;
+                int @SameLen({"a", "b", "c"}) [] d = c;
+            }
+        }
+    }
+
+    void transfer4(int[] a, int[] b, int[] c) {
+        if (b.length == c.length) {
+            if (a.length == b.length) {
+                for (int i = 0; i < c.length; i++) { // i's type is @LTL("c")
+                    a[i] = 1;
+                    int @SameLen({"a", "b", "c"}) [] d = c;
+                }
+            }
+        }
+    }
+}

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -730,10 +730,10 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * @param expression Java expression
      * @param currentPath location at which expression is evaluated
-     * @return
+     * @throws FlowExpressionParseException thrown if the expression cannot be parsed
      */
     public FlowExpressions.Receiver getReceiverFromJavaExpressionString(
-            String expression, TreePath currentPath) {
+            String expression, TreePath currentPath) throws FlowExpressionParseException {
         TypeMirror enclosingClass = InternalUtils.typeOf(TreeUtils.enclosingClass(currentPath));
 
         FlowExpressions.Receiver r =
@@ -744,14 +744,7 @@ public abstract class GenericAnnotatedTypeFactory<
                         FlowExpressions.getParametersOfEnclosingMethod(this, currentPath),
                         this.getContext());
 
-        FlowExpressions.Receiver receiver;
-        try {
-            receiver = FlowExpressionParseUtil.parse(expression, context, currentPath, true);
-        } catch (FlowExpressionParseUtil.FlowExpressionParseException ex) {
-            // ignore parse errors.
-            return null;
-        }
-        return receiver;
+        return FlowExpressionParseUtil.parse(expression, context, currentPath, true);
     }
 
     /**


### PR DESCRIPTION
The fundamental problem is that when a programmer writes annotations, they aren't automatically symmetric. Here's a smaller test case that showcases the problem that this PR fixes:

```java
    void test(int @SameLen("#2") [] a, int[] b) {
	int[] c = new int[a.length];
	for(int i = 0; i < c.length; i++) { // i's type is @LTL("c")
	    b[i] = 1; // b's type is @SameLenUnknown, so fails
	    int @SameLen({"a", "b", "c"}) [] d = c; // succeeds
	}
    }
```

SameLen types are symmetric in the sense that all the ones that are inferred are applied to both of the arrays involved. So for instance in the example above, `int [] c = new int[a.length]` results in both a and c being updated. But it doesn't update the other SameLen types that are associated with a and c - which is to say, while both a and c become `@SameLen({"a","b","c"})`, the type of b never changes. This PR changes that so that all arrays listed in a SameLen type are updated whenever one is.