### PR TITLE
Fix #804: Calling a method annotated with @Holding("this") @MayReleaseLocks does not cause "this" to be released

### DIFF
--- a/checker/src/org/checkerframework/checker/lock/LockStore.java
+++ b/checker/src/org/checkerframework/checker/lock/LockStore.java
@@ -193,6 +193,10 @@ public class LockStore extends CFAbstractStore<CFValue, LockStore> {
                 CFValue newValue = changeLockAnnoToTop(var, localVariableValues.get(var));
                 localVariableValues.put(var, newValue);
             }
+
+            if (thisValue != null) {
+                thisValue = changeLockAnnoToTop(null, thisValue);
+            }
         }
     }
 

--- a/checker/tests/lock/Issue804.java
+++ b/checker/tests/lock/Issue804.java
@@ -1,5 +1,3 @@
-// @skip-test
-
 // Test case for Issue 804:
 // https://github.com/typetools/checker-framework/issues/804
 


### PR DESCRIPTION
Hi @wmdietlGC ,
It seems to me that the cause is that we miss updating `this` type in `LockStore#updateForMethodCall`.
Could you review this?