### PR TITLE
Correct defaults for IntRange annotations on non-Long types

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -300,6 +300,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          * by @BOTTOMVAL. The {@link
          * org.checkerframework.common.value.ValueVisitor#visitAnnotation(com.sun.source.tree.AnnotationTree,
          * Void)} would raise an error to users in this case.
+         *
+         * <p>If a user only writes one side of an {@code IntRange} annotation, this method also
+         * computes an appropriate default based on the underlying type for the other side of the
+         * range. For instance, if the user write {@code @IntRange(from = 1) short x;} then this
+         * method will translate the annotation to {@code @IntRange(from = 1, to = Short.MAX_VALUE}.
          */
         private void replaceWithNewAnnoInSpecialCases(AnnotatedTypeMirror atm) {
             AnnotationMirror anno = atm.getAnnotationInHierarchy(UNKNOWNVAL);
@@ -332,10 +337,49 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                                 createArrayLenRangeAnnotation(new Range(annoMinVal, annoMaxVal)));
                     }
                 } else if (AnnotationUtils.areSameByClass(anno, IntRange.class)) {
-                    long from = AnnotationUtils.getElementValue(anno, "from", Long.class, true);
-                    long to = AnnotationUtils.getElementValue(anno, "to", Long.class, true);
+                    // Compute appropriate defaults for integral ranges.
+                    long from, to;
+                    if (AnnotationUtils.hasElementValue(anno, "from")) {
+                        from = AnnotationUtils.getElementValue(anno, "from", Long.class, false);
+                    } else {
+                        switch (atm.getUnderlyingType().getKind()) {
+                            case INT:
+                                from = Integer.MIN_VALUE;
+                                break;
+                            case SHORT:
+                                from = Short.MIN_VALUE;
+                                break;
+                            case BYTE:
+                                from = Byte.MIN_VALUE;
+                                break;
+                            default:
+                                from = Long.MIN_VALUE;
+                        }
+                    }
+                    if (AnnotationUtils.hasElementValue(anno, "to")) {
+                        to = AnnotationUtils.getElementValue(anno, "to", Long.class, false);
+                    } else {
+                        switch (atm.getUnderlyingType().getKind()) {
+                            case INT:
+                                to = Integer.MAX_VALUE;
+                                break;
+                            case SHORT:
+                                to = Short.MAX_VALUE;
+                                break;
+                            case BYTE:
+                                to = Byte.MAX_VALUE;
+                                break;
+                            default:
+                                to = Long.MAX_VALUE;
+                        }
+                    }
                     if (from > to) {
                         atm.replaceAnnotation(BOTTOMVAL);
+                    } else {
+                        // Always do a replacement of the annotation here so that
+                        // the defaults calculated above are correctly added to the
+                        // annotation (assuming the annotation is well-formed).
+                        atm.replaceAnnotation(createIntRangeAnnotation(from, to));
                     }
                 } else if (AnnotationUtils.areSameByClass(anno, ArrayLenRange.class)) {
                     int from = AnnotationUtils.getElementValue(anno, "from", Integer.class, true);

--- a/framework/src/org/checkerframework/common/value/qual/IntRange.java
+++ b/framework/src/org/checkerframework/common/value/qual/IntRange.java
@@ -12,7 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * represents the four values 6, 7, 8, and 9.
  *
  * <p>If only one of the {@code to} and {@code from} fields is set, then the other will default to
- * the max/min value of the underlying type of the variable that is annotated.
+ * the max/min value of the underlying type of the variable that is annotated. Note that there must
+ * be "default" values (Long.MIN_VALUE and Long.MAX_VALUE below) even though they will be replaced
+ * in order to prevent javac from issuing warnings when only one of the values is set by a user.
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
@@ -21,7 +23,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 public @interface IntRange {
     /** Smallest value in the range, inclusive */
-    long from();
+    long from() default Long.MIN_VALUE;
     /** Largest value in the range, inclusive */
-    long to();
+    long to() default Long.MAX_VALUE;
 }

--- a/framework/src/org/checkerframework/common/value/qual/IntRange.java
+++ b/framework/src/org/checkerframework/common/value/qual/IntRange.java
@@ -11,6 +11,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * the given range. The bounds are inclusive; for example, {@code @IntRange(from=6, to=9)}
  * represents the four values 6, 7, 8, and 9.
  *
+ * <p>If only one of the {@code to} and {@code from} fields is set, then the other will default to
+ * the max/min value of the underlying type of the variable that is annotated.
+ *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
 @SubtypeOf(UnknownVal.class)

--- a/framework/src/org/checkerframework/common/value/qual/IntRange.java
+++ b/framework/src/org/checkerframework/common/value/qual/IntRange.java
@@ -18,7 +18,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 public @interface IntRange {
     /** Smallest value in the range, inclusive */
-    long from() default Long.MIN_VALUE;
+    long from();
     /** Largest value in the range, inclusive */
-    long to() default Long.MAX_VALUE;
+    long to();
 }

--- a/framework/tests/value/ValueCast.java
+++ b/framework/tests/value/ValueCast.java
@@ -8,4 +8,28 @@ class ValueCast {
     void testShort_plus(@IntRange(from = 0) short x) {
         @IntRange(from = 1, to = Short.MAX_VALUE + 1) int y = x + 1;
     }
+
+    void testIntFrom(@IntRange(from = 0) int x) {
+        @IntRange(from = 0, to = Integer.MAX_VALUE) long y = x;
+    }
+
+    void testShortFrom(@IntRange(from = 0) short x) {
+        @IntRange(from = 0, to = Short.MAX_VALUE) int y = x;
+    }
+
+    void testByteFrom(@IntRange(from = 0) byte x) {
+        @IntRange(from = 0, to = Byte.MAX_VALUE) int y = x;
+    }
+
+    void testIntTo(@IntRange(to = 0) int x) {
+        @IntRange(to = 0, from = Integer.MIN_VALUE) long y = x;
+    }
+
+    void testShortTo(@IntRange(to = 0) short x) {
+        @IntRange(to = 0, from = Short.MIN_VALUE) int y = x;
+    }
+
+    void testByteTo(@IntRange(to = 0) byte x) {
+        @IntRange(to = 0, from = Byte.MIN_VALUE) int y = x;
+    }
 }

--- a/framework/tests/value/ValueCast.java
+++ b/framework/tests/value/ValueCast.java
@@ -1,0 +1,11 @@
+// Test case for issue 1299: https://github.com/typetools/checker-framework/issues/1299
+
+//@skip-test
+
+import org.checkerframework.common.value.qual.*;
+
+class ValueCast {
+    void testShort_plus(@IntRange(from = 0) short x) {
+        @IntRange(from = 1, to = Short.MAX_VALUE + 1) int y = x + 1;
+    }
+}

--- a/framework/tests/value/ValueCast.java
+++ b/framework/tests/value/ValueCast.java
@@ -1,7 +1,5 @@
 // Test case for issue 1299: https://github.com/typetools/checker-framework/issues/1299
 
-//@skip-test
-
 import org.checkerframework.common.value.qual.*;
 
 class ValueCast {


### PR DESCRIPTION
This pull request solves #1299. More generally, this PR makes the defaults for `@IntRange` annotations that have no `to` or `from` field be determined by the underlying type of the variable that the annotation applies to.