### PR TITLE
Use areSame when sorting AnnotationMirrors.

### DIFF
--- a/checker/tests/index/Split.java
+++ b/checker/tests/index/Split.java
@@ -1,0 +1,10 @@
+import java.util.regex.Pattern;
+import org.checkerframework.common.value.qual.MinLen;
+
+public class Split {
+    Pattern p = Pattern.compile(".*");
+
+    void test() {
+        String @MinLen(1) [] s = p.split("sdf");
+    }
+}

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2960,6 +2960,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             try {
                 results.add(annotation);
             } catch (com.sun.tools.javac.code.Symbol.CompletionFailure cf) {
+                // If a CompletionFailure occurs, issue a warning.
                 checker.message(
                         Kind.WARNING,
                         annotation.getAnnotationType().asElement(),

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2955,7 +2955,20 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         Set<AnnotationMirror> results = AnnotationUtils.createAnnotationSet();
         // Retrieving the annotations from the element.
-        results.addAll(elements.getAllAnnotationMirrors(elt));
+        List<? extends AnnotationMirror> fromEle = elements.getAllAnnotationMirrors(elt);
+        for (AnnotationMirror annotation : fromEle) {
+            try {
+                results.add(annotation);
+            } catch (com.sun.tools.javac.code.Symbol.CompletionFailure cf) {
+                checker.message(
+                        Kind.WARNING,
+                        annotation.getAnnotationType().asElement(),
+                        "annotation.not.completed",
+                        ElementUtils.getVerboseName(elt),
+                        annotation);
+            }
+        }
+
         // If declAnnosFromStubFiles == null, return the annotations in the element.
         if (declAnnosFromStubFiles != null) {
             // Adding @FromByteCode annotation to declAnnosFromStubFiles entry with key

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -374,9 +374,14 @@ public class AnnotationUtils {
                     if (AnnotationUtils.areSame(a1, a2)) {
                         return 0;
                     }
+
                     String n1 = a1.toString();
                     String n2 = a2.toString();
 
+                    // Because the AnnotationMirror.toString prints the annotation as it appears
+                    // in source code, the order in which annotations of the same class are
+                    // sorted may be confusing.  For example, it might order
+                    // @IntRange(from=1, to=MAX) before @IntRange(to=MAX,from=0).
                     return n1.compareTo(n2);
                 }
             };

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -369,6 +369,11 @@ public class AnnotationUtils {
             new Comparator<AnnotationMirror>() {
                 @Override
                 public int compare(AnnotationMirror a1, AnnotationMirror a2) {
+                    // AnnotationMirror.toString() prints the elements of an annotation in the
+                    // order in which they were written. So, use areSame to check for equality.
+                    if (AnnotationUtils.areSame(a1, a2)) {
+                        return 0;
+                    }
                     String n1 = a1.toString();
                     String n2 = a2.toString();
 


### PR DESCRIPTION
`compare` should return 0 when comparing `@IntRange(from=0, to=MAX)` and `@IntRange(to=MAX,from=0)`.  

The expected `CompletionFailure` exception issued by `checker/tests/nullness-extra/issue309` now occurs in a different method.  So I added a new catch for it.

(This was causing the following error: https://travis-ci.org/typetests/daikon-typecheck/jobs/229178124#L1038)