### PR TITLE
Allow SameLen to correctly handle assignments.

### DIFF
--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -80,7 +80,6 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         newValues.addAll(a1Names);
         newValues.addAll(a2Names);
-
         String[] names = newValues.toArray(new String[newValues.size()]);
         Arrays.sort(names);
         return createSameLen(names);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -80,6 +80,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         newValues.addAll(a1Names);
         newValues.addAll(a2Names);
+
         String[] names = newValues.toArray(new String[newValues.size()]);
         Arrays.sort(names);
         return createSameLen(names);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -119,22 +119,19 @@ public class SameLenTransfer extends CFTransfer {
      */
     private void propagateCombinedSameLen(
             AnnotationMirror combinedSameLen, Node node, CFStore store) {
+        TreePath currentPath = aTypeFactory.getPath(node.getTree());
+        if (currentPath == null) {
+            return;
+        }
         for (String s : SameLenUtils.getValue(combinedSameLen)) {
             Receiver recS;
             try {
-                TreePath currentPath = aTypeFactory.getPath(node.getTree());
-                if (currentPath != null) {
-                    recS = aTypeFactory.getReceiverFromJavaExpressionString(s, currentPath);
-                } else {
-                    return;
-                }
+                recS = aTypeFactory.getReceiverFromJavaExpressionString(s, currentPath);
             } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
-                recS = null;
+                continue;
             }
-            if (recS != null) {
-                store.clearValue(recS);
-                store.insertValue(recS, combinedSameLen);
-            }
+            store.clearValue(recS);
+            store.insertValue(recS, combinedSameLen);
         }
     }
 

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -86,15 +86,19 @@ public class SameLenTransfer extends CFTransfer {
         // If the left side of the assignment is an array, then have both the right and left side be SameLen
         // of each other.
 
+        Receiver targetRec =
+                FlowExpressions.internalReprOf(analysis.getTypeFactory(), node.getTarget());
+
+        Receiver exprRec =
+                FlowExpressions.internalReprOf(analysis.getTypeFactory(), node.getExpression());
+
         if (node.getTarget().getType().getKind() == TypeKind.ARRAY) {
+
+            AnnotationMirror rightAnnoOrUnknown = rightAnno == null ? UNKNOWN : rightAnno;
+
             AnnotationMirror combinedSameLen =
                     aTypeFactory.createCombinedSameLen(
-                            FlowExpressions.internalReprOf(
-                                    analysis.getTypeFactory(), node.getTarget()),
-                            FlowExpressions.internalReprOf(
-                                    analysis.getTypeFactory(), node.getExpression()),
-                            UNKNOWN,
-                            rightAnno == null ? UNKNOWN : rightAnno);
+                            targetRec, exprRec, UNKNOWN, rightAnnoOrUnknown);
 
             propagateCombinedSameLen(combinedSameLen, node, result.getRegularStore());
         }
@@ -104,13 +108,7 @@ public class SameLenTransfer extends CFTransfer {
         if (rightAnno != null && AnnotationUtils.areSameByClass(rightAnno, SameLen.class)) {
 
             AnnotationMirror combinedSameLen =
-                    aTypeFactory.createCombinedSameLen(
-                            FlowExpressions.internalReprOf(
-                                    analysis.getTypeFactory(), node.getTarget()),
-                            FlowExpressions.internalReprOf(
-                                    analysis.getTypeFactory(), node.getExpression()),
-                            UNKNOWN,
-                            rightAnno);
+                    aTypeFactory.createCombinedSameLen(targetRec, exprRec, UNKNOWN, rightAnno);
 
             propagateCombinedSameLen(combinedSameLen, node, result.getRegularStore());
         }

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -92,23 +92,15 @@ public class SameLenTransfer extends CFTransfer {
         Receiver exprRec =
                 FlowExpressions.internalReprOf(analysis.getTypeFactory(), node.getExpression());
 
-        if (node.getTarget().getType().getKind() == TypeKind.ARRAY) {
+        if (node.getTarget().getType().getKind() == TypeKind.ARRAY
+                || (rightAnno != null
+                        && AnnotationUtils.areSameByClass(rightAnno, SameLen.class))) {
 
             AnnotationMirror rightAnnoOrUnknown = rightAnno == null ? UNKNOWN : rightAnno;
 
             AnnotationMirror combinedSameLen =
                     aTypeFactory.createCombinedSameLen(
                             targetRec, exprRec, UNKNOWN, rightAnnoOrUnknown);
-
-            propagateCombinedSameLen(combinedSameLen, node, result.getRegularStore());
-        }
-
-        // If the right side of the assignment has a SameLen type, propogate the right side to the arrays listed there.
-
-        if (rightAnno != null && AnnotationUtils.areSameByClass(rightAnno, SameLen.class)) {
-
-            AnnotationMirror combinedSameLen =
-                    aTypeFactory.createCombinedSameLen(targetRec, exprRec, UNKNOWN, rightAnno);
 
             propagateCombinedSameLen(combinedSameLen, node, result.getRegularStore());
         }

--- a/checker/tests/index/SameLenManyArrays.java
+++ b/checker/tests/index/SameLenManyArrays.java
@@ -1,4 +1,5 @@
 import org.checkerframework.checker.index.qual.*;
+import org.checkerframework.dataflow.qual.Pure;
 
 class SameLenManyArrays {
     void transfer1(int @SameLen("#2") [] a, int[] b) {
@@ -34,4 +35,22 @@ class SameLenManyArrays {
             }
         }
     }
+
+    void transfer5(int[] a, int[] b, int[] c, int[] d) {
+        if (a.length == b.length && b.length == c.length) {
+            int[] x = a;
+            int[] y = x;
+            int index = x.length - 1;
+            if (index > 0) {
+                f(a[index]);
+                f(b[index]);
+                f(c[index]);
+                f(x[index]);
+                f(y[index]);
+            }
+        }
+    }
+
+    @Pure
+    void f(Object o) {}
 }

--- a/checker/tests/index/SimpleCollection.java
+++ b/checker/tests/index/SimpleCollection.java
@@ -1,0 +1,20 @@
+import org.checkerframework.checker.index.qual.*;
+
+class SimpleCollection {
+    private int[] values;
+
+    @IndexOrHigh("values") int size() {
+        return values.length;
+    }
+
+    void interact_with_other(SimpleCollection other) {
+        int[] othervalues = other.values;
+        int @SameLen("other.values") [] x = othervalues;
+        for (int i = 0; i < other.size(); i++) {
+            int k = othervalues[i];
+        }
+        for (int j = 0; j < other.size(); j++) {
+            int k = other.values[j];
+        }
+    }
+}


### PR DESCRIPTION
Consider the following test case, from kelloggm#110:

```java
import org.checkerframework.checker.index.qual.*;

class SimpleCollection {
    private int[] values;

    @IndexOrHigh("values") int size() {
	return values.length;
    }

    void interact_with_other(SimpleCollection other) {
	for(int j = 0; j < other.size(); j++) {
	    int k = other.values[j]; // No warning from index checker
	}
	int[] othervalues = other.values;
	for(int i = 0; i < other.size(); i++) {
	    int k = othervalues[i]; // Index checker issues warning
	}
    }
}
```

This patch fixes that extraneous warning by adding a rule so that when something is assigned into an array, that array and the thing being assigned become part of the same SameLen type. It also corrects a bug in propagateCombinedSameLen that would sometimes pass a null TreePath as the currentPath. I'm not certain of the cause of that, but this fixes it by doing nothing when the TreePath is null. Also fixes a typo in some of the names in SameLenTransfer#visitAssignment, which referred to the right side of an assignment (i.e. the source) as the "left side", which doesn't make sense.