### PR TITLE
Update README-developers file

### DIFF
--- a/README-developers.txt
+++ b/README-developers.txt
@@ -13,7 +13,7 @@ This repository contains several related projects:
 Each of these directories contains Eclipse project configuration files.
 
 This repository also contains the following directories:
- tutorial      a tutorial for the Checker Framework
+ docs	       a tutorial and manual for the Checker Framework
  release       buildfiles for making a release
  eclipse       the Checker Framework Eclipse plug-in
  maven-artifacts  artifacts to be uploaded to Maven Central

--- a/README-developers.txt
+++ b/README-developers.txt
@@ -13,7 +13,7 @@ This repository contains several related projects:
 Each of these directories contains Eclipse project configuration files.
 
 This repository also contains the following directories:
- docs	       a tutorial and manual for the Checker Framework
+ docs	       tutorial and manual for the Checker Framework
  release       buildfiles for making a release
  eclipse       the Checker Framework Eclipse plug-in
  maven-artifacts  artifacts to be uploaded to Maven Central


### PR DESCRIPTION
Directory named 'tutorial' was moved inside the directory 'docs' which also contained manuals.