### PR TITLE
Index Checker: Adds a lengthOf annotation that aliases IndexOrHigh

### DIFF
--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -25,6 +25,7 @@ import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.IndexOrLow;
+import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.LowerBoundUnknown;
 import org.checkerframework.checker.index.qual.MinLen;
 import org.checkerframework.checker.index.qual.NegativeIndexFor;
@@ -91,6 +92,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         addAliasedAnnotation(IndexFor.class, NN);
         addAliasedAnnotation(IndexOrLow.class, GTEN1);
         addAliasedAnnotation(IndexOrHigh.class, NN);
+        addAliasedAnnotation(LengthOf.class, NN);
         addAliasedAnnotation(PolyAll.class, POLY);
         addAliasedAnnotation(PolyIndex.class, POLY);
 

--- a/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
+++ b/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
@@ -1,0 +1,13 @@
+package org.checkerframework.checker.index.qual;
+
+/**
+ * An integer that, for each of the given sequences, is equal to the sequence's length. This is
+ * treated as an {@link IndexOrHigh} annotation internally.
+ *
+ * @see IndexOrHigh
+ * @checker_framework.manual #index-checker Index Checker
+ */
+public @interface LengthOf {
+    /** Sequences that the annotated expression is equal to the lengeth of. */
+    String[] value() default {};
+}

--- a/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
+++ b/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
@@ -1,10 +1,12 @@
 package org.checkerframework.checker.index.qual;
 
 /**
- * An integer that, for each of the given sequences, is equal to the sequence's length. This is
- * treated as an {@link IndexOrHigh} annotation internally.
+ * An integer that, for each of the given sequences, is equal to the sequence's length.
  *
- * @see IndexOrHigh
+ * <p>This is treated as an {@link IndexOrHigh} annotation internally. This is an implementation
+ * detail that may change in the future, when this type may be used to implement more precise
+ * refinements.
+ *
  * @checker_framework.manual #index-checker Index Checker
  */
 public @interface LengthOf {

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.index.qual.IndexOrLow;
 import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 import org.checkerframework.checker.index.qual.LTOMLengthOf;
+import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NegativeIndexFor;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.PolyIndex;
@@ -90,6 +91,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         addAliasedAnnotation(IndexOrHigh.class, createLTEqLengthOfAnnotation());
         addAliasedAnnotation(SearchIndexFor.class, createLTLengthOfAnnotation());
         addAliasedAnnotation(NegativeIndexFor.class, createLTLengthOfAnnotation());
+        addAliasedAnnotation(LengthOf.class, createLTEqLengthOfAnnotation());
         addAliasedAnnotation(PolyAll.class, POLY);
         addAliasedAnnotation(PolyIndex.class, POLY);
 
@@ -259,7 +261,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     AnnotationUtils.getElementValueArray(a, "value", String.class, true);
             return createLTLengthOfAnnotation(stringList.toArray(new String[0]));
         }
-        if (AnnotationUtils.areSameByClass(a, IndexOrHigh.class)) {
+        if (AnnotationUtils.areSameByClass(a, IndexOrHigh.class)
+                || AnnotationUtils.areSameByClass(a, LengthOf.class)) {
             List<String> stringList =
                     AnnotationUtils.getElementValueArray(a, "value", String.class, true);
             return createLTEqLengthOfAnnotation(stringList.toArray(new String[0]));

--- a/checker/tests/index/LengthOfTest.java
+++ b/checker/tests/index/LengthOfTest.java
@@ -1,0 +1,12 @@
+
+import org.checkerframework.checker.index.qual.*;
+
+class LengthOfTest {
+    void foo(int[] a, @LengthOf("#1") int x) {
+        @IndexOrHigh("a") int y = x;
+        //:: error: (assignment.type.incompatible)
+        @IndexFor("a") int w = x;
+        @LengthOf("a")
+        int z = a.length;
+    }
+}

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -120,6 +120,13 @@ are some annotations that give multiple types of information:
   \end{Verbatim}
   \end{mysmall}
 
+ \item[\refqualclasswithparams{checker/index/qual}{LengthOf}{String[] names}]
+   The value is exactly equal to the length of the named
+   arrays. In the implementation, this type aliases
+   \refqualclass{checker/index/qual}{IndexOrHigh}, so writing it
+   only adds documentation (although future versions of the Index Checker
+   may use it to improve precision).
+
  \item[\refqualclasswithparams{checker/index/qual}{IndexOrLow}{String[] names}]
    The value is -1 or is a valid index for
    each named array.  This type combines


### PR DESCRIPTION
This improves the situation in kelloggm#151.