### PR TITLE
Fix index annotation of Arrays.sort(int[],int,int)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,23 @@ matrix:
 env:
 ## Jobs used when downloading JDK during testing.
 ## all-tests = junit + nonjunit + demos.  Separately, test building the JDK.
-#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=all-tests
-#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=jdk.jar
-#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
-#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
-#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=downstream
-#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
-#  - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
+  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=all-tests
+  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=jdk.jar
+  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
+  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
+  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=downstream
+  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
+  - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
 ## Jobs used when building JDK during testing.
-  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=junit
-  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=nonjunit
-  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=demos
-  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=junit
-  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=nonjunit
-  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=demos
-  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=downstream
-  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=downstream
-  - BUILDJDK=buildjdk JDKVER=jdkany GROUP=misc
+#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=junit
+#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=nonjunit
+#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=demos
+#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=junit
+#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=nonjunit
+#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=demos
+#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=downstream
+#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=downstream
+#  - BUILDJDK=buildjdk JDKVER=jdkany GROUP=misc
 
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,23 +19,23 @@ matrix:
 env:
 ## Jobs used when downloading JDK during testing.
 ## all-tests = junit + nonjunit + demos.  Separately, test building the JDK.
-  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=all-tests
-  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=jdk.jar
-  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
-  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
-  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=downstream
-  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
-  - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
+#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=all-tests
+#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=jdk.jar
+#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
+#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
+#  - BUILDJDK=downloadjdk JDKVER=jdk7 GROUP=downstream
+#  - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
+#  - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
 ## Jobs used when building JDK during testing.
-#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=junit
-#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=nonjunit
-#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=demos
-#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=junit
-#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=nonjunit
-#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=demos
-#  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=downstream
-#  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=downstream
-#  - BUILDJDK=buildjdk JDKVER=jdkany GROUP=misc
+  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=junit
+  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=nonjunit
+  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=demos
+  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=junit
+  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=nonjunit
+  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=demos
+  - BUILDJDK=buildjdk JDKVER=jdk7 GROUP=downstream
+  - BUILDJDK=buildjdk JDKVER=jdk8 GROUP=downstream
+  - BUILDJDK=buildjdk JDKVER=jdkany GROUP=misc
 
 
 before_script:

--- a/checker/jdk/index/src/java/util/Arrays.java
+++ b/checker/jdk/index/src/java/util/Arrays.java
@@ -97,7 +97,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(int[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("1") int toIndex) {
+    public static void sort(int[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }

--- a/checker/tests/index/ArraysSort.java
+++ b/checker/tests/index/ArraysSort.java
@@ -1,0 +1,12 @@
+import java.util.Arrays;
+import org.checkerframework.common.value.qual.MinLen;
+
+class ArraysSort {
+
+    void sortInt(int @MinLen(10) [] nums) {
+        // Checks the correct handling of the toIndex parameter
+        Arrays.sort(nums, 0, 10);
+        //:: error: (argument.type.incompatible)
+        Arrays.sort(nums, 0, 11);
+    }
+}


### PR DESCRIPTION
The index checker annotation of `Arrays.sort(int[],int,int)` has an obvious typo of a missing `#`.

This change adds the missing sign and a test case. (Travis configuration is changed to build the jdk.)