### PR TITLE
Index Checker: Fixes bug in SameLen subtyping rule, and several bugs that were masked by that bug

### DIFF
--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -105,7 +105,6 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         newValues.addAll(a1Names);
         newValues.addAll(a2Names);
         String[] names = newValues.toArray(new String[newValues.size()]);
-        Arrays.sort(names);
         return createSameLen(names);
     }
 
@@ -293,7 +292,6 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         if (!arrayAnnoArrays.contains(rec.toString())) {
                             arrayAnnoArrays.add(rec.toString());
                             String[] newArrayAnnoArrays = arrayAnnoArrays.toArray(new String[0]);
-                            Arrays.sort(newArrayAnnoArrays);
                             arrayAnno = createSameLen(newArrayAnnoArrays);
                         }
                     }
@@ -307,10 +305,15 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** Creates a @SameLen annotation whose values are the given strings. */
     public AnnotationMirror createSameLen(String... val) {
         AnnotationBuilder builder = new AnnotationBuilder(processingEnv, SameLen.class);
+        Arrays.sort(val);
         builder.setValue("value", val);
         return builder.build();
     }
 
+    /**
+     * Find all the arrays that are members of the SameLen annotation associated with the array
+     * named in arrayExpression along the current path.
+     */
     public List<String> getSameLensFromString(
             String arrayExpression, Tree tree, TreePath currentPath) {
         AnnotationMirror sameLenAnno = null;

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -110,37 +110,46 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
+     * Combines the given arrays and annotations into a single SameLen annotation. See {@link
+     * #createCombinedSameLen(List, List)}.
+     */
+    public AnnotationMirror createCombinedSameLen(
+            Receiver rec1, Receiver rec2, AnnotationMirror a1, AnnotationMirror a2) {
+        List<Receiver> receivers = new ArrayList<>();
+        receivers.add(rec1);
+        receivers.add(rec2);
+        List<AnnotationMirror> annos = new ArrayList<>();
+        annos.add(a1);
+        annos.add(a2);
+        return createCombinedSameLen(receivers, annos);
+    }
+
+    /**
      * For the use of the transfer function; generates a SameLen that includes a and b, as well as
      * everything in sl1 and sl2, if they are SameLen annotations.
      *
-     * @param aRec receiver representing the first array
-     * @param bRec receiver representing the second array
-     * @param sl1 the current annotation of the first array
-     * @param sl2 the current annotation of the second array
+     * @param receivers a list of receivers representing arrays to be included in the combined
+     *     annotation
+     * @param annos a list of the current annotations of the receivers. Must be the same length as
+     *     receivers.
      * @return a combined SameLen annotation
      */
     public AnnotationMirror createCombinedSameLen(
-            FlowExpressions.Receiver aRec,
-            FlowExpressions.Receiver bRec,
-            AnnotationMirror sl1,
-            AnnotationMirror sl2) {
-        List<String> aValues = new ArrayList<String>();
-        List<String> bValues = new ArrayList<String>();
+            List<FlowExpressions.Receiver> receivers, List<AnnotationMirror> annos) {
 
-        if (isReceiverToStringParsable(aRec)) {
-            aValues.add(aRec.toString());
-            if (AnnotationUtils.areSameByClass(sl1, SameLen.class)) {
-                aValues.addAll(getValueOfAnnotationWithStringArgument(sl1));
+        assert receivers.size() == annos.size();
+        List<String> values = new ArrayList<String>();
+        for (int i = 0; i < receivers.size(); i++) {
+            Receiver rec = receivers.get(i);
+            AnnotationMirror anno = annos.get(i);
+            if (isReceiverToStringParsable(rec)) {
+                values.add(rec.toString());
+            }
+            if (AnnotationUtils.areSameByClass(anno, SameLen.class)) {
+                values.addAll(getValueOfAnnotationWithStringArgument(anno));
             }
         }
-        if (isReceiverToStringParsable(bRec)) {
-            bValues.add(bRec.toString());
-            if (AnnotationUtils.areSameByClass(sl2, SameLen.class)) {
-                bValues.addAll(getValueOfAnnotationWithStringArgument(sl2));
-            }
-        }
-
-        AnnotationMirror res = getCombinedSameLen(aValues, bValues);
+        AnnotationMirror res = getCombinedSameLen(values, new ArrayList<String>());
         return res;
     }
 
@@ -231,10 +240,10 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 return AnnotationUtils.areSameByClass(superAnno, PolySameLen.class);
             } else if (AnnotationUtils.hasElementValue(subAnno, "value")
                     && AnnotationUtils.hasElementValue(superAnno, "value")) {
-                List<String> a1Val = getValueOfAnnotationWithStringArgument(subAnno);
-                List<String> a2Val = getValueOfAnnotationWithStringArgument(superAnno);
+                List<String> subArrays = getValueOfAnnotationWithStringArgument(subAnno);
+                List<String> superArrays = getValueOfAnnotationWithStringArgument(superAnno);
 
-                if (overlap(a1Val, a2Val)) {
+                if (subArrays.containsAll(superArrays)) {
                     return true;
                 }
             }
@@ -270,15 +279,25 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         getAnnotatedType(arrayLength.getExpression())
                                 .getAnnotationInHierarchy(UNKNOWN);
 
-                if (AnnotationUtils.areSameByClass(arrayAnno, SameLenUnknown.class)) {
-                    Receiver rec =
-                            FlowExpressions.internalReprOf(
-                                    this.atypeFactory, arrayLength.getExpression());
-                    if (isReceiverToStringParsable(rec)) {
+                Receiver rec =
+                        FlowExpressions.internalReprOf(
+                                this.atypeFactory, arrayLength.getExpression());
+                if (isReceiverToStringParsable(rec)) {
+                    if (AnnotationUtils.areSameByClass(arrayAnno, SameLenUnknown.class)) {
                         arrayAnno = createSameLen(rec.toString());
+                    } else if (AnnotationUtils.areSameByClass(arrayAnno, SameLen.class)) {
+                        // Ensure that the array whose length is actually being used is part of the
+                        // annotation. If not, add it.
+                        List<String> arrayAnnoArrays =
+                                getValueOfAnnotationWithStringArgument(arrayAnno);
+                        if (!arrayAnnoArrays.contains(rec.toString())) {
+                            arrayAnnoArrays.add(rec.toString());
+                            String[] newArrayAnnoArrays = arrayAnnoArrays.toArray(new String[0]);
+                            Arrays.sort(newArrayAnnoArrays);
+                            arrayAnno = createSameLen(newArrayAnnoArrays);
+                        }
                     }
                 }
-
                 type.addAnnotation(arrayAnno);
             }
             return null;

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -169,7 +169,18 @@ public class SameLenTransfer extends CFTransfer {
         propagateCombinedSameLen(combinedSameLen, left, store);
     }
 
-    /** Return n's annotation from the SameLen hierarchy. */
+    /**
+     * Return n's annotation from the SameLen hierarchy.
+     *
+     * <p>analysis.getValue fails if called on an lvalue. However, this method needs to always
+     * succeed, even when n is an lvalue. Consider this code:
+     *
+     * <pre>{@code if ( (a = b) == c) {...}}</pre>
+     *
+     * where a, b, and c are all arrays, and a has type {@literal @}SameLen("d"). Afterwards, all
+     * three should have the type {@literal @}SameLen({"a", "b", "c", "d"}), but in order to
+     * accomplish this, this method must return the type of a, which is an lvalue.
+     */
     AnnotationMirror getAnno(Node n) {
         if (n.isLValue()) {
             return aTypeFactory.getAnnotatedType(n.getTree()).getAnnotationInHierarchy(UNKNOWN);

--- a/checker/tests/index/SameLenFormalParameter2.java
+++ b/checker/tests/index/SameLenFormalParameter2.java
@@ -1,0 +1,12 @@
+import org.checkerframework.checker.index.qual.*;
+
+//@skip-test
+
+public class SameLenFormalParameter2 {
+
+    void lib(Object @SameLen({"#1", "#2"}) [] valsArg, int @SameLen({"#1", "#2"}) [] modsArg) {}
+
+    void client(Object[] myvals, int[] mymods) {
+        lib(myvals, mymods);
+    }
+}

--- a/checker/tests/index/SameLenFormalParameter2.java
+++ b/checker/tests/index/SameLenFormalParameter2.java
@@ -7,6 +7,7 @@ public class SameLenFormalParameter2 {
     void lib(Object @SameLen({"#1", "#2"}) [] valsArg, int @SameLen({"#1", "#2"}) [] modsArg) {}
 
     void client(Object[] myvals, int[] mymods) {
+        //:: error: (argument.type.incompatible)
         lib(myvals, mymods);
     }
 }

--- a/checker/tests/index/SameLenFormalParameter2.java
+++ b/checker/tests/index/SameLenFormalParameter2.java
@@ -1,7 +1,5 @@
 import org.checkerframework.checker.index.qual.*;
 
-//@skip-test
-
 public class SameLenFormalParameter2 {
 
     void lib(Object @SameLen({"#1", "#2"}) [] valsArg, int @SameLen({"#1", "#2"}) [] modsArg) {}

--- a/docs/manual/figures/samelen.svg
+++ b/docs/manual/figures/samelen.svg
@@ -7,9 +7,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="8.7844019cm"
-   height="4.2340522cm"
-   viewBox="358 100 276.08119 211.7026"
+   width="7.8975224cm"
+   height="5.8961892cm"
+   viewBox="358 100 248.20783 294.80945"
    id="svg3577"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -41,13 +41,13 @@
      inkscape:window-height="698"
      id="namedview3689"
      showgrid="false"
-     inkscape:zoom="1.1774114"
-     inkscape:cx="31.753191"
-     inkscape:cy="25.040327"
+     inkscape:zoom="1.6651112"
+     inkscape:cx="131.75286"
+     inkscape:cy="70.457598"
      inkscape:window-x="0"
      inkscape:window-y="1"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg3577"
+     inkscape:current-layer="g4344"
      inkscape:connector-spacing="5"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -55,7 +55,7 @@
      fit-margin-bottom="0" />
   <g
      id="g3589"
-     transform="translate(35.540547,-18.999996)">
+     transform="translate(24.600084,-18.999985)">
     <rect
        style="fill:#ffffff"
        x="360"
@@ -86,17 +86,17 @@
   <text
      font-size="12.8"
      style="font-style:normal;font-weight:normal;font-size:12.80000019px;font-family:'courier new';text-anchor:start;fill:#000000"
-     x="649.65851"
+     x="638.71808"
      y="257.31573"
      id="text3619">
     <tspan
-       x="649.65851"
+       x="638.71808"
        y="257.31573"
        id="tspan3621" />
   </text>
   <g
      id="g3657"
-     transform="translate(35.540547,-17.999787)">
+     transform="translate(24.600084,-17.999776)">
     <line
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
        x1="460.5"
@@ -106,96 +106,250 @@
        id="line3659" />
     <polygon
        style="fill:#000000"
-       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
        id="polygon3661" />
     <polygon
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
-       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
        id="polygon3663" />
   </g>
   <text
      font-size="12.8"
      style="font-style:normal;font-weight:normal;font-size:12.80000019px;font-family:'courier new';text-anchor:start;fill:#000000"
-     x="649.65851"
+     x="638.71808"
      y="257.31573"
      id="text3673">
     <tspan
-       x="649.65851"
+       x="638.71808"
        y="257.31573"
        id="tspan3675" />
   </text>
-  <rect
-     style="fill:#ffffff"
-     x="395.54056"
-     y="266.70248"
-     width="201"
-     height="44"
-     id="rect3559" />
-  <rect
-     style="fill:none;fill-opacity:0;stroke:#7f7f7f;stroke-width:2.14008689;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     x="381.22867"
-     y="266.7724"
-     width="230.82231"
-     height="43.860157"
-     id="rect3561" />
   <text
      font-size="15.8044"
      style="font-style:normal;font-weight:normal;font-size:15.80440044px;font-family:'courier new';text-anchor:middle;fill:#7f7f7f;fill-opacity:1"
-     x="496.04056"
-     y="293.47449"
+     x="489.33737"
+     y="376.5813"
      id="text3563">
     <tspan
        style="font-size:21.16666603px;fill:#7f7f7f;fill-opacity:1"
-       x="496.04056"
-       y="293.47449"
+       x="489.33737"
+       y="376.5813"
        id="tspan3565">@SameLenBottom</tspan>
   </text>
-  <g
-     transform="translate(35.540537,65.702322)"
-     id="g3590">
-    <line
-       id="line3592"
-       y2="173.73599"
-       x2="460.5"
-       y1="200"
-       x1="460.5"
-       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
-    <polygon
-       id="polygon3594"
-       points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
-       style="fill:#000000" />
-    <polygon
-       id="polygon3596"
-       points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
-       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
-  </g>
   <path
      inkscape:connector-curvature="2"
      inkscape:connector-type="polyline"
      id="path4201"
-     d="m 606.87393,233.39772 0,0"
+     d="m 604.16876,233.39773 0,0"
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.41111112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(26.744567,151.61634)"
+     transform="translate(27.788964,236.70885)"
      id="g4844">
     <rect
-       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.60108316;stroke-miterlimit:4;stroke-dasharray:none"
-       x="250.48653"
-       y="33.693851"
-       width="437.61899"
-       height="42.783855"
+       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.024863;stroke-miterlimit:4;stroke-dasharray:none"
+       x="257.38934"
+       y="31.008766"
+       width="176.92526"
+       height="43.360073"
        id="rect4846" />
     <text
        font-size="15.8044"
        style="font-style:normal;font-weight:normal;font-size:21.16666603px;font-family:'courier new';text-anchor:middle;fill:#000000"
-       x="469.17535"
-       y="56.765598"
+       x="348.12827"
+       y="55.567112"
        id="text4848">
       <tspan
-         x="469.17535"
-         y="56.765598"
+         x="348.12827"
+         y="55.567112"
          id="tspan4850"
-         style="font-size:21.16666603px">@SameLen({&quot;java.lang.String&quot;})</tspan>
+         style="font-size:21.16666603px">@SameLen(&quot;a&quot;)</tspan>
     </text>
+  </g>
+  <g
+     id="g4330"
+     transform="translate(244.71492,236.70885)">
+    <rect
+       id="rect4332"
+       height="43.360073"
+       width="176.92526"
+       y="31.008766"
+       x="257.38934"
+       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.024863;stroke-miterlimit:4;stroke-dasharray:none" />
+    <text
+       id="text4334"
+       y="55.567112"
+       x="348.12827"
+       style="font-style:normal;font-weight:normal;font-size:21.16666603px;font-family:'courier new';text-anchor:middle;fill:#000000"
+       font-size="15.8044">
+      <tspan
+         style="font-size:21.16666603px"
+         id="tspan4336"
+         y="55.567112"
+         x="348.12827">@SameLen(&quot;b&quot;)</tspan>
+    </text>
+  </g>
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.41111112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 501.09897,181.86283 0,0"
+     id="path4342"
+     inkscape:connector-type="polyline"
+     inkscape:connector-curvature="2" />
+  <g
+     transform="translate(141.64512,152.81483)"
+     id="g4344">
+    <rect
+       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.25453866;stroke-miterlimit:4;stroke-dasharray:none"
+       x="212.02193"
+       y="31.123606"
+       width="266.52182"
+       height="43.130394"
+       id="rect4346" />
+    <text
+       font-size="15.8044"
+       style="font-style:normal;font-weight:normal;font-size:21.16666603px;font-family:'courier new';text-anchor:middle;fill:#000000"
+       x="348.12827"
+       y="55.567112"
+       id="text4348">
+      <tspan
+         x="348.12827"
+         y="55.567112"
+         id="tspan4350"
+         style="font-size:21.16666603px">@SameLen({&quot;a&quot;, &quot;b&quot;})</tspan>
+    </text>
+  </g>
+  <g
+     id="g4375"
+     transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,345.06479,-242.6671)">
+    <line
+       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
+       x1="460.5"
+       y1="200"
+       x2="460.5"
+       y2="173.73599"
+       id="line4377" />
+    <polygon
+       style="fill:#000000"
+       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       id="polygon4379" />
+    <polygon
+       style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
+       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       id="polygon4381" />
+  </g>
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 451.3291,247.11202 421.21956,267.5306 Z"
+     id="path4397"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path4401"
+     d="m 449.83099,247.41164 -30.10954,20.41858 z"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     id="g4427"
+     transform="matrix(-1,0,0,1,897.58226,-2.3455547)">
+    <g
+       id="g4403"
+       transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)">
+      <line
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
+         x1="460.5"
+         y1="200"
+         x2="460.5"
+         y2="173.73599"
+         id="line4405" />
+      <polygon
+         style="fill:#000000"
+         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+         id="polygon4407" />
+      <polygon
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
+         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+         id="polygon4409" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 453.28092,331.9049 -30.10954,20.41858 z"
+       id="path4423"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4425"
+       d="M 451.78281,332.20452 421.67327,352.6231 Z"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     transform="translate(77.528521,-2.3455547)"
+     id="g4443">
+    <g
+       transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)"
+       id="g4445">
+      <line
+         id="line4447"
+         y2="173.73599"
+         x2="460.5"
+         y1="200"
+         x1="460.5"
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
+      <polygon
+         id="polygon4449"
+         points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
+         style="fill:#000000" />
+      <polygon
+         id="polygon4451"
+         points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4453"
+       d="m 453.28092,331.9049 -30.10954,20.41858 z"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 451.78281,332.20452 421.67327,352.6231 Z"
+       id="path4455"
+       inkscape:connector-curvature="0" />
+  </g>
+  <rect
+     style="fill:none;fill-opacity:0;stroke:#7f7f7f;stroke-width:2.14008689;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     x="374.52548"
+     y="349.87921"
+     width="230.82231"
+     height="43.860157"
+     id="rect3561" />
+  <g
+     transform="matrix(-1,0,0,1,980.6331,-85.396396)"
+     id="g4457">
+    <g
+       transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)"
+       id="g4459">
+      <line
+         id="line4461"
+         y2="173.73599"
+         x2="460.5"
+         y1="200"
+         x1="460.5"
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
+      <polygon
+         id="polygon4463"
+         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
+         style="fill:#000000" />
+      <polygon
+         id="polygon4465"
+         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
+         style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path4467"
+       d="m 453.28092,331.9049 -30.10954,20.41858 z"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 451.78281,332.20452 421.67327,352.6231 Z"
+       id="path4469"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>

--- a/docs/manual/figures/samelen.svg
+++ b/docs/manual/figures/samelen.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -47,7 +47,7 @@
      inkscape:window-x="0"
      inkscape:window-y="1"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g4344"
+     inkscape:current-layer="svg3577"
      inkscape:connector-spacing="5"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -96,7 +96,7 @@
   </text>
   <g
      id="g3657"
-     transform="translate(24.600084,-17.999776)">
+     transform="translate(27.142456,149.79682)">
     <line
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
        x1="460.5"
@@ -106,11 +106,11 @@
        id="line3659" />
     <polygon
        style="fill:#000000"
-       points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+       points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
        id="polygon3661" />
     <polygon
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
-       points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+       points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
        id="polygon3663" />
   </g>
   <text
@@ -143,7 +143,7 @@
      d="m 604.16876,233.39773 0,0"
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.41111112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(27.788964,236.70885)"
+     transform="translate(28.636421,155.35292)"
      id="g4844">
     <rect
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.024863;stroke-miterlimit:4;stroke-dasharray:none"
@@ -167,7 +167,7 @@
   </g>
   <g
      id="g4330"
-     transform="translate(244.71492,236.70885)">
+     transform="translate(245.56238,155.35292)">
     <rect
        id="rect4332"
        height="43.360073"
@@ -195,7 +195,7 @@
      inkscape:connector-type="polyline"
      inkscape:connector-curvature="2" />
   <g
-     transform="translate(141.64512,152.81483)"
+     transform="translate(143.34003,239.2555)"
      id="g4344">
     <rect
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:1.25453866;stroke-miterlimit:4;stroke-dasharray:none"
@@ -219,7 +219,7 @@
   </g>
   <g
      id="g4375"
-     transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,345.06479,-242.6671)">
+     transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,345.91225,-324.02303)">
     <line
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
        x1="460.5"
@@ -229,26 +229,26 @@
        id="line4377" />
     <polygon
        style="fill:#000000"
-       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
        id="polygon4379" />
     <polygon
        style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
-       points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
+       points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
        id="polygon4381" />
   </g>
   <path
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="M 451.3291,247.11202 421.21956,267.5306 Z"
+     d="m 452.17656,165.75609 -30.10954,20.41858 z"
      id="path4397"
      inkscape:connector-curvature="0" />
   <path
      inkscape:connector-curvature="0"
      id="path4401"
-     d="m 449.83099,247.41164 -30.10954,20.41858 z"
+     d="m 450.67845,166.05571 -30.10954,20.41858 z"
      style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
      id="g4427"
-     transform="matrix(-1,0,0,1,897.58226,-2.3455547)">
+     transform="matrix(-1,0,0,1,898.42972,-83.70148)">
     <g
        id="g4403"
        transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)">
@@ -261,11 +261,11 @@
          id="line4405" />
       <polygon
          style="fill:#000000"
-         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
          id="polygon4407" />
       <polygon
          style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2"
-         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
+         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
          id="polygon4409" />
     </g>
     <path
@@ -280,7 +280,7 @@
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.47461903px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
   <g
-     transform="translate(77.528521,-2.3455547)"
+     transform="translate(78.375978,-83.70148)"
      id="g4443">
     <g
        transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)"
@@ -294,11 +294,11 @@
          style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
       <polygon
          id="polygon4449"
-         points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
+         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
          style="fill:#000000" />
       <polygon
          id="polygon4451"
-         points="455.5,176.236 460.5,166.236 465.5,176.236 460.5,173.736 "
+         points="460.5,166.236 465.5,176.236 460.5,173.736 455.5,176.236 "
          style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
     </g>
     <path
@@ -320,7 +320,7 @@
      height="43.860157"
      id="rect3561" />
   <g
-     transform="matrix(-1,0,0,1,980.6331,-85.396396)"
+     transform="matrix(-1,0,0,1,981.48056,-166.75232)"
      id="g4457">
     <g
        transform="matrix(0.57937742,0.81505938,-0.81505938,0.57937742,347.01661,-157.87422)"
@@ -334,11 +334,11 @@
          style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
       <polygon
          id="polygon4463"
-         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
+         points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
          style="fill:#000000" />
       <polygon
          id="polygon4465"
-         points="465.5,176.236 460.5,173.736 455.5,176.236 460.5,166.236 "
+         points="460.5,173.736 455.5,176.236 460.5,166.236 465.5,176.236 "
          style="fill:none;fill-opacity:0;stroke:#000000;stroke-width:2" />
     </g>
     <path

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -322,7 +322,8 @@ Array minimum lengths use the following type qualifiers
 \end{center}
   \caption{The two type hierarchies for array types used by the Index
     Checker.  On the left is a type system for minimum array lengths.  On
-    the right is a type system for arrays of equal length.  Qualifiers
+    the right is a type system for arrays of equal length ("a" and "b" are
+    assumed to be valid arrays).  Qualifiers
     written in gray should never be written in source code; they are used
     internally by the type system.}
   \label{fig-index-array-types}

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -323,7 +323,7 @@ Array minimum lengths use the following type qualifiers
   \caption{The two type hierarchies for array types used by the Index
     Checker.  On the left is a type system for minimum array lengths.  On
     the right is a type system for arrays of equal length ("a" and "b" are
-    assumed to be valid arrays).  Qualifiers
+    assumed to be in-scope arrays).  Qualifiers
     written in gray should never be written in source code; they are used
     internally by the type system.}
   \label{fig-index-array-types}


### PR DESCRIPTION
The SameLen subtyping rule was too broad. This change restricts it. This fixes kelloggm#133.

I discovered two other bugs that this was hiding, both false positives. Both had tests that failed already, so no new tests are added for either.

The first was SameLen's version of kelloggm#58: when `strengthenEqualTo` is called, `SameLenTranfer` failed to descend into assignments. This is fixed with a call to split assignments, which necessitated some surgery in the `SameLenAnnotatedTypeFactory` to make `createCombinedSameLen` more general; it now takes two corresponding lists instead of two corresponding pairs. I left the pairwise version as well to minimize code churn, but changed it to call the new version.

The second bug occurred when a new array is being typed by the `SameLenTreeAnnotator`. If the new array is created with another array's length as its length (e.g. `int [] a = new int[b.length]`), then the new array's type is the same as the other array (so in the example `new int[b.length]` would have the same type as `b`). The problem was that if `b`'s type was something like `@SameLen("c")`, then the new array is not `@SameLen("b")`. The fix adds the array's name to the type if it is not already there.