### PR TITLE
Remove extraneous MinLen and PolySameLen annotations on Strings in Index JDK

### DIFF
--- a/checker/jdk/index/src/java/io/File.java
+++ b/checker/jdk/index/src/java/io/File.java
@@ -195,7 +195,7 @@ public class File
      * string for convenience.  This string contains a single character, namely
      * <code>{@link #separatorChar}</code>.
      */
-    public static final /*!MinLen(1)*/ String separator = "" + separatorChar;
+    public static final String separator = "" + separatorChar;
 
     /**
      * The system-dependent path-separator character.  This field is

--- a/checker/jdk/index/src/java/io/File.java
+++ b/checker/jdk/index/src/java/io/File.java
@@ -195,7 +195,7 @@ public class File
      * string for convenience.  This string contains a single character, namely
      * <code>{@link #separatorChar}</code>.
      */
-    public static final @MinLen(1) String separator = "" + separatorChar;
+    public static final /*!MinLen(1)*/ String separator = "" + separatorChar;
 
     /**
      * The system-dependent path-separator character.  This field is
@@ -214,7 +214,7 @@ public class File
      * for convenience.  This string contains a single character, namely
      * <code>{@link #pathSeparatorChar}</code>.
      */
-    public static final @MinLen() String pathSeparator = "" + pathSeparatorChar;
+    public static final String pathSeparator = "" + pathSeparatorChar;
 
 
     /* -- Constructors -- */

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -163,7 +163,7 @@ public final class String
      * @param  original
      *         A {@code String}
      */
-    public /*!PolyMinLen*/ @PolySameLen String(/*!PolyMinLen*/ @PolySameLen String original) {
+    public /*!PolyMinLen*/ /*!PolySameLen*/ String(/*!PolyMinLen*/ /*!PolySameLen*/ String original) {
         int size = original.count;
         char[] originalValue = original.value;
         char[] v;
@@ -192,7 +192,7 @@ public final class String
      * @param  value
      *         The initial value of the string
      */
-    public /*!PolyMinLen*/ @PolySameLen String(char /*!PolyMinLen*/ @PolySameLen [] value) {
+    public /*!PolyMinLen*/ /*!PolySameLen*/ String(char /*!PolyMinLen*/ /*!PolySameLen*/ [] value) {
         int size = value.length;
         this.offset = 0;
         this.count = size;
@@ -395,7 +395,7 @@ public final class String
      * @see  #String(byte[])
      */
     @Deprecated
-    public /*!PolyMinLen*/ @PolySameLen String(byte /*!PolyMinLen*/ @PolySameLen [] ascii, int hibyte) {
+    public /*!PolyMinLen*/ /*!PolySameLen*/ String(byte /*!PolyMinLen*/ /*!PolySameLen*/ [] ascii, int hibyte) {
         this(ascii, hibyte, 0, ascii.length);
     }
 
@@ -2917,7 +2917,7 @@ public final class String
      * @return  a newly allocated string representing the same sequence of
      *          characters contained in the character array argument.
      */
-    public static /*!PolyMinLen*/ @PolySameLen String valueOf(char /*!PolyMinLen*/ @PolySameLen [] data) {
+    public static /*!PolyMinLen*/ /*!PolySameLen*/ String valueOf(char /*!PolyMinLen*/ /*!PolySameLen*/ [] data) {
         return new String(data);
     }
 
@@ -2969,7 +2969,7 @@ public final class String
      * @return  a <code>String</code> that contains the characters of the
      *          character array.
      */
-    public static /*!PolyMinLen*/ @PolySameLen String copyValueOf(char /*!PolyMinLen*/ @PolySameLen [] data) {
+    public static /*!PolyMinLen*/ /*!PolySameLen*/ String copyValueOf(char /*!PolyMinLen*/ /*!PolySameLen*/ [] data) {
         return copyValueOf(data, 0, data.length);
     }
 


### PR DESCRIPTION
This is causing the Value Checker to report warnings that it shouldn't when run on Daikon (because #1243 moved the MinLen annotation into the Value Checker). The extraneous PolySameLen annos aren't causing any problems, but they should be removed anyway in case they do cause problems down the line.