### PR TITLE
Add Index Checker test to Value Checker's ignore overflow mode

### DIFF
--- a/framework/tests/value-ignore-range-overflow/Index117.java
+++ b/framework/tests/value-ignore-range-overflow/Index117.java
@@ -1,0 +1,11 @@
+import org.checkerframework.common.value.qual.*;
+
+public class Index117 {
+
+    public static void foo(boolean includeIndex, String[] roots) {
+        @IntRange(from = 2, to = Integer.MAX_VALUE) int x = (includeIndex ? 2 : 1) * roots.length + 2;
+        @IntRange(from = 2, to = Integer.MAX_VALUE) int y = 2 * roots.length + 2;
+        @IntRange(from = 2, to = Integer.MAX_VALUE) int z = roots.length + 2;
+        @IntRange(from = 2, to = 2) int w = 0 + 2;
+    }
+}


### PR DESCRIPTION
This test comes from kelloggm#117. That issue describes some code that can be type checked with ignore-overflow mode in the Value Checker, but cannot be type checked without it. So, I created a Value Checker test case. This should be mergable immediately once tests pass, and should close kelloggm#117.