### PR TITLE
Update maven compiler plugin to 3.6.1

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -429,7 +429,7 @@ For example, to use the \code{org.checkerframework.checker.nullness.NullnessChec
 \begin{alltt}
     <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.6.1</version>
         <configuration>
             <!-- Change source and target to 1.7 if using Java 7 -->
             <source>1.8</source>


### PR DESCRIPTION
As pointed out by @mernst existing maven setup truncated compiler messages.

This update helps avoiding this, by upgrading from the erroneous 3.3 plugin version to the newer 3.6.1. See also

https://issues.apache.org/jira/browse/MCOMPILER-229