### PR TITLE
Index Checker: value offsets

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -383,10 +383,37 @@ public class OffsetEquation {
     }
 
     /**
-     * Creates an offset equation from the Node.
-     *
-     * <p>If node is an int value known at compile time, then the return equation is just the int
+     * If node is an int value known at compile time, then the returned equation is just the int
      * value or if op is '-', the return equation is the negation of the int value.
+     *
+     * <p>Otherwise, null is returned.
+     *
+     * @param node Node from which to create offset equation
+     * @param factory AnnotationTypeFactory
+     * @param op '+' or '-'
+     * @return an offset equation from value of known or null if the value isn't known
+     */
+    public static OffsetEquation createOffsetFromNodesValue(
+            Node node, UpperBoundAnnotatedTypeFactory factory, char op) {
+        if (node.getTree() != null && TreeUtils.isExpressionTree(node.getTree())) {
+            Integer i;
+            if (op == '+') {
+                i = factory.valMinFromExpressionTree((ExpressionTree) node.getTree());
+            } else {
+                i = factory.valMaxFromExpressionTree((ExpressionTree) node.getTree());
+                i = i == null ? null : -i;
+            }
+            if (i != null) {
+                OffsetEquation eq = new OffsetEquation();
+                eq.addInt(i);
+                return eq;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates an offset equation from the Node.
      *
      * <p>If node is an addition or subtracted node, then this method is called recursively on the
      * left and right hand nodes and the two equations are added/subtracted to each other depending
@@ -411,20 +438,6 @@ public class OffsetEquation {
 
     private static void createOffsetFromNode(
             Node node, UpperBoundAnnotatedTypeFactory factory, OffsetEquation eq, char op) {
-        if (node.getTree() != null && TreeUtils.isExpressionTree(node.getTree())) {
-            Integer i;
-            if (op == '+') {
-                i = factory.valMinFromExpressionTree((ExpressionTree) node.getTree());
-            } else {
-                i = factory.valMaxFromExpressionTree((ExpressionTree) node.getTree());
-                i = i == null ? null : -i;
-            }
-            if (i != null) {
-                eq.addInt(i);
-                return;
-            }
-        }
-
         Receiver r = FlowExpressions.internalReprOf(factory, node);
         if (r instanceof Unknown || r == null) {
             if (node instanceof NumericalAdditionNode) {

--- a/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -395,6 +395,7 @@ public class OffsetEquation {
      */
     public static OffsetEquation createOffsetFromNodesValue(
             Node node, UpperBoundAnnotatedTypeFactory factory, char op) {
+        assert op == '+' || op == '-';
         if (node.getTree() != null && TreeUtils.isExpressionTree(node.getTree())) {
             Integer i;
             if (op == '+') {

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -578,11 +578,52 @@ public abstract class UBQualifier {
          */
         @Override
         public UBQualifier plusOffset(Node node, UpperBoundAnnotatedTypeFactory factory) {
-            OffsetEquation newOffset = OffsetEquation.createOffsetFromNode(node, factory, '+');
-            if (newOffset.hasError()) {
-                return UpperBoundUnknownQualifier.UNKNOWN;
+            return pluseOrMinusOffset(node, factory, '+');
+        }
+
+        /**
+         * Adds node as a negative offset to a copy of this qualifier. This is done by creating a
+         * negative offset equation for node and then adding that equation to every offset equation
+         * in a copy of this object.
+         *
+         * @param node Node
+         * @param factory AnnotatedTypeFactory
+         * @return a copy of this qualifier with node add as an offset
+         */
+        @Override
+        public UBQualifier minusOffset(Node node, UpperBoundAnnotatedTypeFactory factory) {
+            return pluseOrMinusOffset(node, factory, '-');
+        }
+
+        private UBQualifier pluseOrMinusOffset(
+                Node node, UpperBoundAnnotatedTypeFactory factory, char op) {
+            assert op == '-' || op == '+';
+            OffsetEquation newOffset = OffsetEquation.createOffsetFromNode(node, factory, op);
+            LessThanLengthOf nodeOffsetQualifier = null;
+            if (!newOffset.hasError()) {
+                nodeOffsetQualifier = addOffset(newOffset);
             }
-            return addOffset(newOffset);
+
+            OffsetEquation valueOffset =
+                    OffsetEquation.createOffsetFromNodesValue(node, factory, op);
+            LessThanLengthOf valueOffsetQualifier = null;
+            if (valueOffset != null && !valueOffset.hasError()) {
+                valueOffsetQualifier = addOffset(valueOffset);
+            }
+
+            if (valueOffsetQualifier == null) {
+                if (nodeOffsetQualifier == null) {
+                    return UpperBoundUnknownQualifier.UNKNOWN;
+                } else {
+                    return nodeOffsetQualifier;
+                }
+            } else {
+                if (nodeOffsetQualifier == null) {
+                    return valueOffsetQualifier;
+                } else {
+                    return nodeOffsetQualifier.glb(valueOffsetQualifier);
+                }
+            }
         }
 
         /**
@@ -599,24 +640,6 @@ public abstract class UBQualifier {
         }
 
         /**
-         * Adds node as a negative offset to a copy of this qualifier. This is done by creating a
-         * negative offset equation for node and then adding that equation to every offset equation
-         * in a copy of this object.
-         *
-         * @param node Node
-         * @param factory AnnotatedTypeFactory
-         * @return a copy of this qualifier with node add as an offset
-         */
-        @Override
-        public UBQualifier minusOffset(Node node, UpperBoundAnnotatedTypeFactory factory) {
-            OffsetEquation newOffset = OffsetEquation.createOffsetFromNode(node, factory, '-');
-            if (newOffset.hasError()) {
-                return UpperBoundUnknownQualifier.UNKNOWN;
-            }
-            return addOffset(newOffset);
-        }
-
-        /**
          * Adds the negation of value as an offset to a copy of this qualifier. This is done by
          * adding the negation of value value to every offset equation in a copy of this object.
          *
@@ -629,7 +652,7 @@ public abstract class UBQualifier {
             return addOffset(newOffset);
         }
 
-        private UBQualifier addOffset(OffsetEquation newOffset) {
+        private LessThanLengthOf addOffset(OffsetEquation newOffset) {
             Map<String, Set<OffsetEquation>> plusMap = new HashMap<>(map.size());
             for (Entry<String, Set<OffsetEquation>> entry : map.entrySet()) {
                 Set<OffsetEquation> plus = new HashSet<>(entry.getValue().size());

--- a/checker/tests/index/ConstantOffsets.java
+++ b/checker/tests/index/ConstantOffsets.java
@@ -1,0 +1,21 @@
+import org.checkerframework.checker.index.qual.LTLengthOf;
+
+public class ConstantOffsets {
+    void method1(int[] a, int offset, @LTLengthOf(value = "#1", offset = "-#2 - 1") int x) {}
+
+    void test1() {
+        int offset = -4;
+        int x = 4;
+        int[] f1 = new int[x - offset];
+        method1(f1, offset, x);
+    }
+
+    void method2(int[] a, int offset, @LTLengthOf(value = "#1", offset = "#2 - 1") int x) {}
+
+    void test2() {
+        int offset = 4;
+        int x = 4;
+        int[] f1 = new int[x + offset];
+        method2(f1, offset, x);
+    }
+}


### PR DESCRIPTION
If an expression has a know value, then both the know value and the expression should be used as offsets.  This fixes the first part of https://github.com/kelloggm/checker-framework/issues/108.