### PR TITLE
Use non-specifc base directory for Checker Framework builds.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,7 +15,7 @@
         basedir=".">
   <property file="${basedir}/local.properties"/>
 
-  <property name="checkerframework" value="${basedir}/../checker-framework"/>
+  <property name="checkerframework" value="${basedir}"/>
   <property file="${checkerframework}/build-common.properties"/>
 
   <target name="dist"


### PR DESCRIPTION
Fixes https://github.com/typetools/checker-framework/issues/1127