### PR TITLE
Value Checker: override strengthenAnnotationOfEqualTo

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -195,21 +195,23 @@ public class ValueTransfer extends CFTransfer {
     }
 
     private Range getIntRangeFromAnnotation(Node node, AnnotationMirror val) {
-        Range range = Range.EVERYTHING;
+        Range range;
         if (val == null || AnnotationUtils.areSameByClass(val, UnknownVal.class)) {
-            return Range.EVERYTHING;
+            range = Range.EVERYTHING;
         } else if (AnnotationUtils.areSameByClass(val, IntRange.class)) {
-            return ValueAnnotatedTypeFactory.getRange(val);
+            range = ValueAnnotatedTypeFactory.getRange(val);
         } else if (AnnotationUtils.areSameByClass(val, IntVal.class)) {
             List<Long> values =
                     AnnotationUtils.getElementValueArray(val, "value", Long.class, true);
-            return ValueCheckerUtils.getRangeFromValues(values);
+            range = ValueCheckerUtils.getRangeFromValues(values);
         } else if (AnnotationUtils.areSameByClass(val, DoubleVal.class)) {
             List<Double> values =
                     AnnotationUtils.getElementValueArray(val, "value", Double.class, true);
-            return ValueCheckerUtils.getRangeFromValues(values);
+            range = ValueCheckerUtils.getRangeFromValues(values);
         } else if (AnnotationUtils.areSameByClass(val, BottomVal.class)) {
-            return Range.NOTHING;
+            range = Range.NOTHING;
+        } else {
+            range = Range.EVERYTHING;
         }
         return NumberUtils.castRange(node.getType(), range);
     }
@@ -799,23 +801,6 @@ public class ValueTransfer extends CFTransfer {
 
     private List<Boolean> calculateBinaryComparison(
             Node leftNode,
-            Node rightNode,
-            ComparisonOperators op,
-            TransferInput<CFValue, CFStore> p,
-            CFStore thenStore,
-            CFStore elseStore) {
-        return calculateBinaryComparison(
-                leftNode,
-                p.getValueOfSubNode(leftNode),
-                rightNode,
-                p.getValueOfSubNode(rightNode),
-                op,
-                thenStore,
-                elseStore);
-    }
-
-    private List<Boolean> calculateBinaryComparison(
-            Node leftNode,
             CFValue leftValue,
             Node rightNode,
             CFValue rightValue,
@@ -1023,9 +1008,10 @@ public class ValueTransfer extends CFTransfer {
         List<Boolean> resultValues =
                 calculateBinaryComparison(
                         n.getLeftOperand(),
+                        p.getValueOfSubNode(n.getLeftOperand()),
                         n.getRightOperand(),
+                        p.getValueOfSubNode(n.getRightOperand()),
                         ComparisonOperators.LESS_THAN,
-                        p,
                         thenStore,
                         elseStore);
         TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();
@@ -1041,9 +1027,10 @@ public class ValueTransfer extends CFTransfer {
         List<Boolean> resultValues =
                 calculateBinaryComparison(
                         n.getLeftOperand(),
+                        p.getValueOfSubNode(n.getLeftOperand()),
                         n.getRightOperand(),
+                        p.getValueOfSubNode(n.getRightOperand()),
                         ComparisonOperators.LESS_THAN_EQ,
-                        p,
                         thenStore,
                         elseStore);
         TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();
@@ -1059,9 +1046,10 @@ public class ValueTransfer extends CFTransfer {
         List<Boolean> resultValues =
                 calculateBinaryComparison(
                         n.getLeftOperand(),
+                        p.getValueOfSubNode(n.getLeftOperand()),
                         n.getRightOperand(),
+                        p.getValueOfSubNode(n.getRightOperand()),
                         ComparisonOperators.GREATER_THAN,
-                        p,
                         thenStore,
                         elseStore);
         TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();
@@ -1077,9 +1065,10 @@ public class ValueTransfer extends CFTransfer {
         List<Boolean> resultValues =
                 calculateBinaryComparison(
                         n.getLeftOperand(),
+                        p.getValueOfSubNode(n.getLeftOperand()),
                         n.getRightOperand(),
+                        p.getValueOfSubNode(n.getRightOperand()),
                         ComparisonOperators.GREATER_THAN_EQ,
-                        p,
                         thenStore,
                         elseStore);
         TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();

--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -32,7 +32,6 @@ import org.checkerframework.dataflow.cfg.node.BitwiseXorNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalAndNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalNotNode;
 import org.checkerframework.dataflow.cfg.node.ConditionalOrNode;
-import org.checkerframework.dataflow.cfg.node.EqualToNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
 import org.checkerframework.dataflow.cfg.node.FloatingDivisionNode;
 import org.checkerframework.dataflow.cfg.node.FloatingRemainderNode;
@@ -44,7 +43,6 @@ import org.checkerframework.dataflow.cfg.node.LeftShiftNode;
 import org.checkerframework.dataflow.cfg.node.LessThanNode;
 import org.checkerframework.dataflow.cfg.node.LessThanOrEqualNode;
 import org.checkerframework.dataflow.cfg.node.Node;
-import org.checkerframework.dataflow.cfg.node.NotEqualNode;
 import org.checkerframework.dataflow.cfg.node.NumericalAdditionNode;
 import org.checkerframework.dataflow.cfg.node.NumericalMinusNode;
 import org.checkerframework.dataflow.cfg.node.NumericalMultiplicationNode;
@@ -151,32 +149,40 @@ public class ValueTransfer extends CFTransfer {
         return new ArrayList<Character>();
     }
 
+    private AnnotationMirror getValueAnnotation(Node subNode, TransferInput<CFValue, CFStore> p) {
+        CFValue value = p.getValueOfSubNode(subNode);
+        return getValueAnnotation(value);
+    }
+
+    private AnnotationMirror getValueAnnotation(CFValue cfValue) {
+        return atypefactory
+                .getQualifierHierarchy()
+                .findAnnotationInHierarchy(cfValue.getAnnotations(), atypefactory.UNKNOWNVAL);
+    }
+
     /**
      * Returns a list of possible values, or null if no estimate is available and any value is
      * possible.
      */
     private List<? extends Number> getNumericalValues(
             Node subNode, TransferInput<CFValue, CFStore> p) {
-        CFValue value = p.getValueOfSubNode(subNode);
-        List<? extends Number> values = null;
-        AnnotationMirror intValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), IntVal.class);
-        if (intValAnno != null) {
-            values = AnnotationUtils.getElementValueArray(intValAnno, "value", Long.class, true);
-        }
-        AnnotationMirror doubleValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), DoubleVal.class);
-        if (doubleValAnno != null) {
-            values =
-                    AnnotationUtils.getElementValueArray(
-                            doubleValAnno, "value", Double.class, true);
-        }
-        AnnotationMirror bottomValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), BottomVal.class);
-        if (bottomValAnno != null) {
+        AnnotationMirror valueAnno = getValueAnnotation(subNode, p);
+        return getNumericalValues(subNode, valueAnno);
+    }
+
+    private List<? extends Number> getNumericalValues(Node subNode, AnnotationMirror valueAnno) {
+
+        if (valueAnno == null || AnnotationUtils.areSameByClass(valueAnno, UnknownVal.class)) {
+            return null;
+        } else if (AnnotationUtils.areSameByClass(valueAnno, BottomVal.class)) {
             return new ArrayList<>();
         }
-        if (values == null) {
+        List<? extends Number> values;
+        if (AnnotationUtils.areSameByClass(valueAnno, IntVal.class)) {
+            values = AnnotationUtils.getElementValueArray(valueAnno, "value", Long.class, true);
+        } else if (AnnotationUtils.areSameByClass(valueAnno, DoubleVal.class)) {
+            values = AnnotationUtils.getElementValueArray(valueAnno, "value", Double.class, true);
+        } else {
             return null;
         }
         return NumberUtils.castNumbers(subNode.getType(), values);
@@ -184,34 +190,28 @@ public class ValueTransfer extends CFTransfer {
 
     /** Get possible integer range from annotation. */
     private Range getIntRange(Node subNode, TransferInput<CFValue, CFStore> p) {
-        CFValue value = p.getValueOfSubNode(subNode);
+        AnnotationMirror val = getValueAnnotation(subNode, p);
+        return getIntRangeFromAnnotation(subNode, val);
+    }
+
+    private Range getIntRangeFromAnnotation(Node node, AnnotationMirror val) {
         Range range = Range.EVERYTHING;
-        AnnotationMirror intRangeAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), IntRange.class);
-        if (intRangeAnno != null) {
-            range = ValueAnnotatedTypeFactory.getRange(intRangeAnno);
-        }
-        AnnotationMirror intValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), IntVal.class);
-        if (intValAnno != null) {
+        if (val == null || AnnotationUtils.areSameByClass(val, UnknownVal.class)) {
+            return Range.EVERYTHING;
+        } else if (AnnotationUtils.areSameByClass(val, IntRange.class)) {
+            return ValueAnnotatedTypeFactory.getRange(val);
+        } else if (AnnotationUtils.areSameByClass(val, IntVal.class)) {
             List<Long> values =
-                    AnnotationUtils.getElementValueArray(intValAnno, "value", Long.class, true);
-            range = ValueCheckerUtils.getRangeFromValues(values);
-        }
-        AnnotationMirror doubleValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), DoubleVal.class);
-        if (doubleValAnno != null) {
+                    AnnotationUtils.getElementValueArray(val, "value", Long.class, true);
+            return ValueCheckerUtils.getRangeFromValues(values);
+        } else if (AnnotationUtils.areSameByClass(val, DoubleVal.class)) {
             List<Double> values =
-                    AnnotationUtils.getElementValueArray(
-                            doubleValAnno, "value", Double.class, true);
-            range = ValueCheckerUtils.getRangeFromValues(values);
-        }
-        AnnotationMirror bottomValAnno =
-                AnnotationUtils.getAnnotationByClass(value.getAnnotations(), BottomVal.class);
-        if (bottomValAnno != null) {
+                    AnnotationUtils.getElementValueArray(val, "value", Double.class, true);
+            return ValueCheckerUtils.getRangeFromValues(values);
+        } else if (AnnotationUtils.areSameByClass(val, BottomVal.class)) {
             return Range.NOTHING;
         }
-        return NumberUtils.castRange(subNode.getType(), range);
+        return NumberUtils.castRange(node.getType(), range);
     }
 
     /** a helper function to determine if this node is annotated with @IntRange */
@@ -221,9 +221,8 @@ public class ValueTransfer extends CFTransfer {
     }
 
     /** a helper function to determine if this node is annotated with @UnknownVal */
-    private boolean isIntegralUnknownVal(Node node, TransferInput<CFValue, CFStore> p) {
-        CFValue value = p.getValueOfSubNode(node);
-        return AnnotationUtils.containsSameByClass(value.getAnnotations(), UnknownVal.class)
+    private boolean isIntegralUnknownVal(Node node, AnnotationMirror anno) {
+        return AnnotationUtils.areSameByClass(anno, UnknownVal.class)
                 && TypesUtils.isIntegral(node.getType());
     }
 
@@ -805,36 +804,49 @@ public class ValueTransfer extends CFTransfer {
             TransferInput<CFValue, CFStore> p,
             CFStore thenStore,
             CFStore elseStore) {
-        if (isIntRange(leftNode, p)
-                || isIntRange(rightNode, p)
-                || isIntegralUnknownVal(rightNode, p)
-                || isIntegralUnknownVal(leftNode, p)) {
+        return calculateBinaryComparison(
+                leftNode,
+                p.getValueOfSubNode(leftNode),
+                rightNode,
+                p.getValueOfSubNode(rightNode),
+                op,
+                thenStore,
+                elseStore);
+    }
+
+    private List<Boolean> calculateBinaryComparison(
+            Node leftNode,
+            CFValue leftValue,
+            Node rightNode,
+            CFValue rightValue,
+            ComparisonOperators op,
+            CFStore thenStore,
+            CFStore elseStore) {
+        AnnotationMirror leftAnno = getValueAnnotation(leftValue);
+        AnnotationMirror rightAnno = getValueAnnotation(rightValue);
+
+        if (AnnotationUtils.areSameByClass(leftAnno, IntRange.class)
+                || AnnotationUtils.areSameByClass(rightAnno, IntRange.class)
+                || isIntegralUnknownVal(rightNode, rightAnno)
+                || isIntegralUnknownVal(leftNode, leftAnno)) {
             // If either is @UnknownVal, then refineIntRanges will treat it as the max range and
             // thus refine it if possible.  Also, if either is an @IntVal, then it will be
             // converted to a range.  This is less precise in some cases, but avoids the
             // complexity of comparing a list of values to a range. (This could be implemented in
             // the future.)
-            return refineIntRanges(leftNode, rightNode, op, p, thenStore, elseStore);
+            return refineIntRanges(
+                    leftNode, leftAnno, rightNode, rightAnno, op, thenStore, elseStore);
         }
         List<Boolean> resultValues = new ArrayList<>();
 
-        List<? extends Number> lefts = getNumericalValues(leftNode, p);
-        List<? extends Number> rights = getNumericalValues(rightNode, p);
+        List<? extends Number> lefts = getNumericalValues(leftNode, leftAnno);
+        List<? extends Number> rights = getNumericalValues(rightNode, rightAnno);
 
         if (lefts == null || rights == null) {
             // Appropriately handle bottom when something is compared to bottom.
-            AnnotationMirror leftAnno =
-                    atypefactory
-                            .getAnnotatedType(leftNode.getTree())
-                            .getAnnotationInHierarchy(atypefactory.BOTTOMVAL);
-            AnnotationMirror rightAnno =
-                    atypefactory
-                            .getAnnotatedType(rightNode.getTree())
-                            .getAnnotationInHierarchy(atypefactory.BOTTOMVAL);
-
             if (AnnotationUtils.areSame(leftAnno, atypefactory.BOTTOMVAL)
                     || AnnotationUtils.areSame(rightAnno, atypefactory.BOTTOMVAL)) {
-                return new ArrayList<Boolean>();
+                return new ArrayList<>();
             }
             return null;
         }
@@ -897,13 +909,15 @@ public class ValueTransfer extends CFTransfer {
      */
     private List<Boolean> refineIntRanges(
             Node leftNode,
+            AnnotationMirror leftAnno,
             Node rightNode,
+            AnnotationMirror rightAnno,
             ComparisonOperators op,
-            TransferInput<CFValue, CFStore> p,
             CFStore thenStore,
             CFStore elseStore) {
-        Range leftRange = getIntRange(leftNode, p);
-        Range rightRange = getIntRange(rightNode, p);
+
+        Range leftRange = getIntRangeFromAnnotation(leftNode, leftAnno);
+        Range rightRange = getIntRangeFromAnnotation(rightNode, rightAnno);
 
         final Range thenRightRange;
         final Range thenLeftRange;
@@ -1073,50 +1087,39 @@ public class ValueTransfer extends CFTransfer {
     }
 
     @Override
-    public TransferResult<CFValue, CFStore> visitEqualTo(
-            EqualToNode n, TransferInput<CFValue, CFStore> p) {
-        TransferResult<CFValue, CFStore> transferResult = super.visitEqualTo(n, p);
-        if (TypesUtils.isPrimitive(n.getLeftOperand().getType())
-                || TypesUtils.isPrimitive(n.getRightOperand().getType())) {
+    protected TransferResult<CFValue, CFStore> strengthenAnnotationOfEqualTo(
+            TransferResult<CFValue, CFStore> transferResult,
+            Node firstNode,
+            Node secondNode,
+            CFValue firstValue,
+            CFValue secondValue,
+            boolean notEqualTo) {
+        if (firstValue == null) {
+            return transferResult;
+        }
+        if (TypesUtils.isNumeric(firstNode.getType())
+                || TypesUtils.isNumeric(secondNode.getType())) {
             CFStore thenStore = transferResult.getThenStore();
             CFStore elseStore = transferResult.getElseStore();
             // At least one must be a primitive otherwise reference equality is used.
             List<Boolean> resultValues =
                     calculateBinaryComparison(
-                            n.getLeftOperand(),
-                            n.getRightOperand(),
-                            ComparisonOperators.EQUAL,
-                            p,
+                            firstNode,
+                            firstValue,
+                            secondNode,
+                            secondValue,
+                            notEqualTo ? ComparisonOperators.NOT_EQUAL : ComparisonOperators.EQUAL,
                             thenStore,
                             elseStore);
+            if (transferResult.getResultValue() == null) {
+                // Happens for case labels
+                return transferResult;
+            }
             TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();
             return createNewResultBoolean(thenStore, elseStore, resultValues, underlyingType);
         }
-        return transferResult;
-    }
-
-    @Override
-    public TransferResult<CFValue, CFStore> visitNotEqual(
-            NotEqualNode n, TransferInput<CFValue, CFStore> p) {
-        TransferResult<CFValue, CFStore> transferResult = super.visitNotEqual(n, p);
-        if (TypesUtils.isPrimitive(n.getLeftOperand().getType())
-                || TypesUtils.isPrimitive(n.getRightOperand().getType())) {
-            CFStore thenStore = transferResult.getThenStore();
-            CFStore elseStore = transferResult.getElseStore();
-            // At least one must be a primitive otherwise reference equality is
-            // used.
-            List<Boolean> resultValues =
-                    calculateBinaryComparison(
-                            n.getLeftOperand(),
-                            n.getRightOperand(),
-                            ComparisonOperators.NOT_EQUAL,
-                            p,
-                            thenStore,
-                            elseStore);
-            TypeMirror underlyingType = transferResult.getResultValue().getUnderlyingType();
-            return createNewResultBoolean(thenStore, elseStore, resultValues, underlyingType);
-        }
-        return transferResult;
+        return super.strengthenAnnotationOfEqualTo(
+                transferResult, firstNode, secondNode, firstValue, secondValue, notEqualTo);
     }
 
     enum ConditionalOperators {

--- a/framework/src/org/checkerframework/common/value/util/NumberUtils.java
+++ b/framework/src/org/checkerframework/common/value/util/NumberUtils.java
@@ -23,6 +23,12 @@ public class NumberUtils {
                     bytes.add(l.byteValue());
                 }
                 return bytes;
+            case CHAR:
+                List<Integer> chars = new ArrayList<>();
+                for (Number l : numbers) {
+                    chars.add(l.intValue());
+                }
+                return chars;
             case DOUBLE:
                 List<Double> doubles = new ArrayList<>();
                 for (Number l : numbers) {

--- a/framework/tests/value/Switch.java
+++ b/framework/tests/value/Switch.java
@@ -94,4 +94,48 @@ class Switch {
         //:: error: (assignment.type.incompatible)
         @IntVal(4) int y2 = x;
     }
+
+    void testInts(@IntRange(from = 0, to = 100) int x) {
+        switch (x) {
+            case 0:
+            case 1:
+            case 2:
+                @IntVal({0, 1, 2}) int z = x;
+                return;
+            default:
+        }
+
+        @IntRange(from = 1, to = 100) int z = x;
+    }
+
+    void testChars(char x) {
+        switch (x) {
+            case 'a':
+            case 2:
+                @IntVal({'a', 2}) int z = x;
+                break;
+            case 'b':
+                @IntVal('b') int v = x;
+                break;
+            default:
+                return;
+        }
+        @IntVal({'a', 2, 'b'}) int y = x;
+    }
+
+    void testStrings(String s) {
+        switch (s) {
+            case "Good":
+                @StringVal("Good") String x = s;
+            case "Bye":
+                @StringVal({"Good", "Bye"}) String y = s;
+                break;
+            case "Hello":
+                @StringVal("Hello") String z = s;
+                break;
+            default:
+                return;
+        }
+        @StringVal({"Good", "Bye", "Hello"}) String q = s;
+    }
 }


### PR DESCRIPTION
Override strengthenAnnotationOfEqualTo rather than visitEqual and visitNotEqual.

This way switch statements are refined as the same as ==.  Also, fixes a crash when chars are in a switch statement. 

(Blocking #1243 )