### PR TITLE
Keep uninferred type arguments in functional interfaces.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3514,7 +3514,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                             wildcardType.getExtendsBound().getUnderlyingType();
                     final TypeMirror typeParamUbType =
                             bounds.get(i).getUpperBound().getUnderlyingType();
-                    if (isExtendsWildcard(wildcardType)) {
+                    if (wildcardType.isUninferredTypeArgument()) {
+                        newTypeArguments.set(i, wildcardType);
+                    } else if (isExtendsWildcard(wildcardType)) {
                         TypeMirror glbType =
                                 InternalUtils.greatestLowerBound(
                                         this.checker.getProcessingEnvironment(),

--- a/framework/tests/all-systems/java8inference/Issue1377.java
+++ b/framework/tests/all-systems/java8inference/Issue1377.java
@@ -1,12 +1,12 @@
 // Test case for Issue 1377.
 // https://github.com/typetools/checker-framework/issues/1377
 // @below-java8-jdk-skip-test
-// @skip-test
 
 interface Func1377<P, R> {
     R apply(P p);
 }
 
+@SuppressWarnings("") // just check for crashes
 interface Issue1377<V> {
     static <U> Issue1377<U> of(Issue1377<U> in) {
         return in;
@@ -17,6 +17,7 @@ interface Issue1377<V> {
     <T> Issue1377<T> m2(Func1377<V, T> f);
 }
 
+@SuppressWarnings("") // just check for crashes
 class Crash1377 {
     void foo(Issue1377<Void> p) {
         Issue1377.of(p.m1(in -> p)).m2(empty -> 5);

--- a/framework/tests/all-systems/java8inference/Issue1379.java
+++ b/framework/tests/all-systems/java8inference/Issue1379.java
@@ -1,0 +1,22 @@
+// Test case for Issue 1379.
+// https://github.com/typetools/checker-framework/issues/1379
+// @below-java8-jdk-skip-test
+
+interface Box1379<V> {}
+
+interface Trans1379<I, O> {
+    Box1379<O> apply(I in);
+}
+
+@SuppressWarnings("") // just check for crashes
+abstract class Issue1379 {
+    abstract <I, O> Box1379<O> app(Box1379<I> in, Trans1379<? super I, ? extends O> t);
+
+    abstract <I, O> Trans1379<I, O> pass(Trans1379<I, O> t);
+
+    abstract Box1379<Number> box(Number p);
+
+    void foo(Box1379<Number> p) {
+        app(p, pass(this::box));
+    }
+}


### PR DESCRIPTION
This prevents crashes elsewhere.  Fixes #1377 and Fixes #1379.