### PR TITLE
Remove incorrect code (Fixes #1274)

### DIFF
--- a/framework/src/org/checkerframework/framework/type/visitor/VisitHistory.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/VisitHistory.java
@@ -116,12 +116,6 @@ public class VisitHistory {
             }
 
             if (thisType.getClass().equals(AnnotatedTypeMirror.AnnotatedWildcardType.class)) {
-                if (thisType.getUnderlyingType().equals(thatType.getUnderlyingType())) {
-                    //TODO: Investigate WHY we get wildcards that are essentially recursive since I
-                    //TODO: don't think we can write these wildcards. Perhaps it is related to our lack of
-                    //TODO: capture conversion or inferring void methods
-                    return true; // Handles the case of recursive wildcard types
-                }
                 if (!AnnotationUtils.areSame(
                         thisType.getAnnotations(), thatType.getAnnotations())) {
                     return false;

--- a/framework/tests/all-systems/Issue1274.java
+++ b/framework/tests/all-systems/Issue1274.java
@@ -1,0 +1,22 @@
+// Test case for Issue 1274
+// https://github.com/typetools/checker-framework/issues/1274
+
+public class Issue1274 {
+    static class Mine<T> {
+        static <S> Mine<S> of(S p1, S p2) {
+            return null;
+        }
+    }
+
+    class Two<U, V> {}
+
+    class C extends Two<Float, Float> {}
+
+    class D extends Two<String, String> {}
+
+    class Crash {
+        {
+            Mine.of(new C(), new D());
+        }
+    }
+}


### PR DESCRIPTION
If an AnnotatedWildcardType has been substituted for a type parameter, then two wildcards with the same underlying type may appear a type, so this code is incorrect.  This code was causing the crash reported in #1274 because it stopped the AtmLubVisitor from visiting a wildcard.
(Fixes #1274)

The following test cases use to return true here, but still pass.  So the concern about recursive wildcards must have been resolved since the comment was written.
tests/all-systems/AsSuperCrashes.java
tests/all-systems/GenericCrazyBounds.java
tests/all-systems/Issue717.java
tests/all-systems/Issue759.java
tests/all-systems/Issue953.java
tests/all-systems/Issue953b.java
tests/all-systems/MissingBoundAnnotations.java
tests/all-systems/AsSuperCrashes.java
tests/all-systems/GenericCrazyBounds.java
tests/all-systems/Issue717.java
tests/all-systems/Issue759.java
tests/all-systems/Issue953.java
tests/all-systems/Issue953b.java
tests/all-systems/MissingBoundAnnotations.java
tests/nullness/Issue415.java
tests/nullness/Issue415.java
tests/nullness/Issue759.java
tests/nullness/Issue759.java
tests/nullness/MissingBoundAnnotations.java
tests/nullness/MissingBoundAnnotations.java
tests/nullness/Issue415.java
tests/nullness/Issue415.java
tests/nullness/Issue759.java
tests/nullness/Issue759.java
tests/nullness/MissingBoundAnnotations.java
tests/nullness/MissingBoundAnnotations.java
tests/nullness/generics/GenericArgs2.java
tests/nullness/generics/GenericArgs2.java
tests/nullness/generics/WildcardSubtyping.java
tests/nullness/generics/WildcardSubtyping.java
tests/nullness/generics/GenericArgs2.java
tests/nullness/generics/GenericArgs2.java
tests/nullness/generics/WildcardSubtyping.java
tests/nullness/generics/WildcardSubtyping.java
tests/nullness/java8/lambda/Issue953b.java
tests/nullness/java8/lambda/Issue953b.java
tests/nullness/java8/lambda/Issue953b.java
tests/nullness/java8/lambda/Issue953b.java
tests/nullness/java8inference/Inference.java
tests/nullness/java8inference/Inference.java
tests/nullness/java8inference/Issue953b.java
tests/nullness/java8inference/Issue953b.java
tests/nullness/java8inference/Issue980.java
tests/nullness/java8inference/Issue980.java
tests/nullness/java8inference/Inference.java
tests/nullness/java8inference/Inference.java
tests/nullness/java8inference/Issue953b.java
tests/nullness/java8inference/Issue953b.java
tests/nullness/java8inference/Issue980.java
tests/nullness/java8inference/Issue980.java