### PR TITLE
Return unique values from methods in ValueAnnotatedTypeFactory

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1599,7 +1599,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return null;
         }
         List<Long> list = AnnotationUtils.getElementValueArray(intAnno, "value", Long.class, true);
-        ValueCheckerUtils.removeDuplicates(list);
+        list = ValueCheckerUtils.removeDuplicates(list);
         return list;
     }
 
@@ -1617,7 +1617,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
         List<Double> list =
                 AnnotationUtils.getElementValueArray(doubleAnno, "value", Double.class, true);
-        ValueCheckerUtils.removeDuplicates(list);
+        list = ValueCheckerUtils.removeDuplicates(list);
         return list;
     }
 
@@ -1635,7 +1635,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
         List<Integer> list =
                 AnnotationUtils.getElementValueArray(arrayAnno, "value", Integer.class, true);
-        ValueCheckerUtils.removeDuplicates(list);
+        list = ValueCheckerUtils.removeDuplicates(list);
         return list;
     }
 

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1584,7 +1584,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Returns the set of possible values as a sorted listed with no duplicate values. Returns the
+     * Returns the set of possible values as a sorted list with no duplicate values. Returns the
      * empty list if no values are possible (for dead code). Returns null if any value is possible
      * -- that is, if no estimate can be made -- and this includes when there is no constant-value
      * annotation so the argument is null.
@@ -1604,7 +1604,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Returns the set of possible values as a sorted listed with no duplicate values. Returns the
+     * Returns the set of possible values as a sorted list with no duplicate values. Returns the
      * empty list if no values are possible (for dead code). Returns null if any value is possible
      * -- that is, if no estimate can be made -- and this includes when there is no constant-value
      * annotation so the argument is null.
@@ -1622,9 +1622,9 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Returns the set of possible array lengths as a sorted listed with no duplicate values.
-     * Returns the empty list if no values are possible (for dead code). Returns null if any value
-     * is possible -- that is, if no estimate can be made -- and this includes when there is no
+     * Returns the set of possible array lengths as a sorted list with no duplicate values. Returns
+     * the empty list if no values are possible (for dead code). Returns null if any value is
+     * possible -- that is, if no estimate can be made -- and this includes when there is no
      * constant-value annotation so the argument is null.
      *
      * @param arrayAnno an {@code @ArrayLen} annotation, or null
@@ -1640,7 +1640,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Returns the set of possible values as a sorted listed with no duplicate values. Returns the
+     * Returns the set of possible values as a sorted list with no duplicate values. Returns the
      * empty list if no values are possible (for dead code). Returns null if any value is possible
      * -- that is, if no estimate can be made -- and this includes when there is no constant-value
      * annotation so the argument is null.
@@ -1661,7 +1661,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Returns the set of possible values as a sorted listed with no duplicate values. Returns the
+     * Returns the set of possible values as a sorted list with no duplicate values. Returns the
      * empty list if no values are possible (for dead code). Returns null if any value is possible
      * -- that is, if no estimate can be made -- and this includes when there is no constant-value
      * annotation so the argument is null.


### PR DESCRIPTION
I noticed that in `ValueAnnotatedTypeFactory`, there are cases where the result of `ValueCheckerUtils.removeDuplicates` is ignored, making it a no-op.

This apparently unintended behavior is probably not observable, but the javadoc of `getIntValues`, `getDoubleValues` and `getArrayLength` requires that the returned lists are sorted and have no duplicates.

This change uses the return value of `ValueCheckerUtils.removeDuplicates` to ensure this behavior and fixes a typo in the javadoc describing it.