### PR TITLE
Make it clear that a crash is from the Checker Framework.

### DIFF
--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -784,7 +784,9 @@ public abstract class SourceChecker extends AbstractTypeProcessor
             if (ce.userError) {
                 msg.append('.');
             } else {
-                msg.append("; invoke the compiler with -AprintErrorStack to see the stack trace.");
+                msg.append(
+                        "; The Checker Framework crashed.  Please report the crash.  To see "
+                                + "the full stack trace invoke the compiler with -AprintErrorStack");
             }
         }
 


### PR DESCRIPTION
As proposed here: https://github.com/typetools/checker-framework/issues/1111#issuecomment-317847932.