### PR TITLE
Use the PropagationTreeAnnotator visitNewArray to correctly type new arrays.

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -53,6 +53,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayTyp
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.ListTypeAnnotator;
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
@@ -630,10 +631,20 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected TreeAnnotator createTreeAnnotator() {
+        TreeAnnotator arrayCreation =
+                new TreeAnnotator(this) {
+                    PropagationTreeAnnotator propagationTreeAnnotator =
+                            new PropagationTreeAnnotator(atypeFactory);
+
+                    @Override
+                    public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror mirror) {
+                        return propagationTreeAnnotator.visitNewArray(node, mirror);
+                    }
+                };
         // The ValueTreeAnnotator handles propagation differently,
         // so it doesn't need PropgationTreeAnnotator.
         return new ListTreeAnnotator(
-                new ValueTreeAnnotator(this), new ImplicitsTreeAnnotator(this));
+                new ValueTreeAnnotator(this), new ImplicitsTreeAnnotator(this), arrayCreation);
     }
 
     /** The TreeAnnotator for this AnnotatedTypeFactory. It adds/replaces annotations. */

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -631,6 +631,9 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected TreeAnnotator createTreeAnnotator() {
+        // Only use the PropagationTreeAnnotator for typing new arrays.  The Value Checker
+        // computes types differently for all other trees normally typed by the
+        // PropagationTreeAnnotator.
         TreeAnnotator arrayCreation =
                 new TreeAnnotator(this) {
                     PropagationTreeAnnotator propagationTreeAnnotator =
@@ -641,8 +644,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         return propagationTreeAnnotator.visitNewArray(node, mirror);
                     }
                 };
-        // The ValueTreeAnnotator handles propagation differently,
-        // so it doesn't need PropgationTreeAnnotator.
         return new ListTreeAnnotator(
                 new ValueTreeAnnotator(this), new ImplicitsTreeAnnotator(this), arrayCreation);
     }

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -92,7 +92,6 @@ class ArrayInit {
     public void nullableArrays() {
         Object @ArrayLen(2) [] @ArrayLen(1) [] o = new Object[][] {new Object[] {null}, null};
         Object @ArrayLen(1) [][] o2 = new Object[][] {null};
-        //:: error: (assignment.type.incompatible)
         Object @ArrayLen(1) [] @ArrayLen(1) [] o3 = new Object[][] {null};
     }
 

--- a/framework/tests/value/Issue1229.java
+++ b/framework/tests/value/Issue1229.java
@@ -1,0 +1,19 @@
+import org.checkerframework.common.value.qual.*;
+
+public class Issue1229 {
+
+    Object @ArrayLen(1) [] @ArrayLen(1) [] o3 = new Object[][] {null};
+
+    @IntVal({0, 1, 2, 3}) int[] a1 = new @IntVal({0, 1, 2, 3}) int[] {0, 1, 2, 3};
+
+    int[] a2 = new @IntVal({0, 1, 2, 3}) int[] {0, 1, 2, 3};
+
+    @IntVal({0, 1, 2, 3}) int[] a3 = new int[] {0, 1, 2, 3};
+
+    void test() {
+
+        @IntVal({0, 1, 2, 3}) int[] a1 = new @IntVal({0, 1, 2, 3}) int[] {0, 1, 2, 3};
+        int[] a2 = new @IntVal({0, 1, 2, 3}) int[] {0, 1, 2, 3};
+        @IntVal({0, 1, 2, 3}) int[] a3 = new int[] {0, 1, 2, 3};
+    }
+}


### PR DESCRIPTION
Fixes #1229.