### PR TITLE
Index Checker: imprecise ArrayLen annotations no longer override precise MinLen annotations

### DIFF
--- a/checker/src/org/checkerframework/checker/index/minlen/MinLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/minlen/MinLenAnnotatedTypeFactory.java
@@ -206,7 +206,9 @@ public class MinLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (valueType.hasAnnotation(ArrayLen.class)) {
             AnnotationMirror anm = valueType.getAnnotation(ArrayLen.class);
             Integer val = Collections.min(ValueAnnotatedTypeFactory.getArrayLength(anm));
-            type.replaceAnnotation(createMinLen(val));
+            type.replaceAnnotation(
+                    qualHierarchy.greatestLowerBound(
+                            createMinLen(val), type.getAnnotationInHierarchy(MIN_LEN_0)));
         }
     }
 

--- a/checker/tests/index/Index115.java
+++ b/checker/tests/index/Index115.java
@@ -1,0 +1,28 @@
+import org.checkerframework.common.value.qual.*;
+
+public class Index115 {
+
+    public static void main(String[] args) {
+        if ((args.length > 1) && (args[1].equals("foo"))) {
+            System.out.println("First argument is foo");
+        }
+    }
+
+    public static void main2(String... args) {
+        if ((args.length > 1) && (args[1].equals("foo"))) {
+            System.out.println("First argument is foo");
+        }
+    }
+
+    public static void main3(String /*@ArrayLen({1,2})*/[] args) {
+        if ((args.length > 1) && (args[1].equals("foo"))) {
+            System.out.println("First argument is foo");
+        }
+    }
+
+    public static void main4(String /*@ArrayLen({1,2})*/... args) {
+        if ((args.length > 1) && (args[1].equals("foo"))) {
+            System.out.println("First argument is foo");
+        }
+    }
+}


### PR DESCRIPTION
Fixes kelloggm#115