### PR TITLE
Remove dangling symbolic links.

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1067,42 +1067,6 @@
         </antcall>
     </target>
 
-    <target name="fenum-extension-tests" depends="jar,build-tests"
-            description="Run tests for the Fenum Checker extension capabilities">
-        <exec executable="chmod" failonerror="true">
-            <arg line="+x ${basedir}/bin/javac"/>
-        </exec>
-
-        <exec executable="make" failonerror="${halt.on.test.failure}">
-            <env key="JAVAC" value="${basedir}/bin/javac"/>
-            <arg line="-C tests/fenum-extension/"/>
-        </exec>
-    </target>
-
-    <target name="subtyping-extension-tests" depends="jar,build-tests"
-            description="Run tests for the Subtyping Checker extension capabilities">
-        <exec executable="chmod" failonerror="true">
-            <arg line="+x ${basedir}/bin/javac"/>
-        </exec>
-
-        <exec executable="make" failonerror="${halt.on.test.failure}">
-            <env key="JAVAC" value="${basedir}/bin/javac"/>
-            <arg line="-C tests/subtyping-extension/"/>
-        </exec>
-    </target>
-
-    <target name="units-extension-tests" depends="jar,build-tests"
-            description="Run tests for the Units Checker extension capabilities">
-        <exec executable="chmod" failonerror="true">
-            <arg line="+x ${basedir}/bin/javac"/>
-        </exec>
-
-        <exec executable="make" failonerror="${halt.on.test.failure}">
-            <env key="JAVAC" value="${basedir}/bin/javac"/>
-            <arg line="-C tests/units-extension/"/>
-        </exec>
-    </target>
-
     <target name="guieffect-tests" depends="jar,build-tests"
             description="Run tests for the GUI Effect Checker">
         <antcall target="-run-tests">

--- a/checker/tests/fenum-extension
+++ b/checker/tests/fenum-extension
@@ -1,1 +1,0 @@
-../examples/fenum-extension/

--- a/checker/tests/subtyping-extension
+++ b/checker/tests/subtyping-extension
@@ -1,1 +1,0 @@
-../examples/subtyping-extension/

--- a/checker/tests/units-extension
+++ b/checker/tests/units-extension
@@ -1,1 +1,0 @@
-../examples/units-extension/


### PR DESCRIPTION
And the targets that used to refer to them.  The directories are tested via example-tests target instead individual ones.  Fixes #1053.