### PR TITLE
Correct lub for uninfered wildcards 

### DIFF
--- a/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
+++ b/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
@@ -119,6 +119,9 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
                 && (type1.getAnnotations().size() != type2.getAnnotations().size()
                         || type1.getAnnotations().isEmpty()
                         || type2.getAnnotations().isEmpty())) {
+            // qualifierHierarchy.leastUpperBounds errors if the sets of annotations passed are
+            // not the same size and non-empty.  But, if either type is from an uninferred
+            // wildcard, then avoid this crash.
             if (type1.getAnnotations().size() > type2.getAnnotations().size()) {
                 lubSet = partialQualifierLub(type1.getAnnotations(), type2.getAnnotations());
             } else {

--- a/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
+++ b/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
@@ -116,8 +116,9 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
             AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, AnnotatedTypeMirror lub) {
         Set<? extends AnnotationMirror> lubSet;
         if (visitingUninferedWildcard
-                        && type1.getAnnotations().size() != type1.getAnnotations().size()
-                || type1.getAnnotations().isEmpty()) {
+                && (type1.getAnnotations().size() != type2.getAnnotations().size()
+                        || type1.getAnnotations().isEmpty()
+                        || type2.getAnnotations().isEmpty())) {
             if (type1.getAnnotations().size() > type2.getAnnotations().size()) {
                 lubSet = partialQualifierLub(type1.getAnnotations(), type2.getAnnotations());
             } else {

--- a/framework/tests/all-systems/LubRawTypes.java
+++ b/framework/tests/all-systems/LubRawTypes.java
@@ -7,4 +7,8 @@ public class LubRawTypes {
     MyGen<MyGen<MyGen<String>>> test(MyGen myGen1, MyGen myGen2) {
         return flag ? myGen1 : myGen2;
     }
+
+    MyGen<MyGen<MyGen<String>>> test2(MyGen myGen1, MyGen<MyGen<MyGen<String>>> myGen2) {
+        return flag ? myGen2 : myGen1;
+    }
 }


### PR DESCRIPTION
framework/tests/all-systems/LubRawTypes.java tests the case where `getAnnotations()` is empty.  I'm not sure if the case where `type1.getAnnotations().size() != type2.getAnnotations().size()` can happens in practice, but if it does, it shouldn't cause a crash.

This corrects a problem @wmdietl found in #1235.