### PR TITLE
Index Checker: Adds a special case when dividing an array length

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -463,6 +463,20 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 result = ((LessThanLengthOf) numerator).divide(divisor.intValue());
             }
             result = result.glb(plusTreeDivideByVal(divisor.intValue(), numeratorTree));
+
+            // If the numerator is an array length access of an array with length greater than 1, and the divisor is
+            // positive, glb the result with an LTL of the array.
+            if (TreeUtils.isArrayLengthAccess(numeratorTree) && divisor > 1) {
+                String arrayName = ((MemberSelectTree) numeratorTree).getExpression().toString();
+                int minlen =
+                        getMinLenAnnotatedTypeFactory()
+                                .getMinLenFromString(
+                                        arrayName, numeratorTree, getPath(numeratorTree));
+                if (minlen > 0) {
+                    result = result.glb(UBQualifier.createUBQualifier(arrayName, "0"));
+                }
+            }
+
             resultType.addAnnotation(convertUBQualifierToAnnotation(result));
         }
 

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -464,8 +464,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
             result = result.glb(plusTreeDivideByVal(divisor.intValue(), numeratorTree));
 
-            // If the numerator is an array length access of an array with length greater than 1, and the divisor is
-            // positive, glb the result with an LTL of the array.
+            // If the numerator is an array length access of an array with non-zero length, and the divisor is
+            // greater than one, glb the result with an LTL of the array.
             if (TreeUtils.isArrayLengthAccess(numeratorTree) && divisor > 1) {
                 String arrayName = ((MemberSelectTree) numeratorTree).getExpression().toString();
                 int minlen =

--- a/checker/tests/index/MinLenOneAndLength.java
+++ b/checker/tests/index/MinLenOneAndLength.java
@@ -1,0 +1,9 @@
+import org.checkerframework.checker.index.qual.*;
+
+public class MinLenOneAndLength {
+    public void m1(int @MinLen(1) [] a, int[] b) {
+        @IndexFor("a") int i = a.length / 2;
+        //:: error: (assignment.type.incompatible)
+        @IndexFor("b") int j = b.length / 2;
+    }
+}


### PR DESCRIPTION
If the array's minimum length is 1 or more, then dividing it by a constant >= 2 now results in a `LTLengthOf` for the array. Before it was (conservatively) a `LTEqLengthOf`.

Fixes kelloggm#137