### PR TITLE
Aliasing Checker fixes

### DIFF
--- a/framework/src/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.aliasing;
 
+import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
 import java.lang.annotation.Annotation;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class AliasingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return ret;
     }
 
-    protected static class AliasingTreeAnnotator extends TreeAnnotator {
+    protected class AliasingTreeAnnotator extends TreeAnnotator {
 
         public AliasingTreeAnnotator(AliasingAnnotatedTypeFactory atypeFactory) {
             super(atypeFactory);
@@ -76,6 +77,12 @@ public class AliasingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             Set<AnnotationMirror> defaultedSet = defaulted.getAnnotations();
             p.replaceAnnotations(defaultedSet);
             return null;
+        }
+
+        @Override
+        public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+            type.replaceAnnotation(UNIQUE);
+            return super.visitNewArray(node, type);
         }
     }
 

--- a/framework/src/org/checkerframework/common/aliasing/qual/MaybeAliased.java
+++ b/framework/src/org/checkerframework/common/aliasing/qual/MaybeAliased.java
@@ -5,10 +5,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * An expression with this type might have an alias. In other words, some other expression,
@@ -19,6 +21,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @DefaultQualifierInHierarchy
+@DefaultFor({TypeUseLocation.UPPER_BOUND, TypeUseLocation.LOWER_BOUND})
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 @ImplicitFor(

--- a/framework/src/org/checkerframework/common/aliasing/qual/Unique.java
+++ b/framework/src/org/checkerframework/common/aliasing/qual/Unique.java
@@ -5,9 +5,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
-import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * An expression with this type has no aliases. In other words, no other expression, evaluated at
@@ -24,5 +22,4 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({MaybeAliased.class})
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface Unique {}

--- a/framework/tests/aliasing/ArrayInitializerTest.java
+++ b/framework/tests/aliasing/ArrayInitializerTest.java
@@ -7,8 +7,12 @@ class ArrayInitializerTest {
         //:: error: (unique.leaked)
         Object[] ar = new Object[] {o};
 
+        @Unique Object o2 = new Object();
+        //:: error: (unique.leaked)
+        Object @Unique [] ar2 = new Object[] {o2};
+
         Object[] arr = new Object[] {new Object()};
 
-        Object[] arrr = new Object[2];
+        Object @Unique [] arrr = new Object[2];
     }
 }

--- a/framework/tests/aliasing/ForbiddenUniqueTest.java
+++ b/framework/tests/aliasing/ForbiddenUniqueTest.java
@@ -9,7 +9,7 @@ class ForbiddenUniqueTest {
     void notAllowed() {
         //:: error: (unique.location.forbidden)
         @Unique Object[] arr;
-        //:: error: (unique.location.forbidden)
+        //:: error: (type.argument.type.incompatible) :: error: (unique.location.forbidden)
         List<@Unique Object> list;
     }
 

--- a/framework/tests/all-systems/WildcardSuper2.java
+++ b/framework/tests/all-systems/WildcardSuper2.java
@@ -8,7 +8,7 @@ interface AInterface<T> {
 
 class B implements AInterface<Object> {
     // This shouldn't work for nullness as the function won't take possibly nullable values.
-    @SuppressWarnings({"nullness", "fenum:override.param.invalid"})
+    @SuppressWarnings({"nullness", "fenum:override.param.invalid", "aliasing"})
     @Override
     public int transform(List<Object> function) {
         return 0;

--- a/framework/tests/src/tests/AliasingTest.java
+++ b/framework/tests/src/tests/AliasingTest.java
@@ -19,6 +19,6 @@ public class AliasingTest extends CheckerFrameworkPerDirectoryTest {
 
     @Parameters
     public static String[] getTestDirs() {
-        return new String[] {"aliasing"};
+        return new String[] {"aliasing", "all-systems"};
     }
 }


### PR DESCRIPTION
1. New arrays are @Unique.
2. Since type arguments may not be annotated with @Unique, All bounds should be @MaybeAliased by default.
3. Run all-system tests.