### PR TITLE
Fix #1411 (AssertionError in substituteMethodReturnType)

### DIFF
--- a/checker/tests/index/Issue1411.java
+++ b/checker/tests/index/Issue1411.java
@@ -1,0 +1,17 @@
+// Test case for Issue 1411:
+// https://github.com/typetools/checker-framework/issues/1411
+
+import org.checkerframework.dataflow.qual.Pure;
+
+interface IGeneric<V> {
+    @Pure
+    public V get();
+}
+
+interface IConcrete extends IGeneric<char[]> {}
+
+public class Issue1411 {
+    static void m(IConcrete ic) {
+        char[] val = ic.get();
+    }
+}

--- a/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -609,7 +609,7 @@ public class FlowExpressionParseUtil {
             }
             TypeMirror methodType =
                     InternalUtils.substituteMethodReturnType(
-                            env.getTypeUtils(), methodElement, context.receiver.getType());
+                            env, methodElement, context.receiver.getType());
             return new MethodCall(methodType, methodElement, context.receiver, parameters);
         }
     }

--- a/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -609,7 +609,7 @@ public class FlowExpressionParseUtil {
             }
             TypeMirror methodType =
                     InternalUtils.substituteMethodReturnType(
-                            ElementUtils.getType(methodElement), context.receiver.getType());
+                            env.getTypeUtils(), methodElement, context.receiver.getType());
             return new MethodCall(methodType, methodElement, context.receiver, parameters);
         }
     }

--- a/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
@@ -372,11 +372,10 @@ public class InternalUtils {
     public static TypeMirror substituteMethodReturnType(
             ProcessingEnvironment env, Element methodElement, TypeMirror substitutedReceiverType) {
 
-        JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) env;
-        Types typeUtils = Types.instance(javacEnv.getContext());
+        Types types = Types.instance(getJavacContext(env));
 
         Type substitutedMethodType =
-                typeUtils.memberType((Type) substitutedReceiverType, (Symbol) methodElement);
+                types.memberType((Type) substitutedReceiverType, (Symbol) methodElement);
         return substitutedMethodType.getReturnType();
     }
 

--- a/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/InternalUtils.java
@@ -38,7 +38,6 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
@@ -371,18 +370,13 @@ public class InternalUtils {
 
     /** Returns the return type of a method, given the receiver of the method call. */
     public static TypeMirror substituteMethodReturnType(
-            javax.lang.model.util.Types typeUtils,
-            Element methodElement,
-            TypeMirror substitutedReceiverType) {
+            ProcessingEnvironment env, Element methodElement, TypeMirror substitutedReceiverType) {
 
-        if (!(substitutedReceiverType instanceof DeclaredType)) {
-            // For example arrays
-            return ElementUtils.getType(methodElement);
-        }
+        JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) env;
+        Types typeUtils = Types.instance(javacEnv.getContext());
 
-        DeclaredType declaredReceiverType = (DeclaredType) substitutedReceiverType;
         Type substitutedMethodType =
-                (Type) typeUtils.asMemberOf(declaredReceiverType, methodElement);
+                typeUtils.memberType((Type) substitutedReceiverType, (Symbol) methodElement);
         return substitutedMethodType.getReturnType();
     }
 


### PR DESCRIPTION
This is an attempt at fixing #1411. I would like to get feedback on whether this is a correct apporach. 

Previously `InternalUtils.substituteMethodReturnType` worked only in simple cases and crashed in some.
This PR uses `Types.memberType` to view the method as a member of the receiver type and then gets the return type of the method.

Notes:
- I don't know whether the casts are guaranteed to succeed.
- `JavacTypes.asMemberOf` cannot be used, because the check in that method may fail (and does for some tests).