### PR TITLE
Do not replace explicit annotations on casts in Value checker

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -945,11 +945,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         List<?> values = ValueCheckerUtils.getValuesCastedToType(oldAnno, newType);
                         newAnno = createResultingAnnotation(atm.getUnderlyingType(), values);
                     }
-                    atm.replaceAnnotation(newAnno);
+                    atm.addMissingAnnotations(Collections.singleton(newAnno));
                 }
             } else if (atm.getKind() == TypeKind.ARRAY) {
                 if (tree.getExpression().getKind() == Kind.NULL_LITERAL) {
-                    atm.replaceAnnotation(BOTTOMVAL);
+                    atm.addMissingAnnotations(Collections.singleton(BOTTOMVAL));
                 }
             }
             return null;

--- a/framework/tests/value/Basics.java
+++ b/framework/tests/value/Basics.java
@@ -163,6 +163,13 @@ class Basics {
         @IntRange(from = 0, to = 30) int test9 = a;
     }
 
+    public void intCastTest(@IntVal({0, 1}) int input) {
+        @IntVal({0, 1}) int c = (int) input;
+        @IntVal({0, 1}) int ac = (@IntVal({0, 1}) int) input;
+        //:: warning: (cast.unsafe)
+        @IntVal({1}) int uc = (@IntVal({1}) int) input;
+    }
+
     public void IntDoubleTest(
             @IntVal({0, 1}) int iv,
             @IntRange(from = 2, to = 3) int ir,

--- a/framework/tests/value/Basics.java
+++ b/framework/tests/value/Basics.java
@@ -169,6 +169,8 @@ class Basics {
         @IntVal({0, 1, 2}) int sc = (@IntVal({0, 1, 2}) int) input;
         //:: warning: (cast.unsafe)
         @IntVal({1}) int uc = (@IntVal({1}) int) input;
+        //:: warning: (cast.unsafe)
+        @IntVal({2}) int bc = (@IntVal({2}) int) input;
     }
 
     public void IntDoubleTest(

--- a/framework/tests/value/Basics.java
+++ b/framework/tests/value/Basics.java
@@ -166,6 +166,7 @@ class Basics {
     public void intCastTest(@IntVal({0, 1}) int input) {
         @IntVal({0, 1}) int c = (int) input;
         @IntVal({0, 1}) int ac = (@IntVal({0, 1}) int) input;
+        @IntVal({0, 1, 2}) int sc = (@IntVal({0, 1, 2}) int) input;
         //:: warning: (cast.unsafe)
         @IntVal({1}) int uc = (@IntVal({1}) int) input;
     }


### PR DESCRIPTION
Fixes #1333 