### PR TITLE
Fix ValueCheckerUtils.getValuesFromRange

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -134,11 +134,10 @@ public class ValueCheckerUtils {
     }
 
     /**
-     * Get all possible values from the given type and cast them into Long type, Double type, or
-     * Character type accordingly. Only support casting to integral type and double type.
+     * Get all possible values from the given type and cast them into a boxed primitive type.
      *
      * @param range the given range
-     * @param expectedType the expected type
+     * @param expectedType the expected type (must be a class type)
      * @return a list of all the values in the range
      */
     public static <T> List<T> getValuesFromRange(Range range, Class<T> expectedType) {
@@ -149,27 +148,33 @@ public class ValueCheckerUtils {
         if (range.isNothing()) {
             return values;
         }
-        if (expectedType == Integer.class
-                || expectedType == int.class
-                || expectedType == Long.class
-                || expectedType == long.class
-                || expectedType == Short.class
-                || expectedType == short.class
-                || expectedType == Byte.class
-                || expectedType == byte.class) {
-            for (Long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast(value.longValue()));
+        if (expectedType == Integer.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((int) value));
             }
-        } else if (expectedType == Double.class
-                || expectedType == double.class
-                || expectedType == Float.class
-                || expectedType == float.class) {
-            for (Long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast(value.doubleValue()));
+        } else if (expectedType == Short.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((short) value));
             }
-        } else if (expectedType == Character.class || expectedType == char.class) {
-            for (Long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((char) value.intValue()));
+        } else if (expectedType == Byte.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((byte) value));
+            }
+        } else if (expectedType == Long.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast(value));
+            }
+        } else if (expectedType == Double.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((double) value));
+            }
+        } else if (expectedType == Float.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((float) value));
+            }
+        } else if (expectedType == Character.class) {
+            for (long value = range.from; value <= range.to; value++) {
+                values.add(expectedType.cast((char) value));
             }
         } else {
             throw new UnsupportedOperationException(

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -159,6 +159,7 @@ public class ValueCheckerUtils {
         // Each value is computed as a sum of the first value and an offset within the range,
         // to avoid having range.to as an upper bound of the loop. range.to can be Long.MAX_VALUE,
         // in which case a comparison value <= range.to would be always true.
+        // boundDifference is always much smaller than Long.MAX_VALUE
         for (long offset = 0; offset <= boundDifference; offset++) {
             long value = range.from + offset;
 

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -137,7 +137,7 @@ public class ValueCheckerUtils {
      * Get all possible values from the given type and cast them into a boxed primitive type.
      *
      * @param range the given range
-     * @param expectedType the expected type (must be a class type)
+     * @param expectedType the expected type (must be a boxed type, not a primitive type)
      * @return a list of all the values in the range
      */
     public static <T> List<T> getValuesFromRange(Range range, Class<T> expectedType) {

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -134,6 +134,36 @@ public class ValueCheckerUtils {
     }
 
     /**
+     * Converts a long value to a boxed numeric type.
+     *
+     * @param value a long value
+     * @param expectedType the boxed numeric type of the result
+     * @return {@code value} converted to {@code expectedType} using standard conversion rules
+     */
+    private static <T> T convertLongToType(long value, Class<T> expectedType) {
+        Object convertedValue;
+        if (expectedType == Integer.class) {
+            convertedValue = (int) value;
+        } else if (expectedType == Short.class) {
+            convertedValue = (short) value;
+        } else if (expectedType == Byte.class) {
+            convertedValue = (byte) value;
+        } else if (expectedType == Long.class) {
+            convertedValue = value;
+        } else if (expectedType == Double.class) {
+            convertedValue = (double) value;
+        } else if (expectedType == Float.class) {
+            convertedValue = (float) value;
+        } else if (expectedType == Character.class) {
+            convertedValue = (char) value;
+        } else {
+            throw new UnsupportedOperationException(
+                    "ValueCheckerUtils: unexpected class: " + expectedType);
+        }
+        return expectedType.cast(convertedValue);
+    }
+
+    /**
      * Get all possible values from the given type and cast them into a boxed primitive type.
      *
      * <p>{@code expectedType} must be a boxed type, not a primitive type, because primitive types
@@ -162,27 +192,7 @@ public class ValueCheckerUtils {
         // boundDifference is always much smaller than Long.MAX_VALUE
         for (long offset = 0; offset <= boundDifference; offset++) {
             long value = range.from + offset;
-
-            Object convertedValue;
-            if (expectedType == Integer.class) {
-                convertedValue = (int) value;
-            } else if (expectedType == Short.class) {
-                convertedValue = (short) value;
-            } else if (expectedType == Byte.class) {
-                convertedValue = (byte) value;
-            } else if (expectedType == Long.class) {
-                convertedValue = value;
-            } else if (expectedType == Double.class) {
-                convertedValue = (double) value;
-            } else if (expectedType == Float.class) {
-                convertedValue = (float) value;
-            } else if (expectedType == Character.class) {
-                convertedValue = (char) value;
-            } else {
-                throw new UnsupportedOperationException(
-                        "ValueCheckerUtils: unexpected class: " + expectedType);
-            }
-            values.add(expectedType.cast(convertedValue));
+            values.add(convertLongToType(value, expectedType));
         }
         return values;
     }

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -148,37 +148,35 @@ public class ValueCheckerUtils {
         if (range.isNothing()) {
             return values;
         }
-        if (expectedType == Integer.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((int) value));
+
+        // Does not overflow, because the width has already been checked.
+        long length = range.to - range.from;
+
+        // Each value is computed as a sum of the first value and an offset within the range,
+        // to avoid comparing to range.to, which may be Long.MAX_VALUE
+        for (long offset = 0; offset <= length; offset++) {
+            long value = range.from + offset;
+
+            Object convertedValue;
+            if (expectedType == Integer.class) {
+                convertedValue = (int) value;
+            } else if (expectedType == Short.class) {
+                convertedValue = (short) value;
+            } else if (expectedType == Byte.class) {
+                convertedValue = (byte) value;
+            } else if (expectedType == Long.class) {
+                convertedValue = value;
+            } else if (expectedType == Double.class) {
+                convertedValue = (double) value;
+            } else if (expectedType == Float.class) {
+                convertedValue = (float) value;
+            } else if (expectedType == Character.class) {
+                convertedValue = (char) value;
+            } else {
+                throw new UnsupportedOperationException(
+                        "ValueCheckerUtils: unexpected class: " + expectedType);
             }
-        } else if (expectedType == Short.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((short) value));
-            }
-        } else if (expectedType == Byte.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((byte) value));
-            }
-        } else if (expectedType == Long.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast(value));
-            }
-        } else if (expectedType == Double.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((double) value));
-            }
-        } else if (expectedType == Float.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((float) value));
-            }
-        } else if (expectedType == Character.class) {
-            for (long value = range.from; value <= range.to; value++) {
-                values.add(expectedType.cast((char) value));
-            }
-        } else {
-            throw new UnsupportedOperationException(
-                    "ValueCheckerUtils: unexpected class: " + expectedType);
+            values.add(expectedType.cast(convertedValue));
         }
         return values;
     }

--- a/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -136,8 +136,11 @@ public class ValueCheckerUtils {
     /**
      * Get all possible values from the given type and cast them into a boxed primitive type.
      *
+     * <p>{@code expectedType} must be a boxed type, not a primitive type, because primitive types
+     * cannot be stored in a list.
+     *
      * @param range the given range
-     * @param expectedType the expected type (must be a boxed type, not a primitive type)
+     * @param expectedType the expected type
      * @return a list of all the values in the range
      */
     public static <T> List<T> getValuesFromRange(Range range, Class<T> expectedType) {
@@ -149,12 +152,14 @@ public class ValueCheckerUtils {
             return values;
         }
 
-        // Does not overflow, because the width has already been checked.
-        long length = range.to - range.from;
+        // The subtraction does not overflow, because the width has already been checked, so the
+        // bound difference is less than ValueAnnotatedTypeFactory.MAX_VALUES.
+        long boundDifference = range.to - range.from;
 
         // Each value is computed as a sum of the first value and an offset within the range,
-        // to avoid comparing to range.to, which may be Long.MAX_VALUE
-        for (long offset = 0; offset <= length; offset++) {
+        // to avoid having range.to as an upper bound of the loop. range.to can be Long.MAX_VALUE,
+        // in which case a comparison value <= range.to would be always true.
+        for (long offset = 0; offset <= boundDifference; offset++) {
             long value = range.from + offset;
 
             Object convertedValue;

--- a/framework/tests/value/LongMax.java
+++ b/framework/tests/value/LongMax.java
@@ -1,0 +1,9 @@
+import org.checkerframework.common.value.qual.*;
+// Test for handling value annotations involving Long.MAX_VALUE
+public class LongMax {
+
+    public void longMaxRange() {
+        @IntRange(from = 9223372036854775807l, to = 9223372036854775807l) long i = 9223372036854775807l;
+        @IntRange(from = 9223372036854775807l, to = 9223372036854775807l) long j = i;
+    }
+}

--- a/framework/tests/value/LongMax.java
+++ b/framework/tests/value/LongMax.java
@@ -1,4 +1,4 @@
-import org.checkerframework.common.value.qual.*;
+import org.checkerframework.common.value.qual.IntRange;
 // Test for PR 1370: https://github.com/typetools/checker-framework/pull/1370
 // This test contains range annotations with both bounds equal to Long.MAX_VALUE
 // The Value checker tried to extract a list of values from that range by looping

--- a/framework/tests/value/LongMax.java
+++ b/framework/tests/value/LongMax.java
@@ -1,5 +1,11 @@
 import org.checkerframework.common.value.qual.*;
-// Test for handling value annotations involving Long.MAX_VALUE
+// Test for PR 1370: https://github.com/typetools/checker-framework/pull/1370
+// This test contains range annotations with both bounds equal to Long.MAX_VALUE
+// The Value checker tried to extract a list of values from that range by looping
+// from the lower bound to the upper bound. The loop was implemented in a way that
+// if the upper bound is Long.MAX_VALUE, the loop condition was always true, the
+// loop variable overflowed and OutOfMemoryError was caused by infinitely growing
+// the list of values.
 public class LongMax {
 
     public void longMaxRange() {


### PR DESCRIPTION
The method `ValueCheckerUtils.getValuesFromRange` contains code that does not work properly. Furthemore, the method may cause an `OutOfMemoryError` if the upper bound of the input range is `Long.MAX_VALUE`, because in that case the condition of the loop `value<=range.to` always succeeds and the loop variable `value` overflows. Then the list of values grows until memory is exhausted.
This problem can be reproduced by running the value checker on this code:
```java
import org.checkerframework.common.value.qual.*;
public class LongMax {
 public void longMaxRange() {
  @IntRange(from = 9223372036854775807l, to = 9223372036854775807l) long i = 9223372036854775807l;
  @IntRange(from = 9223372036854775807l, to = 9223372036854775807l) long j = i;
 }
}
```
Run the checker by:
```
checker/bin/javac -processor org.checkerframework.common.value.ValueChecker LongMax.java
```
The error output is:
```
error: SourceChecker.typeProcess: unexpected Throwable (OutOfMemoryError) while processing LongMax.java; message: Java heap space; invoke the compiler with -AprintErrorStack to see the stack trace.
```

This PR changes the implementation to:
- not cause `OutOfMemoryError` if `range.to` is `Long.MAX_VALUE`. This is done by looping from 0 to `range.to-range.from` instead of looping from `range.from` to `range.to`. This makes the upper bound of the loop very small (limited by `ValueAnnotatedTypeFactory.MAX_VALUES`), so the loop variable will not overflow before hitting the bound.
- support conversion to `Integer`, `Short`, `Byte` and `Float`
- remove support (which didn't work) for primitive types
- avoid unnecessary boxing and unboxing

An earlier similar change of this method (not fixing the out-of-memory error) was a part of #1352. This PR should be merged before #1352, which requires these fixes.