### PR TITLE
Add ArrayLenRange annotation to Value Checker

### DIFF
--- a/checker/tests/index/Polymorphic3.java
+++ b/checker/tests/index/Polymorphic3.java
@@ -4,8 +4,7 @@ class Polymorphic3 {
 
     //Identity functions
 
-    @PolyIndex
-    int identity(@PolyIndex int a) {
+    @PolyIndex int identity(@PolyIndex int a) {
         return a;
     }
 

--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -41,8 +41,9 @@ The main type annotations are
 \refqualclass{common/value/qual}{IntRange},
 \refqualclass{common/value/qual}{DoubleVal}, and
 \refqualclass{common/value/qual}{StringVal}.
-An additional type annotation is
-\refqualclass{common/value/qual}{ArrayLen}.
+Additional type annotations for arrays are
+\refqualclass{common/value/qual}{ArrayLen} and
+\refqualclass{common/value/qual}{ArrayLenRange}.
 
 Each \<*Val> type annotation takes as an argument a set of values, and its
 meaning is that at run time, the expression evaluates to one of the values.  For
@@ -52,7 +53,8 @@ one of the values \<"a">, \<"b">, or \<null>.
 The set is limited to 10 entries; if a variable
 could be more than 10 different values, the Constant Value
 Checker gives up and its type becomes
-\refqualclass{common/value/qual}{IntRange} for integral types and
+\refqualclass{common/value/qual}{IntRange} for integral types,
+\refqualclass{common/value/qual}{ArrayLenRange} for array types, and
 \refqualclass{common/value/qual}{UnknownVal} for all other types.
 The \<@ArrayLen> annotation means that at run time, the expression
 evaluates to an array whose length is one of the annotation's arguments.
@@ -69,6 +71,10 @@ An \refqualclass{common/value/qual}{IntVal} and
 \refqualclass{common/value/qual}{IntRange} annotation that represent the
 same set of values are semantically identical and interchangeable:  they
 have exactly the same meaning, and using either one has the same effect.
+\refqualclass{common/value/qual}{ArrayLenRange} has the same relationship
+to \refqualclass{common/value/qual}{ArrayLen} that
+\refqualclass{common/value/qual}{IntRange} has to
+\refqualclass{common/value/qual}{IntVal}.
 
 Figure~\ref{fig-value-hierarchy} shows the
 subtyping relationship among the type annotations.
@@ -241,7 +247,7 @@ warning message:
 
   The Constant Value Checker only tracks up to 10 possible values for an
   expression.  If you write an annotation with more values than will be
-  tracked, the annotation is replaced with \<@IntRange> or \<@UnknownVal>.
+  tracked, the annotation is replaced with \<@IntRange>, \<@ArrayLenRange>, or \<@UnknownVal>.
 
 \end{itemize}
 \end{sloppypar}

--- a/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
+++ b/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
@@ -1,0 +1,95 @@
+package org.checkerframework.common.value;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.common.value.qual.ArrayLen;
+import org.checkerframework.common.value.qual.ArrayLenRange;
+import org.checkerframework.common.value.qual.IntVal;
+import org.checkerframework.common.value.util.Range;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
+
+/**
+ * An abstraction that can be either a range or a list of values that could come from an {@link
+ * ArrayLen} or {@link IntVal}. This abstraction reduces the number of cases that {@link
+ * org.checkerframework.common.value.ValueAnnotatedTypeFactory.ValueTreeAnnotator#handleInitializers(List,
+ * AnnotatedTypeMirror.AnnotatedArrayType)} and {@link
+ * org.checkerframework.common.value.ValueAnnotatedTypeFactory.ValueTreeAnnotator#handleDimensions(List,
+ * AnnotatedTypeMirror.AnnotatedArrayType)} must handle.
+ */
+class RangeOrListOfValues {
+    Range range;
+    List<Integer> values;
+    boolean isRange;
+
+    public RangeOrListOfValues() {
+        this.values = new ArrayList<>();
+        isRange = false;
+    }
+
+    public RangeOrListOfValues(List<Integer> values) {
+        this.values = new ArrayList<>();
+        isRange = false;
+        addAll(values);
+    }
+
+    public RangeOrListOfValues(Range range) {
+        this.range = range;
+        isRange = true;
+    }
+
+    /**
+     * If this is not a range, adds all members of newValues to the list. Otherwise, extends the
+     * range as appropriate based on the max and min of newValues. If adding newValues to a
+     * non-range would cause the list to become too large, converts this into a range.
+     */
+    public void addAll(List<Integer> newValues) {
+        if (isRange) {
+            Range newValueRange = new Range(Collections.min(newValues), Collections.max(newValues));
+            range = range.union(newValueRange);
+        } else {
+            for (Integer i : newValues) {
+                if (!values.contains(i)) {
+                    values.add(i);
+                }
+            }
+            if (values.size() > ValueAnnotatedTypeFactory.MAX_VALUES) {
+                convertToRange();
+            }
+        }
+    }
+
+    /**
+     * Produces the most precise annotation that captures the information stored in this
+     * RangeOrListofValues. The result is either a {@link ArrayLen} or a {@link ArrayLenRange}.
+     */
+    public AnnotationMirror createAnnotation(ValueAnnotatedTypeFactory atypefactory) {
+        if (isRange) {
+            return atypefactory.createArrayLenRangeAnnotation(range);
+        } else {
+            return atypefactory.createArrayLenAnnotation(values);
+        }
+    }
+
+    // To be called before addAll
+    public static List<Integer> convertLongsToInts(List<Long> newValues) {
+        List<Integer> result = new ArrayList<>(newValues.size());
+        for (Long l : newValues) {
+            result.add(l.intValue());
+        }
+        return result;
+    }
+
+    /**
+     * Transforms this into a range. Fails if there are no values in the list. Has no effect if this
+     * is already a range.
+     */
+    public void convertToRange() {
+        if (!isRange) {
+            isRange = true;
+            range = new Range(Collections.min(values), Collections.max(values));
+            values = null;
+        }
+    }
+}

--- a/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
+++ b/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
@@ -19,9 +19,9 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
  * AnnotatedTypeMirror.AnnotatedArrayType)} must handle.
  */
 class RangeOrListOfValues {
-    Range range;
-    List<Integer> values;
-    boolean isRange;
+    private Range range;
+    private List<Integer> values;
+    private boolean isRange;
 
     public RangeOrListOfValues() {
         this.values = new ArrayList<>();
@@ -37,6 +37,15 @@ class RangeOrListOfValues {
     public RangeOrListOfValues(Range range) {
         this.range = range;
         isRange = true;
+    }
+
+    public void add(Range otherRange) {
+        if (isRange) {
+            range = range.union(otherRange);
+        } else {
+            convertToRange();
+            add(otherRange);
+        }
     }
 
     /**

--- a/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
+++ b/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
@@ -55,6 +55,9 @@ class RangeOrListOfValues {
      * If this is not a range, adds all members of newValues to the list. Otherwise, extends the
      * range as appropriate based on the max and min of newValues. If adding newValues to a
      * non-range would cause the list to become too large, converts this into a range.
+     *
+     * <p>If reading from an {@link org.checkerframework.common.value.qual.IntRange} annotation,
+     * {@link #convertLongsToInts(List)} should be called before calling this method.
      */
     public void addAll(List<Integer> newValues) {
         if (isRange) {

--- a/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
+++ b/framework/src/org/checkerframework/common/value/RangeOrListOfValues.java
@@ -17,6 +17,9 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
  * AnnotatedTypeMirror.AnnotatedArrayType)} and {@link
  * org.checkerframework.common.value.ValueAnnotatedTypeFactory.ValueTreeAnnotator#handleDimensions(List,
  * AnnotatedTypeMirror.AnnotatedArrayType)} must handle.
+ *
+ * <p>Tracks Ints in the list, and creates ArrayLen or ArrayLenRange annotations, because it's meant
+ * to be used to reason about ArrayLen and ArrayLenRange values.
  */
 class RangeOrListOfValues {
     private Range range;
@@ -81,11 +84,20 @@ class RangeOrListOfValues {
         }
     }
 
-    // To be called before addAll
+    /**
+     * To be called before addAll. Converts Longs to Ints; meant to be used with ArrayLenRange
+     * (which only handles Ints).
+     */
     public static List<Integer> convertLongsToInts(List<Long> newValues) {
         List<Integer> result = new ArrayList<>(newValues.size());
         for (Long l : newValues) {
-            result.add(l.intValue());
+            if (l > Integer.MAX_VALUE) {
+                result.add(Integer.MAX_VALUE);
+            } else if (l < Integer.MIN_VALUE) {
+                result.add(Integer.MIN_VALUE);
+            } else {
+                result.add(l.intValue());
+            }
         }
         return result;
     }

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -468,6 +468,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
+
             if (AnnotationUtils.areSameByClass(superAnno, UnknownVal.class)
                     || AnnotationUtils.areSameByClass(subAnno, BottomVal.class)) {
                 return true;

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -284,7 +284,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 } else if (AnnotationUtils.areSameByClass(anno, ArrayLenRange.class)) {
                     int from = AnnotationUtils.getElementValue(anno, "from", Integer.class, true);
                     int to = AnnotationUtils.getElementValue(anno, "to", Integer.class, true);
-                    if (from > to) {
+                    if (from > to || from < 0) {
                         atm.replaceAnnotation(BOTTOMVAL);
                     }
                 } else {

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -693,8 +693,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                                 componentType.getAnnotation(ArrayLenRange.class);
                         if (arrayLenRangeAnno != null) {
                             Range range = getRange(arrayLenRangeAnno);
-                            rolv.convertToRange();
-                            rolv.range = range.union(rolv.range);
+                            rolv.add(range);
                         }
                     }
 

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -679,23 +679,14 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotatedTypeMirror componentType = getAnnotatedType(init);
                 int dimension = 0;
                 while (componentType.getKind() == TypeKind.ARRAY) {
-                    RangeOrListOfValues rolv = null;
                     if (dimension == arrayLenOfDimensions.size()) {
                         arrayLenOfDimensions.add(new RangeOrListOfValues());
                     }
+                    RangeOrListOfValues rolv = arrayLenOfDimensions.get(dimension);
                     AnnotationMirror arrayLen = componentType.getAnnotation(ArrayLen.class);
                     if (arrayLen != null) {
-                        rolv = arrayLenOfDimensions.get(dimension);
                         List<Integer> currentLengths = getArrayLength(arrayLen);
-                        if (rolv.isRange) {
-                            Range range =
-                                    new Range(
-                                            Collections.min(currentLengths),
-                                            Collections.max(currentLengths));
-                            rolv.range = range.union(rolv.range);
-                        } else {
-                            rolv.addAll(currentLengths);
-                        }
+                        rolv.addAll(currentLengths);
                     } else {
                         // Check for an arrayLenRange annotation
                         AnnotationMirror arrayLenRangeAnno =

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -27,6 +27,7 @@ import javax.lang.model.type.TypeMirror;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.qual.ArrayLen;
+import org.checkerframework.common.value.qual.ArrayLenRange;
 import org.checkerframework.common.value.qual.BoolVal;
 import org.checkerframework.common.value.qual.BottomVal;
 import org.checkerframework.common.value.qual.DoubleVal;
@@ -131,7 +132,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public AnnotationMirror aliasedAnnotation(AnnotationMirror anno) {
         if (AnnotationUtils.areSameByClass(anno, android.support.annotation.IntRange.class)) {
-            Range range = getIntRange(anno);
+            Range range = getRange(anno);
             return createIntRangeAnnotation(range);
         }
         return super.aliasedAnnotation(anno);
@@ -237,14 +238,14 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          * This method performs pre-processing on annotations written by users.
          *
          * <p>If any *Val annotation has &gt; MAX_VALUES number of values provided, replaces the
-         * annotation by @IntRange for integral types and @UnknownVal for all other types. Works
-         * together with {@link
+         * annotation by @IntRange for integral types, @ArrayLenRange for arrays, and @UnknownVal
+         * for all other types. Works together with {@link
          * org.checkerframework.common.value.ValueVisitor#visitAnnotation(com.sun.source.tree.AnnotationTree,
          * Void)} which issues warnings to users in these cases.
          *
-         * <p>If any @IntRange annotation has incorrect parameters, e.g. the value "from" is
-         * specified to be greater than the value "to", replaces the annotation by @BOTTOMVAL as
-         * well. The {@link
+         * <p>If any @IntRange or @ArrayLenRange annotation has incorrect parameters, e.g. the value
+         * "from" is specified to be greater than the value "to", replaces the annotation
+         * by @BOTTOMVAL as well. The {@link
          * org.checkerframework.common.value.ValueVisitor#visitAnnotation(com.sun.source.tree.AnnotationTree,
          * Void)} would raise error to users in this case.
          */
@@ -261,9 +262,25 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         atm.replaceAnnotation(
                                 createIntRangeAnnotation(new Range(annoMinVal, annoMaxVal)));
                     }
+                } else if (AnnotationUtils.areSameByClass(anno, ArrayLen.class)) {
+                    List<Integer> values =
+                            AnnotationUtils.getElementValueArray(
+                                    anno, "value", Integer.class, true);
+                    if (values.size() > MAX_VALUES) {
+                        long annoMinVal = Collections.min(values);
+                        long annoMaxVal = Collections.max(values);
+                        atm.replaceAnnotation(
+                                createArrayLenRangeAnnotation(new Range(annoMinVal, annoMaxVal)));
+                    }
                 } else if (AnnotationUtils.areSameByClass(anno, IntRange.class)) {
                     long from = AnnotationUtils.getElementValue(anno, "from", Long.class, true);
                     long to = AnnotationUtils.getElementValue(anno, "to", Long.class, true);
+                    if (from > to) {
+                        atm.replaceAnnotation(BOTTOMVAL);
+                    }
+                } else if (AnnotationUtils.areSameByClass(anno, ArrayLenRange.class)) {
+                    int from = AnnotationUtils.getElementValue(anno, "from", Integer.class, true);
+                    int to = AnnotationUtils.getElementValue(anno, "to", Integer.class, true);
                     if (from > to) {
                         atm.replaceAnnotation(BOTTOMVAL);
                     }
@@ -311,7 +328,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         public AnnotationMirror widenUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
             AnnotationMirror lub = leastUpperBound(a1, a2);
             if (AnnotationUtils.areSameByClass(lub, IntRange.class)) {
-                Range range = getIntRange(lub);
+                Range range = getRange(lub);
                 if (range.isWithin(Byte.MIN_VALUE, Byte.MAX_VALUE)) {
                     return createIntRangeAnnotation(Range.BYTE_EVERYTHING);
                 } else if (range.isWithin(Short.MIN_VALUE, Short.MAX_VALUE)) {
@@ -348,9 +365,14 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 // If both are the same type, determine the type and merge
                 if (AnnotationUtils.areSameByClass(a1, IntRange.class)) {
                     // special handling for IntRange
-                    Range range1 = getIntRange(a1);
-                    Range range2 = getIntRange(a2);
+                    Range range1 = getRange(a1);
+                    Range range2 = getRange(a2);
                     return createIntRangeAnnotation(range1.union(range2));
+                } else if (AnnotationUtils.areSameByClass(a1, ArrayLenRange.class)) {
+                    // special handling for ArrayLenRange
+                    Range range1 = getRange(a1);
+                    Range range2 = getRange(a2);
+                    return createArrayLenRangeAnnotation(range1.union(range2));
                 } else {
                     List<Object> a1Values =
                             AnnotationUtils.getElementValueArray(a1, "value", Object.class, true);
@@ -363,6 +385,26 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     // createAnnotation returns @UnknownVal if the list is longer than MAX_VALUES
                     return createAnnotation(a1.getAnnotationType().toString(), newValues);
                 }
+            }
+
+            // Special handling for dealing with the lub of an ArrayLenRange and an ArrayLen.
+
+            AnnotationMirror arrayLenAnno = null;
+            AnnotationMirror arrayLenRangeAnno = null;
+            if (AnnotationUtils.areSameByClass(a1, ArrayLen.class)) {
+                arrayLenAnno = a1;
+            } else if (AnnotationUtils.areSameByClass(a2, ArrayLen.class)) {
+                arrayLenAnno = a2;
+            }
+            if (AnnotationUtils.areSameByClass(a1, ArrayLenRange.class)) {
+                arrayLenRangeAnno = a1;
+            } else if (AnnotationUtils.areSameByClass(a2, ArrayLenRange.class)) {
+                arrayLenRangeAnno = a2;
+            }
+
+            if (arrayLenAnno != null && arrayLenRangeAnno != null) {
+                return leastUpperBound(
+                        arrayLenRangeAnno, convertArrayLenToArrayLenRange(arrayLenAnno));
             }
 
             // Annotations are both in the same hierarchy, but they are not the same.
@@ -426,7 +468,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-
             if (AnnotationUtils.areSameByClass(superAnno, UnknownVal.class)
                     || AnnotationUtils.areSameByClass(subAnno, BottomVal.class)) {
                 return true;
@@ -435,10 +476,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 return false;
             } else if (AnnotationUtils.areSameIgnoringValues(superAnno, subAnno)) {
                 // Same type, so might be subtype
-                if (AnnotationUtils.areSameByClass(subAnno, IntRange.class)) {
-                    // Special case for IntRange
-                    Range superRange = getIntRange(superAnno);
-                    Range subRange = getIntRange(subAnno);
+                if (AnnotationUtils.areSameByClass(subAnno, IntRange.class)
+                        || AnnotationUtils.areSameByClass(subAnno, ArrayLenRange.class)) {
+                    // Special case for range-based annotations
+                    Range superRange = getRange(superAnno);
+                    Range subRange = getRange(subAnno);
                     return superRange.contains(subRange);
                 } else {
                     List<Object> superValues =
@@ -459,17 +501,18 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         AnnotationUtils.getElementValueArray(
                                 superAnno, "value", Double.class, true);
                 return superValues.containsAll(subValues);
-            } else if (AnnotationUtils.areSameByClass(superAnno, IntRange.class)
-                    && AnnotationUtils.areSameByClass(subAnno, IntVal.class)) {
-                List<Long> subValues =
-                        AnnotationUtils.getElementValueArray(subAnno, "value", Long.class, true);
-                Range superRange = getIntRange(superAnno);
+            } else if ((AnnotationUtils.areSameByClass(superAnno, IntRange.class)
+                            && AnnotationUtils.areSameByClass(subAnno, IntVal.class))
+                    || (AnnotationUtils.areSameByClass(superAnno, ArrayLenRange.class)
+                            && AnnotationUtils.areSameByClass(subAnno, ArrayLen.class))) {
+                List<Long> subValues = getValues(subAnno);
+                Range superRange = getRange(superAnno);
                 long subMinVal = Collections.min(subValues);
                 long subMaxVal = Collections.max(subValues);
                 return subMinVal >= superRange.from && subMaxVal <= superRange.to;
             } else if (AnnotationUtils.areSameByClass(superAnno, DoubleVal.class)
                     && AnnotationUtils.areSameByClass(subAnno, IntRange.class)) {
-                Range subRange = getIntRange(subAnno);
+                Range subRange = getRange(subAnno);
                 if (subRange.isWiderThan(MAX_VALUES)) {
                     return false;
                 }
@@ -479,20 +522,40 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 List<Double> subValues =
                         ValueCheckerUtils.getValuesFromRange(subRange, Double.class);
                 return superValues.containsAll(subValues);
-            } else if (AnnotationUtils.areSameByClass(superAnno, IntVal.class)
-                    && AnnotationUtils.areSameByClass(subAnno, IntRange.class)) {
-                Range subRange = getIntRange(subAnno);
+            } else if ((AnnotationUtils.areSameByClass(superAnno, IntVal.class)
+                            && AnnotationUtils.areSameByClass(subAnno, IntRange.class))
+                    || (AnnotationUtils.areSameByClass(superAnno, ArrayLen.class)
+                            && AnnotationUtils.areSameByClass(subAnno, ArrayLenRange.class))) {
+                Range subRange = getRange(subAnno);
                 if (subRange.isWiderThan(MAX_VALUES)) {
                     return false;
                 }
-                List<Long> superValues =
-                        AnnotationUtils.getElementValueArray(superAnno, "value", Long.class, true);
+                List<Long> superValues = getValues(superAnno);
                 List<Long> subValues = ValueCheckerUtils.getValuesFromRange(subRange, Long.class);
                 return superValues.containsAll(subValues);
             } else {
                 return false;
             }
         }
+    }
+
+    /**
+     * Gets the values stored in either an ArrayLen annotation (ints) or an IntVal/DoubleVal/etc.
+     * annnotation (longs), and casts the result to a long.
+     */
+    private List<Long> getValues(AnnotationMirror anno) {
+        List<Long> result;
+        if (AnnotationUtils.areSameByClass(anno, ArrayLen.class)) {
+            List<Integer> superValuesInt =
+                    AnnotationUtils.getElementValueArray(anno, "value", Integer.class, true);
+            result = new ArrayList<Long>(superValuesInt.size());
+            for (Integer i : superValuesInt) {
+                result.add(i.longValue());
+            }
+        } else {
+            result = AnnotationUtils.getElementValueArray(anno, "value", Long.class, true);
+        }
+        return result;
     }
 
     @Override
@@ -548,10 +611,9 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          * find each dimension's size and create the appropriate annotation for it.
          *
          * <p>If the annotation of the dimension is {@code @IntVal}, create an {@code @ArrayLen}
-         * with the same set of possible values. If the annotation is {@code @IntRange} and the
-         * specified range is not wider than 10, create an {@code @ArrayLen} by the same method as
-         * above. If the annotation is {@code @BottomVal}, create an {@code @BottomVal} instead. In
-         * other cases, no annotations are created.
+         * with the same set of possible values. If the annotation is {@code @IntRange}, create an
+         * {@code @ArrayLenRange}. If the annotation is {@code @BottomVal}, create an
+         * {@code @BottomVal} instead. In other cases, no annotations are created.
          *
          * @param dimensions a list of ExpressionTrees where each ExpressionTree is a specifier of
          *     the size of that dimension
@@ -570,26 +632,79 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             if (AnnotationUtils.areSameIgnoringValues(dimType, BOTTOMVAL)) {
                 type.replaceAnnotation(BOTTOMVAL);
             } else {
-                List<Long> longLengths = null;
+                RangeOrListOfValues rolv = null;
                 if (AnnotationUtils.areSameByClass(dimType, IntRange.class)) {
-                    longLengths =
-                            ValueCheckerUtils.getValuesFromRange(getIntRange(dimType), Long.class);
+                    rolv = new RangeOrListOfValues(getRange(dimType));
                 } else if (AnnotationUtils.areSameByClass(dimType, IntVal.class)) {
-                    longLengths = getIntValues(dimType);
+                    rolv = new RangeOrListOfValues();
+                    rolv.addAll(rolv.convertLongsToInts(getIntValues(dimType)));
                 }
-                if (longLengths != null) {
-                    HashSet<Integer> lengths = new HashSet<Integer>(longLengths.size());
-                    for (Long l : longLengths) {
-                        lengths.add(l.intValue());
+                if (rolv != null) {
+                    AnnotationMirror newQual;
+                    if (rolv.isRange) {
+                        newQual = createArrayLenRangeAnnotation(rolv.range);
+                    } else {
+                        newQual = createArrayLenAnnotation(rolv.values);
                     }
-                    AnnotationMirror newQual = createArrayLenAnnotation(new ArrayList<>(lengths));
                     type.replaceAnnotation(newQual);
                 }
             }
         }
 
+        // An abstraction that can be either a range or a list of values that could come from an
+        // ArrayLen or IntVal. This abstraction reduces the number of cases that handleInitializers
+        // and handleDimensions must handle.
+        private class RangeOrListOfValues {
+            Range range;
+            List<Integer> values;
+            boolean isRange;
+
+            public RangeOrListOfValues(Integer... values) {
+                this.values = new ArrayList<>(values.length);
+                for (Integer l : values) {
+                    if (!this.values.contains(l)) {
+                        this.values.add(l);
+                    }
+                }
+                isRange = false;
+            }
+
+            public RangeOrListOfValues(Range range) {
+                this.range = range;
+                isRange = true;
+            }
+
+            public void addAll(List<Integer> newValues) {
+                for (Integer i : newValues) {
+                    if (!values.contains(i)) {
+                        values.add(i);
+                    }
+                }
+                if (values.size() > MAX_VALUES) {
+                    convertToRange();
+                }
+            }
+
+            // To be called before addAll
+            public List<Integer> convertLongsToInts(List<Long> newValues) {
+                List<Integer> result = new ArrayList<>(newValues.size());
+                for (Long l : newValues) {
+                    result.add(l.intValue());
+                }
+                return result;
+            }
+
+            public void convertToRange() {
+                if (!isRange) {
+                    isRange = true;
+                    range = new Range(Collections.min(values), Collections.max(values));
+                    values = null;
+                }
+            }
+        }
+
         /**
-         * Adds the ArrayLen annotation from the array initializers to {@code type}.
+         * Adds the ArrayLen/ArrayLenRange annotation from the array initializers to {@code type}.
          *
          * <p>If type is a multi-dimensional array, the initializers might also contain arrays, so
          * this method adds the annotations for those initializers, too.
@@ -610,23 +725,43 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
             // A list of arrayLens.  arrayLenOfDimensions.get(i) is the array lengths for the ith
             // dimension.
-            List<List<Integer>> arrayLenOfDimensions = new ArrayList<>();
+            List<RangeOrListOfValues> arrayLenOfDimensions = new ArrayList<>();
             for (ExpressionTree init : initializers) {
                 AnnotatedTypeMirror componentType = getAnnotatedType(init);
                 int dimension = 0;
                 while (componentType.getKind() == TypeKind.ARRAY) {
-                    List<Integer> arrayLens;
+                    RangeOrListOfValues rolv = null;
                     if (dimension == arrayLenOfDimensions.size()) {
-                        arrayLens = new ArrayList<>();
-                        arrayLenOfDimensions.add(arrayLens);
-                    } else {
-                        arrayLens = arrayLenOfDimensions.get(dimension);
+                        arrayLenOfDimensions.add(new RangeOrListOfValues());
                     }
                     AnnotationMirror arrayLen = componentType.getAnnotation(ArrayLen.class);
                     if (arrayLen != null) {
+                        rolv = arrayLenOfDimensions.get(dimension);
                         List<Integer> currentLengths = getArrayLength(arrayLen);
-                        arrayLens.addAll(currentLengths);
+                        if (rolv.isRange) {
+                            Range range =
+                                    new Range(
+                                            Collections.min(currentLengths),
+                                            Collections.max(currentLengths));
+                            rolv.range = range.union(rolv.range);
+                        } else {
+                            rolv.addAll(currentLengths);
+                        }
+                    } else {
+                        // Check for an arrayLenRange annotation
+                        AnnotationMirror arrayLenRangeAnno =
+                                componentType.getAnnotation(ArrayLenRange.class);
+                        if (arrayLenRangeAnno != null) {
+                            Range range = getRange(arrayLenRangeAnno);
+                            rolv.convertToRange();
+                            rolv.range = range.union(rolv.range);
+                        }
                     }
+
+                    // replace the current dimension's range with this one.
+                    arrayLenOfDimensions.remove(dimension);
+                    arrayLenOfDimensions.add(dimension, rolv);
+
                     dimension++;
                     componentType = ((AnnotatedArrayType) componentType).getComponentType();
                 }
@@ -635,7 +770,12 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror componentType = type.getComponentType();
             int i = 0;
             while (componentType.getKind() == TypeKind.ARRAY && i < arrayLenOfDimensions.size()) {
-                componentType.addAnnotation(createArrayLenAnnotation(arrayLenOfDimensions.get(i)));
+                RangeOrListOfValues rolv = arrayLenOfDimensions.get(i);
+                if (rolv.isRange) {
+                    componentType.addAnnotation(createArrayLenRangeAnnotation(rolv.range));
+                } else {
+                    componentType.addAnnotation(createArrayLenAnnotation(rolv.values));
+                }
                 componentType = ((AnnotatedArrayType) componentType).getComponentType();
                 i++;
             }
@@ -697,7 +837,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     AnnotationMirror newAnno;
                     Range range;
                     if (AnnotationUtils.areSameByClass(oldAnno, IntRange.class)
-                            && (range = getIntRange(oldAnno)).isWiderThan(MAX_VALUES)) {
+                            && (range = getRange(oldAnno)).isWiderThan(MAX_VALUES)) {
                         Class<?> newClass = ValueCheckerUtils.getClassFromType(newType);
                         if (newClass == String.class) {
                             newAnno = UNKNOWNVAL;
@@ -908,6 +1048,14 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                                     createNumberAnnotationMirror(new ArrayList<Number>(lengths)));
                             return null;
                         }
+                        // Check for an ArrayLenRange annotation.
+                        arrayAnno = receiverType.getAnnotation(ArrayLenRange.class);
+                        if (arrayAnno != null) {
+                            // array.length, where array : @ArrayLenRange(x)
+                            Range range = getRange(arrayAnno);
+                            type.replaceAnnotation(createIntRangeAnnotation(range));
+                            return null;
+                        }
                     }
                 }
             }
@@ -1052,7 +1200,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * the input is too wide to be represented as an {@code @IntVal}.
      */
     public AnnotationMirror convertIntRangeToIntVal(AnnotationMirror intRangeAnno) {
-        Range range = getIntRange(intRangeAnno);
+        Range range = getRange(intRangeAnno);
         List<Long> values = ValueCheckerUtils.getValuesFromRange(range, Long.class);
         return createIntValAnnotation(values);
     }
@@ -1125,7 +1273,9 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /**
      * Returns a {@link ArrayLen} annotation using the values. If {@code values} is null, then
      * UnknownVal is returned; if {@code values} is empty, then bottom is returned. The values are
-     * sorted and duplicates are removed before the annotation is created.
+     * sorted and duplicates are removed before the annotation is created. If values is larger than
+     * the max number of values allowed (10 by default), then an {@link ArrayLenRange} annotation is
+     * returned.
      *
      * @param values list of integers; duplicates are allowed and the values may be in any order
      * @return a {@link ArrayLen} annotation using the values
@@ -1141,7 +1291,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (values.isEmpty()) {
             return BOTTOMVAL;
         } else if (values.size() > MAX_VALUES) {
-            return UNKNOWNVAL;
+            return createArrayLenRangeAnnotation(Collections.min(values), Collections.max(values));
         } else {
             AnnotationBuilder builder = new AnnotationBuilder(processingEnv, ArrayLen.class);
             builder.setValue("value", values);
@@ -1254,6 +1404,39 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     }
 
+    /**
+     * Create an {@code @ArrayLenRange} annotation from the two (inclusive) bounds. Does not return
+     * BOTTOMVAL or UNKNOWNVAL.
+     */
+    public AnnotationMirror createArrayLenRangeAnnotation(int from, int to) {
+        assert from <= to;
+        AnnotationBuilder builder = new AnnotationBuilder(processingEnv, ArrayLenRange.class);
+        builder.setValue("from", from);
+        builder.setValue("to", to);
+        return builder.build();
+    }
+
+    /**
+     * Create an {@code @ArrayLenRange} annotation from the range. May return BOTTOMVAL or
+     * UNKNOWNVAL.
+     */
+    public AnnotationMirror createArrayLenRangeAnnotation(Range range) {
+        if (range.isNothing()) {
+            return BOTTOMVAL;
+        } else if (range.isEverything() || !range.isWithin(Integer.MIN_VALUE, Integer.MAX_VALUE)) {
+            return UNKNOWNVAL;
+        } else {
+            return createArrayLenRangeAnnotation(
+                    Long.valueOf(range.from).intValue(), Long.valueOf(range.to).intValue());
+        }
+    }
+
+    /** Converts an {@code @ArrayLen} annotation to an {@code @ArrayLenRange} annotation. */
+    public AnnotationMirror convertArrayLenToArrayLenRange(AnnotationMirror arrayLenAnno) {
+        List<Integer> values = getArrayLength(arrayLenAnno);
+        return createArrayLenRangeAnnotation(Collections.min(values), Collections.max(values));
+    }
+
     /** Converts an {@code @IntVal} annotation to an {@code @IntRange} annotation. */
     public AnnotationMirror convertIntValToIntRange(AnnotationMirror intValAnno) {
         List<Long> intValues = getIntValues(intValAnno);
@@ -1261,14 +1444,20 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /** Returns a {@code Range} bounded by the values specified in the given annotation. */
-    public static Range getIntRange(AnnotationMirror rangeAnno) {
+    public static Range getRange(AnnotationMirror rangeAnno) {
         if (rangeAnno == null) {
             return null;
         }
         // Assume rangeAnno is well-formed, i.e., 'from' is less than or equal to 'to'.
-        return new Range(
-                AnnotationUtils.getElementValue(rangeAnno, "from", Long.class, true),
-                AnnotationUtils.getElementValue(rangeAnno, "to", Long.class, true));
+        if (AnnotationUtils.areSameByClass(rangeAnno, IntRange.class)) {
+            return new Range(
+                    AnnotationUtils.getElementValue(rangeAnno, "from", Long.class, true),
+                    AnnotationUtils.getElementValue(rangeAnno, "to", Long.class, true));
+        } else {
+            return new Range(
+                    AnnotationUtils.getElementValue(rangeAnno, "from", Integer.class, true),
+                    AnnotationUtils.getElementValue(rangeAnno, "to", Integer.class, true));
+        }
     }
 
     /**

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1059,6 +1059,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                             Range range = getRange(arrayAnno);
                             type.replaceAnnotation(createIntRangeAnnotation(range));
                             return null;
+                        } else {
+                            type.replaceAnnotation(createIntRangeAnnotation(0, Integer.MAX_VALUE));
                         }
                     }
                 }

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -101,7 +101,7 @@ public class ValueCheckerUtils {
             List<Long> longs = ValueAnnotatedTypeFactory.getIntValues(anno);
             values = convertIntVal(longs, castType, castTo);
         } else if (AnnotationUtils.areSameByClass(anno, IntRange.class)) {
-            Range range = ValueAnnotatedTypeFactory.getIntRange(anno);
+            Range range = ValueAnnotatedTypeFactory.getRange(anno);
             List<Long> longs = getValuesFromRange(range, Long.class);
             values = convertIntVal(longs, castType, castTo);
         } else if (AnnotationUtils.areSameByClass(anno, StringVal.class)) {

--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -286,14 +286,16 @@ public class ValueTransfer extends CFTransfer {
         }
 
         if (lengthAnno != null) {
-            Range range;
+            RangeOrListOfValues rolv;
             if (isIntRange) {
-                range = ValueAnnotatedTypeFactory.getRange(lengthAnno);
+                rolv = new RangeOrListOfValues(ValueAnnotatedTypeFactory.getRange(lengthAnno));
             } else {
                 List<Long> lengthValues = ValueAnnotatedTypeFactory.getIntValues(lengthAnno);
-                range = new Range(Collections.min(lengthValues), Collections.max(lengthValues));
+                rolv =
+                        new RangeOrListOfValues(
+                                RangeOrListOfValues.convertLongsToInts(lengthValues));
             }
-            AnnotationMirror newArrayAnno = atypefactory.createArrayLenRangeAnnotation(range);
+            AnnotationMirror newArrayAnno = rolv.createAnnotation(atypefactory);
             AnnotationMirror oldArrayAnno =
                     atypefactory.getAnnotationMirror(
                             arrayLengthNode.getReceiver().getTree(), ArrayLen.class);

--- a/framework/src/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/org/checkerframework/common/value/ValueVisitor.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.common.value.qual.ArrayLen;
+import org.checkerframework.common.value.qual.ArrayLenRange;
 import org.checkerframework.common.value.qual.BoolVal;
 import org.checkerframework.common.value.qual.DoubleVal;
 import org.checkerframework.common.value.qual.IntRange;
@@ -111,6 +112,16 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
                             Result.warning("negative.arraylen", Collections.min(arrayLens)), node);
                     return null;
                 }
+            }
+        } else if (AnnotationUtils.areSameByClass(anno, ArrayLenRange.class)) {
+            int from = AnnotationUtils.getElementValue(anno, "from", Integer.class, true);
+            int to = AnnotationUtils.getElementValue(anno, "to", Integer.class, true);
+            if (from > to) {
+                checker.report(Result.failure("from.greater.than.to"), node);
+                return null;
+            } else if (from < 0) {
+                checker.report(Result.warning("negative.arraylen", from), node);
+                return null;
             }
         }
 

--- a/framework/src/org/checkerframework/common/value/qual/ArrayLenRange.java
+++ b/framework/src/org/checkerframework/common/value/qual/ArrayLenRange.java
@@ -18,7 +18,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 public @interface ArrayLenRange {
     /** Smallest value in the range, inclusive */
-    int from(); // default Integer.MIN_VALUE;
+    int from() default 0;
     /** Largest value in the range, inclusive */
-    int to(); // default Integer.MAX_VALUE;
+    int to() default Integer.MAX_VALUE;
 }

--- a/framework/src/org/checkerframework/common/value/qual/ArrayLenRange.java
+++ b/framework/src/org/checkerframework/common/value/qual/ArrayLenRange.java
@@ -1,0 +1,24 @@
+package org.checkerframework.common.value.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+/**
+ * An expression with this type evaluates to an array whose length is in the given range. The bounds
+ * are inclusive; for example, {@code @ArrayLenRange(from=6, to=9)} represents an array with four
+ * possible values for its length: 6, 7, 8, and 9.
+ *
+ * @checker_framework.manual #constant-value-checker Constant Value Checker
+ */
+@SubtypeOf(UnknownVal.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+public @interface ArrayLenRange {
+    /** Smallest value in the range, inclusive */
+    int from(); // default Integer.MIN_VALUE;
+    /** Largest value in the range, inclusive */
+    int to(); // default Integer.MAX_VALUE;
+}

--- a/framework/src/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/org/checkerframework/common/value/qual/BottomVal.java
@@ -20,7 +20,15 @@ import org.checkerframework.framework.qual.TypeUseLocation;
     literals = {LiteralKind.NULL},
     typeNames = {java.lang.Void.class}
 )
-@SubtypeOf({ArrayLen.class, BoolVal.class, DoubleVal.class, IntVal.class, StringVal.class})
+@SubtypeOf({
+    ArrayLen.class,
+    BoolVal.class,
+    DoubleVal.class,
+    IntVal.class,
+    StringVal.class,
+    ArrayLenRange.class,
+    IntRange.class
+})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface BottomVal {}

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -10,6 +10,14 @@ class ArrayInit {
                     {{1}, {1}, {1, 1, 1, 1}}
                 };
 
+        int @ArrayLen(4) [] @ArrayLen({1, 3, 4}) [] @ArrayLenRange(from = 1, to = 12) [] gamma =
+                new int[][][] {
+                    {{1, 1}, {1, 1, 1}, {1}, {1}},
+                    {{1}, {1}, {1}, {1, 1}},
+                    {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}},
+                    {{1}, {1}, {1, 1, 1, 1}}
+                };
+
         int @ArrayLen(4) [] @ArrayLen({1, 2, 3}) [] a = {{1, 1}, {1, 1, 1}, {1}, {1}};
         int @ArrayLen(4) [] @ArrayLen({1, 2}) [] b = {{1}, {1}, {1}, {1, 1}};
         int @ArrayLen(1) [] @ArrayLen(7) [] c = {{1, 2, 3, 4, 5, 6, 7}};
@@ -40,6 +48,7 @@ class ArrayInit {
         int @ArrayLen({1, 2}) [] a = new int[shortLength];
         //:: error: (assignment.type.incompatible)
         int @ArrayLen({1, 2}) [] b = new int[longLength];
+        int @ArrayLenRange(from = 1, to = 20) [] d = new int[longLength];
         int @ArrayLen({0}) [] c = new int[bottom];
     }
 

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -87,4 +87,26 @@ class ArrayInit {
         //:: error: (assignment.type.incompatible)
         Object @ArrayLen(1) [] @ArrayLen(1) [] o3 = new Object[][] {null};
     }
+
+    public void subtyping1(int @ArrayLen({1, 5}) [] a) {
+        int @ArrayLenRange(from = 1, to = 5) [] b = a;
+        //:: error: (assignment.type.incompatible)
+        int @ArrayLenRange(from = 2, to = 5) [] c = a;
+    }
+
+    public void subtyping2(int @ArrayLenRange(from = 1, to = 5) [] a) {
+        int @ArrayLen({1, 2, 3, 4, 5}) [] b = a;
+        //:: error: (assignment.type.incompatible)
+        int @ArrayLen({1, 5}) [] c = a;
+    }
+
+    // The argument is an arraylen with too many values.
+    //:: warning: (too.many.values.given)
+    public void coerce(int @ArrayLen({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 36}) [] a) {
+        int @ArrayLenRange(from = 1, to = 36) [] b = a;
+        if (a.length < 15) {
+            //:: error: (assignment.type.incompatible)
+            int @ArrayLen({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) [] c = a;
+        }
+    }
 }

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -26,6 +26,14 @@ class ArrayInit {
         int @ArrayLen(4) [] @ArrayLen({1, 3, 4}) [] @ArrayLen({1, 2, 3, 4, 7}) [] beta = {
             a, b, c, d
         };
+
+        int @ArrayLen(4) [] @ArrayLen({1, 2, 3}) [] a1 = {{1, 1}, {1, 1, 1}, {1}, {1}};
+        int @ArrayLen(4) [] @ArrayLen({1, 2}) [] b1 = {{1}, {1}, {1}, {1, 1}};
+        int @ArrayLen(1) [] @ArrayLen(11) [] c1 = {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}};
+        int @ArrayLen(3) [] @ArrayLen({1, 4}) [] d1 = {{1}, {1}, {1, 1, 1, 1}};
+
+        int @ArrayLen(4) [] @ArrayLenRange(from = 1, to = 4) [] @ArrayLenRange(from = 1, to = 11) []
+                delta = {a1, b1, c1, d1};
     }
 
     public void numberInit() {

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -100,6 +100,61 @@ class ArrayInit {
         int @ArrayLen({1, 5}) [] c = a;
     }
 
+    public void subtyping3(int @ArrayLenRange(from = 1, to = 17) [] a) {
+        //:: error: (assignment.type.incompatible)
+        int @ArrayLenRange(from = 1, to = 12) [] b = a;
+        //:: error: (assignment.type.incompatible)
+        int @ArrayLenRange(from = 5, to = 18) [] c = a;
+        int @ArrayLenRange(from = 0, to = 20) [] d = a;
+    }
+
+    public void lub1(boolean flag, @IntRange(from = 1, to = 200) int x) {
+        int[] a;
+        if (flag) {
+            a = new int[x];
+        } else {
+            a = new int[250];
+        }
+
+        int @ArrayLenRange(from = 1, to = 250) [] b = a;
+    }
+
+    public void lub2(
+            boolean flag, @IntRange(from = 1, to = 20) int x, @IntRange(from = 50, to = 75) int y) {
+        int[] a;
+        if (flag) {
+            a = new int[x];
+        } else {
+            a = new int[y];
+        }
+
+        int @ArrayLenRange(from = 1, to = 75) [] b = a;
+    }
+
+    public void lub3(
+            boolean flag, @IntRange(from = 1, to = 5) int x, @IntRange(from = 3, to = 7) int y) {
+        int[] a;
+        if (flag) {
+            a = new int[x];
+        } else {
+            a = new int[y];
+        }
+
+        int @ArrayLenRange(from = 1, to = 7) [] b = a;
+        int @ArrayLen({1, 2, 3, 4, 5, 6, 7}) [] c = a;
+    }
+
+    public void refine(int[] q) {
+        if (q.length < 20) {
+            @IntRange(from = 0, to = 19)
+            int x = q.length;
+            int @ArrayLenRange(from = 0, to = 19) [] b = q;
+            if (q.length < 5) {
+                int @ArrayLen({0, 1, 2, 3, 4}) [] c = q;
+            }
+        }
+    }
+
     // The argument is an arraylen with too many values.
     //:: warning: (too.many.values.given)
     public void coerce(int @ArrayLen({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 36}) [] a) {

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -164,4 +164,11 @@ class ArrayInit {
             int @ArrayLen({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}) [] c = a;
         }
     }
+
+    public void warnings() {
+        //:: warning: (negative.arraylen)
+        int @ArrayLenRange(from = -1, to = 5) [] a;
+        //:: error: (from.greater.than.to)
+        int @ArrayLenRange(from = 10, to = 3) [] b;
+    }
 }


### PR DESCRIPTION
Adds an `@ArrayLenRange` annotation, which expresses that an array's length must be between the two values the annotation holds. The relationship between `@ArrayLenRange` and `@ArrayLen` is analogous to the relationship between `@IntRange` and `@IntVal`.

Fixes kelloggm#150