### PR TITLE
Fixed blatantly incorrect figure in the manual

### DIFF
--- a/docs/manual/figures/upperbound.svg
+++ b/docs/manual/figures/upperbound.svg
@@ -152,7 +152,7 @@
   </text>
   <g
      id="g3631"
-     transform="translate(63.835771,149.91457)">
+     transform="translate(63.835768,310.93151)">
     <rect
        id="rect3583"
        height="42.243332"
@@ -260,7 +260,7 @@
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
   </g>
   <g
-     transform="translate(62.988313,311.77898)"
+     transform="translate(63.835771,150.76204)"
      id="g3704">
     <rect
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.32192183;stroke-miterlimit:4;stroke-dasharray:none"


### PR DESCRIPTION
LTOM and LTEL were in the wrong places in the manual figures. Mike noticed this.