### PR TITLE
Adds polymorphic qualifiers for the Index Checkers

### DIFF
--- a/checker/jdk/index/src/java/lang/Byte.java
+++ b/checker/jdk/index/src/java/lang/Byte.java
@@ -98,7 +98,7 @@ public final class Byte extends Number implements Comparable<Byte> {
      * @return a {@code Byte} instance representing {@code b}.
      * @since  1.5
      */
-    public static /*@ PolyLowerBound @ PolyUpperBound*/ Byte valueOf(/*@ PolyLowerBound @ PolyUpperBound*/ byte b) {
+    public static @PolyIndex Byte valueOf(@PolyIndex byte b) {
         final int offset = 128;
         return ByteCache.cache[(int)b + offset];
     }
@@ -295,7 +295,7 @@ public final class Byte extends Number implements Comparable<Byte> {
      * @param value     the value to be represented by the
      *                  {@code Byte}.
      */
-    public /*@ PolyLowerBound @ PolyUpperBound*/ Byte(/*@ PolyLowerBound @ PolyUpperBound*/ byte value) {
+    public @PolyIndex Byte(@PolyIndex byte value) {
         this.value = value;
     }
 

--- a/checker/jdk/index/src/java/lang/Integer.java
+++ b/checker/jdk/index/src/java/lang/Integer.java
@@ -636,7 +636,7 @@ public final class Integer extends Number implements Comparable<Integer> {
      * @return an {@code Integer} instance representing {@code i}.
      * @since  1.5
      */
-    public static /*@ PolyLowerBound @ PolyUpperBound*/ Integer valueOf(/*@ PolyLowerBound @ PolyUpperBound*/ int i) {
+    public static @PolyIndex Integer valueOf(@PolyIndex int i) {
         assert IntegerCache.high >= 127;
         if (i >= IntegerCache.low && i <= IntegerCache.high)
             return IntegerCache.cache[i + (-IntegerCache.low)];
@@ -657,7 +657,7 @@ public final class Integer extends Number implements Comparable<Integer> {
      * @param   value   the value to be represented by the
      *                  {@code Integer} object.
      */
-    public /*@ PolyLowerBound @ PolyUpperBound*/ Integer(/*@ PolyLowerBound @ PolyUpperBound*/ int value) {
+    public @PolyIndex Integer(@PolyIndex int value) {
         this.value = value;
     }
 

--- a/checker/jdk/index/src/java/lang/Long.java
+++ b/checker/jdk/index/src/java/lang/Long.java
@@ -682,7 +682,7 @@ public final class Long extends Number implements Comparable<Long> {
      * @param   value   the value to be represented by the
      *          {@code Long} object.
      */
-    public /*@ PolyLowerBound @ PolyUpperBound*/ Long(/*@ PolyLowerBound @ PolyUpperBound*/ long value) {
+    public @PolyIndex Long(@PolyIndex long value) {
         this.value = value;
     }
 

--- a/checker/jdk/index/src/java/lang/Math.java
+++ b/checker/jdk/index/src/java/lang/Math.java
@@ -875,7 +875,7 @@ public final class Math {
      * @param   b   another argument.
      * @return  the smaller of {@code a} and {@code b}.
      */
-    public static int min(int a, int b) {
+    public static @PolyLowerBound int min(@PolyLowerBound int a, @PolyLowerBound int b) {
         return (a <= b) ? a : b;
     }
 
@@ -889,7 +889,7 @@ public final class Math {
      * @param   b   another argument.
      * @return  the smaller of {@code a} and {@code b}.
      */
-    public static long min(long a, long b) {
+    public static @PolyLowerBound long min(@PolyLowerBound long a, @PolyLowerBound long b) {
         return (a <= b) ? a : b;
     }
 

--- a/checker/jdk/index/src/java/lang/Short.java
+++ b/checker/jdk/index/src/java/lang/Short.java
@@ -227,7 +227,7 @@ public final class Short extends Number implements Comparable<Short> {
      * @return a {@code Short} instance representing {@code s}.
      * @since  1.5
      */
-    public static /*@ PolyLowerBound @ PolyUpperBound*/ Short valueOf(/*@ PolyLowerBound @ PolyUpperBound*/ short s) {
+    public static @PolyIndex Short valueOf(@PolyIndex short s) {
         final int offset = 128;
         int sAsInt = s;
         if (sAsInt >= -128 && sAsInt <= 127) { // must cache
@@ -300,7 +300,7 @@ public final class Short extends Number implements Comparable<Short> {
      * @param value     the value to be represented by the
      *                  {@code Short}.
      */
-    public /*@ PolyLowerBound @ PolyUpperBound*/ Short(/*@ PolyLowerBound @ PolyUpperBound*/ short value) {
+    public @PolyIndex Short(@PolyIndex short value) {
         this.value = value;
     }
 

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -162,7 +162,7 @@ public final class String
      * @param  original
      *         A {@code String}
      */
-    public /*@ PolyMinLen @ PolySameLen*/ String(/*@ PolyMinLen @ PolySameLen*/ String original) {
+    public @PolyMinLen @PolySameLen String(@PolyMinLen @PolySameLen String original) {
         int size = original.count;
         char[] originalValue = original.value;
         char[] v;
@@ -191,7 +191,7 @@ public final class String
      * @param  value
      *         The initial value of the string
      */
-    public /*@ PolyMinLen @ PolySameLen*/ String(char /*@ PolyMinLen @ PolySameLen*/ [] value) {
+    public @PolyMinLen @PolySameLen String(char @PolyMinLen @PolySameLen [] value) {
         int size = value.length;
         this.offset = 0;
         this.count = size;
@@ -394,7 +394,7 @@ public final class String
      * @see  #String(byte[])
      */
     @Deprecated
-    public /*@ PolyMinLen @ PolySameLen*/ String(byte /*@ PolyMinLen @ PolySameLen*/ [] ascii, int hibyte) {
+    public @PolyMinLen @PolySameLen String(byte @PolyMinLen @PolySameLen [] ascii, int hibyte) {
         this(ascii, hibyte, 0, ascii.length);
     }
 
@@ -2916,7 +2916,7 @@ public final class String
      * @return  a newly allocated string representing the same sequence of
      *          characters contained in the character array argument.
      */
-    public static /*@ PolyMinLen @ PolySameLen*/ String valueOf(char /*@ PolyMinLen @ PolySameLen*/ [] data) {
+    public static @PolyMinLen @PolySameLen String valueOf(char @PolyMinLen @PolySameLen [] data) {
         return new String(data);
     }
 
@@ -2968,7 +2968,7 @@ public final class String
      * @return  a <code>String</code> that contains the characters of the
      *          character array.
      */
-    public static /*@ PolyMinLen @ PolySameLen*/ String copyValueOf(char /*@ PolyMinLen @ PolySameLen*/ [] data) {
+    public static @PolyMinLen @PolySameLen String copyValueOf(char @PolyMinLen @PolySameLen [] data) {
         return copyValueOf(data, 0, data.length);
     }
 

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -25,12 +25,15 @@ import org.checkerframework.checker.index.qual.IndexOrLow;
 import org.checkerframework.checker.index.qual.LowerBoundUnknown;
 import org.checkerframework.checker.index.qual.MinLen;
 import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.PolyIndex;
+import org.checkerframework.checker.index.qual.PolyLowerBound;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.common.value.qual.IntVal;
+import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
@@ -70,6 +73,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** The canonical @{@link LowerBoundUnknown} annotation. */
     public final AnnotationMirror UNKNOWN =
             AnnotationUtils.fromClass(elements, LowerBoundUnknown.class);
+    /** The canonical @{@link PolyLowerBound} annotation. */
+    public final AnnotationMirror POLY = AnnotationUtils.fromClass(elements, PolyLowerBound.class);
 
     private final IndexMethodIdentifier imf;
 
@@ -78,6 +83,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         addAliasedAnnotation(IndexFor.class, NN);
         addAliasedAnnotation(IndexOrLow.class, GTEN1);
         addAliasedAnnotation(IndexOrHigh.class, NN);
+        addAliasedAnnotation(PolyAll.class, POLY);
+        addAliasedAnnotation(PolyIndex.class, POLY);
 
         imf = new IndexMethodIdentifier(processingEnv);
 
@@ -92,7 +99,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         Positive.class,
                         NonNegative.class,
                         GTENegativeOne.class,
-                        LowerBoundUnknown.class));
+                        LowerBoundUnknown.class,
+                        PolyLowerBound.class));
     }
 
     /**
@@ -278,18 +286,9 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return super.visitUnary(tree, typeDst);
         }
 
-        /** Special handling for min and max from Math. Min is LUB, max is GLB. */
+        /** Special handling for Math.max. The return is the GLB of the arguments. */
         @Override
         public Void visitMethodInvocation(MethodInvocationTree tree, AnnotatedTypeMirror type) {
-
-            if (imf.isMathMin(tree, processingEnv)) {
-                ExpressionTree left = tree.getArguments().get(0);
-                ExpressionTree right = tree.getArguments().get(1);
-                type.replaceAnnotation(
-                        qualHierarchy.leastUpperBound(
-                                getAnnotatedType(left).getAnnotationInHierarchy(POS),
-                                getAnnotatedType(right).getAnnotationInHierarchy(POS)));
-            }
             if (imf.isMathMax(tree, processingEnv)) {
                 ExpressionTree left = tree.getArguments().get(0);
                 ExpressionTree right = tree.getArguments().get(1);

--- a/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
@@ -1,0 +1,15 @@
+package org.checkerframework.checker.index.qual;
+
+/**
+ * A polymorphic qualifier for the Lower and Upper Bound type system.
+ *
+ * <p>Writing {@code @PolyIndex} is equivalent to writing {@link PolyUpperBound @PolyUpperBound}
+ * {@link PolyLowerBound @PolyLowerBound}, and that is how it is treated internally by the checker.
+ * Thus, if you write an {@code @PolyIndex} annotation, you might see warnings about
+ * {@code @PolyUpperBound} or {@code @PolyLowerBound}.
+ *
+ * @checker_framework.manual #index-checker Index Checker
+ * @see PolyUpperBound
+ * @see PolyLowerBound
+ */
+public @interface PolyIndex {}

--- a/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
@@ -9,6 +9,7 @@ package org.checkerframework.checker.index.qual;
  * {@code @PolyUpperBound} or {@code @PolyLowerBound}.
  *
  * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  * @see PolyUpperBound
  * @see PolyLowerBound
  */

--- a/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyIndex.java
@@ -1,7 +1,7 @@
 package org.checkerframework.checker.index.qual;
 
 /**
- * A polymorphic qualifier for the Lower and Upper Bound type system.
+ * A polymorphic qualifier for the Lower Bound and Upper Bound type systems.
  *
  * <p>Writing {@code @PolyIndex} is equivalent to writing {@link PolyUpperBound @PolyUpperBound}
  * {@link PolyLowerBound @PolyLowerBound}, and that is how it is treated internally by the checker.

--- a/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
@@ -1,0 +1,14 @@
+package org.checkerframework.checker.index.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.PolymorphicQualifier;
+
+/**
+ * A polymorphic qualifier for the Lower Bound type system.
+ *
+ * <p>* @checker_framework.manual #index-checker Index Checker
+ */
+@PolymorphicQualifier(LowerBoundUnknown.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface PolyLowerBound {}

--- a/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
@@ -8,6 +8,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * A polymorphic qualifier for the Lower Bound type system.
  *
  * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @PolymorphicQualifier(LowerBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyLowerBound.java
@@ -7,7 +7,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 /**
  * A polymorphic qualifier for the Lower Bound type system.
  *
- * <p>* @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #index-checker Index Checker
  */
 @PolymorphicQualifier(LowerBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 /**
  * A polymorphic qualifier for the MinLen type system.
  *
- * <p>* @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #index-checker Index Checker
  */
 @PolymorphicQualifier(MinLen.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
@@ -7,6 +7,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * A polymorphic qualifier for the MinLen type system.
  *
  * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @PolymorphicQualifier(MinLen.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyMinLen.java
@@ -1,0 +1,13 @@
+package org.checkerframework.checker.index.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.PolymorphicQualifier;
+/**
+ * A polymorphic qualifier for the MinLen type system.
+ *
+ * <p>* @checker_framework.manual #index-checker Index Checker
+ */
+@PolymorphicQualifier(MinLen.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface PolyMinLen {}

--- a/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
@@ -7,7 +7,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 /**
  * A polymorphic qualifier for the SameLen type system.
  *
- * <p>* @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #index-checker Index Checker
  */
 @PolymorphicQualifier(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
@@ -8,6 +8,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * A polymorphic qualifier for the SameLen type system.
  *
  * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @PolymorphicQualifier(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolySameLen.java
@@ -1,0 +1,14 @@
+package org.checkerframework.checker.index.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.PolymorphicQualifier;
+
+/**
+ * A polymorphic qualifier for the SameLen type system.
+ *
+ * <p>* @checker_framework.manual #index-checker Index Checker
+ */
+@PolymorphicQualifier(SameLenUnknown.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface PolySameLen {}

--- a/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
@@ -1,0 +1,13 @@
+package org.checkerframework.checker.index.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.PolymorphicQualifier;
+/**
+ * A polymorphic qualifier for the Upper Bound type system.
+ *
+ * <p>* @checker_framework.manual #index-checker Index Checker
+ */
+@PolymorphicQualifier(UpperBoundUnknown.class)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+public @interface PolyUpperBound {}

--- a/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
@@ -7,6 +7,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * A polymorphic qualifier for the Upper Bound type system.
  *
  * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
+++ b/checker/src/org/checkerframework/checker/index/qual/PolyUpperBound.java
@@ -6,7 +6,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 /**
  * A polymorphic qualifier for the Upper Bound type system.
  *
- * <p>* @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #index-checker Index Checker
  */
 @PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.checker.index.qual.PolySameLen;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.checker.index.qual.SameLenBottom;
 import org.checkerframework.checker.index.qual.SameLenUnknown;
@@ -15,6 +16,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
+import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotationBuilder;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
@@ -29,12 +31,16 @@ import org.checkerframework.javacutil.AnnotationUtils;
 public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     public final AnnotationMirror UNKNOWN;
-    private AnnotationMirror BOTTOM;
+    private final AnnotationMirror BOTTOM;
+    private final AnnotationMirror POLY;
 
     public SameLenAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
         UNKNOWN = AnnotationUtils.fromClass(elements, SameLenUnknown.class);
         BOTTOM = AnnotationUtils.fromClass(elements, SameLenBottom.class);
+        POLY = AnnotationUtils.fromClass(elements, PolySameLen.class);
+        addAliasedAnnotation(PolyAll.class, POLY);
+
         this.postInit();
     }
 
@@ -42,7 +48,11 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
         // Because the Index Checker is a subclass, the qualifiers have to be explicitly defined.
         return new LinkedHashSet<>(
-                Arrays.asList(SameLen.class, SameLenBottom.class, SameLenUnknown.class));
+                Arrays.asList(
+                        SameLen.class,
+                        SameLenBottom.class,
+                        SameLenUnknown.class,
+                        PolySameLen.class));
     }
 
     @Override
@@ -189,6 +199,9 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     return a2;
                 } else if (AnnotationUtils.areSameByClass(a2, SameLenBottom.class)) {
                     return a1;
+                } else if (AnnotationUtils.areSameByClass(a1, PolySameLen.class)
+                        && AnnotationUtils.areSameByClass(a2, PolySameLen.class)) {
+                    return a1;
                 } else {
                     return UNKNOWN;
                 }
@@ -199,11 +212,11 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         public boolean isSubtype(AnnotationMirror rhs, AnnotationMirror lhs) {
             if (AnnotationUtils.areSameByClass(rhs, SameLenBottom.class)) {
                 return true;
-            }
-            if (AnnotationUtils.areSameByClass(lhs, SameLenUnknown.class)) {
+            } else if (AnnotationUtils.areSameByClass(lhs, SameLenUnknown.class)) {
                 return true;
-            }
-            if (AnnotationUtils.hasElementValue(rhs, "value")
+            } else if (AnnotationUtils.areSameByClass(rhs, PolySameLen.class)) {
+                return AnnotationUtils.areSameByClass(lhs, PolySameLen.class);
+            } else if (AnnotationUtils.hasElementValue(rhs, "value")
                     && AnnotationUtils.hasElementValue(lhs, "value")) {
                 List<String> a1Val = SameLenUtils.getValue(rhs);
                 List<String> a2Val = SameLenUtils.getValue(lhs);

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenVisitor.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
+import org.checkerframework.checker.index.qual.PolySameLen;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
@@ -30,14 +31,17 @@ public class SameLenVisitor extends BaseTypeVisitor<SameLenAnnotatedTypeFactory>
             AnnotatedTypeMirror valueType,
             Tree valueTree,
             /*@CompilerMessageKey*/ String errorKey) {
-        if (valueType.getKind() == TypeKind.ARRAY && TreeUtils.isExpressionTree(valueTree)) {
+        if (valueType.getKind() == TypeKind.ARRAY
+                && TreeUtils.isExpressionTree(valueTree)
+                && !(valueType.hasAnnotation(PolySameLen.class)
+                        && varType.hasAnnotation(PolySameLen.class))) {
+
             AnnotationMirror am = valueType.getAnnotation(SameLen.class);
             List<String> arraysInAnno =
                     am == null ? new ArrayList<String>() : SameLenUtils.getValue(am);
 
             Receiver rec = FlowExpressions.internalReprOf(atypeFactory, (ExpressionTree) valueTree);
             if (rec != null && !(rec instanceof Unknown)) {
-
                 List<String> itself = Collections.singletonList(rec.toString());
                 AnnotationMirror newSameLen = atypeFactory.getCombinedSameLen(arraysInAnno, itself);
                 valueType.replaceAnnotation(newSameLen);

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -13,6 +13,7 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 import org.checkerframework.checker.index.qual.LTOMLengthOf;
+import org.checkerframework.checker.index.qual.PolyUpperBound;
 import org.checkerframework.checker.index.qual.UpperBoundBottom;
 import org.checkerframework.checker.index.qual.UpperBoundUnknown;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -44,6 +45,8 @@ public abstract class UBQualifier {
             return parseLTEqLengthOf(am);
         } else if (AnnotationUtils.areSameByClass(am, LTOMLengthOf.class)) {
             return parseLTOMLengthOf(am);
+        } else if (AnnotationUtils.areSameByClass(am, PolyUpperBound.class)) {
+            return PolyQualifier.POLY;
         }
         assert false;
         return UpperBoundUnknownQualifier.UNKNOWN;
@@ -141,13 +144,21 @@ public abstract class UBQualifier {
         return UpperBoundUnknownQualifier.UNKNOWN;
     }
 
-    public final boolean isUnknownOrBottom() {
-        return isBottom() || isUnknown();
+    public boolean isLessThanLengthQualifier() {
+        return false;
     }
 
-    public abstract boolean isUnknown();
+    public boolean isUnknown() {
+        return false;
+    }
 
-    public abstract boolean isBottom();
+    public boolean isBottom() {
+        return false;
+    }
+
+    public boolean isPoly() {
+        return false;
+    }
 
     public abstract boolean isSubtype(UBQualifier superType);
 
@@ -348,13 +359,8 @@ public abstract class UBQualifier {
         }
 
         @Override
-        public boolean isUnknown() {
-            return false;
-        }
-
-        @Override
-        public boolean isBottom() {
-            return false;
+        public boolean isLessThanLengthQualifier() {
+            return true;
         }
 
         /**
@@ -468,7 +474,7 @@ public abstract class UBQualifier {
         @Override
         public UBQualifier widenUpperBound(UBQualifier obj) {
             UBQualifier lub = lub(obj);
-            if (lub.isUnknownOrBottom() || obj.isUnknownOrBottom()) {
+            if (!lub.isLessThanLengthQualifier() || !obj.isLessThanLengthQualifier()) {
                 return lub;
             }
             Map<String, Set<OffsetEquation>> lubMap = ((LessThanLengthOf) lub).map;
@@ -845,11 +851,6 @@ public abstract class UBQualifier {
         private UpperBoundUnknownQualifier() {}
 
         @Override
-        public boolean isBottom() {
-            return false;
-        }
-
-        @Override
         public boolean isSubtype(UBQualifier superType) {
             return superType.isUnknown();
         }
@@ -879,11 +880,6 @@ public abstract class UBQualifier {
         static final UBQualifier BOTTOM = new UpperBoundBottomQualifier();
 
         @Override
-        public boolean isUnknown() {
-            return false;
-        }
-
-        @Override
         public boolean isBottom() {
             return true;
         }
@@ -906,6 +902,36 @@ public abstract class UBQualifier {
         @Override
         public String toString() {
             return "BOTTOM";
+        }
+    }
+
+    private static class PolyQualifier extends UBQualifier {
+        static final UBQualifier POLY = new UpperBoundBottomQualifier();
+
+        @Override
+        public boolean isPoly() {
+            return true;
+        }
+
+        @Override
+        public boolean isSubtype(UBQualifier superType) {
+            return superType.isUnknown() || superType.isPoly();
+        }
+
+        @Override
+        public UBQualifier lub(UBQualifier other) {
+            if (other.isPoly() || other.isBottom()) {
+                return this;
+            }
+            return UpperBoundUnknownQualifier.UNKNOWN;
+        }
+
+        @Override
+        public UBQualifier glb(UBQualifier other) {
+            if (other.isPoly() || other.isUnknown()) {
+                return this;
+            }
+            return UpperBoundBottomQualifier.BOTTOM;
         }
     }
 }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -31,6 +31,8 @@ import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 import org.checkerframework.checker.index.qual.LTOMLengthOf;
 import org.checkerframework.checker.index.qual.MinLen;
+import org.checkerframework.checker.index.qual.PolyIndex;
+import org.checkerframework.checker.index.qual.PolyUpperBound;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.checker.index.qual.UpperBoundBottom;
 import org.checkerframework.checker.index.qual.UpperBoundUnknown;
@@ -44,6 +46,7 @@ import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
@@ -67,7 +70,7 @@ import org.checkerframework.javacutil.TreeUtils;
  */
 public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
-    public final AnnotationMirror UNKNOWN, BOTTOM;
+    public final AnnotationMirror UNKNOWN, BOTTOM, POLY;
 
     private final IndexMethodIdentifier imf;
 
@@ -75,10 +78,13 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         super(checker);
         UNKNOWN = AnnotationUtils.fromClass(elements, UpperBoundUnknown.class);
         BOTTOM = AnnotationUtils.fromClass(elements, UpperBoundBottom.class);
+        POLY = AnnotationUtils.fromClass(elements, PolyUpperBound.class);
 
         addAliasedAnnotation(IndexFor.class, createLTLengthOfAnnotation());
         addAliasedAnnotation(IndexOrLow.class, createLTLengthOfAnnotation());
         addAliasedAnnotation(IndexOrHigh.class, createLTEqLengthOfAnnotation());
+        addAliasedAnnotation(PolyAll.class, POLY);
+        addAliasedAnnotation(PolyIndex.class, POLY);
 
         imf = new IndexMethodIdentifier(processingEnv);
 
@@ -94,7 +100,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         LTEqLengthOf.class,
                         LTLengthOf.class,
                         LTOMLengthOf.class,
-                        UpperBoundBottom.class));
+                        UpperBoundBottom.class,
+                        PolyUpperBound.class));
     }
 
     /**
@@ -508,7 +515,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             UBQualifier result = UpperBoundUnknownQualifier.UNKNOWN;
             UBQualifier numerator =
                     UBQualifier.createUBQualifier(getAnnotatedType(numeratorTree), UNKNOWN);
-            if (!numerator.isUnknownOrBottom()) {
+            if (numerator.isLessThanLengthQualifier()) {
                 result = ((LessThanLengthOf) numerator).divide(divisor);
             }
             result = result.glb(plusTreeDivideByVal(divisor, numeratorTree));
@@ -531,7 +538,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             UBQualifier right =
                     UBQualifier.createUBQualifier(
                             getAnnotatedType(plusTree.getRightOperand()), UNKNOWN);
-            if (!(left.isUnknownOrBottom() || right.isUnknownOrBottom())) {
+            if (left.isLessThanLengthQualifier() && right.isLessThanLengthQualifier()) {
                 LessThanLengthOf leftLTL = (LessThanLengthOf) left;
                 LessThanLengthOf rightLTL = (LessThanLengthOf) right;
                 List<String> arrays = new ArrayList<>();
@@ -589,6 +596,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return UNKNOWN;
         } else if (qualifier.isBottom()) {
             return BOTTOM;
+        } else if (qualifier.isPoly()) {
+            return POLY;
         }
 
         LessThanLengthOf ltlQualifier = (LessThanLengthOf) qualifier;

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -352,7 +352,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         UBQualifier S = right.minusOffset(n.getLeftOperand(), atypeFactory);
 
         UBQualifier glb = T.glb(S);
-        if (!(left.isUnknownOrBottom() || right.isUnknownOrBottom())) {
+        if (left.isLessThanLengthQualifier() && right.isLessThanLengthQualifier()) {
             // If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int and
             // expression j is less than or equal to the length of f1, then the type of i + j is
             // @LTLengthOf("f2").
@@ -415,7 +415,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
                 || atypeFactory.hasLowerBoundTypeByClass(n.getRightOperand(), Positive.class)) {
             // If the right side of the expression is NN or POS, then all the left side's
             // annotations should be kept.
-            if (!left.isUnknownOrBottom()) {
+            if (left.isLessThanLengthQualifier()) {
                 leftWithOffset = left.glb(leftWithOffset);
             }
         }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -119,7 +119,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
         }
 
         // If the qualifier is uninteresting or the type is unannotated, do nothing else.
-        if (qualifier == null || qualifier.isUnknownOrBottom()) { // TODO after merge
+        if (qualifier == null || !qualifier.isLessThanLengthQualifier()) {
             super.commonAssignmentCheck(varType, valueExp, errorKey);
             return;
         }

--- a/checker/tests/index/Polymorphic.java
+++ b/checker/tests/index/Polymorphic.java
@@ -1,0 +1,80 @@
+import org.checkerframework.checker.index.qual.*;
+
+class Polymorphic {
+
+    //Identity functions
+
+    @PolyLowerBound
+    int lbc_identity(@PolyLowerBound int a) {
+        return a;
+    }
+
+    int @PolyMinLen [] minlen_identity(int @PolyMinLen [] a) {
+        return a;
+    }
+
+    int @PolySameLen [] samelen_identity(int @PolySameLen [] a) {
+        int @SameLen("a") [] x = a;
+        return a;
+    }
+
+    @PolyUpperBound
+    int ubc_identity(@PolyUpperBound int a) {
+        return a;
+    }
+
+    // MinLen tests
+    void minlen_id(int @MinLen(5) [] a) {
+        int @MinLen(5) [] b = minlen_identity(a);
+        //:: error: (assignment.type.incompatible)
+        int @MinLen(6) [] c = minlen_identity(b);
+    }
+
+    // SameLen tests
+    void samelen_id(int @SameLen("#2") [] a, int[] a2) {
+        int[] banana;
+        int @SameLen("a2") [] b = samelen_identity(a);
+        //:: error: (assignment.type.incompatible)
+        int @SameLen("banana") [] c = samelen_identity(b);
+    }
+
+    // UpperBound tests
+    void ubc_id(
+            int[] a,
+            int[] b,
+            @LTLengthOf("#1") int ai,
+            @LTEqLengthOf("#1") int al,
+            @LTLengthOf({"#1", "#2"}) int abi,
+            @LTEqLengthOf({"#1", "#2"}) int abl) {
+        int[] c;
+
+        @LTLengthOf("a") int ai1 = ubc_identity(ai);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("b") int ai2 = ubc_identity(ai);
+
+        @LTEqLengthOf("a") int al1 = ubc_identity(al);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("a") int al2 = ubc_identity(al);
+
+        @LTLengthOf({"a", "b"}) int abi1 = ubc_identity(abi);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf({"a", "b", "c"}) int abi2 = ubc_identity(abi);
+
+        @LTEqLengthOf({"a", "b"}) int abl1 = ubc_identity(abl);
+        //:: error: (assignment.type.incompatible)
+        @LTEqLengthOf({"a", "b", "c"}) int abl2 = ubc_identity(abl);
+    }
+
+    // LowerBound tests
+    void lbc_id(@NonNegative int n, @Positive int p, @GTENegativeOne int g) {
+        @NonNegative int an = lbc_identity(n);
+        //:: error: (assignment.type.incompatible)
+        @Positive int bn = lbc_identity(n);
+
+        @GTENegativeOne int ag = lbc_identity(g);
+        //:: error: (assignment.type.incompatible)
+        @NonNegative int bg = lbc_identity(g);
+
+        @Positive int ap = lbc_identity(p);
+    }
+}

--- a/checker/tests/index/Polymorphic2.java
+++ b/checker/tests/index/Polymorphic2.java
@@ -1,0 +1,85 @@
+import org.checkerframework.checker.index.qual.*;
+import org.checkerframework.framework.qual.PolyAll;
+
+class Polymorphic2 {
+    public static boolean flag = false;
+
+    @PolyAll int merge(@PolyAll int a, @PolyAll int b) {
+        return flag ? a : b;
+    }
+
+    int @PolyAll [] merge(int @PolyAll [] a, int @PolyAll [] b) {
+        return flag ? a : b;
+    }
+
+    int @PolyMinLen [] mergeMinLen(int @PolyMinLen [] a, int @PolyMinLen [] b) {
+        return flag ? a : b;
+    }
+
+    void testMinLen(int @MinLen(2) [] a, int @MinLen(5) [] b) {
+        int @MinLen(2) [] x = merge(a, b);
+        //:: error: (assignment.type.incompatible)
+        int @MinLen(5) [] y = merge(a, b);
+
+        int @MinLen(2) [] z = mergeMinLen(a, b);
+        //:: error: (assignment.type.incompatible)
+        int @MinLen(5) [] zz = mergeMinLen(a, b);
+    }
+
+    int @PolySameLen [] mergeSameLen(int @PolySameLen [] a, int @PolySameLen [] b) {
+        return flag ? a : b;
+    }
+
+    int[] array1 = new int[2];
+    int[] array2 = new int[2];
+
+    void testSameLen(int @SameLen("array1") [] a, int @SameLen("array2") [] b) {
+        int[] x = merge(a, b);
+        //:: error: (assignment.type.incompatible)
+        int @SameLen("array1") [] y = merge(a, b);
+
+        int[] z = mergeMinLen(a, b);
+        //:: error: (assignment.type.incompatible)
+        int @SameLen("array1") [] zz = mergeMinLen(a, b);
+    }
+
+    @PolyUpperBound
+    int mergeUpperBound(@PolyUpperBound int a, @PolyUpperBound int b) {
+        return flag ? a : b;
+    }
+    // UpperBound tests
+    void testUpperBound(@LTLengthOf("array1") int a, @LTLengthOf("array2") int b) {
+        int x = merge(a, b);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("array1") int y = merge(a, b);
+
+        int z = mergeUpperBound(a, b);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("array1") int zz = mergeUpperBound(a, b);
+    }
+
+    void testUpperBound2(@LTLengthOf("array1") int a, @LTEqLengthOf("array1") int b) {
+        @LTEqLengthOf("array1") int x = merge(a, b);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("array1") int y = merge(a, b);
+
+        @LTEqLengthOf("array1") int z = mergeUpperBound(a, b);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("array1") int zz = mergeUpperBound(a, b);
+    }
+
+    @PolyLowerBound
+    int mergeLowerBound(@PolyLowerBound int a, @PolyLowerBound int b) {
+        return flag ? a : b;
+    }
+    // LowerBound tests
+    void lbc_id(@NonNegative int n, @Positive int p) {
+        @NonNegative int x = merge(n, p);
+        //:: error: (assignment.type.incompatible)
+        @Positive int y = merge(n, p);
+
+        @NonNegative int z = mergeLowerBound(n, p);
+        //:: error: (assignment.type.incompatible)
+        @Positive int zz = mergeLowerBound(n, p);
+    }
+}

--- a/checker/tests/index/Polymorphic3.java
+++ b/checker/tests/index/Polymorphic3.java
@@ -1,0 +1,51 @@
+import org.checkerframework.checker.index.qual.*;
+
+class Polymorphic3 {
+
+    //Identity functions
+
+    @PolyIndex
+    int identity(@PolyIndex int a) {
+        return a;
+    }
+
+    // UpperBound tests
+    void ubc_id(
+            int[] a,
+            int[] b,
+            @LTLengthOf("#1") int ai,
+            @LTEqLengthOf("#1") int al,
+            @LTLengthOf({"#1", "#2"}) int abi,
+            @LTEqLengthOf({"#1", "#2"}) int abl) {
+        int[] c;
+
+        @LTLengthOf("a") int ai1 = identity(ai);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("b") int ai2 = identity(ai);
+
+        @LTEqLengthOf("a") int al1 = identity(al);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf("a") int al2 = identity(al);
+
+        @LTLengthOf({"a", "b"}) int abi1 = identity(abi);
+        //:: error: (assignment.type.incompatible)
+        @LTLengthOf({"a", "b", "c"}) int abi2 = identity(abi);
+
+        @LTEqLengthOf({"a", "b"}) int abl1 = identity(abl);
+        //:: error: (assignment.type.incompatible)
+        @LTEqLengthOf({"a", "b", "c"}) int abl2 = identity(abl);
+    }
+
+    // LowerBound tests
+    void lbc_id(@NonNegative int n, @Positive int p, @GTENegativeOne int g) {
+        @NonNegative int an = identity(n);
+        //:: error: (assignment.type.incompatible)
+        @Positive int bn = identity(n);
+
+        @GTENegativeOne int ag = identity(g);
+        //:: error: (assignment.type.incompatible)
+        @NonNegative int bg = identity(g);
+
+        @Positive int ap = identity(p);
+    }
+}

--- a/docs/manual/Makefile
+++ b/docs/manual/Makefile
@@ -53,7 +53,7 @@ manual.pdf: bib-update figures-all check-labels
 	while grep "Rerun to get" manual.log; do pdflatex manual.tex; done
 
 html: manual.html
-manual.html: manual.pdf CFLogo.png favicon-checkerframework.png
+manual.html: manual.pdf CFLogo.png favicon-checkerframework.png ../docs/api
 	hevea -fix -exec xxdate.exe manual.tex
 # I'm not sure why this is necessary; "hevea -fix" should run it automatically.
 # Also, you need ImageMagick 6.8.0-2 Beta or later to avoid a bug.
@@ -69,6 +69,9 @@ manual.html: manual.pdf CFLogo.png favicon-checkerframework.png
 #	html-update-toc manual.html
 # Add CSS styling, since \newstyle doesn't work for me.
 	sed -i -e "s%<style type=\"text/css\">%<style type=\"text/css\">\nimg { max-width: 100\%; max-height: 100\%; }%" manual.html
+
+../docs/api:
+	cd .. && ln -s ../checker/api api
 
 CFLogo.png: ../logo/Logo/CFLogo.png
 	cp -p $< $@

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -133,7 +133,7 @@ are some annotations that give multiple types of information:
   }
   \end{Verbatim}
 
- \item[\refqualclasswithparams{checker/index/qual}{PolyIndex}]
+ \item[\refqualclass{checker/index/qual}{PolyIndex}]
    indicates qualifier polymorphism.  This type combines
    \refqualclass{checker/index/qual}{PolyLowerBound} and
    \refqualclass{checker/index/qual}{PolyUpperBound}.
@@ -161,7 +161,7 @@ qualifiers:
 \item[\refqualclass{checker/index/qual}{LowerBoundUnknown}]
   There is no information about the value.
   It may not be used as an index for a sequence, because it might be too low.
-\item[\refqualclasswithparams{checker/index/qual}{PolyLowerBound}]
+\item[\refqualclass{checker/index/qual}{PolyLowerBound}]
   indicates qualifier polymorphism.
   For a description of qualifier polymorphism, see
   Section~\ref{qualifier-polymorphism}.
@@ -257,7 +257,7 @@ or \code{@LTOMLengthOf({"arr"})}.
   This is the bottom type for the upper bound type system. It should
   never need to be written by the programmer.
 
- \item[\refqualclasswithparams{checker/index/qual}{PolyUpperBound}]
+ \item[\refqualclass{checker/index/qual}{PolyUpperBound}]
    indicates qualifier polymorphism.
    For a description of qualifier polymorphism, see
    Section~\ref{qualifier-polymorphism}.
@@ -306,7 +306,7 @@ Array minimum lengths use the following type qualifiers
   This is the bottom type for the MinLen type system.
   Programmers should rarely need to write it.
   \code{null} has this type.
-\item[\refqualclasswithparams{checker/index/qual}{PolyMinLen}]
+\item[\refqualclass{checker/index/qual}{PolyMinLen}]
   indicates qualifier polymorphism.
   For a description of qualifier polymorphism, see
   Section~\ref{qualifier-polymorphism}.
@@ -363,7 +363,7 @@ When needed, you can specify which sequences have the same length using the foll
   This is the top type, and programmers should never need to write it.
 \item[\refqualclass{checker/index/qual}{SameLenBottom}]
   This is the bottom type, and programmers should rarely need to write it.
-\item[\refqualclasswithparams{checker/index/qual}{PolySameLen}]
+\item[\refqualclass{checker/index/qual}{PolySameLen}]
   indicates qualifier polymorphism.
   For a description of qualifier polymorphism, see
   Section~\ref{qualifier-polymorphism}.

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -133,6 +133,13 @@ are some annotations that give multiple types of information:
   }
   \end{Verbatim}
 
+ \item[\refqualclasswithparams{checker/index/qual}{PolyIndex}]
+   indicates qualifier polymorphism.  This type combines
+   \refqualclass{checker/index/qual}{PolyLowerBound} and
+   \refqualclass{checker/index/qual}{PolyUpperBound}.
+   For a description of qualifier polymorphism, see
+   Section~\ref{qualifier-polymorphism}.
+
 \end{description}
 
 \section{Lower bounds\label{index-lowerbound}}
@@ -154,6 +161,10 @@ qualifiers:
 \item[\refqualclass{checker/index/qual}{LowerBoundUnknown}]
   There is no information about the value.
   It may not be used as an index for a sequence, because it might be too low.
+\item[\refqualclasswithparams{checker/index/qual}{PolyLowerBound}]
+  indicates qualifier polymorphism.
+  For a description of qualifier polymorphism, see
+  Section~\ref{qualifier-polymorphism}.
 \end{description}
 
 \begin{figure}
@@ -246,6 +257,11 @@ or \code{@LTOMLengthOf({"arr"})}.
   This is the bottom type for the upper bound type system. It should
   never need to be written by the programmer.
 
+ \item[\refqualclasswithparams{checker/index/qual}{PolyUpperBound}]
+   indicates qualifier polymorphism.
+   For a description of qualifier polymorphism, see
+   Section~\ref{qualifier-polymorphism}.
+
 \end{description}
 
 
@@ -290,7 +306,11 @@ Array minimum lengths use the following type qualifiers
   This is the bottom type for the MinLen type system.
   Programmers should rarely need to write it.
   \code{null} has this type.
-  \end{description}
+\item[\refqualclasswithparams{checker/index/qual}{PolyMinLen}]
+  indicates qualifier polymorphism.
+  For a description of qualifier polymorphism, see
+  Section~\ref{qualifier-polymorphism}.
+\end{description}
 
 \begin{figure}
 \begin{center}
@@ -343,8 +363,12 @@ When needed, you can specify which sequences have the same length using the foll
   This is the top type, and programmers should never need to write it.
 \item[\refqualclass{checker/index/qual}{SameLenBottom}]
   This is the bottom type, and programmers should rarely need to write it.
+\item[\refqualclasswithparams{checker/index/qual}{PolySameLen}]
+  indicates qualifier polymorphism.
+  For a description of qualifier polymorphism, see
+  Section~\ref{qualifier-polymorphism}.
   \code{null} has this type.
-  \end{description}
+\end{description}
 
 %%  LocalWords:  NegativeArraySizeException pre myArray IndexFor someArray
 %%  LocalWords:  MyJavaFile LTLengthOf LTEqLengthOf GTENegativeOne GTE


### PR DESCRIPTION
This is the same code that was in (closed) PR #1112, except the new poly qualifiers have proper Javadocs and are mentioned in the manual.  I also add `@PolyIndex` that is syntactic sugar for `@PolyUpperBound @PolyLowerBound`.