### PR TITLE
Allows LBC to correctly handle assignments in comparisons

### DIFF
--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.lowerbound;
 
+import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
 import org.checkerframework.checker.index.IndexRefinementInfo;
@@ -131,13 +132,19 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
 
         if (integerLiteralOrNull == 0) {
             if (AnnotationUtils.areSameByClass(otherAnno, NonNegative.class)) {
-                Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, otherNode);
-                store.insertValue(rec, POS);
+                List<Node> internals = splitAssignments(otherNode);
+                for (Node internal : internals) {
+                    Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, internal);
+                    store.insertValue(rec, POS);
+                }
             }
         } else if (integerLiteralOrNull == -1) {
             if (AnnotationUtils.areSameByClass(otherAnno, GTENegativeOne.class)) {
-                Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, otherNode);
-                store.insertValue(rec, NN);
+                List<Node> internals = splitAssignments(otherNode);
+                for (Node internal : internals) {
+                    Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, internal);
+                    store.insertValue(rec, NN);
+                }
             }
         }
     }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -293,11 +293,17 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         UBQualifier glb = rightQualifier.glb(leftQualifier);
         AnnotationMirror glbAnno = atypeFactory.convertUBQualifierToAnnotation(glb);
 
-        Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), right);
-        store.insertValue(rightRec, glbAnno);
+        List<Node> internalsRight = splitAssignments(right);
+        for (Node internal : internalsRight) {
+            Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), internal);
+            store.insertValue(rightRec, glbAnno);
+        }
 
-        Receiver leftRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), left);
-        store.insertValue(leftRec, glbAnno);
+        List<Node> internalsLeft = splitAssignments(left);
+        for (Node internal : internalsLeft) {
+            Receiver leftRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), internal);
+            store.insertValue(leftRec, glbAnno);
+        }
     }
 
     /**
@@ -315,10 +321,13 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
                 String array = fa.getReceiver().toString();
                 if (otherQualifier.hasArrayWithOffsetNeg1(array)) {
                     otherQualifier = otherQualifier.glb(UBQualifier.createUBQualifier(array, "0"));
-                    Receiver leftRec =
-                            FlowExpressions.internalReprOf(analysis.getTypeFactory(), otherNode);
-                    store.insertValue(
-                            leftRec, atypeFactory.convertUBQualifierToAnnotation(otherQualifier));
+                    for (Node internal : splitAssignments(otherNode)) {
+                        Receiver leftRec =
+                                FlowExpressions.internalReprOf(analysis.getTypeFactory(), internal);
+                        store.insertValue(
+                                leftRec,
+                                atypeFactory.convertUBQualifierToAnnotation(otherQualifier));
+                    }
                 }
             }
         }

--- a/checker/tests/index/CheckAgainstNegativeOne.java
+++ b/checker/tests/index/CheckAgainstNegativeOne.java
@@ -1,5 +1,3 @@
-// @skip-test so that the travis build stops failing...
-
 class CheckAgainstNegativeOne {
 
     public static String replaceString(String target, String oldStr, String newStr) {

--- a/checker/tests/index/Issue58Minimization.java
+++ b/checker/tests/index/Issue58Minimization.java
@@ -4,9 +4,25 @@ class Issue58Minimization {
 
     void test(@GTENegativeOne int x) {
         int z;
-        int w = (z = x);
         if ((z = x) != -1) {
             @NonNegative int y = z;
+        }
+        if ((z = x) != 1) {
+            //:: error: (assignment.type.incompatible)
+            @NonNegative int y = z;
+        }
+    }
+
+    void test2(@NonNegative int x) {
+        int z;
+        if ((z = x) != 0) {
+            @Positive int y = z;
+        }
+        if ((z = x) == 0) {
+            // do nothing
+            int y = 5;
+        } else {
+            @Positive int y = x;
         }
     }
 }

--- a/checker/tests/index/Issue58Minimization.java
+++ b/checker/tests/index/Issue58Minimization.java
@@ -33,10 +33,24 @@ class Issue58Minimization {
         }
     }
 
-    void minlen_test(int[] a, int[] c) {
+    void samelen_test(int[] a, int[] c) {
         int[] b;
         if ((b = a) == c) {
             int @SameLen({"a", "b", "c"}) [] d = b;
+        }
+    }
+
+    void minlen_test(int[] a, int @MinLen(1) [] c) {
+        int[] b;
+        if ((b = a) == c) {
+            int @MinLen(1) [] d = b;
+        }
+    }
+
+    void minlen_test2(int[] a, int x) {
+        int one = 1;
+        if ((x = one) == a.length) {
+            int @MinLen(1) [] b = a;
         }
     }
 }

--- a/checker/tests/index/Issue58Minimization.java
+++ b/checker/tests/index/Issue58Minimization.java
@@ -1,0 +1,12 @@
+import org.checkerframework.checker.index.qual.*;
+
+class Issue58Minimization {
+
+    void test(@GTENegativeOne int x) {
+        int z;
+        int w = (z = x);
+        if ((z = x) != -1) {
+            @NonNegative int y = z;
+        }
+    }
+}

--- a/checker/tests/index/Issue58Minimization.java
+++ b/checker/tests/index/Issue58Minimization.java
@@ -25,4 +25,18 @@ class Issue58Minimization {
             @Positive int y = x;
         }
     }
+
+    void ubc_test(int[] a, @LTEqLengthOf("#1") int x) {
+        int z;
+        if ((z = x) != a.length) {
+            @LTLengthOf("a") int y = z;
+        }
+    }
+
+    void minlen_test(int[] a, int[] c) {
+        int[] b;
+        if ((b = a) == c) {
+            int @SameLen({"a", "b", "c"}) [] d = b;
+        }
+    }
 }

--- a/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -704,6 +704,10 @@ public abstract class CFAbstractTransfer<
      * precise than {@code firstvalue}. This is possible, if {@code secondNode} is an expression
      * that is tracked by the store (e.g., a local variable or a field).
      *
+     * <p>Note that when overriding this method, when a new type is inserted into the store,
+     * splitAssignments should be called, and the new type should be inserted into the store for
+     * each of the resulting nodes.
+     *
      * @param res the previous result
      * @param notEqualTo if true, indicates that the logic is flipped (i.e., the information is
      *     added to the {@code elseStore} instead of the {@code thenStore}) for a not-equal


### PR DESCRIPTION
Following the example of the nullness checker, which handles this correctly.

Fixes kelloggm#58