### PR TITLE
Add defaults even if an element for a tree can't be found.

### DIFF
--- a/checker/tests/index/OneOrTwo.java
+++ b/checker/tests/index/OneOrTwo.java
@@ -5,7 +5,12 @@ class OneOrTwo {
         return 1;
     }
 
-    void test() {
-        int[] a = new int[getOneOrTwo()];
+    void test(@BottomVal int x) {
+        int[] a = new int[Integer.valueOf(getOneOrTwo())];
+        int[] b = new int[Integer.valueOf(x)];
+    }
+
+    @PolyValue int poly(@PolyValue int y) {
+        return y;
     }
 }

--- a/checker/tests/index/PolyCrash.java
+++ b/checker/tests/index/PolyCrash.java
@@ -1,0 +1,5 @@
+public class PolyCrash {
+    void test1(Integer integer) {
+        ++integer;
+    }
+}

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -473,19 +473,17 @@ public class QualifierDefaults {
         // System.out.println("applyDefaults on tree " + tree +
         //        " gives elt: " + elt + "(" + elt.getKind() + ")");
 
-        if (elt != null) {
-            boolean defaultTypeVarLocals =
-                    (atypeFactory instanceof GenericAnnotatedTypeFactory<?, ?, ?, ?>)
-                            && (((GenericAnnotatedTypeFactory<?, ?, ?, ?>) atypeFactory)
-                                    .getShouldDefaultTypeVarLocals());
-
-            applyToTypeVar =
-                    defaultTypeVarLocals
-                            && elt.getKind() == ElementKind.LOCAL_VARIABLE
-                            && type.getKind() == TypeKind.TYPEVAR;
-            applyDefaultsElement(elt, type);
-            applyToTypeVar = false;
-        }
+        boolean defaultTypeVarLocals =
+                (atypeFactory instanceof GenericAnnotatedTypeFactory<?, ?, ?, ?>)
+                        && (((GenericAnnotatedTypeFactory<?, ?, ?, ?>) atypeFactory)
+                                .getShouldDefaultTypeVarLocals());
+        applyToTypeVar =
+                defaultTypeVarLocals
+                        && elt != null
+                        && elt.getKind() == ElementKind.LOCAL_VARIABLE
+                        && type.getKind() == TypeKind.TYPEVAR;
+        applyDefaultsElement(elt, type);
+        applyToTypeVar = false;
     }
 
     private DefaultSet fromDefaultQualifier(DefaultQualifier dq) {


### PR DESCRIPTION
This happens when a type is requested from a subchecker for a synthetic tree.