### PR TITLE
Fixes issue where SameLen didn't interact correctly with constant index checks.

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -195,7 +195,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
                     valueAnnotatedTypeFactory.getMinLenFromString(
                             arrayName, valueExp, getCurrentPath());
             if (testMinLen(value, minlen, arrayName, varLtlQual)) {
-                continue checkloop;
+                continue;
             }
             for (String array : sameLenArrays) {
                 int minlenSL =

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -63,6 +63,11 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
             return;
         }
 
+        // Find max because it's important to determine whether the index is less than the
+        // minimum length of the array. If it could be any of several values, only the max is of
+        // interest.
+        Long valMax = IndexUtil.getMaxValue(indexTree, atypeFactory.getValueAnnotatedTypeFactory());
+
         AnnotationMirror sameLenAnno = atypeFactory.sameLenAnnotationFromTree(arrTree);
         // Produce the full list of relevant names by checking the SameLen type.
         if (sameLenAnno != null && AnnotationUtils.areSameByClass(sameLenAnno, SameLen.class)) {
@@ -73,13 +78,21 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
                 if (qualifier.isLessThanLengthOfAny(slNames)) {
                     return;
                 }
+                for (String slName : slNames) {
+                    // Check if any of the arrays have a minlen that is greater than the
+                    // known constant value.
+                    int minlenSL =
+                            atypeFactory
+                                    .getValueAnnotatedTypeFactory()
+                                    .getMinLenFromString(slName, arrTree, getCurrentPath());
+                    if (valMax != null && valMax < minlenSL) {
+                        return;
+                    }
+                }
             }
         }
 
-        // Find max because it's important to determine whether the index is less than the
-        // minimum length of the array. If it could be any of several values, only the max is of
-        // interest.
-        Long valMax = IndexUtil.getMaxValue(indexTree, atypeFactory.getValueAnnotatedTypeFactory());
+        // Check against the minlen of the array itself.
         Integer minLen = IndexUtil.getMinLen(arrTree, atypeFactory.getValueAnnotatedTypeFactory());
         if (valMax != null && minLen != null && valMax < minLen) {
             return;
@@ -169,6 +182,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
         SameLenAnnotatedTypeFactory sameLenFactory = atypeFactory.getSameLenAnnotatedTypeFactory();
         ValueAnnotatedTypeFactory valueAnnotatedTypeFactory =
                 atypeFactory.getValueAnnotatedTypeFactory();
+        checkloop:
         for (String arrayName : varLtlQual.getArrays()) {
 
             List<String> sameLenArrays =
@@ -177,12 +191,19 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
                 continue;
             }
 
-            int minLen =
+            int minlen =
                     valueAnnotatedTypeFactory.getMinLenFromString(
                             arrayName, valueExp, getCurrentPath());
-
-            if (testMinLen(value, minLen, arrayName, varLtlQual)) {
-                continue;
+            if (testMinLen(value, minlen, arrayName, varLtlQual)) {
+                continue checkloop;
+            }
+            for (String array : sameLenArrays) {
+                int minlenSL =
+                        valueAnnotatedTypeFactory.getMinLenFromString(
+                                array, valueExp, getCurrentPath());
+                if (testMinLen(value, minlenSL, arrayName, varLtlQual)) {
+                    continue checkloop;
+                }
             }
 
             return false;
@@ -217,7 +238,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
     }
 
     /**
-     * Tests a constant value (value) against the minlen (minlen) of an array (arrayName) with a
+     * Tests a constant value (value) against the minlen (minlens) of an array (arrayName) with a
      * qualifier (varQual).
      */
     private boolean testMinLen(Long value, int minLen, String arrayName, LessThanLengthOf varQual) {

--- a/checker/tests/index/MinLenSameLenInteraction.java
+++ b/checker/tests/index/MinLenSameLenInteraction.java
@@ -1,0 +1,9 @@
+import org.checkerframework.checker.index.qual.*;
+
+class MinLenSameLenInteraction {
+    void test(int @SameLen("#2") [] a, int @SameLen("#1") [] b) {
+        if (a.length == 1) {
+            int x = b[0];
+        }
+    }
+}


### PR DESCRIPTION
When checking whether a constant index was less than the length of an array, other arrays that are known to have the same length were not being considered. This PR corrects this mistake.