### PR TITLE
Index JDK: Comment out MinLen annotation in String because Strings aren't supported

### DIFF
--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -2980,7 +2980,7 @@ public final class String
      *          <code>"true"</code> is returned; otherwise, a string equal to
      *          <code>"false"</code> is returned.
      */
-    public static @MinLen(4) String valueOf(boolean b) {
+    public static /*@ MinLen(4)*/ String valueOf(boolean b) {
         return b ? "true" : "false";
     }
 


### PR DESCRIPTION
This is causing a problem in the plume-lib case study for the index checker