### PR TITLE
Add refinement to Upper Bound Checker:

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -117,6 +117,27 @@ public class OffsetEquation {
     }
 
     /**
+     * Makes a copy of this offset and removes any added terms that are accesses to the length of
+     * the listed arrays. If any terms were removed, then the copy is returned. Otherwise, null is
+     * returned.
+     *
+     * @param arrays List of arrays
+     * @return a copy of this equation with array.length removed or null if no array.lengths could
+     *     be removed
+     */
+    public OffsetEquation removeArrayLengths(List<String> arrays) {
+        OffsetEquation copy = new OffsetEquation(this);
+        boolean simplified = false;
+        for (String array : arrays) {
+            String arrayLen = array + ".length";
+            if (addedTerms.contains(arrayLen)) {
+                copy.addedTerms.remove(arrayLen);
+                simplified = true;
+            }
+        }
+        return simplified ? copy : null;
+    }
+    /**
      * Adds or subtracts the other equation to a copy of this one.
      *
      * <p>If subtraction is specified, then every term in other is subtracted.

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -671,7 +671,8 @@ public abstract class UBQualifier {
         /**
          * Returns a copy of this qualifier with array-offset pairs where in the original the offset
          * contains an access of an array length in arrays. The array length access has been removed
-         * from the offset.
+         * from the offset. If the original qualifier has no array length offsets, then UNKNOWN is
+         * returned.
          *
          * @param arrays access of the length of these arrays are removed
          * @return Returns a copy of this qualifier with some offsets removed
@@ -795,8 +796,8 @@ public abstract class UBQualifier {
          * applied to each offset.
          *
          * <p>If the {@link OffsetEquationFunction} returns null, it's not added as an offset. If
-         * after all functions have been applied, an array as no offsets, then that array is not
-         * added to the returned qualifier. If no arrays are added to the returned qualifier, the
+         * after all functions have been applied, an array has no offsets, then that array is not
+         * added to the returned qualifier. If no arrays are added to the returned qualifier, then
          * UNKNOWN is returned.
          *
          * @param f function to apply

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -681,13 +681,14 @@ public abstract class UBQualifier {
             if (arrays.isEmpty()) {
                 return UpperBoundUnknownQualifier.UNKNOWN;
             }
-            return computeNewOffsets(
+            OffsetEquationFunction removeArrayLengthsFunc =
                     new OffsetEquationFunction() {
                         @Override
                         public OffsetEquation compute(OffsetEquation eq) {
                             return eq.removeArrayLengths(arrays);
                         }
-                    });
+                    };
+            return computeNewOffsets(removeArrayLengthsFunc);
         }
         /**
          * Returns a copy of this qualifier with array-offset pairs where in the original the offset
@@ -701,7 +702,7 @@ public abstract class UBQualifier {
             if (arrays.isEmpty()) {
                 return UpperBoundUnknownQualifier.UNKNOWN;
             }
-            return computeNewOffsets(
+            OffsetEquationFunction removeArrayLenFunc =
                     new OffsetEquationFunction() {
                         @Override
                         public OffsetEquation compute(OffsetEquation eq) {
@@ -714,17 +715,19 @@ public abstract class UBQualifier {
                             }
                             return newEq;
                         }
-                    });
+                    };
+            return computeNewOffsets(removeArrayLenFunc);
         }
 
         private UBQualifier addOffset(final OffsetEquation newOffset) {
-            return computeNewOffsets(
+            OffsetEquationFunction addOffsetFunc =
                     new OffsetEquationFunction() {
                         @Override
                         public OffsetEquation compute(OffsetEquation eq) {
                             return eq.copyAdd('+', newOffset);
                         }
-                    });
+                    };
+            return computeNewOffsets(addOffsetFunc);
         }
 
         /**
@@ -742,7 +745,7 @@ public abstract class UBQualifier {
             if (divisor == 1) {
                 return this;
             } else if (divisor > 1) {
-                return computeNewOffsets(
+                OffsetEquationFunction divideFunc =
                         new OffsetEquationFunction() {
                             @Override
                             public OffsetEquation compute(OffsetEquation eq) {
@@ -751,7 +754,8 @@ public abstract class UBQualifier {
                                 }
                                 return null;
                             }
-                        });
+                        };
+                return computeNewOffsets(divideFunc);
             }
             return UpperBoundUnknownQualifier.UNKNOWN;
         }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -177,6 +177,16 @@ public abstract class UBQualifier {
     }
 
     /**
+     * Returns whether or not this qualifier has array with offset of -1.
+     *
+     * @param array array expression
+     * @return whether or not this qualifier has array with offset of -1.
+     */
+    public boolean hasArrayWithOffsetNeg1(String array) {
+        return false;
+    }
+
+    /**
      * Is the value with this qualifier less than or equal to the length of array?
      *
      * @param array String array
@@ -196,6 +206,15 @@ public abstract class UBQualifier {
             this.map = map;
         }
 
+        @Override
+        public boolean hasArrayWithOffsetNeg1(String array) {
+            Set<OffsetEquation> offsets = map.get(array);
+            if (offsets == null) {
+                return false;
+            }
+            return offsets.contains(OffsetEquation.NEG_1);
+        }
+
         /**
          * Is a value with this type less than or equal to the length of array?
          *
@@ -204,11 +223,7 @@ public abstract class UBQualifier {
          */
         @Override
         public boolean isLessThanOrEqualTo(String array) {
-            Set<OffsetEquation> offsets = map.get(array);
-            if (offsets == null) {
-                return false;
-            }
-            return offsets.contains(OffsetEquation.NEG_1);
+            return isLessThanLengthOf(array) || hasArrayWithOffsetNeg1(array);
         }
 
         /**
@@ -598,17 +613,18 @@ public abstract class UBQualifier {
         private UBQualifier pluseOrMinusOffset(
                 Node node, UpperBoundAnnotatedTypeFactory factory, char op) {
             assert op == '-' || op == '+';
+
             OffsetEquation newOffset = OffsetEquation.createOffsetFromNode(node, factory, op);
             LessThanLengthOf nodeOffsetQualifier = null;
             if (!newOffset.hasError()) {
-                nodeOffsetQualifier = addOffset(newOffset);
+                nodeOffsetQualifier = (LessThanLengthOf) addOffset(newOffset);
             }
 
             OffsetEquation valueOffset =
                     OffsetEquation.createOffsetFromNodesValue(node, factory, op);
             LessThanLengthOf valueOffsetQualifier = null;
             if (valueOffset != null && !valueOffset.hasError()) {
-                valueOffsetQualifier = addOffset(valueOffset);
+                valueOffsetQualifier = (LessThanLengthOf) addOffset(valueOffset);
             }
 
             if (valueOffsetQualifier == null) {
@@ -652,16 +668,62 @@ public abstract class UBQualifier {
             return addOffset(newOffset);
         }
 
-        private LessThanLengthOf addOffset(OffsetEquation newOffset) {
-            Map<String, Set<OffsetEquation>> plusMap = new HashMap<>(map.size());
-            for (Entry<String, Set<OffsetEquation>> entry : map.entrySet()) {
-                Set<OffsetEquation> plus = new HashSet<>(entry.getValue().size());
-                for (OffsetEquation eq : entry.getValue()) {
-                    plus.add(eq.copyAdd('+', newOffset));
-                }
-                plusMap.put(entry.getKey(), plus);
+        /**
+         * Returns a copy of this qualifier with array-offset pairs where in the original the offset
+         * contains an access of an array length in arrays. The array length access has been removed
+         * from the offset.
+         *
+         * @param arrays access of the length of these arrays are removed
+         * @return Returns a copy of this qualifier with some offsets removed
+         */
+        public UBQualifier removeArrayLengthAccess(final List<String> arrays) {
+            if (arrays.isEmpty()) {
+                return UpperBoundUnknownQualifier.UNKNOWN;
             }
-            return new LessThanLengthOf(plusMap);
+            return computeNewOffsets(
+                    new OffsetEquationFunction() {
+                        @Override
+                        public OffsetEquation compute(OffsetEquation eq) {
+                            return eq.removeArrayLengths(arrays);
+                        }
+                    });
+        }
+        /**
+         * Returns a copy of this qualifier with array-offset pairs where in the original the offset
+         * contains an access of an array length in arrays. The array length access has been removed
+         * from the offset. If the offset also has -1 then -1 is also removed.
+         *
+         * @param arrays access of the length of these arrays are removed
+         * @return Returns a copy of this qualifier with some offsets removed
+         */
+        public UBQualifier removeArrayLengthAccessAndNeg1(final List<String> arrays) {
+            if (arrays.isEmpty()) {
+                return UpperBoundUnknownQualifier.UNKNOWN;
+            }
+            return computeNewOffsets(
+                    new OffsetEquationFunction() {
+                        @Override
+                        public OffsetEquation compute(OffsetEquation eq) {
+                            OffsetEquation newEq = eq.removeArrayLengths(arrays);
+                            if (newEq == null) {
+                                return null;
+                            }
+                            if (newEq.getInt() == -1) {
+                                return newEq.copyAdd('+', OffsetEquation.ONE);
+                            }
+                            return newEq;
+                        }
+                    });
+        }
+
+        private UBQualifier addOffset(final OffsetEquation newOffset) {
+            return computeNewOffsets(
+                    new OffsetEquationFunction() {
+                        @Override
+                        public OffsetEquation compute(OffsetEquation eq) {
+                            return eq.copyAdd('+', newOffset);
+                        }
+                    });
         }
 
         /**
@@ -679,23 +741,16 @@ public abstract class UBQualifier {
             if (divisor == 1) {
                 return this;
             } else if (divisor > 1) {
-                Map<String, Set<OffsetEquation>> divideMap = new HashMap<>(map.size());
-                for (Entry<String, Set<OffsetEquation>> entry : map.entrySet()) {
-                    Set<OffsetEquation> divide = new HashSet<>(entry.getValue().size());
-                    for (OffsetEquation eq : entry.getValue()) {
-                        if (eq.isNegativeOrZero()) {
-                            divide.add(eq);
-                        }
-                    }
-                    if (!divide.isEmpty()) {
-                        divideMap.put(entry.getKey(), divide);
-                    }
-                }
-
-                if (divideMap.isEmpty()) {
-                    return UpperBoundUnknownQualifier.UNKNOWN;
-                }
-                return new LessThanLengthOf(divideMap);
+                return computeNewOffsets(
+                        new OffsetEquationFunction() {
+                            @Override
+                            public OffsetEquation compute(OffsetEquation eq) {
+                                if (eq.isNegativeOrZero()) {
+                                    return eq;
+                                }
+                                return null;
+                            }
+                        });
             }
             return UpperBoundUnknownQualifier.UNKNOWN;
         }
@@ -720,6 +775,52 @@ public abstract class UBQualifier {
 
         public Iterable<? extends String> getArrays() {
             return map.keySet();
+        }
+
+        /** Functional interface that operates on {@link OffsetEquation}s */
+        interface OffsetEquationFunction {
+            /**
+             * Returns the result of the computation or null if the passed equation should be
+             * removed.
+             *
+             * @param eq Current offset equation
+             * @return the result of the computation or null if the passed equation should be
+             *     removed
+             */
+            OffsetEquation compute(OffsetEquation eq);
+        }
+
+        /**
+         * Returns a new qualifier that is a copy of this qualifier with the OffsetEquationFunction
+         * applied to each offset.
+         *
+         * <p>If the {@link OffsetEquationFunction} returns null, it's not added as an offset. If
+         * after all functions have been applied, an array as no offsets, then that array is not
+         * added to the returned qualifier. If no arrays are added to the returned qualifier, the
+         * UNKNOWN is returned.
+         *
+         * @param f function to apply
+         * @return a new qualifier that is a copy of this qualifier with the OffsetEquationFunction
+         *     applied to each offset.
+         */
+        private UBQualifier computeNewOffsets(OffsetEquationFunction f) {
+            Map<String, Set<OffsetEquation>> newMap = new HashMap<>(map.size());
+            for (Entry<String, Set<OffsetEquation>> entry : map.entrySet()) {
+                Set<OffsetEquation> offsets = new HashSet<>(entry.getValue().size());
+                for (OffsetEquation eq : entry.getValue()) {
+                    OffsetEquation newEq = f.compute(eq);
+                    if (newEq != null) {
+                        offsets.add(newEq);
+                    }
+                }
+                if (!offsets.isEmpty()) {
+                    newMap.put(entry.getKey(), offsets);
+                }
+            }
+            if (newMap.isEmpty()) {
+                return UpperBoundUnknownQualifier.UNKNOWN;
+            }
+            return new LessThanLengthOf(newMap);
         }
     }
 

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -388,7 +388,13 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
                 lessThanOrEqaul.add(array);
             }
         }
+        // Creates a qualifier that is the same a j with the array.length offsets removed. If
+        // an offset doesn't have an array.length, then the offset/array pair is removed. If
+        // there are no such pairs, Unknown is returned.
         UBQualifier lessThanEqQ = j.removeArrayLengthAccess(lessThanOrEqaul);
+        // Creates a qualifier that is the same a j with the array.length - 1 offsets removed. If
+        // an offset doesn't have an array.length, then the offset/array pair is removed. If
+        // there are no such pairs, Unknown is returned.
         UBQualifier lessThanQ = j.removeArrayLengthAccessAndNeg1(lessThan);
 
         return lessThanEqQ.glb(lessThanQ);

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.index.upperbound;
 
 import com.sun.source.tree.ExpressionTree;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
@@ -8,6 +9,7 @@ import org.checkerframework.checker.index.IndexAbstractTransfer;
 import org.checkerframework.checker.index.IndexRefinementInfo;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
+import org.checkerframework.checker.index.upperbound.UBQualifier.LessThanLengthOf;
 import org.checkerframework.checker.index.upperbound.UBQualifier.UpperBoundUnknownQualifier;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
@@ -311,7 +313,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
                             atypeFactory, (FieldAccessNode) arrayLengthAccess);
             if (!fa.getReceiver().containsUnknown()) {
                 String array = fa.getReceiver().toString();
-                if (otherQualifier.isLessThanOrEqualTo(array)) {
+                if (otherQualifier.hasArrayWithOffsetNeg1(array)) {
                     otherQualifier = otherQualifier.glb(UBQualifier.createUBQualifier(array, "0"));
                     Receiver leftRec =
                             FlowExpressions.internalReprOf(analysis.getTypeFactory(), otherNode);
@@ -331,6 +333,10 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * to a (the type of a is @LTLengthOf(value="x", offset="o")), then the type of a + b
      * is @LTLengthOf(value="x",offset="o - b"). (Note, if "o - b" can be computed, then it is and
      * the result is used in the annotation.)
+     *
+     * <p>In addition, If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int
+     * and expression j is less than or equal to the length of f1, then the type of i + j is
+     * .@LTLengthOf("f2").
      */
     @Override
     public TransferResult<CFValue, CFStore> visitNumericalAddition(
@@ -346,8 +352,46 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         UBQualifier S = right.minusOffset(n.getLeftOperand(), atypeFactory);
 
         UBQualifier glb = T.glb(S);
+        if (!(left.isUnknownOrBottom() || right.isUnknownOrBottom())) {
+            // If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and
+            // expression j is less than or equal to the length of f1, then the type of i + j is
+            // @LTLengthOf("f2").
+            UBQualifier r = removeArrayLengths((LessThanLengthOf) left, (LessThanLengthOf) right);
+            glb = glb.glb(r);
+            UBQualifier l = removeArrayLengths((LessThanLengthOf) right, (LessThanLengthOf) left);
+            glb = glb.glb(l);
+        }
 
         return createTransferResult(n, in, glb);
+    }
+
+    /**
+     * Return the result of adding i to j,when expression i has type @LTLengthOf(value = "f2",
+     * offset = "f1.length") int and expression j is less than or equal to the length of f1, then
+     * the type of i + j is @LTLengthOf("f2").
+     *
+     * <p>Return the result of adding i to j,when expression i has type @LTLengthOf(value = "f2",
+     * offset = "f1.length - 1") int and expression j is less than the length of f1, then the type
+     * of i + j is @LTLengthOf("f2").
+     *
+     * @param i expression added to j
+     * @param j expression added to i
+     * @return the type of i + j
+     */
+    private UBQualifier removeArrayLengths(LessThanLengthOf i, LessThanLengthOf j) {
+        List<String> lessThan = new ArrayList<>();
+        List<String> lessThanOrEqaul = new ArrayList<>();
+        for (String array : i.getArrays()) {
+            if (i.isLessThanLengthOf(array)) {
+                lessThan.add(array);
+            } else if (i.hasArrayWithOffsetNeg1(array)) {
+                lessThanOrEqaul.add(array);
+            }
+        }
+        UBQualifier lessThanEqQ = j.removeArrayLengthAccess(lessThanOrEqaul);
+        UBQualifier lessThanQ = j.removeArrayLengthAccessAndNeg1(lessThan);
+
+        return lessThanEqQ.glb(lessThanQ);
     }
 
     /**

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -366,16 +366,16 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * Return the result of adding i to j,when expression i has type @LTLengthOf(value = "f2",
+     * Return the result of adding i to j, when expression i has type @LTLengthOf(value = "f2",
      * offset = "f1.length") int and expression j is less than or equal to the length of f1, then
      * the type of i + j is @LTLengthOf("f2").
      *
-     * <p>Return the result of adding i to j,when expression i has type @LTLengthOf(value = "f2",
-     * offset = "f1.length - 1") int and expression j is less than the length of f1, then the type
-     * of i + j is @LTLengthOf("f2").
+     * <p>Similarly, return the result of adding i to j,when expression i has type @LTLengthOf
+     * (value = "f2", offset = "f1.length - 1") int and expression j is less than the length of f1,
+     * then the type of i + j is @LTLengthOf("f2").
      *
-     * @param i expression added to j
-     * @param j expression added to i
+     * @param i the type of the expression added to j
+     * @param j the type of the expression added to i
      * @return the type of i + j
      */
     private UBQualifier removeArrayLengths(LessThanLengthOf i, LessThanLengthOf j) {

--- a/checker/tests/index/UpperBoundRefinement.java
+++ b/checker/tests/index/UpperBoundRefinement.java
@@ -1,0 +1,41 @@
+import org.checkerframework.checker.index.qual.LTLengthOf;
+
+@SuppressWarnings("lowerbound")
+public class UpperBoundRefinement {
+    /*If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and expression
+    j is less than or equal to the length of f1, then the type of i + j is @LTLengthOf("f2")
+     */
+    void test(int[] f1, int[] f2) {
+        @LTLengthOf(value = "f2", offset = "f1.length") int i = (f2.length - 1) - f1.length;
+        @LTLengthOf("f1") int j = f1.length - 1;
+        @LTLengthOf("f2") int x = i + j;
+        @LTLengthOf("f2") int y = i + f1.length;
+    }
+
+    void test2() {
+        double[] f1 = new double[10];
+        double[] f2 = new double[20];
+
+        for (int j = 0; j < f2.length; j++) {
+            f2[j] = j;
+        }
+        for (int i = 0; i < f2.length - f1.length; i++) {
+            //fill up f1 with elements of f2
+            for (int j = 0; j < f1.length; j++) {
+                f1[j] = f2[i + j]; // Index checker warns here
+            }
+        }
+    }
+
+    public void test3(double[] a, double[] sub) {
+        int a_index_max = a.length - sub.length;
+        // Has type @LTL(value={"a","sub"}, offset={"-1 + sub.length", "-1 + a.length"})
+
+        for (int i = 0; i <= a_index_max; i++) { // i has the same type as a_index_max
+            for (int j = 0; j < sub.length; j++) { // j is @LTL("sub")
+                // i + j is safe here. Because j is LTL("sub"), it should count as ("-1 + sub.length")
+                double d = a[i + j];
+            }
+        }
+    }
+}

--- a/checker/tests/index/UpperBoundRefinement.java
+++ b/checker/tests/index/UpperBoundRefinement.java
@@ -2,9 +2,8 @@ import org.checkerframework.checker.index.qual.LTLengthOf;
 
 @SuppressWarnings("lowerbound")
 public class UpperBoundRefinement {
-    /*If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and expression
-    j is less than or equal to the length of f1, then the type of i + j is @LTLengthOf("f2")
-     */
+    // If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and expression
+    // j is less than or equal to the length of f1, then the type of i + j is @LTLengthOf("f2")
     void test(int[] f1, int[] f2) {
         @LTLengthOf(value = "f2", offset = "f1.length") int i = (f2.length - 1) - f1.length;
         @LTLengthOf("f1") int j = f1.length - 1;
@@ -22,7 +21,7 @@ public class UpperBoundRefinement {
         for (int i = 0; i < f2.length - f1.length; i++) {
             //fill up f1 with elements of f2
             for (int j = 0; j < f1.length; j++) {
-                f1[j] = f2[i + j]; // Index checker warns here
+                f1[j] = f2[i + j];
             }
         }
     }


### PR DESCRIPTION
If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and expression j is less than or equal to the length of f1, then the type of i + j is @LTLengthOf("f2").

Fixes kelloggm/checker-framework#108 and fixes kelloggm/checker-framework#113