### PR TITLE
Dealing with Value Checker integration problems

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/org/checkerframework/common/value/ValueVisitor.java
@@ -1,5 +1,9 @@
 package org.checkerframework.common.value;
 
+/*>>>
+import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
+*/
+
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
@@ -18,6 +22,7 @@ import org.checkerframework.common.value.qual.IntRange;
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.common.value.qual.StringVal;
 import org.checkerframework.framework.source.Result;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.InternalUtils;
 
@@ -126,6 +131,20 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         }
 
         return super.visitAnnotation(node, p);
+    }
+
+    @Override
+    protected void commonAssignmentCheck(
+            AnnotatedTypeMirror varType,
+            ExpressionTree valueExp,
+            /*@CompilerMessageKey*/ String errorKey) {
+
+        // This is definitely a hack. However, it does prevent some spurious warnings
+        // from the Value Checker when interacting with unannotated bytecode.
+        if (varType.toString().contains("@")
+                || varType.getUnderlyingType().toString().contains("@")) {
+            super.commonAssignmentCheck(varType, valueExp, errorKey);
+        }
     }
 
     @Override


### PR DESCRIPTION
@cmackie reported an issue integrating the signedness checker with the value checker yesterday via email - when typechecking code that interacts with unannotated libraries, the value checker issues spurious warnings. I've looked into it, and it seems that the value checker is assigning `@BottomVal` to some code that it shouldn't be. I didn't see why, and what I've got here is an awful hack, but it does resolve the problem. I'd like to know why, but to be honest I don't know why it works. 

@smillst, I'd appreciate your input here. The relevant test (that this "fixes") is `checker/tests/signedness/TestUncheckedByteCode.java`, which fails on lines 8, 13, and 14 because the constants being passed to the function are expected to be `@BottomVal` for some reason. 