### PR TITLE
Fix NPE in visualizataion CFG of varargs method invocation

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -120,6 +120,11 @@ public class AnalysisResult<A extends AbstractValue<A>, S extends Store<S>> {
         if (node == null) {
             return null;
         }
+        return getStoreAfter(node);
+    }
+
+    /** @return the store immediately after a given {@link Node}. */
+    public S getStoreAfter(Node node) {
         return runAnalysisFor(node, false);
     }
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -396,7 +396,7 @@ public class DOTCFGVisualizer<
                 this.sbStore.setLength(0);
                 this.sbStore.append("\\n~~~~~~~~~\\n");
                 this.sbStore.append("After:");
-                visualizeStore(analysis.getResult().getStoreAfter(lastNode.getTree()));
+                visualizeStore(analysis.getResult().getStoreAfter(lastNode));
                 this.sbBlock.append(this.sbStore);
             }
         }

--- a/framework/jtreg/DOTCFGVisualizerForVarargsTest.java
+++ b/framework/jtreg/DOTCFGVisualizerForVarargsTest.java
@@ -1,0 +1,21 @@
+/*
+ * @test
+ * @summary Test the DOTCFGVisualizer doesn't crash for varargs method invocation.
+ *
+ * @compile -Aflowdotdir=. -Averbosecfg  -processor org.checkerframework.common.value.ValueChecker DOTCFGVisualizerForVarargsTest.java -AprintErrorStack
+ */
+
+class DOTCFGVisualizerForVarargsTest {
+
+    public DOTCFGVisualizerForVarargsTest(Object... objs) {}
+
+    public static void method(Object... objs) {}
+
+    public void call() {
+        new DOTCFGVisualizerForVarargsTest();
+        new DOTCFGVisualizerForVarargsTest(1, 2);
+
+        method();
+        method("", null);
+    }
+}


### PR DESCRIPTION
When the last node of a block doesn't have tree, DOTCFGVisualizer throws NPE if it's verbose mode.
Especially visualize varargs call is always failed.