### PR TITLE
Don't call super in BaseTypeVisitor#visitNewClass.

### DIFF
--- a/checker/jtreg/tainting/NewClass.java
+++ b/checker/jtreg/tainting/NewClass.java
@@ -1,0 +1,20 @@
+/*
+ * @test
+ * @summary Test for bug where arguments to constructors were visited twice.
+ *
+ * @compile/fail/ref=NewClass.out -XDrawDiagnostics -processor org.checkerframework.checker.tainting.TaintingChecker -AprintErrorStack -Alint NewClass.java
+ */
+
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+public class NewClass {
+    public NewClass(Object param) {}
+
+    Object get(@Untainted Object o) {
+        return o;
+    }
+
+    void test() {
+        NewClass newClass = new NewClass(get(get("")));
+    }
+}

--- a/checker/jtreg/tainting/NewClass.out
+++ b/checker/jtreg/tainting/NewClass.out
@@ -1,0 +1,4 @@
+NewClass.java:18:49: compiler.err.proc.messager: [argument.type.incompatible] incompatible types in argument.
+found   : @Tainted Object
+required: @Untainted Object
+1 error

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1114,8 +1114,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
             checkConstructorInvocation(dt, constructor, node);
         }
+        // Do not call super, as that would observe the arguments without
+        // a set assignment context.
+        scan(node.getEnclosingExpression(), p);
+        scan(node.getIdentifier(), p);
+        scan(node.getClassBody(), p);
 
-        return super.visitNewClass(node, p);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Otherwise, the arguments are visited twice.  (This is what [BaseTypeVisitor#visitMethodInvocation](https://github.com/typetools/checker-framework/blob/master/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java#L939) already does.)