### PR TITLE
Tweak wording to highlight the syntax used for formal parameters.

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1149,7 +1149,7 @@ The set of permitted expressions is a subset of all Java expressions:
   referenced by \<o>.
 
 \item
-  a formal parameter.  Write \<\#> followed by the \textbf{one-based} parameter
+  a formal parameter, represented as \<\#> followed by the \textbf{one-based} parameter
   index.  For example: \<\#1>, \<\#3>.  It is not permitted to write \<\#0> to
   refer to the receiver object; use \<this> instead.  (A side note:
   The formal parameter syntax \<\#1> is less natural in source code


### PR DESCRIPTION
Compare to the entry for "local variable", where we are actually
allowed to use the local variable identifier, the "formal parameter"
did not mean that we can use a formal parameter identifier.