### PR TITLE
Allows UB transfer to handle arrays that are cast when they're created

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -40,8 +40,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     // Refine the type of expressions used as an array dimension to be
-    // less than length of the array to which the new array is
-    // assigned.  For example int[] array = new int[expr]; the type of expr is @LTEqLength("array")
+    // less than length of the array to which the new array is assigned.
+    // For example, in "int[] array = new int[expr];", the type of expr is @LTEqLength("array").
     @Override
     public TransferResult<CFValue, CFStore> visitAssignment(
             AssignmentNode node, TransferInput<CFValue, CFStore> in) {
@@ -49,18 +49,17 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
 
         Node expNode = node.getExpression();
 
+        // strip off typecast if any
+        Node expNodeSansCast =
+                (expNode instanceof TypeCastNode) ? ((TypeCastNode) expNode).getOperand() : expNode;
+        // null if right-hand-side is not an array creation expression
         ArrayCreationNode acNode =
-                expNode instanceof ArrayCreationNode ? (ArrayCreationNode) expNode : null;
-
-        if (expNode instanceof TypeCastNode) {
-            Node innerExpNode = ((TypeCastNode) expNode).getOperand();
-            acNode =
-                    innerExpNode instanceof ArrayCreationNode
-                            ? (ArrayCreationNode) innerExpNode
-                            : null;
-        }
+                (expNodeSansCast instanceof ArrayCreationNode)
+                        ? acNode = (ArrayCreationNode) expNodeSansCast
+                        : null;
 
         if (acNode != null) {
+            // Right-hand side of assignment is an array creation expression
             List<Node> nodeList = acNode.getDimensions();
             if (nodeList.size() < 1) {
                 return result;

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -23,6 +23,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.NumericalAdditionNode;
 import org.checkerframework.dataflow.cfg.node.NumericalMultiplicationNode;
 import org.checkerframework.dataflow.cfg.node.NumericalSubtractionNode;
+import org.checkerframework.dataflow.cfg.node.TypeCastNode;
 import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
@@ -46,8 +47,20 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             AssignmentNode node, TransferInput<CFValue, CFStore> in) {
         TransferResult<CFValue, CFStore> result = super.visitAssignment(node, in);
 
-        if (node.getExpression() instanceof ArrayCreationNode) {
-            ArrayCreationNode acNode = (ArrayCreationNode) node.getExpression();
+        Node expNode = node.getExpression();
+
+        ArrayCreationNode acNode =
+                expNode instanceof ArrayCreationNode ? (ArrayCreationNode) expNode : null;
+
+        if (expNode instanceof TypeCastNode) {
+            Node innerExpNode = ((TypeCastNode) expNode).getOperand();
+            acNode =
+                    innerExpNode instanceof ArrayCreationNode
+                            ? (ArrayCreationNode) innerExpNode
+                            : null;
+        }
+
+        if (acNode != null) {
             List<Node> nodeList = acNode.getDimensions();
             if (nodeList.size() < 1) {
                 return result;

--- a/checker/tests/index/ArrayIntroWithCast.java
+++ b/checker/tests/index/ArrayIntroWithCast.java
@@ -1,0 +1,15 @@
+import org.checkerframework.checker.index.qual.*;
+
+class ArrayIntroWithCast<T> {
+
+    void test(String[] a, String[] b) {
+        Object result = new Object[a.length + b.length];
+        System.arraycopy(a, 0, result, 0, a.length);
+    }
+
+    void test2(String[] a, String[] b) {
+        @SuppressWarnings("unchecked")
+        T[] result = (T[]) new Object[a.length + b.length];
+        System.arraycopy(a, 0, result, 0, a.length);
+    }
+}


### PR DESCRIPTION
Consider the following testcase:

```java
import org.checkerframework.checker.index.qual.*;

class ArrayIntroWithCast<T> {

   void test(String[] a, String[] b) {
        Object result = new Object[a.length + b.length];
	System.arraycopy(a, 0, result, 0, a.length);
    }
    
    void test2(String[] a, String[] b) {
	@SuppressWarnings("unchecked")
        T[] result = (T[]) new Object[a.length + b.length];
	System.arraycopy(a, 0, result, 0, a.length);
    }
}
```

The first function (`test`) compiles with no warnings, but the second function (`test2`) does not in master. The only difference is the addition of the cast to a generic argument. This PR fixes this problem, allowing both versions to compile. See kelloggm#106