### PR TITLE
Make the check-nullness target actually process all source files.

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -777,6 +777,7 @@
         <antcall target="check-compilermsgs"/>
         <antcall target="check-purity"/>
 
+        <antcall target="check-nullness"/>
     </target>
 
     <target name="aggregate-tests" depends="jar,build-tests"

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1237,7 +1237,6 @@ So, use our own archived version.
                 <fileset dir="${src}">
                     <include name="**/*.java"/>
                     <exclude name="${checker.jdk8orhigher.sources}"/>
-                    <exclude name=""/>
                 </fileset>
                 <fileset dir="${javacutil.loc}/${src}">
                     <include name="**/*.java"/>
@@ -1262,6 +1261,11 @@ So, use our own archived version.
                 <fileset dir="${framework.loc}/${src}">
                     <include name="**/*.java"/>
                 </fileset>
+                <!-- TODO: check-nullness doesn't properly work with this.
+                <fileset dir="${checker-jdk}" erroronmissingdir="false">
+                    <include name="**/*.java"/>
+                </fileset>
+                -->
             </path>
         </pathconvert>
 
@@ -1277,21 +1281,16 @@ So, use our own archived version.
             <jvmarg line="-Xbootclasspath/p:${javac.lib}"/>
             <jvmarg line="${maybeDebug}"/>
             <arg value="-g"/>
-            <!-- Make sure we only have Java 7 source code and generate Java 7 bytecode. -->
-            <arg value="-source"/>
-            <arg value="7"/>
-            <arg value="-target"/>
-            <arg value="7"/>
             <arg value="-encoding"/>
             <arg value="utf-8"/>
             <!-- To not get a warning about bootstrap classpath -->
             <arg value="-Xlint:-options"/>
-            <arg line="-sourcepath ${src}:${checker-jdk}"/>
             <arg line="-d ${build}"/>
             <arg line="@${tmpdir}/srcfiles-checker.txt"/>
             <arg line="-version"/>
             <arg line="-proc:only"/>
             <arg line="-processor ${checker-name}"/>
+            <arg line="-AprintErrorStack"/>
             <arg line="${checker-args}"/>
         </java>
         <delete file="${tmpdir}/srcfiles-checker.txt"/>
@@ -1302,7 +1301,7 @@ So, use our own archived version.
         <antcall target="-run-checker">
             <param name="checker-name" value="org.checkerframework.checker.nullness.NullnessChecker"/>
             <param name="checker-jdk" value="jdk/nullness/src"/>
-            <param name="checker-args" value="-Awarns"/>
+            <param name="checker-args" value="-Awarns -Xmaxwarns 10000"/>
         </antcall>
     </target>
 
@@ -1319,7 +1318,7 @@ So, use our own archived version.
             description="Run the Purity Checker on the Framework">
         <antcall target="-run-checker">
             <param name="checker-name" value="org.checkerframework.framework.util.PurityChecker"/>
-            <param name="checker-args" value="-AprintErrorStack"/>
+            <param name="checker-args" value=""/>
         </antcall>
     </target>
 

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1274,6 +1274,11 @@ So, use our own archived version.
         </condition>
 
         <echo message="${src.files}" file="${tmpdir}/srcfiles-checker.txt"/>
+
+        <echo message="Applying ${checker-name} to the Checker Framework sources."/>
+        <!-- Use this if you want to see the file names:
+        <echo message="Applying ${checker-name} to: ${src.files}"/>
+        -->
         <java fork="true"
               failonerror="true"
               classpath="${build}:${javac.lib}:${checker.lib}:${framework.lib}:${junit.lib}:${hamcrest.lib}:${annotation-file-utilities.lib}"

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -777,7 +777,9 @@
         <antcall target="check-compilermsgs"/>
         <antcall target="check-purity"/>
 
-        <antcall target="check-nullness"/>
+        <!-- Eventually we would also want this:
+          <antcall target="check-nullness"/>
+        -->
     </target>
 
     <target name="aggregate-tests" depends="jar,build-tests"

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -342,11 +342,11 @@ public class AnnotatedTypeCopier
         originalToCopy.put(original, copy);
 
         if (original.getExtendsBoundField() != null) {
-            copy.setExtendsBound(visit(original.getExtendsBoundField(), originalToCopy));
+            copy.setExtendsBound(visit(original.getExtendsBoundField(), originalToCopy).asUse());
         }
 
         if (original.getSuperBoundField() != null) {
-            copy.setSuperBound(visit(original.getSuperBoundField(), originalToCopy));
+            copy.setSuperBound(visit(original.getSuperBoundField(), originalToCopy).asUse());
         }
 
         return copy;

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -287,11 +287,13 @@ public class AnnotatedTypeCopier
         originalToCopy.put(original, copy);
 
         if (original.getUpperBoundField() != null) {
-            copy.setUpperBoundField(visit(original.getUpperBoundField(), originalToCopy));
+            // TODO: figure out why asUse is needed here and remove it.
+            copy.setUpperBound(visit(original.getUpperBoundField(), originalToCopy).asUse());
         }
 
         if (original.getLowerBoundField() != null) {
-            copy.setLowerBoundField(visit(original.getLowerBoundField(), originalToCopy));
+            // TODO: figure out why asUse is needed here and remove it.
+            copy.setLowerBound(visit(original.getLowerBoundField(), originalToCopy).asUse());
         }
 
         return copy;

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1862,7 +1862,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     protected static void adaptGetClassReturnTypeToReceiver(
             final AnnotatedExecutableType getClassType, final AnnotatedTypeMirror receiverType) {
-        final AnnotatedTypeMirror newBound = receiverType.getErased();
+        // TODO: should the receiver type ever be a declaration??
+        // Work on removing the asUse() call.
+        final AnnotatedTypeMirror newBound = receiverType.getErased().asUse();
 
         final AnnotatedTypeMirror returnType = getClassType.getReturnType();
         if (returnType == null

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1517,21 +1517,16 @@ public abstract class AnnotatedTypeMirror {
          * @param type the lower bound type
          */
         void setLowerBound(AnnotatedTypeMirror type) {
-            if (type != null) {
-                type = type.asUse();
+            if (type == null || type.isDeclaration()) {
+                ErrorReporter.errorAbort(
+                        "Lower bounds should never be null or a declaration.\n"
+                                + "  new bound = "
+                                + type
+                                + "\n  type = "
+                                + this);
             }
             this.lowerBound = type;
-        }
-
-        /**
-         * Sets the lower bound of this type variable without calling asUse (and therefore making a
-         * copy)
-         */
-        void setLowerBoundField(AnnotatedTypeMirror type) {
-            this.lowerBound = type;
-            if (lowerBound != null) {
-                fixupBoundAnnotations();
-            }
+            fixupBoundAnnotations();
         }
 
         /**
@@ -1616,23 +1611,16 @@ public abstract class AnnotatedTypeMirror {
          * @param type the upper bound type
          */
         void setUpperBound(AnnotatedTypeMirror type) {
-            if (type.isDeclaration()) {
+            if (type == null || type.isDeclaration()) {
                 ErrorReporter.errorAbort(
-                        "Upper bounds should never contain declarations.\n" + "type=" + type);
+                        "Upper bounds should never be null or a declaration.\n"
+                                + "  new bound = "
+                                + type
+                                + "\n  type = "
+                                + this);
             }
             this.upperBound = type;
-        }
-
-        /**
-         * Set the upper bound of this variable type without making a copy using asUse
-         *
-         * @param type the upper bound type
-         */
-        void setUpperBoundField(final AnnotatedTypeMirror type) {
-            this.upperBound = type;
-            if (upperBound != null) {
-                fixupBoundAnnotations();
-            }
+            fixupBoundAnnotations();
         }
 
         /**
@@ -1905,13 +1893,16 @@ public abstract class AnnotatedTypeMirror {
          * @param type the type of the lower bound
          */
         void setSuperBound(AnnotatedTypeMirror type) {
-            if (type != null) {
-                type = type.asUse();
+            if (type == null || type.isDeclaration()) {
+                ErrorReporter.errorAbort(
+                        "Super bounds should never be null or a declaration.\n"
+                                + "  new bound = "
+                                + type
+                                + "\n  type = "
+                                + this);
             }
             this.superBound = type;
-            if (superBound != null) {
-                fixupBoundAnnotations();
-            }
+            fixupBoundAnnotations();
         }
 
         public AnnotatedTypeMirror getSuperBoundField() {
@@ -1936,13 +1927,16 @@ public abstract class AnnotatedTypeMirror {
          * @param type the type of the upper bound
          */
         void setExtendsBound(AnnotatedTypeMirror type) {
-            if (type != null) {
-                type = type.asUse();
+            if (type == null || type.isDeclaration()) {
+                ErrorReporter.errorAbort(
+                        "Extends bounds should never be null or a declaration.\n"
+                                + "  new bound = "
+                                + type
+                                + "\n  type = "
+                                + this);
             }
             this.extendsBound = type;
-            if (extendsBound != null) {
-                fixupBoundAnnotations();
-            }
+            fixupBoundAnnotations();
         }
 
         public AnnotatedTypeMirror getExtendsBoundField() {

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -68,11 +68,11 @@ public class AnnotatedTypeReplacer {
                 originalToCopy.put(original, copy);
 
                 if (original.getUpperBoundField() != null) {
-                    copy.setUpperBoundField(visit(original.getUpperBoundField(), originalToCopy));
+                    copy.setUpperBound(visit(original.getUpperBoundField(), originalToCopy));
                 }
 
                 if (original.getLowerBoundField() != null) {
-                    copy.setLowerBoundField(visit(original.getLowerBoundField(), originalToCopy));
+                    copy.setLowerBound(visit(original.getLowerBoundField(), originalToCopy));
                 }
                 return copy;
             }

--- a/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -369,10 +369,10 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     @Override
     public AnnotatedTypeMirror visitDeclared_Typevar(
             AnnotatedDeclaredType type, AnnotatedTypeVariable superType, Void p) {
-        AnnotatedTypeMirror upperBound = visit(type, superType.getUpperBound(), p);
+        AnnotatedTypeMirror upperBound = visit(type, superType.getUpperBound(), p).asUse();
         superType.setUpperBound(upperBound);
 
-        AnnotatedTypeMirror lowerBound = asSuperTypevarLowerBound(type, superType, p);
+        AnnotatedTypeMirror lowerBound = asSuperTypevarLowerBound(type, superType, p).asUse();
         superType.setLowerBound(lowerBound);
 
         return copyPrimaryAnnos(type, superType);
@@ -388,10 +388,10 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     @Override
     public AnnotatedTypeMirror visitDeclared_Wildcard(
             AnnotatedDeclaredType type, AnnotatedWildcardType superType, Void p) {
-        AnnotatedTypeMirror upperBound = visit(type, superType.getExtendsBound(), p);
+        AnnotatedTypeMirror upperBound = visit(type, superType.getExtendsBound(), p).asUse();
         superType.setExtendsBound(upperBound);
 
-        AnnotatedTypeMirror lowerBound = asSuperWildcardLowerBound(type, superType, p);
+        AnnotatedTypeMirror lowerBound = asSuperWildcardLowerBound(type, superType, p).asUse();
         superType.setSuperBound(lowerBound);
 
         return copyPrimaryAnnos(type, superType);

--- a/framework/src/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/org/checkerframework/framework/type/BoundsInitializer.java
@@ -578,7 +578,7 @@ public class BoundsInitializer {
 
             for (final Entry<BoundPath, AnnotatedTypeVariable> pathToRef : refMap.entrySet()) {
                 final BoundPath path = pathToRef.getKey();
-                final AnnotatedTypeVariable replacement = pathToRef.getValue();
+                final AnnotatedTypeVariable replacement = pathToRef.getValue().asUse();
 
                 AnnotatedTypeMirror parent = traverseToParent(type, path);
                 BoundPathNode terminus = path.getLast();
@@ -603,7 +603,7 @@ public class BoundsInitializer {
         final AnnotatedTypeMirror upperBound =
                 AnnotatedTypeMirror.createType(
                         typeVar.getUnderlyingType().getUpperBound(), typeVar.atypeFactory, false);
-        typeVar.setUpperBoundField(upperBound);
+        typeVar.setUpperBound(upperBound);
         return upperBound;
     }
 
@@ -618,7 +618,7 @@ public class BoundsInitializer {
         }
         final AnnotatedTypeMirror lowerBound =
                 AnnotatedTypeMirror.createType(lb, typeVar.atypeFactory, false);
-        typeVar.setLowerBoundField(lowerBound);
+        typeVar.setLowerBound(lowerBound);
         return lowerBound;
     }
 
@@ -836,7 +836,7 @@ public class BoundsInitializer {
 
         @Override
         public void setType(AnnotatedTypeMirror parent, AnnotatedTypeVariable replacement) {
-            ((AnnotatedTypeVariable) parent).setUpperBoundField(replacement);
+            ((AnnotatedTypeVariable) parent).setUpperBound(replacement);
         }
 
         @Override
@@ -866,7 +866,7 @@ public class BoundsInitializer {
 
         @Override
         public void setType(AnnotatedTypeMirror parent, AnnotatedTypeVariable replacement) {
-            ((AnnotatedTypeVariable) parent).setLowerBoundField(replacement);
+            ((AnnotatedTypeVariable) parent).setLowerBound(replacement);
         }
 
         @Override


### PR DESCRIPTION
Currently, `ant check-nullness` only checks the JDK annotations instead of all source files.
We already type check the JDK annotations when building the annotated JDK.
This PR type-checks the source code itself, which isn't type-checked yet.
Unfortunately, when trying to do both, either one didn't work. This PR checks the parts that we haven't checked yet.
It also uses Java 8, because the source code uses Java 8 type annotations.

We should add 'ant check-nullness' to the travis tests and ensure that there are no errors. There are currently many warnings, but only two errors, of the form:

```
     [java] error: Upper bounds should never contain declarations.
     [java]   type=@Initialized @NonNull Annotation
     [java]   Compilation unit: .../checker-framework/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
     [java]   Exception: java.lang.Throwable; Stack trace: org.checkerframework.framework.source.SourceChecker.errorAbort(SourceChecker.java:722)
     [java]   org.checkerframework.javacutil.ErrorReporter.errorAbort(ErrorReporter.java:25)
     [java]   org.checkerframework.framework.type.AnnotatedTypeMirror$AnnotatedTypeVariable.setUpperBound(AnnotatedTypeMirror.java:1624)
     [java]   org.checkerframework.framework.type.AsSuperVisitor.visitDeclared_Typevar(AsSuperVisitor.java:373)
     [java]   org.checkerframework.framework.type.AsSuperVisitor.visitDeclared_Typevar(AsSuperVisitor.java:29)
     [java]   org.checkerframework.framework.util.AtmCombo.accept(AtmCombo.java:338)
     [java]   org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor.visit(AbstractAtmComboVisitor.java:59)
     [java]   org.checkerframework.framework.type.AsSuperVisitor.visit(AsSuperVisitor.java:86)
```