### PR TITLE
Use TypeAnnotationUtils.unannotatedType instead of Type.unannotatedType;

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -39,6 +39,7 @@ import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -678,15 +679,14 @@ public class FlowExpressions {
             LocalVariable other = (LocalVariable) obj;
             VarSymbol vs = (VarSymbol) element;
             VarSymbol vsother = (VarSymbol) other.element;
-            // Use type.unannotatedType().toString().equals(...) instead of Types.isSameType(...)
+            // Use TypeAnnotationUtils.unannotatedType(type).toString().equals(...) instead of Types.isSameType(...)
             // because Types requires a processing environment, and FlowExpressions is
             // designed to be independent of processing environment.  See also
             // calls to getType().toString() in FlowExpressions.
             return vsother.name.contentEquals(vs.name)
-                    && vsother.type
-                            .unannotatedType()
+                    && TypeAnnotationUtils.unannotatedType(vsother.type)
                             .toString()
-                            .equals(vs.type.unannotatedType().toString())
+                            .equals(TypeAnnotationUtils.unannotatedType(vs.type).toString())
                     && vsother.owner.toString().equals(vs.owner.toString());
         }
 
@@ -698,7 +698,9 @@ public class FlowExpressions {
         public int hashCode() {
             VarSymbol vs = (VarSymbol) element;
             return HashCodeUtils.hash(
-                    vs.name.toString(), vs.type.unannotatedType().toString(), vs.owner.toString());
+                    vs.name.toString(),
+                    TypeAnnotationUtils.unannotatedType(vs.type).toString(),
+                    vs.owner.toString());
         }
 
         @Override

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -54,6 +54,7 @@ import org.checkerframework.framework.util.typeinference.solver.SupertypesSolver
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -737,7 +738,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
 
         for (AnnotatedTypeVariable atv : methodType.getTypeVariables()) {
             final TypeVariable typeVar = atv.getUnderlyingType();
-            if (targets.contains(typeVar)) {
+            if (targets.contains(TypeAnnotationUtils.unannotatedType(typeVar))) {
                 final AnnotatedTypeMirror inferredType = inferredArgs.get(typeVar);
                 if (inferredType == null) {
                     AnnotatedTypeMirror dummy = typeFactory.getUninferredWildcardType(atv);

--- a/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -45,6 +45,7 @@ import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /** Miscellaneous utilities to help in type argument inference. */
@@ -97,7 +98,8 @@ public class TypeArgInferenceUtil {
     public static boolean isATarget(
             final AnnotatedTypeMirror type, final Set<TypeVariable> targetTypeVars) {
         return type.getKind() == TypeKind.TYPEVAR
-                && targetTypeVars.contains(type.getUnderlyingType());
+                && targetTypeVars.contains(
+                        TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()));
     }
 
     /**
@@ -109,7 +111,8 @@ public class TypeArgInferenceUtil {
         final Set<TypeVariable> targets = new LinkedHashSet<>(annotatedTypeVars.size());
 
         for (final AnnotatedTypeVariable atv : annotatedTypeVars) {
-            targets.add(atv.getUnderlyingType());
+            targets.add(
+                    (TypeVariable) TypeAnnotationUtils.unannotatedType(atv.getUnderlyingType()));
         }
 
         return targets;
@@ -319,7 +322,10 @@ public class TypeArgInferenceUtil {
         final List<TypeVariable> typeVars = new ArrayList<>(annotatedTypeVars.size());
 
         for (AnnotatedTypeVariable annotatedTypeVar : annotatedTypeVars) {
-            typeVars.add(annotatedTypeVar.getUnderlyingType());
+            typeVars.add(
+                    (TypeVariable)
+                            TypeAnnotationUtils.unannotatedType(
+                                    annotatedTypeVar.getUnderlyingType()));
         }
 
         // note NULL values creep in because the underlying visitor uses them in various places
@@ -378,7 +384,7 @@ public class TypeArgInferenceUtil {
 
         @Override
         public Boolean visitTypeVariable(AnnotatedTypeVariable type, List<TypeVariable> typeVars) {
-            if (typeVars.contains(type.getUnderlyingType())) {
+            if (typeVars.contains(TypeAnnotationUtils.unannotatedType(type.getUnderlyingType()))) {
                 return true;
             } else {
                 return super.visitTypeVariable(type, typeVars);
@@ -421,7 +427,9 @@ public class TypeArgInferenceUtil {
     public static AnnotatedTypeMirror substitute(
             Map<TypeVariable, AnnotatedTypeMirror> substitutions,
             final AnnotatedTypeMirror toModify) {
-        final AnnotatedTypeMirror substitution = substitutions.get(toModify.getUnderlyingType());
+        final AnnotatedTypeMirror substitution =
+                substitutions.get(
+                        TypeAnnotationUtils.unannotatedType(toModify.getUnderlyingType()));
         if (substitution != null) {
             return substitution.deepCopy();
         }

--- a/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMapBuilder.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/solver/ConstraintMapBuilder.java
@@ -12,6 +12,7 @@ import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.typeinference.constraint.TIsU;
 import org.checkerframework.framework.util.typeinference.constraint.TSuperU;
 import org.checkerframework.framework.util.typeinference.constraint.TUConstraint;
+import org.checkerframework.javacutil.TypeAnnotationUtils;
 
 /** Converts a set of TUConstraints into a ConstraintMap. */
 public class ConstraintMapBuilder {
@@ -68,7 +69,8 @@ public class ConstraintMapBuilder {
             final AnnotatedTypeMirror typeU = constraint.relatedType;
 
             if (typeU.getKind() == TypeKind.TYPEVAR
-                    && targets.contains(typeU.getUnderlyingType())) {
+                    && targets.contains(
+                            TypeAnnotationUtils.unannotatedType(typeU.getUnderlyingType()))) {
                 if (typeT.getAnnotations().isEmpty() && typeU.getAnnotations().isEmpty()) {
                     hierarchiesInRelation.addAll(tops);
 
@@ -102,7 +104,9 @@ public class ConstraintMapBuilder {
                     // This case also covers the case where i = j
                     if (!tAnnos.isEmpty()) {
                         addToPrimaryRelationship(
-                                typeT.getUnderlyingType(),
+                                (TypeVariable)
+                                        TypeAnnotationUtils.unannotatedType(
+                                                typeT.getUnderlyingType()),
                                 constraint,
                                 result,
                                 tAnnos,
@@ -111,7 +115,9 @@ public class ConstraintMapBuilder {
 
                     if (!uAnnos.isEmpty()) {
                         addToPrimaryRelationship(
-                                (TypeVariable) typeU.getUnderlyingType(),
+                                (TypeVariable)
+                                        TypeAnnotationUtils.unannotatedType(
+                                                typeU.getUnderlyingType()),
                                 constraint,
                                 result,
                                 uAnnos,
@@ -120,10 +126,13 @@ public class ConstraintMapBuilder {
                 }
 
                 // This is the case where we have a relationship between two different targets (Ti <?> Tj and i != j)
-                if (!typeT.getUnderlyingType().equals(typeU.getUnderlyingType())) {
+                if (!TypeAnnotationUtils.unannotatedType(typeT.getUnderlyingType())
+                        .equals(TypeAnnotationUtils.unannotatedType(typeU.getUnderlyingType()))) {
                     addToTargetRelationship(
-                            typeT.getUnderlyingType(),
-                            (TypeVariable) typeU.getUnderlyingType(),
+                            (TypeVariable)
+                                    TypeAnnotationUtils.unannotatedType(typeT.getUnderlyingType()),
+                            (TypeVariable)
+                                    TypeAnnotationUtils.unannotatedType(typeU.getUnderlyingType()),
                             result,
                             constraint,
                             hierarchiesInRelation);
@@ -138,7 +147,8 @@ public class ConstraintMapBuilder {
                 }
 
                 addToTypeRelationship(
-                        typeT.getUnderlyingType(),
+                        (TypeVariable)
+                                TypeAnnotationUtils.unannotatedType(typeT.getUnderlyingType()),
                         typeU,
                         result,
                         constraint,

--- a/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
@@ -236,13 +236,13 @@ public class InternalUtils {
 
     /** Returns whether a TypeVariable represents a captured type. */
     public static boolean isCaptured(TypeVariable typeVar) {
-        return ((Type.TypeVar) ((Type) typeVar).unannotatedType()).isCaptured();
+        return ((Type.TypeVar) TypeAnnotationUtils.unannotatedType(typeVar)).isCaptured();
     }
 
     /** If typeVar is a captured wildcard, returns that wildcard; otherwise returns null. */
     public static WildcardType getCapturedWildcard(TypeVariable typeVar) {
         if (isCaptured(typeVar)) {
-            return ((CapturedType) ((Type) typeVar).unannotatedType()).wildcard;
+            return ((CapturedType) TypeAnnotationUtils.unannotatedType(typeVar)).wildcard;
         }
         return null;
     }
@@ -266,8 +266,8 @@ public class InternalUtils {
      */
     public static TypeMirror leastUpperBound(
             ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
-        Type t1 = ((Type) tm1).unannotatedType();
-        Type t2 = ((Type) tm2).unannotatedType();
+        Type t1 = TypeAnnotationUtils.unannotatedType(tm1);
+        Type t2 = TypeAnnotationUtils.unannotatedType(tm2);
         JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
         Types types = Types.instance(javacEnv.getContext());
         if (types.isSameType(t1, t2)) {
@@ -328,8 +328,8 @@ public class InternalUtils {
      */
     public static TypeMirror greatestLowerBound(
             ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
-        Type t1 = ((Type) tm1).unannotatedType();
-        Type t2 = ((Type) tm2).unannotatedType();
+        Type t1 = TypeAnnotationUtils.unannotatedType(tm1);
+        Type t2 = TypeAnnotationUtils.unannotatedType(tm2);
         JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
         Types types = Types.instance(javacEnv.getContext());
         if (types.isSameType(t1, t2)) {
@@ -379,7 +379,7 @@ public class InternalUtils {
             return methodType;
         }
         // TODO: find a nicer way to substitute type variables
-        String t = methodType.toString();
+        String t = TypeAnnotationUtils.unannotatedType(methodType).toString();
         Type finalReceiverType = (Type) substitutedReceiverType;
         int i = 0;
         for (TypeSymbol typeParam : finalReceiverType.tsym.getTypeParameters()) {

--- a/javacutil/src/org/checkerframework/javacutil/TypeAnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TypeAnnotationUtils.java
@@ -12,7 +12,9 @@ import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Name;
 import com.sun.tools.javac.util.Pair;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Map;
@@ -305,13 +307,7 @@ public class TypeAnnotationUtils {
      */
     private static <RET> RET call8or9(Call8or9<RET> tc) {
         try {
-            boolean hasNine;
-            try {
-                hasNine = SourceVersion.valueOf("RELEASE_9") != null;
-            } catch (IllegalArgumentException iae) {
-                hasNine = false;
-            }
-            if (hasNine) {
+            if (hasReleaseNine) {
                 return tc.call9();
             } else {
                 boolean hasEight;
@@ -334,6 +330,251 @@ public class TypeAnnotationUtils {
         }
     }
 
+    private static final boolean hasReleaseNine;
+
+    private static final Object TAP_field_emptyPath_value;
+    private static final TypeAnnotationPosition TAP_field_unknown_value;
+
+    private static final Field TAP_field_bound_index;
+    private static final Field TAP_field_parameter_index;
+    private static final Field TAP_field_pos;
+    private static final Field TAP_field_type;
+    private static final Field TAP_field_type_index;
+
+    private static final Method TAP_meth_classExtends;
+    private static final Method TAP_meth_copy;
+    private static final Method TAP_meth_field;
+    private static final Method TAP_meth_methodParameter;
+    private static final Method TAP_meth_methodReceiver;
+    private static final Method TAP_meth_methodReturn;
+    private static final Method TAP_meth_methodThrows;
+    private static final Method TAP_meth_methodTypeParameter;
+    private static final Method TAP_meth_methodTypeParameterBound;
+    private static final Method TAP_meth_typeParameter;
+    private static final Method TAP_meth_typeParameterBound;
+
+    static {
+        boolean hasNine;
+        try {
+            hasNine = SourceVersion.valueOf("RELEASE_9") != null;
+        } catch (IllegalArgumentException iae) {
+            hasNine = false;
+        }
+        hasReleaseNine = hasNine;
+
+        if (hasReleaseNine) {
+            Object otmp;
+            try {
+                otmp = TypeAnnotationPosition.class.getField("emptyPath").get(null);
+            } catch (Throwable t) {
+                otmp = null;
+            }
+            TAP_field_emptyPath_value = otmp;
+
+            TypeAnnotationPosition taptmp;
+            try {
+                taptmp =
+                        (TypeAnnotationPosition)
+                                TypeAnnotationPosition.class.getField("unknown").get(null);
+            } catch (Throwable t) {
+                taptmp = null;
+            }
+            TAP_field_unknown_value = taptmp;
+
+            Method methodtmp;
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "classExtends", int.class, int.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_classExtends = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "copy", TypeAnnotationPosition.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_copy = methodtmp;
+
+            try {
+                methodtmp = TypeAnnotationPosition.class.getMethod("field", int.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_field = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "methodParameter", int.class, int.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodParameter = methodtmp;
+
+            try {
+                methodtmp = TypeAnnotationPosition.class.getMethod("methodReceiver", int.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodReceiver = methodtmp;
+
+            try {
+                methodtmp = TypeAnnotationPosition.class.getMethod("methodReturn", int.class);
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodReturn = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "methodThrows", List.class, JCLambda.class, int.class, int.class);
+
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodThrows = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "methodTypeParameter",
+                                List.class,
+                                JCLambda.class,
+                                int.class,
+                                int.class);
+
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodTypeParameter = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "methodTypeParameterBound",
+                                List.class,
+                                JCLambda.class,
+                                int.class,
+                                int.class,
+                                int.class);
+
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_methodTypeParameterBound = methodtmp;
+
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "typeParameter", List.class, JCLambda.class, int.class, int.class);
+
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_typeParameter = methodtmp;
+            try {
+                methodtmp =
+                        TypeAnnotationPosition.class.getMethod(
+                                "typeParameterBound",
+                                List.class,
+                                JCLambda.class,
+                                int.class,
+                                int.class,
+                                int.class);
+
+            } catch (Throwable t) {
+                methodtmp = null;
+            }
+            TAP_meth_typeParameterBound = methodtmp;
+
+            TAP_field_bound_index = null;
+            TAP_field_parameter_index = null;
+            TAP_field_pos = null;
+            TAP_field_type = null;
+            TAP_field_type_index = null;
+
+        } else {
+            Field fieldtmp;
+            try {
+                fieldtmp = TypeAnnotationPosition.class.getField("bound_index");
+            } catch (Throwable t) {
+                fieldtmp = null;
+            }
+            TAP_field_bound_index = fieldtmp;
+
+            try {
+                fieldtmp = TypeAnnotationPosition.class.getField("parameter_index");
+            } catch (Throwable t) {
+                fieldtmp = null;
+            }
+            TAP_field_parameter_index = fieldtmp;
+
+            try {
+                fieldtmp = TypeAnnotationPosition.class.getField("pos");
+            } catch (Throwable t) {
+                fieldtmp = null;
+            }
+            TAP_field_pos = fieldtmp;
+
+            try {
+                fieldtmp = TypeAnnotationPosition.class.getField("type");
+            } catch (Throwable t) {
+                fieldtmp = null;
+            }
+            TAP_field_type = fieldtmp;
+
+            try {
+                fieldtmp = TypeAnnotationPosition.class.getField("type_index");
+            } catch (Throwable t) {
+                fieldtmp = null;
+            }
+            TAP_field_type_index = fieldtmp;
+
+            TAP_field_emptyPath_value = null;
+            TAP_field_unknown_value = null;
+
+            TAP_meth_classExtends = null;
+            TAP_meth_copy = null;
+            TAP_meth_field = null;
+            TAP_meth_methodParameter = null;
+            TAP_meth_methodReceiver = null;
+            TAP_meth_methodReturn = null;
+            TAP_meth_methodThrows = null;
+            TAP_meth_methodTypeParameter = null;
+            TAP_meth_methodTypeParameterBound = null;
+            TAP_meth_typeParameter = null;
+            TAP_meth_typeParameterBound = null;
+        }
+        /*
+        TAP_field_emptyPath_value = null;
+        TAP_field_unknown_value = null;
+
+        TAP_field_bound_index = null;
+        TAP_field_parameter_index = null;
+        TAP_field_pos = null;
+        TAP_field_type = null;
+        TAP_field_type_index = null;
+
+        TAP_meth_classExtends = null;
+        TAP_meth_copy = null;
+        TAP_meth_field = null;
+        TAP_meth_methodParameter = null;
+        TAP_meth_methodReceiver = null;
+        TAP_meth_methodReturn = null;
+        TAP_meth_methodThrows = null;
+        TAP_meth_methodTypeParameter = null;
+        TAP_meth_methodTypeParameterBound = null;
+        TAP_meth_typeParameter = null;
+        TAP_meth_typeParameterBound = null;
+        */
+    }
+
     public static TypeAnnotationPosition unknownTAPosition() {
         return call8or9(
                 new Call8or9<TypeAnnotationPosition>() {
@@ -347,8 +588,7 @@ public class TypeAnnotationUtils {
                     public TypeAnnotationPosition call9()
                             throws IllegalArgumentException, IllegalAccessException,
                                     NoSuchFieldException, SecurityException {
-                        return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class.getField("unknown").get(null);
+                        return TAP_field_unknown_value;
                     }
                 });
     }
@@ -362,10 +602,8 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.METHOD_RETURN);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.METHOD_RETURN);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -374,10 +612,7 @@ public class TypeAnnotationUtils {
                             throws IllegalAccessException, IllegalArgumentException,
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
-                        return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("methodReturn", int.class)
-                                        .invoke(null, pos);
+                        return (TypeAnnotationPosition) TAP_meth_methodReturn.invoke(null, pos);
                     }
                 });
     }
@@ -391,10 +626,8 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.METHOD_RECEIVER);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.METHOD_RECEIVER);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -403,10 +636,7 @@ public class TypeAnnotationUtils {
                             throws IllegalAccessException, IllegalArgumentException,
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
-                        return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("methodReceiver", int.class)
-                                        .invoke(null, pos);
+                        return (TypeAnnotationPosition) TAP_meth_methodReceiver.invoke(null, pos);
                     }
                 });
     }
@@ -420,11 +650,9 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.METHOD_FORMAL_PARAMETER);
-                        TypeAnnotationPosition.class.getField("parameter_index").set(tapos, pidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.METHOD_FORMAL_PARAMETER);
+                        TAP_field_parameter_index.set(tapos, pidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -434,9 +662,7 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("methodParameter", int.class, int.class)
-                                        .invoke(null, pidx, pos);
+                                TAP_meth_methodParameter.invoke(null, pidx, pos);
                     }
                 });
     }
@@ -450,9 +676,9 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class.getField("type").set(tapos, TargetType.THROWS);
-                        TypeAnnotationPosition.class.getField("type_index").set(tapos, tidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.THROWS);
+                        TAP_field_type_index.set(tapos, tidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -462,21 +688,8 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException, NoSuchFieldException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod(
-                                                "methodThrows",
-                                                List.class,
-                                                JCLambda.class,
-                                                int.class,
-                                                int.class)
-                                        .invoke(
-                                                null,
-                                                TypeAnnotationPosition.class
-                                                        .getField("emptyPath")
-                                                        .get(null),
-                                                null,
-                                                tidx,
-                                                pos);
+                                TAP_meth_methodThrows.invoke(
+                                        null, TAP_field_emptyPath_value, null, tidx, pos);
                     }
                 });
     }
@@ -490,8 +703,8 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class.getField("type").set(tapos, TargetType.FIELD);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.FIELD);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -500,10 +713,7 @@ public class TypeAnnotationUtils {
                             throws IllegalAccessException, IllegalArgumentException,
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
-                        return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("field", int.class)
-                                        .invoke(null, pos);
+                        return (TypeAnnotationPosition) TAP_meth_field.invoke(null, pos);
                     }
                 });
     }
@@ -517,11 +727,9 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.CLASS_EXTENDS);
-                        TypeAnnotationPosition.class.getField("type_index").set(tapos, implidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.CLASS_EXTENDS);
+                        TAP_field_type_index.set(tapos, implidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -531,9 +739,7 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("classExtends", int.class, int.class)
-                                        .invoke(null, implidx, pos);
+                                TAP_meth_classExtends.invoke(null, implidx, pos);
                     }
                 });
     }
@@ -547,11 +753,9 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.CLASS_TYPE_PARAMETER);
-                        TypeAnnotationPosition.class.getField("parameter_index").set(tapos, tpidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.CLASS_TYPE_PARAMETER);
+                        TAP_field_parameter_index.set(tapos, tpidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -561,21 +765,8 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException, NoSuchFieldException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod(
-                                                "typeParameter",
-                                                List.class,
-                                                JCLambda.class,
-                                                int.class,
-                                                int.class)
-                                        .invoke(
-                                                null,
-                                                TypeAnnotationPosition.class
-                                                        .getField("emptyPath")
-                                                        .get(null),
-                                                null,
-                                                tpidx,
-                                                pos);
+                                TAP_meth_typeParameter.invoke(
+                                        null, TAP_field_emptyPath_value, null, tpidx, pos);
                     }
                 });
     }
@@ -590,11 +781,9 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.METHOD_TYPE_PARAMETER);
-                        TypeAnnotationPosition.class.getField("parameter_index").set(tapos, tpidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.METHOD_TYPE_PARAMETER);
+                        TAP_field_parameter_index.set(tapos, tpidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -604,21 +793,8 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException, NoSuchFieldException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod(
-                                                "methodTypeParameter",
-                                                List.class,
-                                                JCLambda.class,
-                                                int.class,
-                                                int.class)
-                                        .invoke(
-                                                null,
-                                                TypeAnnotationPosition.class
-                                                        .getField("emptyPath")
-                                                        .get(null),
-                                                null,
-                                                tpidx,
-                                                pos);
+                                TAP_meth_methodTypeParameter.invoke(
+                                        null, TAP_field_emptyPath_value, null, tpidx, pos);
                     }
                 });
     }
@@ -633,12 +809,10 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.CLASS_TYPE_PARAMETER_BOUND);
-                        TypeAnnotationPosition.class.getField("parameter_index").set(tapos, tpidx);
-                        TypeAnnotationPosition.class.getField("bound_index").set(tapos, bndidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.CLASS_TYPE_PARAMETER_BOUND);
+                        TAP_field_parameter_index.set(tapos, tpidx);
+                        TAP_field_bound_index.set(tapos, bndidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -648,23 +822,8 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException, NoSuchFieldException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod(
-                                                "typeParameterBound",
-                                                List.class,
-                                                JCLambda.class,
-                                                int.class,
-                                                int.class,
-                                                int.class)
-                                        .invoke(
-                                                null,
-                                                TypeAnnotationPosition.class
-                                                        .getField("emptyPath")
-                                                        .get(null),
-                                                null,
-                                                tpidx,
-                                                bndidx,
-                                                pos);
+                                TAP_meth_typeParameterBound.invoke(
+                                        null, TAP_field_emptyPath_value, null, tpidx, bndidx, pos);
                     }
                 });
     }
@@ -679,12 +838,10 @@ public class TypeAnnotationUtils {
                                     IllegalArgumentException, NoSuchFieldException,
                                     SecurityException {
                         TypeAnnotationPosition tapos = TypeAnnotationPosition.class.newInstance();
-                        TypeAnnotationPosition.class
-                                .getField("type")
-                                .set(tapos, TargetType.METHOD_TYPE_PARAMETER_BOUND);
-                        TypeAnnotationPosition.class.getField("parameter_index").set(tapos, tpidx);
-                        TypeAnnotationPosition.class.getField("bound_index").set(tapos, bndidx);
-                        TypeAnnotationPosition.class.getField("pos").set(tapos, pos);
+                        TAP_field_type.set(tapos, TargetType.METHOD_TYPE_PARAMETER_BOUND);
+                        TAP_field_parameter_index.set(tapos, tpidx);
+                        TAP_field_bound_index.set(tapos, bndidx);
+                        TAP_field_pos.set(tapos, pos);
                         return tapos;
                     }
 
@@ -694,23 +851,8 @@ public class TypeAnnotationUtils {
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException, NoSuchFieldException {
                         return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod(
-                                                "methodTypeParameterBound",
-                                                List.class,
-                                                JCLambda.class,
-                                                int.class,
-                                                int.class,
-                                                int.class)
-                                        .invoke(
-                                                null,
-                                                TypeAnnotationPosition.class
-                                                        .getField("emptyPath")
-                                                        .get(null),
-                                                null,
-                                                tpidx,
-                                                bndidx,
-                                                pos);
+                                TAP_meth_methodTypeParameterBound.invoke(
+                                        null, TAP_field_emptyPath_value, null, tpidx, bndidx, pos);
                     }
                 });
     }
@@ -731,10 +873,7 @@ public class TypeAnnotationUtils {
                             throws IllegalArgumentException, IllegalAccessException,
                                     NoSuchFieldException, SecurityException,
                                     InvocationTargetException, NoSuchMethodException {
-                        return (TypeAnnotationPosition)
-                                TypeAnnotationPosition.class
-                                        .getMethod("copy", TypeAnnotationPosition.class)
-                                        .invoke(null, tapos);
+                        return (TypeAnnotationPosition) TAP_meth_copy.invoke(null, tapos);
                     }
                 });
     }
@@ -744,7 +883,7 @@ public class TypeAnnotationUtils {
                     NoSuchFieldException, SecurityException {
         TypeAnnotationPosition res = TypeAnnotationPosition.class.newInstance();
         res.isValidOffset = tapos.isValidOffset;
-        TypeAnnotationPosition.class.getField("bound_index").set(res, tapos.bound_index);
+        TAP_field_bound_index.set(res, tapos.bound_index);
         res.exception_index = tapos.exception_index;
         res.location = List.from(tapos.location);
         if (tapos.lvarIndex != null) {
@@ -757,15 +896,17 @@ public class TypeAnnotationUtils {
             res.lvarOffset = Arrays.copyOf(tapos.lvarOffset, tapos.lvarOffset.length);
         }
         res.offset = tapos.offset;
+        // TODO
         TypeAnnotationPosition.class.getField("onLambda").set(res, tapos.onLambda);
-        TypeAnnotationPosition.class.getField("parameter_index").set(res, tapos.parameter_index);
-        TypeAnnotationPosition.class.getField("pos").set(res, tapos.pos);
-        TypeAnnotationPosition.class.getField("type").set(res, tapos.type);
-        TypeAnnotationPosition.class.getField("type_index").set(res, tapos.type_index);
+        TAP_field_parameter_index.set(res, tapos.parameter_index);
+        TAP_field_pos.set(res, tapos.pos);
+        TAP_field_type.set(res, tapos.type);
+        TAP_field_type_index.set(res, tapos.type_index);
         return res;
     }
 
-    public static Type unannotatedType(final Type in) {
+    public static Type unannotatedType(final TypeMirror in) {
+        final Type impl = (Type) in;
         return call8or9(
                 new Call8or9<Type>() {
                     @Override
@@ -773,12 +914,12 @@ public class TypeAnnotationUtils {
                             throws IllegalAccessException, IllegalArgumentException,
                                     InvocationTargetException, NoSuchMethodException,
                                     SecurityException {
-                        return (Type) Type.class.getMethod("unannotatedType").invoke(in);
+                        return (Type) Type.class.getMethod("unannotatedType").invoke(impl);
                     }
 
                     @Override
                     public Type call9() {
-                        return in;
+                        return impl;
                     }
                 });
     }

--- a/javacutil/src/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TypesUtils.java
@@ -343,7 +343,7 @@ public final class TypesUtils {
             Type.WildcardType w = (Type.WildcardType) TypeAnnotationUtils.unannotatedType(t);
             return w.isExtendsBound() ? syms.botType : wildLowerBound(env, w.type);
         } else {
-            return t.unannotatedType();
+            return TypeAnnotationUtils.unannotatedType(t);
         }
     }
     /** Returns the {@link TypeMirror} for a given {@link Class}. */


### PR DESCRIPTION
the latter will be removed in Java 9.
Implement TypeAnnotationUtils without reflection. This makes the code easier to read, but unfortunately didn't speed up execution.