### PR TITLE
Fixed spaces in path to javac compiler leads to error

### DIFF
--- a/checker/bin/javac.bat
+++ b/checker/bin/javac.bat
@@ -1,3 +1,3 @@
 @echo off
 
-java -jar %~dp0\..\dist\checker.jar %*
+java -jar "%~dp0\..\dist\checker.jar" %*


### PR DESCRIPTION
Issue #1110: The solution was simple. We just had to put the offending part in double quotes.

If the expansion is `C:\Users\Vatsal Sura\Downloads\checker-framework-2.1.9\checker\bin`, then without quotes, `-jar` is only seeing up to the first space as it's argument (i.e. `-jar C:\Users\Vatsal`) and the remainder (`Sura\Downloads\checker-framework-2.1.9\checker\bin`) is a completely different argument not related to the `-jar`.

Double quotes will still allow any expansion to happen but everything within the quotes will be seen as a single item (the quotes won't be there when java sees it).