### PR TITLE
Add new instructions for configuring Android.

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -562,16 +562,20 @@ allprojects {
 
 \section{Android Studio 3.0 and the Android Gradle Plugin 3.0\label{android-gradle}}
 
-Android Studio 3.0 and Android Gradle Plugin 3.0.0 support type annotations.
-(See \url{https://developer.android.com/studio/preview/features/java8-support.html} for more details.)
-This section explains how to configure your Andriod project to use the Checker Framework.  All the changes should be made to the module's build.gradle file -- not the app's build.gradle file.
+Android Studio 3.0 and Android Gradle Plugin 3.0.0 support type
+annotations.  (See
+\url{https://developer.android.com/studio/preview/features/java8-support.html}
+for more details.)  This section explains how to configure your Andriod
+project to use the Checker Framework.  All the changes should be made to
+the module's \<build.gradle> file --- not the app's \<build.gradle> file.
 
 \begin{enumerate}
 
-\item In your module's build.gradle file, set the source and target compatiblity to \<JavaVersion.VERSION\_1\_8>
+\item In your module's \<build.gradle> file, set the source and target
+  compatiblity to \<JavaVersion.VERSION\_1\_8>
 
- \begin{Verbatim}
- android {
+\begin{Verbatim}
+android {
     ...
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -580,7 +584,7 @@ This section explains how to configure your Andriod project to use the Checker F
 }
 \end{Verbatim}
 
-\item Add a build variant for running checkers. (in your module's build.gradle file)
+\item Add a build variant for running checkers.
 
  \begin{Verbatim}
  android {
@@ -590,14 +594,14 @@ This section explains how to configure your Andriod project to use the Checker F
         checkTypes {
             javaCompileOptions.annotationProcessorOptions.
                     classNames.add("org.checkerframework.checker.nullness.NullnessChecker")
-            // You can pass options like so
+            // You can pass options like so:
             // javaCompileOptions.annotationProcessorOptions.arguments.put("warns", "")
         }
     }
 }
 \end{Verbatim}
 
-\item Add a dependency configurations for the annotated JDK:
+\item Add a dependency configuration for the annotated JDK:
 
 \begin{mysmall}
 \begin{Verbatim}
@@ -624,7 +628,7 @@ dependencies {
 \end{Verbatim}
 \end{mysmall}
 
-\item Direct all tasks of type \<JavaCompile> used by the CheckTypes build variant to use the annotated jdk.
+\item Direct all tasks of type \<JavaCompile> used by the CheckTypes build variant to use the annotated JDK.
 \begin{mysmall}
 \begin{Verbatim}
 gradle.projectsEvaluated {

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -11,7 +11,7 @@ build system, or from an IDE\@.  You can skip to the appropriate section:
 \item Ant (Section~\ref{ant-task})
 \item Maven (Section~\ref{maven})
 \item Gradle (Section~\ref{gradle})
-\item Android plugin for Gradle (Section~\ref{android-gradle})
+\item Android Gradle Plugin(Section~\ref{android-gradle})
 \item IntelliJ IDEA (Section~\ref{intellij})
 \item Eclipse (Section~\ref{eclipse})
 \item tIDE (Section~\ref{tide})
@@ -708,15 +708,6 @@ It is necessary to manually inform the IDE via a plugin if an annotation
 system adds any dependencies beyond those that normally exist in Java.
 For information about the extension points, see
 \url{https://youtrack.jetbrains.com/issue/IDEA-159286}.
-
-
-\subsection{Android Studio\label{android-studio}}
-
-Some people have reported success running the Checker Framework with
-Android Studio, but others have had trouble.  We do not currently have
-instructions for using the Checker Framework with Android Studio.  If you
-are able to contribute such instructions, please do so.
-
 
 \section{Eclipse\label{eclipse}}
 

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -560,7 +560,7 @@ allprojects {
 \end{mysmall}
 \end{enumerate}
 
-\section{Android Studio 3.0 and the Android Gradle Plugin 3.0}
+\section{Android Studio 3.0 and the Android Gradle Plugin 3.0\label{android-gradle}}
 
 Android Studio 3.0 and Android Gradle Plugin 3.0.0 support type annotations.
 (See \url{https://developer.android.com/studio/preview/features/java8-support.html} for more details.)

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -560,43 +560,53 @@ allprojects {
 \end{mysmall}
 \end{enumerate}
 
-\section{Android plugin for Gradle\label{android-gradle}}
+\section{Android Studio 3.0 and the Android Gradle Plugin 3.0}
 
-If you use the
-\href{https://developer.android.com/studio/build/index.html}{Android plugin for Gradle},
-then you can run a checker by following the instructions below.
-
-These instructions can be used with Java 7 or Java 8.  Because Android does not
-support type annotations, they must be placed in comments as explained in
-Section~\ref{annotations-in-comments}.
+Android Studio 3.0 and Android Gradle Plugin 3.0.0 support type annotations.
+(See \url{https://developer.android.com/studio/preview/features/java8-support.html} for more details.)
+This section explains how to configure your Andriod project to use the Checker Framework.  All the changes should be made to the module's build.gradle file -- not the app's build.gradle file.
 
 \begin{enumerate}
 
-\item Use the Maven Central repository:
+\item In your module's build.gradle file, set the source and target compatiblity to \<JavaVersion.VERSION\_1\_8>
 
-\begin{Verbatim}
-repositories {
-  ... existing repositories...
-  mavenCentral()
+ \begin{Verbatim}
+ android {
+    ...
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 \end{Verbatim}
 
-\item Add dependency configurations for the annotated JDK, \<checker.jar>, and the Type Annotations compiler:
+\item Add a build variant for running checkers. (in your module's build.gradle file)
+
+ \begin{Verbatim}
+ android {
+    ...
+      buildTypes {
+      ...
+        checkTypes {
+            javaCompileOptions.annotationProcessorOptions.
+                    classNames.add("org.checkerframework.checker.nullness.NullnessChecker")
+            // You can pass options like so
+            // javaCompileOptions.annotationProcessorOptions.arguments.put("warns", "")
+        }
+    }
+}
+\end{Verbatim}
+
+\item Add a dependency configurations for the annotated JDK:
 
 \begin{mysmall}
 \begin{Verbatim}
 configurations {
-    ... existing configurations ...
-    checkerFrameworkJavac {
-        description = 'a customization of the OpenJDK javac compiler with additional support for type annotations'
-    }
     checkerFrameworkAnnotatedJDK {
-       description = 'a copy of JDK classes with Checker Framework type qualifers inserted'
-    }
-    checkerFramework {
-       description = 'The Checker Framework: custom pluggable types for Java'
+        description = 'a copy of JDK classes with Checker Framework type qualifers inserted'
     }
 }
+
 \end{Verbatim}
 \end{mysmall}
 
@@ -607,50 +617,34 @@ configurations {
 dependencies {
     ... existing dependencies...
     ext.checkerFrameworkVersion = '2.1.12'
-    ext.jdkVersion = JavaVersion.current().isJava7() ? 'jdk7' : 'jdk8'
-    checkerFrameworkAnnotatedJDK "org.checkerframework:${jdkVersion}:${checkerFrameworkVersion}"
-    checkerFrameworkJavac "org.checkerframework:compiler:${checkerFrameworkVersion}"
-    checkerFramework "org.checkerframework:checker:${checkerFrameworkVersion}"
-    compile "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
+    implementation "org.checkerframework:checker-qual:${checkerFrameworkVersion}"
+    annotationProcessor "org.checkerframework:checker:${checkerFrameworkVersion}"
+    checkerFrameworkAnnotatedJDK "org.checkerframework:jdk8:${checkerFrameworkVersion}"
 }
 \end{Verbatim}
 \end{mysmall}
 
-\item Direct all tasks of type \<JavaCompile> to use the desired checkers, when the \<typecheck> project property is set:
-
+\item Direct all tasks of type \<JavaCompile> used by the CheckTypes build variant to use the annotated jdk.
 \begin{mysmall}
 \begin{Verbatim}
-def typecheck = project.properties['typecheck'] ?: false
-allprojects {
-if (typecheck) {
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile).all { JavaCompile compile ->
-        compile.options.compilerArgs = [
-                '-processor', 'org.checkerframework.checker.nullness.NullnessChecker',
-                '-processorpath', "${configurations.checkerFramework.asPath}",
-                // uncomment to turn Checker Framework errors into warnings
-                //'-Awarns',
-                "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}"
-        ]
-            compile.options.compilerArgs += ['-source', '7', '-target', '7']
-            options.bootClasspath = System.getProperty("sun.boot.class.path") + ":" + options.bootClasspath
-            options.bootClasspath = "${configurations.checkerFrameworkJavac.asPath}:" + ":" + options.bootClasspath
-            options.fork = true
-            options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.checkerFrameworkJavac.asPath}"]
+gradle.projectsEvaluated {
+    tasks.withType(JavaCompile).all { compile ->
+        if (compile.name.contains("CheckTypes")) {
+            compile.options.compilerArgs += [
+                    "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}"
+            ]
         }
     }
 }
-}
 \end{Verbatim}
 \end{mysmall}
 
-\item Run the checkers:
-
+\item To run the checkers, build using the checkTypes variant.
 \begin{Verbatim}
-gradle compileReleaseJavaWithJavac -Ptypecheck=true
+gradlew checkTypes
 \end{Verbatim}
-\end{enumerate}
 
+\end{enumerate}
 
 \section{IntelliJ IDEA\label{intellij}}
 


### PR DESCRIPTION
Now that Android supports type annotations (https://developer.android.com/studio/preview/features/java8-support.html), change the instructions to use the standard Java 8 compiler.