### PR TITLE
Don't apply @StringVal to byte arrays.

### DIFF
--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -62,6 +62,11 @@ Checker gives up and its type becomes
 The \<@ArrayLen> annotation means that at run time, the expression
 evaluates to an array whose length is one of the annotation's arguments.
 
+The \<@StringVal> annotation may be applied to a char array.  Although byte
+arrays are often converted to/from strings, the \<@StringVal> annotation may
+not be applied to them.  This is because the conversion depends on the
+platform's character set.
+
 % \refqualclass{checker/value/qual}{BottomVal}, meaning that the expression
 % is dead or always has the value \<null>.
 

--- a/framework/src/org/checkerframework/common/value/ReflectiveEvaluator.java
+++ b/framework/src/org/checkerframework/common/value/ReflectiveEvaluator.java
@@ -288,7 +288,7 @@ public class ReflectiveEvaluator {
             for (Object[] arguments : listOfArguments) {
                 try {
                     results.add(constructor.newInstance(arguments));
-                } catch (ReflectiveOperationException e) {
+                } catch (Exception e) {
                     if (reportWarnings) {
                         checker.report(Result.warning("constructor.invocation.failed"), tree);
                     }

--- a/framework/src/org/checkerframework/common/value/ReflectiveEvaluator.java
+++ b/framework/src/org/checkerframework/common/value/ReflectiveEvaluator.java
@@ -267,42 +267,48 @@ public class ReflectiveEvaluator {
 
     public List<?> evaluteConstructorCall(
             ArrayList<List<?>> argValues, NewClassTree tree, TypeMirror typeToCreate) {
+        Constructor<?> constructor;
         try {
             // get the constructor
-            Constructor<?> constructor = getConstructorObject(tree, typeToCreate);
-            if (constructor == null) {
-                return null;
-            }
-
-            List<Object[]> listOfArguments;
-            if (argValues == null) {
-                // Method does not have arguments
-                listOfArguments = new ArrayList<Object[]>();
-                listOfArguments.add(null);
-            } else {
-                // Find all possible argument sets
-                listOfArguments = cartesianProduct(argValues, argValues.size() - 1);
-            }
-
-            List<Object> results = new ArrayList<>();
-            for (Object[] arguments : listOfArguments) {
-                try {
-                    results.add(constructor.newInstance(arguments));
-                } catch (Exception e) {
-                    if (reportWarnings) {
-                        checker.report(Result.warning("constructor.invocation.failed"), tree);
-                    }
-                    return null;
-                }
-            }
-            return results;
-
-        } catch (ReflectiveOperationException e) {
+            constructor = getConstructorObject(tree, typeToCreate);
+        } catch (Exception e) {
+            // Catch all exception so that the checker doesn't crash
             if (reportWarnings) {
-                checker.report(Result.warning("constructor.evaluation.failed"), tree);
+                checker.report(Result.warning("constructor.invocation.failed"), tree);
             }
             return null;
         }
+        if (constructor == null) {
+            return null;
+        }
+
+        List<Object[]> listOfArguments;
+        if (argValues == null) {
+            // Method does not have arguments
+            listOfArguments = new ArrayList<Object[]>();
+            listOfArguments.add(null);
+        } else {
+            // Find all possible argument sets
+            listOfArguments = cartesianProduct(argValues, argValues.size() - 1);
+        }
+
+        List<Object> results = new ArrayList<>();
+        for (Object[] arguments : listOfArguments) {
+            try {
+                results.add(constructor.newInstance(arguments));
+            } catch (Exception e) {
+                if (reportWarnings) {
+                    checker.report(
+                            Result.warning(
+                                    "constructor.evaluation.failed",
+                                    typeToCreate,
+                                    PluginUtil.join(", ", arguments)),
+                            tree);
+                }
+                return null;
+            }
+        }
+        return results;
     }
 
     private Constructor<?> getConstructorObject(NewClassTree tree, TypeMirror typeToCreate)

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -122,7 +122,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         backingSet.add("java.lang.Long");
         backingSet.add("short");
         backingSet.add("java.lang.Short");
-        backingSet.add("byte[]");
+        backingSet.add("char[]");
         coveredClassStrings = Collections.unmodifiableSet(backingSet);
     }
 
@@ -752,9 +752,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror newQual;
                 Class<?> clazz = ValueCheckerUtils.getClassFromType(type.getUnderlyingType());
                 String stringVal = null;
-                if (clazz.equals(byte[].class)) {
-                    stringVal = getByteArrayStringVal(initializers);
-                } else if (clazz.equals(char[].class)) {
+                if (clazz.equals(char[].class)) {
                     stringVal = getCharArrayStringVal(initializers);
                 }
 
@@ -872,29 +870,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 componentType = ((AnnotatedArrayType) componentType).getComponentType();
                 i++;
             }
-        }
-
-        /** Convert a byte array to a String. Return null if unable to convert. */
-        private String getByteArrayStringVal(List<? extends ExpressionTree> initializers) {
-            // True iff every element of the array is a literal.
-            boolean allLiterals = true;
-            byte[] bytes = new byte[initializers.size()];
-            for (int i = 0; i < initializers.size(); i++) {
-                ExpressionTree e = initializers.get(i);
-                if (e.getKind() == Tree.Kind.INT_LITERAL) {
-                    bytes[i] = (byte) (((Integer) ((LiteralTree) e).getValue()).intValue());
-                } else if (e.getKind() == Tree.Kind.CHAR_LITERAL) {
-                    bytes[i] = (byte) (((Character) ((LiteralTree) e).getValue()).charValue());
-                } else {
-                    allLiterals = false;
-                }
-            }
-            if (allLiterals) {
-                return new String(bytes);
-            }
-            // If any part of the initializer isn't known,
-            // the stringval isn't known.
-            return null;
         }
 
         /** Convert a char array to a String. Return null if unable to convert. */
@@ -1069,14 +1044,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public Void visitNewClass(NewClassTree tree, AnnotatedTypeMirror type) {
-            boolean wrapperClass =
-                    TypesUtils.isBoxedPrimitive(type.getUnderlyingType())
-                            || TypesUtils.isDeclaredOfName(
-                                    type.getUnderlyingType(), "java.lang.String");
-
-            if (wrapperClass
-                    || (handledByValueChecker(type)
-                            && methodIsStaticallyExecutable(TreeUtils.elementFromUse(tree)))) {
+            if (handledByValueChecker(type)
+                    && methodIsStaticallyExecutable(TreeUtils.elementFromUse(tree))) {
                 // get argument values
                 List<? extends ExpressionTree> arguments = tree.getArguments();
                 ArrayList<List<?>> argValues;
@@ -1206,11 +1175,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 stringVals.add((String) o);
             }
             return createStringAnnotation(stringVals);
-        } else if (ValueCheckerUtils.getClassFromType(resultType) == byte[].class) {
+        } else if (ValueCheckerUtils.getClassFromType(resultType) == char[].class) {
             List<String> stringVals = new ArrayList<>(values.size());
             for (Object o : values) {
-                if (o instanceof byte[]) {
-                    stringVals.add(new String((byte[]) o));
+                if (o instanceof char[]) {
+                    stringVals.add(new String((char[]) o));
                 } else {
                     stringVals.add(o.toString());
                 }

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -202,14 +202,7 @@ public class ValueCheckerUtils {
     private static List<?> convertStringVal(AnnotationMirror anno, Class<?> newClass) {
         List<String> strings =
                 AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
-
-        if (newClass == byte[].class) {
-            List<byte[]> bytes = new ArrayList<>();
-            for (String s : strings) {
-                bytes.add(s.getBytes());
-            }
-            return bytes;
-        } else if (newClass == char[].class) {
+        if (newClass == char[].class) {
             List<char[]> chars = new ArrayList<>();
             for (String s : strings) {
                 chars.add(s.toCharArray());

--- a/framework/src/org/checkerframework/common/value/statically-executable.astub
+++ b/framework/src/org/checkerframework/common/value/statically-executable.astub
@@ -1,21 +1,10 @@
 import org.checkerframework.common.value.qual.*;
 
-package android.util;
-
-class Base64{
-    @StaticallyExecutable static byte[] decode(byte[] input, int offet, int len, int flags);
-    @StaticallyExecutable static byte[] decode(byte[] input, int flags);
-    @StaticallyExecutable static byte[] decode(String input, int flags);
-    @StaticallyExecutable static byte[] encode(byte[] input, int flags);
-    @StaticallyExecutable static byte[] encode(byte[] input, int offset, int len, int flags);
-    @StaticallyExecutable static String encodeToString(byte[] input, int offset, int len, int flags);
-    @StaticallyExecutable static String encodeToString(byte[] input, int flags);
-}
-
-
 package java.lang;
 
 class Boolean{
+    @StaticallyExecutable Boolean(boolean value);
+    @StaticallyExecutable Boolean(String s);
     @StaticallyExecutable boolean booleanValue();
     @StaticallyExecutable static boolean getBoolean(String name);
     @StaticallyExecutable static boolean parseBoolean(String s);
@@ -26,6 +15,9 @@ class Boolean{
 }
 
 class Byte{
+    @StaticallyExecutable Byte(byte value);
+    @StaticallyExecutable Byte(String s);
+
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static Byte decode(String nm);
     @StaticallyExecutable @PolyValue double doubleValue() @PolyValue;
@@ -43,6 +35,8 @@ class Byte{
 }
 
 class Character{
+    @StaticallyExecutable Character(char value);
+
     @StaticallyExecutable static int charCount(int codePoint);
     @StaticallyExecutable char charValue();
     @StaticallyExecutable static int codePointAt(char[] a, int index);
@@ -120,6 +114,9 @@ class Character{
 }
 
 class Double{
+    @StaticallyExecutable Double(double value);
+    @StaticallyExecutable Double(String s);
+
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static int compare(double d1, double d2);
     @StaticallyExecutable static long doubleToLongBits(double value);
@@ -142,6 +139,10 @@ class Double{
     @StaticallyExecutable static Double valueOf(String s);
 }
 class Float{
+    @StaticallyExecutable Float(double value);
+    @StaticallyExecutable Float(float value);
+    @StaticallyExecutable Float(String s);
+
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static int compare(float f1, float f2);
     @StaticallyExecutable @PolyValue double doubleValue() @PolyValue;
@@ -165,6 +166,9 @@ class Float{
 }
 
 class Integer{
+    @StaticallyExecutable Integer(int value);
+    @StaticallyExecutable Integer(String s);
+
     @StaticallyExecutable static int bitCount(int i);
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static Integer decode(String nm);
@@ -199,6 +203,9 @@ class Integer{
 }
 
 class Long{
+    @StaticallyExecutable Long(long value);
+    @StaticallyExecutable Long(String s);
+
     @StaticallyExecutable static int bitCount(long i);
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static Long decode(String nm);
@@ -233,6 +240,9 @@ class Long{
 }
 
 class Short{
+    @StaticallyExecutable Short(short value);
+    @StaticallyExecutable Short(String s);
+
     @StaticallyExecutable @PolyValue byte byteValue() @PolyValue;
     @StaticallyExecutable static Short decode(String nm);
     @StaticallyExecutable @PolyValue double doubleValue() @PolyValue;
@@ -251,6 +261,14 @@ class Short{
 }
 
 class String{
+    @StaticallyExecutable String();
+    @StaticallyExecutable String(String original);
+    @StaticallyExecutable String(StringBuffer buffer);
+    @StaticallyExecutable String(StringBuilder builder);
+    @StaticallyExecutable String(char[] value);
+    @StaticallyExecutable String(char[] value, int offset, int count);
+    @StaticallyExecutable String(int[] codePoints, int offset, int count);
+
     @StaticallyExecutable char charAt(int index);
     @StaticallyExecutable int codePointAt(int index);
     @StaticallyExecutable int codePointBefore(int index);
@@ -267,11 +285,11 @@ class String{
     @StaticallyExecutable boolean equalsIgnoreCase(String anotherString);
     @StaticallyExecutable static String format(Locale l, String format, Object... args);
     @StaticallyExecutable static String format(String format, Object... args);
-    @StaticallyExecutable byte[] getBytes();
-    @StaticallyExecutable byte[] getBytes(Charset charset);
-    @StaticallyExecutable void getBytes(int srcBegin, int srcEnd, byte[] dst, int dstBegin);
-    @StaticallyExecutable byte[] getBytes(String charsetName);
-    @StaticallyExecutable void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin);
+    byte[] getBytes();
+    byte[] getBytes(Charset charset);
+    void getBytes(int srcBegin, int srcEnd, byte[] dst, int dstBegin);
+    byte[] getBytes(String charsetName);
+    void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin);
     @StaticallyExecutable int indexOf(int ch);
     @StaticallyExecutable int indexOf(int ch, int fromIndex);
     @StaticallyExecutable int indexOf(String str);
@@ -291,8 +309,8 @@ class String{
     @StaticallyExecutable String replace(CharSequence target, CharSequence replacement);
     @StaticallyExecutable String replaceAll(String regex, String replacement);
     @StaticallyExecutable String replaceFirst(String regex, String replacement);
-    @StaticallyExecutable String @MinLen(1) [] split(String regex);
-    @StaticallyExecutable String @MinLen(1) [] split(String regex, int limit);
+    String @MinLen(1) [] split(String regex);
+    String @MinLen(1) [] split(String regex, int limit);
     @StaticallyExecutable boolean  startsWith(String prefix);
     @StaticallyExecutable boolean  startsWith(String prefix, int toffset);
     @StaticallyExecutable CharSequence subSequence(int beginIndex, int endIndex);

--- a/framework/tests/value/ArrayInit.java
+++ b/framework/tests/value/ArrayInit.java
@@ -71,7 +71,6 @@ class ArrayInit {
 
     public void initilizer() {
         int @ArrayLen(3) [] ints = new int[] {2, 2, 2};
-        byte @StringVal("d%") [] bytes = new byte[] {100, '%'};
         char @StringVal("-A%") [] chars = new char[] {45, 'A', '%'};
         int @ArrayLen(3) [] ints2 = {2, 2, 2};
     }

--- a/framework/tests/value/StringValOfArrays.java
+++ b/framework/tests/value/StringValOfArrays.java
@@ -1,17 +1,9 @@
 import org.checkerframework.common.value.qual.StringVal;
 
 class StringValOfArrays {
-
-    void bytes() {
-        String s = "hello";
-        byte @StringVal("hello") [] bytes = s.getBytes();
-        @StringVal("hello") String s2 = new String(bytes);
-    }
-
     void chars() {
         String s = "$-hello@";
-        // Not Implemented.
-        //        char @StringVal("$-hello@") [] chars = s.toCharArray();
-        //        @StringVal("$-hello@") String s2 = new String(chars);
+        char @StringVal("$-hello@") [] chars = s.toCharArray();
+        @StringVal("$-hello@") String s2 = new String(chars);
     }
 }


### PR DESCRIPTION
Also, several methods that use byte or char arrays are no longer statically executable, so was updated statically-executable.astub. All constructors of a primitive wrapper or String were hard coded as statically-executable, but now some of the String constructors are not.

@panacekcz is implementing treating `@StringVal("abc")` as a subtype of `@ArrayLen(3)`.

(This is a follow up to PR #1322 which removed `@StringVal` from both byte and char arrays.)  
