### PR TITLE
Don't use VisitHistory to stop recursion in AtmLubVisitor. (Fixes #1274)

### DIFF
--- a/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
+++ b/framework/src/org/checkerframework/framework/util/AtmLubVisitor.java
@@ -19,7 +19,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedUnionTyp
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor;
-import org.checkerframework.framework.type.visitor.VisitHistory;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 
@@ -33,7 +32,12 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
 
     private final AnnotatedTypeFactory atypeFactory;
     private final QualifierHierarchy qualifierHierarchy;
-    private final VisitHistory visitHistory = new VisitHistory();
+    /**
+     * List of {@link AnnotatedTypeVariable} or {@link AnnotatedWildcardType} that have been
+     * visited. Call {@link #visited(AnnotatedTypeMirror)} to check if the type have been visited,
+     * so that reference equality is used rather than {@link #equals(Object)}.
+     */
+    private final List<AnnotatedTypeMirror> visited = new ArrayList<>();
 
     AtmLubVisitor(AnnotatedTypeFactory atypeFactory) {
         this.atypeFactory = atypeFactory;
@@ -60,7 +64,7 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
         AnnotatedTypeMirror type2AsLub = AnnotatedTypes.asSuper(atypeFactory, type2, lub);
 
         visit(type1AsLub, type2AsLub, lub);
-        visitHistory.clear();
+        visited.clear();
         return lub;
     }
 
@@ -201,10 +205,9 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
         // (Note the lub of  Gen<@A ? super @A Object> and Gen<@A ? super @B Object> does not
         // exist, but Gen<@A ? super @B Object> is returned.)
         if (lub.getKind() == TypeKind.WILDCARD) {
-            if (visitHistory.contains(type1AsLub, type2AsLub)) {
+            if (visited(lub)) {
                 return;
             }
-            visitHistory.add(type1AsLub, type2AsLub);
             AnnotatedWildcardType type1Wildcard = (AnnotatedWildcardType) type1AsLub;
             AnnotatedWildcardType type2Wildcard = (AnnotatedWildcardType) type2AsLub;
             AnnotatedWildcardType lubWildcard = (AnnotatedWildcardType) lub;
@@ -221,10 +224,9 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
                     lubWildcard.getExtendsBound());
         } else if (lub.getKind() == TypeKind.TYPEVAR
                 && InternalUtils.isCaptured((TypeVariable) lub.getUnderlyingType())) {
-            if (visitHistory.contains(type1AsLub, type2AsLub)) {
+            if (visited(lub)) {
                 return;
             }
-            visitHistory.add(type1AsLub, type2AsLub);
             AnnotatedTypeVariable type1typevar = (AnnotatedTypeVariable) type1AsLub;
             AnnotatedTypeVariable type2typevar = (AnnotatedTypeVariable) type2AsLub;
             AnnotatedTypeVariable lubTypevar = (AnnotatedTypeVariable) lub;
@@ -277,11 +279,10 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
     @Override
     public Void visitTypevar_Typevar(
             AnnotatedTypeVariable type1, AnnotatedTypeVariable type2, AnnotatedTypeMirror lub1) {
-
-        if (visitHistory.contains(type1, type2)) {
+        if (visited(lub1)) {
             return null;
         }
-        visitHistory.add(type1, type2);
+
         AnnotatedTypeVariable lub = castLub(type1, lub1);
         visit(type1.getUpperBound(), type2.getUpperBound(), lub.getUpperBound());
         visit(type1.getLowerBound(), type2.getLowerBound(), lub.getLowerBound());
@@ -294,10 +295,9 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
     @Override
     public Void visitWildcard_Wildcard(
             AnnotatedWildcardType type1, AnnotatedWildcardType type2, AnnotatedTypeMirror lub1) {
-        if (visitHistory.contains(type1, type2)) {
+        if (visited(lub1)) {
             return null;
         }
-        visitHistory.add(type1, type2);
         AnnotatedWildcardType lub = castLub(type1, lub1);
         visit(type1.getExtendsBound(), type2.getExtendsBound(), lub.getExtendsBound());
         visit(type1.getSuperBound(), type2.getSuperBound(), lub.getSuperBound());
@@ -376,5 +376,23 @@ class AtmLubVisitor extends AbstractAtmComboVisitor<Void, AnnotatedTypeMirror> {
                 "AtmLubVisitor: Unexpected combination: type1: %s type2: %s.\ntype1: %s"
                         + "\ntype2: %s\nlub: %s",
                 type1.getKind(), type2.getKind(), type1, type2, lub);
+    }
+
+    /**
+     * Returns true if the {@link AnnotatedTypeMirror} has been visited. If it has not, then it is
+     * added to the list of visited AnnotatedTypeMirrors. This prevents infinite recursion on
+     * recursive types.
+     */
+    private boolean visited(AnnotatedTypeMirror atm) {
+        for (AnnotatedTypeMirror atmVisit : visited) {
+            // Use reference equality rather than equals because the visitor may visit two types
+            // that are structurally equal, but not actually the same.  For example, the
+            // wildcards in Pair<?,?> may be equal, but they both should be visited.
+            if (atmVisit == atm) {
+                return true;
+            }
+        }
+        visited.add(atm);
+        return false;
     }
 }

--- a/framework/tests/all-systems/Issue1274.java
+++ b/framework/tests/all-systems/Issue1274.java
@@ -1,0 +1,23 @@
+// Test case for Issue 1274
+// https://github.com/typetools/checker-framework/issues/1274
+
+@SuppressWarnings("") // Just check for crashes
+public class Issue1274 {
+    static class Mine<T> {
+        static <S> Mine<S> of(S p1, S p2) {
+            return null;
+        }
+    }
+
+    class Two<U, V> {}
+
+    class C extends Two<Float, Float> {}
+
+    class D extends Two<String, String> {}
+
+    class Crash {
+        {
+            Mine.of(new C(), new D());
+        }
+    }
+}


### PR DESCRIPTION
Instead, just check that the same ATM has not been visited before.

Fixes #1274.