### PR TITLE
Avoid possible ambiguity between different `message` overloads.

### DIFF
--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -1039,7 +1039,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor
      * @throws IllegalArgumentException if {@code source} is neither a {@link Tree} nor an {@link
      *     Element}
      */
-    public void message(
+    private void message(
             Diagnostic.Kind kind,
             Object source,
             /*@CompilerMessageKey*/ String msgKey,
@@ -1181,10 +1181,11 @@ public abstract class SourceChecker extends AbstractTypeProcessor
      * @see SourceChecker#message(Diagnostic.Kind, Object, String, Object...)
      */
     public void message(Diagnostic.Kind kind, String msg, Object... args) {
+        String ftdmsg = String.format(msg, args);
         if (messager != null) {
-            messager.printMessage(kind, String.format(msg, args));
+            messager.printMessage(kind, ftdmsg);
         } else {
-            System.err.println(kind + ": " + String.format(msg, args));
+            System.err.println(kind + ": " + ftdmsg);
         }
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -82,6 +82,7 @@ import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 import org.checkerframework.framework.qual.StubFiles;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.stub.StubParser;
 import org.checkerframework.framework.stub.StubResource;
@@ -2969,12 +2970,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 results.add(annotation);
             } catch (com.sun.tools.javac.code.Symbol.CompletionFailure cf) {
                 // If a CompletionFailure occurs, issue a warning.
-                checker.message(
-                        Kind.WARNING,
-                        annotation.getAnnotationType().asElement(),
-                        "annotation.not.completed",
-                        ElementUtils.getVerboseName(elt),
-                        annotation);
+                checker.report(
+                        Result.warning(
+                                "annotation.not.completed",
+                                ElementUtils.getVerboseName(elt),
+                                annotation),
+                        annotation.getAnnotationType().asElement());
             }
         }
 
@@ -3027,12 +3028,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     } catch (com.sun.tools.javac.code.Symbol.CompletionFailure cf) {
                         // Fix for Issue 348: If a CompletionFailure occurs,
                         // issue a warning.
-                        checker.message(
-                                Kind.WARNING,
-                                annotation.getAnnotationType().asElement(),
-                                "annotation.not.completed",
-                                ElementUtils.getVerboseName(elt),
-                                annotation);
+                        checker.report(
+                                Result.warning(
+                                        "annotation.not.completed",
+                                        ElementUtils.getVerboseName(elt),
+                                        annotation),
+                                annotation.getAnnotationType().asElement());
                         continue;
                     }
                     if (AnnotationUtils.containsSameByClass(
@@ -3097,12 +3098,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 // I didn't find a nicer alternative to check whether the Symbol can be completed.
                 // The completer field of a Symbol might be non-null also in successful cases.
                 // Issue a warning (exception only happens once) and continue.
-                checker.message(
-                        Kind.WARNING,
-                        annotation.getAnnotationType().asElement(),
-                        "annotation.not.completed",
-                        ElementUtils.getVerboseName(element),
-                        annotation);
+                checker.report(
+                        Result.warning(
+                                "annotation.not.completed",
+                                ElementUtils.getVerboseName(element),
+                                annotation),
+                        annotation.getAnnotationType().asElement());
                 continue;
             }
             // First call copier, if exception, continue normal modula laws.


### PR DESCRIPTION
Make one message version private and replace calls by the appropriate
existing method.