### PR TITLE
Fixes Issue #1189

### DIFF
--- a/checker/jdk/nullness/src/java/io/ObjectOutput.java
+++ b/checker/jdk/nullness/src/java/io/ObjectOutput.java
@@ -1,7 +1,9 @@
 package java.io;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 public interface ObjectOutput extends DataOutput {
-  void writeObject(Object a1) throws IOException;
+  void writeObject(@Nullable Object a1) throws IOException;
   void write(int a1) throws IOException;
   void write(byte[] a1) throws IOException;
   void write(byte[] a1, int a2, int a3) throws IOException;


### PR DESCRIPTION
This will help to sync type parameters with classes implementing this interface. The parameter can be null for 
ObjectOutput.writeObject(Object ) which claims to serialize the Objects passed as parameters.

Please review this PR and suggest me the changes required.  