### PR TITLE
Fix #1198:

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -548,10 +548,10 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          * find each dimension's size and create the appropriate annotation for it.
          *
          * <p>If the annotation of the dimension is {@code @IntVal}, create an {@code @ArrayLen}
-         * with the same set of possible values. If the annotation is {@code @IntRange}, convert it
-         * to {@code @IntVal} before creating the {@code @ArrayLen} by the same method as above. If
-         * the annotation is {@code @BottomVal}, create an {@code @BottomVal} instead. In other
-         * cases, no annotations would be created.
+         * with the same set of possible values. If the annotation is {@code @IntRange} and the
+         * specified range is not wider than 10, create an {@code @ArrayLen} by the same method as
+         * above. If the annotation is {@code @BottomVal}, create an {@code @BottomVal} instead. In
+         * other cases, no annotations are created.
          *
          * @param dimensions a list of ExpressionTrees where each ExpressionTree is a specifier of
          *     the size of that dimension
@@ -566,20 +566,24 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
             AnnotationMirror dimType =
                     getAnnotatedType(dimensions.get(0)).getAnnotationInHierarchy(UNKNOWNVAL);
-            if (AnnotationUtils.areSameByClass(dimType, IntRange.class)) {
-                dimType = convertIntRangeToIntVal(dimType);
-            }
-            if (AnnotationUtils.areSameByClass(dimType, IntVal.class)) {
-                List<Long> longLengths = getIntValues(dimType);
-
-                HashSet<Integer> lengths = new HashSet<Integer>(longLengths.size());
-                for (Long l : longLengths) {
-                    lengths.add(l.intValue());
-                }
-                AnnotationMirror newQual = createArrayLenAnnotation(new ArrayList<>(lengths));
-                type.replaceAnnotation(newQual);
-            } else if (AnnotationUtils.areSameIgnoringValues(dimType, BOTTOMVAL)) {
+            if (AnnotationUtils.areSameIgnoringValues(dimType, BOTTOMVAL)) {
                 type.replaceAnnotation(BOTTOMVAL);
+            } else {
+                List<Long> longLengths = null;
+                if (AnnotationUtils.areSameByClass(dimType, IntRange.class)) {
+                    longLengths =
+                            ValueCheckerUtils.getValuesFromRange(getIntRange(dimType), Long.class);
+                } else if (AnnotationUtils.areSameByClass(dimType, IntVal.class)) {
+                    longLengths = getIntValues(dimType);
+                }
+                if (longLengths != null) {
+                    HashSet<Integer> lengths = new HashSet<Integer>(longLengths.size());
+                    for (Long l : longLengths) {
+                        lengths.add(l.intValue());
+                    }
+                    AnnotationMirror newQual = createArrayLenAnnotation(new ArrayList<>(lengths));
+                    type.replaceAnnotation(newQual);
+                }
             }
         }
 

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -33,6 +33,16 @@ class ArrayInit {
         int @ArrayLen({1}) [] a = new int[i];
     }
 
+    public void rangeInit(
+            @IntRange(from = 1, to = 2) int shortLength,
+            @IntRange(from = 1, to = 20) int longLength,
+            @BottomVal int bottom) {
+        int @ArrayLen({1, 2}) [] a = new int[shortLength];
+        //:: error: (assignment.type.incompatible)
+        int @ArrayLen({1, 2}) [] b = new int[longLength];
+        int @ArrayLen({0}) [] c = new int[bottom];
+    }
+
     public void multiDim() {
         int i = 2;
         int j = 3;
@@ -50,13 +60,13 @@ class ArrayInit {
     }
 
     public void vargsTest() {
-        // type of arg should be @UnknownValue Object @BottomVal[]
+        // type of arg should be @UnknownVal Object @BottomVal[]
         vargs((Object[]) null);
 
-        // type of arg should be @UnknownValue int @BottomVal[]
+        // type of arg should be @UnknownVal int @BottomVal[]
         vargs((int[]) null);
 
-        // type of arg should be @UnknownValue byte @BottomVal[]
+        // type of arg should be @UnknownVal byte @BottomVal[]
         vargs((byte[]) null);
     }
 


### PR DESCRIPTION
Convert @IntRange to @IntVal before creating the corresponding @ArrayLen.
Handle @BottomVal annotated dimension by creating a @BottomVal.
Don't create annotation if the dimension is not @IntRange, @IntVal or @BottomVal.