### PR TITLE
FlowExpressionParse should parse array lengths and clone()

### DIFF
--- a/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -352,6 +352,10 @@ public class FlowExpressionParseUtil {
         boolean originalReceiver = true;
         VariableElement fieldElem = null;
 
+        if (receiverType.getKind() == TypeKind.ARRAY && s.equals("length")) {
+            fieldElem = resolver.findField(s, receiverType, path);
+        }
+
         // Search for field in each enclosing class.
         while (receiverType.getKind() == TypeKind.DECLARED) {
             fieldElem = resolver.findField(s, receiverType, path);
@@ -469,6 +473,10 @@ public class FlowExpressionParseUtil {
             // try to find the correct method
             Resolver resolver = new Resolver(env);
             TypeMirror receiverType = context.receiver.getType();
+
+            if (receiverType.getKind() == TypeKind.ARRAY) {
+                element = resolver.findMethod(methodName, receiverType, path, parameterTypes);
+            }
 
             // Search for method in each enclosing class.
             while (receiverType.getKind() == TypeKind.DECLARED) {

--- a/framework/tests/flowexpression/TestParsing.java
+++ b/framework/tests/flowexpression/TestParsing.java
@@ -1,0 +1,11 @@
+import testlib.flowexpression.qual.FlowExp;
+
+public class TestParsing {
+    int[] a = {1, 2};
+
+    void test(@FlowExp("a.length") Object a, @FlowExp("this.a.length") Object b) {}
+
+    void test2(@FlowExp("a.clone()") Object a, @FlowExp("this.a.clone()") Object b) {}
+    //:: error: (expression.unparsable.type.invalid)
+    void test3(@FlowExp("a.leng") Object a) {}
+}


### PR DESCRIPTION
Is there a better way to get the element for `length` or `clone` than using the resolver?