### PR TITLE
Update Index JDK

### DIFF
--- a/checker/jdk/index/src/java/io/BufferedInputStream.java
+++ b/checker/jdk/index/src/java/io/BufferedInputStream.java
@@ -320,7 +320,7 @@ class BufferedInputStream extends FilterInputStream {
      *                          invoking its {@link #close()} method,
      *                          or an I/O error occurs.
      */
-    public synchronized @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         getBufIfOpen(); // Check for closed stream

--- a/checker/jdk/index/src/java/io/BufferedReader.java
+++ b/checker/jdk/index/src/java/io/BufferedReader.java
@@ -267,7 +267,7 @@ public class BufferedReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/ByteArrayInputStream.java
+++ b/checker/jdk/index/src/java/io/ByteArrayInputStream.java
@@ -174,7 +174,7 @@ class ByteArrayInputStream extends InputStream {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public synchronized @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/CharArrayReader.java
+++ b/checker/jdk/index/src/java/io/CharArrayReader.java
@@ -118,7 +118,7 @@ public class CharArrayReader extends Reader {
      *
      * @exception   IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/Console.java
+++ b/checker/jdk/index/src/java/io/Console.java
@@ -417,7 +417,7 @@ public final class Console implements Flushable
             return in.ready();
         }
 
-        public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+        public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
             throws IOException
         {
             int off = offset;

--- a/checker/jdk/index/src/java/io/DataInputStream.java
+++ b/checker/jdk/index/src/java/io/DataInputStream.java
@@ -97,7 +97,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final @GTENegativeOne int read(byte b[]) throws IOException {
+    public final @IndexOrLow("#1") int read(byte b[]) throws IOException {
         return in.read(b, 0, b.length);
     }
 
@@ -146,7 +146,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public final @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FileInputStream.java
+++ b/checker/jdk/index/src/java/io/FileInputStream.java
@@ -206,7 +206,7 @@ class FileInputStream extends InputStream
      *             the file has been reached.
      * @exception  IOException  if an I/O error occurs.
      */
-    public @GTENegativeOne int read(byte b[]) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
         return readBytes(b, 0, b.length);
     }
 
@@ -228,7 +228,7 @@ class FileInputStream extends InputStream
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FilterInputStream.java
+++ b/checker/jdk/index/src/java/io/FilterInputStream.java
@@ -104,7 +104,7 @@ class FilterInputStream extends InputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#read(byte[], int, int)
      */
-    public @GTENegativeOne int read(byte b[]) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -130,7 +130,7 @@ class FilterInputStream extends InputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FilterReader.java
+++ b/checker/jdk/index/src/java/io/FilterReader.java
@@ -71,7 +71,7 @@ public abstract class FilterReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(cbuf, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/InputStream.java
+++ b/checker/jdk/index/src/java/io/InputStream.java
@@ -98,7 +98,7 @@ public abstract class InputStream implements Closeable {
      * @exception  NullPointerException  if <code>b</code> is <code>null</code>.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public @GTENegativeOne int read(byte b[]) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -159,7 +159,7 @@ public abstract class InputStream implements Closeable {
      * <code>b.length - off</code>
      * @see        java.io.InputStream#read()
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/InputStreamReader.java
+++ b/checker/jdk/index/src/java/io/InputStreamReader.java
@@ -181,7 +181,7 @@ public class InputStreamReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
         return sd.read(cbuf, offset, length);
     }
 

--- a/checker/jdk/index/src/java/io/LineNumberInputStream.java
+++ b/checker/jdk/index/src/java/io/LineNumberInputStream.java
@@ -127,7 +127,7 @@ class LineNumberInputStream extends FilterInputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.LineNumberInputStream#read()
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/LineNumberReader.java
+++ b/checker/jdk/index/src/java/io/LineNumberReader.java
@@ -160,7 +160,7 @@ public class LineNumberReader extends BufferedReader {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             int n = super.read(cbuf, off, len);
 

--- a/checker/jdk/index/src/java/io/ObjectInput.java
+++ b/checker/jdk/index/src/java/io/ObjectInput.java
@@ -68,7 +68,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @exception IOException If an I/O error has occurred.
      */
-    public @GTENegativeOne int read(byte b[]) throws IOException;
+    public @IndexOrLow("#1") int read(byte b[]) throws IOException;
 
     /**
      * Reads into an array of bytes.  This method will
@@ -80,7 +80,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @exception IOException If an I/O error has occurred.
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /**
      * Skips n bytes of input.

--- a/checker/jdk/index/src/java/io/ObjectInputStream.java
+++ b/checker/jdk/index/src/java/io/ObjectInputStream.java
@@ -852,7 +852,7 @@ public class ObjectInputStream
      * @throws  IOException If an I/O error has occurred.
      * @see java.io.DataInputStream#readFully(byte[],int,int)
      */
-    public @GTENegativeOne int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (buf == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/io/PipedInputStream.java
+++ b/checker/jdk/index/src/java/io/PipedInputStream.java
@@ -366,7 +366,7 @@ public class PipedInputStream extends InputStream {
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
      *           closed, or if an I/O error occurs.
      */
-    public synchronized @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/PipedReader.java
+++ b/checker/jdk/index/src/java/io/PipedReader.java
@@ -289,7 +289,7 @@ public class PipedReader extends Reader {
      *                  {@link #connect(java.io.PipedWriter) unconnected}, closed,
      *                  or an I/O error occurs.
      */
-    public synchronized @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (!connected) {
             throw new IOException("Pipe not connected");
         } else if (closedByReader) {

--- a/checker/jdk/index/src/java/io/PushbackInputStream.java
+++ b/checker/jdk/index/src/java/io/PushbackInputStream.java
@@ -163,7 +163,7 @@ class PushbackInputStream extends FilterInputStream {
      *             or an I/O error occurs.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public @GTENegativeOne int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();

--- a/checker/jdk/index/src/java/io/PushbackReader.java
+++ b/checker/jdk/index/src/java/io/PushbackReader.java
@@ -104,7 +104,7 @@ public class PushbackReader extends FilterReader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             try {

--- a/checker/jdk/index/src/java/io/RandomAccessFile.java
+++ b/checker/jdk/index/src/java/io/RandomAccessFile.java
@@ -343,7 +343,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 
@@ -366,7 +366,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * some other I/O error occurs.
      * @exception  NullPointerException If <code>b</code> is <code>null</code>.
      */
-    public @GTENegativeOne int read(byte b[]) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
         return readBytes(b, 0, b.length);
     }
 

--- a/checker/jdk/index/src/java/io/Reader.java
+++ b/checker/jdk/index/src/java/io/Reader.java
@@ -137,7 +137,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * @exception   IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[]) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[]) throws IOException {
         return read(cbuf, 0, cbuf.length);
     }
 
@@ -155,7 +155,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    abstract public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    abstract public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /** Maximum skip-buffer size */
     private static final int maxSkipBufferSize = 8192;

--- a/checker/jdk/index/src/java/io/SequenceInputStream.java
+++ b/checker/jdk/index/src/java/io/SequenceInputStream.java
@@ -195,7 +195,7 @@ class SequenceInputStream extends InputStream {
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (in == null) {
             return -1;
         } else if (b == null) {

--- a/checker/jdk/index/src/java/io/StringBufferInputStream.java
+++ b/checker/jdk/index/src/java/io/StringBufferInputStream.java
@@ -109,7 +109,7 @@ class StringBufferInputStream extends InputStream {
      *             <code>-1</code> if there is no more data because the end of
      *             the stream has been reached.
      */
-    public synchronized @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/StringReader.java
+++ b/checker/jdk/index/src/java/io/StringReader.java
@@ -86,7 +86,7 @@ public class StringReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -657,7 +657,7 @@ public final class String
      * @return  the length of the sequence of characters represented by this
      *          object.
      */
-    public /*@ IndexOrHigh("this")*/ int length() {
+    public @NonNegative /*@ IndexOrHigh("this")*/ int length() {
         return count;
     }
 

--- a/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
@@ -79,7 +79,7 @@ class CheckedInputStream extends FilterInputStream {
      * <code>buf.length - off</code>
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         len = in.read(buf, off, len);
         if (len != -1) {
             cksum.update(buf, off, len);

--- a/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
@@ -169,7 +169,7 @@ public class DeflaterInputStream extends FilterInputStream {
      * @throws IOException if an I/O error occurs or if this input stream is
      * already closed
      */
-    public @GTENegativeOne int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         // Sanity checks
         ensureOpen();
         if (b == null) {

--- a/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
@@ -109,7 +109,7 @@ class GZIPInputStream extends InflaterInputStream {
      * @exception IOException if an I/O error has occurred.
      *
      */
-    public @GTENegativeOne int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (eos) {
             return -1;

--- a/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
@@ -139,7 +139,7 @@ class InflaterInputStream extends FilterInputStream {
      * @exception ZipException if a ZIP format error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();

--- a/checker/jdk/index/src/java/util/zip/ZipFile.java
+++ b/checker/jdk/index/src/java/util/zip/ZipFile.java
@@ -662,7 +662,7 @@ class ZipFile implements ZipConstants, Closeable {
             this.jzentry = jzentry;
         }
 
-        public @GTENegativeOne int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+       public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
             if (rem == 0) {
                 return -1;
             }

--- a/checker/jdk/index/src/java/util/zip/ZipInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/ZipInputStream.java
@@ -178,7 +178,7 @@ class ZipInputStream extends InflaterInputStream implements ZipConstants {
      * @exception ZipException if a ZIP file error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (off < 0 || len < 0 || off > b.length - len) {
             throw new IndexOutOfBoundsException();


### PR DESCRIPTION
Addresses two weaknesses in the Index JDK:
- methods that read an array and then return either -1 or the number of elements read should have return type of `@IndexOrLow` of the array that they read
- String.length should be `@NonNegative` until String support is added

Both of these changes are motivated by the plume-lib case study.