### PR TITLE
Fixes bug in Value Checker's transfer function for refining ranges when encountering a GTE

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -925,7 +925,7 @@ public class ValueTransfer extends CFTransfer {
                 break;
             case GREATER_THAN_EQ:
                 thenRightRange = rightRange.refineLessThanEq(leftRange);
-                thenLeftRange = leftRange.refineGreaterThan(rightRange);
+                thenLeftRange = leftRange.refineGreaterThanEq(rightRange);
                 elseLeftRange = leftRange.refineLessThan(rightRange);
                 elseRightRange = rightRange.refineGreaterThan(leftRange);
                 break;

--- a/framework/tests/value/GTETransferBug.java
+++ b/framework/tests/value/GTETransferBug.java
@@ -1,0 +1,12 @@
+import org.checkerframework.common.value.qual.*;
+
+class GTETransferBug {
+    void gte_bad_check(int[] a) {
+        if (a.length >= 1) {
+            //:: error: (assignment.type.incompatible)
+            int @ArrayLenRange(from = 2) [] b = a;
+
+            int @ArrayLenRange(from = 1) [] c = a;
+        }
+    }
+}


### PR DESCRIPTION
I didn't include a more comprehensive set of tests because typetools#1243 includes them already (so I've run them, and they pass), but those tests are needed anyway because they also test that the `@MinLen` annotation is working correctly.