### PR TITLE
Support string literals in ValueAnnotatedTypeFactory.getMinLenFromString

### DIFF
--- a/checker/tests/index/Index165StringLiteral.java
+++ b/checker/tests/index/Index165StringLiteral.java
@@ -1,0 +1,15 @@
+// Test case for Issue 165, where the argument is a string literal:
+// https://github.com/kelloggm/checker-framework/issues/165
+
+import org.checkerframework.checker.index.qual.IndexFor;
+
+public class Index165StringLiteral {
+	
+    public void testMethodInvocation() {
+    	requiresIndex("012345", 5);
+    	//:: error: (argument.type.incompatible)
+    	requiresIndex("012345", 6);
+    }
+    
+    public void requiresIndex(String str, @IndexFor("#1") int index) {    }
+}

--- a/checker/tests/index/Index165StringLiteral.java
+++ b/checker/tests/index/Index165StringLiteral.java
@@ -4,12 +4,12 @@
 import org.checkerframework.checker.index.qual.IndexFor;
 
 public class Index165StringLiteral {
-	
+
     public void testMethodInvocation() {
-    	requiresIndex("012345", 5);
-    	//:: error: (argument.type.incompatible)
-    	requiresIndex("012345", 6);
+        requiresIndex("012345", 5);
+        //:: error: (argument.type.incompatible)
+        requiresIndex("012345", 6);
     }
-    
-    public void requiresIndex(String str, @IndexFor("#1") int index) {    }
+
+    public void requiresIndex(String str, @IndexFor("#1") int index) {}
 }

--- a/checker/tests/index/Index166.java
+++ b/checker/tests/index/Index166.java
@@ -1,9 +1,9 @@
-// Test case for Issue 165, where the argument is a string literal:
-// https://github.com/kelloggm/checker-framework/issues/165
+// Test case for Issue 166:
+// https://github.com/kelloggm/checker-framework/issues/166
 
 import org.checkerframework.checker.index.qual.IndexFor;
 
-public class Index165StringLiteral {
+public class Index166 {
 
     public void testMethodInvocation() {
         requiresIndex("012345", 5);

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -711,12 +711,26 @@ public abstract class GenericAnnotatedTypeFactory<
 
         FlowExpressions.Receiver expressionObj =
                 getReceiverFromJavaExpressionString(expression, path);
+        return getAnnotationFromReceiver(expressionObj, tree, clazz);
+    }
+    /**
+     * Returns the primary annotation on a receiver.
+     *
+     * @param receiver the receiver for which the annotation is returned
+     * @param tree current tree
+     * @param clazz Class of the annotation
+     * @return the annotation on expression or null if one does not exist
+     * @throws FlowExpressionParseException thrown if the expression cannot be parsed
+     */
+    public AnnotationMirror getAnnotationFromReceiver(
+            FlowExpressions.Receiver receiver, Tree tree, Class<? extends Annotation> clazz)
+            throws FlowExpressionParseException {
 
         AnnotationMirror annotationMirror = null;
-        if (CFAbstractStore.canInsertReceiver(expressionObj)) {
+        if (CFAbstractStore.canInsertReceiver(receiver)) {
             Store store = getStoreBefore(tree);
             if (store != null) {
-                Value value = store.getValue(expressionObj);
+                Value value = store.getValue(receiver);
                 if (value != null) {
                     annotationMirror =
                             AnnotationUtils.getAnnotationByClass(value.getAnnotations(), clazz);
@@ -724,11 +738,11 @@ public abstract class GenericAnnotatedTypeFactory<
             }
         }
         if (annotationMirror == null) {
-            if (expressionObj instanceof LocalVariable) {
-                Element ele = ((LocalVariable) expressionObj).getElement();
+            if (receiver instanceof LocalVariable) {
+                Element ele = ((LocalVariable) receiver).getElement();
                 annotationMirror = getAnnotatedType(ele).getAnnotation(clazz);
-            } else if (expressionObj instanceof FieldAccess) {
-                Element ele = ((FieldAccess) expressionObj).getField();
+            } else if (receiver instanceof FieldAccess) {
+                Element ele = ((FieldAccess) receiver).getField();
                 annotationMirror = getAnnotatedType(ele).getAnnotation(clazz);
             }
         }


### PR DESCRIPTION
This PR improves `ValueAnnotatedTypeFactory.getMinLenFromString` to return the length of the string if the expression is a string literal.

This fixes a warning from index checker with string support (#1413) in plume-lib ([`TestPlume.java`](https://github.com/mernst/plume-lib-check-index-new/blob/3f82f73faaf4c01bee92944a1ea16d8e854bf2fb/java/src/plume/TestPlume.java#L2585)), reported as kelloggm#166.
This can be merged independently of #1413.