### PR TITLE
Improve index annotations in java.util.regex.Matcher

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1476,8 +1476,8 @@ So, use our own archived version.
     </target>
 
     <target name="download-jdk" description="Downloads jdk7.jar and jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/fix-matcher-lowerbound-1/jdk7.jar" dest="jdk/jdk7.jar"/>
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/fix-matcher-lowerbound-1/jdk8.jar" dest="jdk/jdk8.jar"/>
+        <get src="https://checkerframework.org/dev-jdk/jdk7.jar" dest="jdk/jdk7.jar"/>
+        <get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
         <copy file="jdk/jdk7.jar" tofile="dist/jdk7.jar"/>

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1476,8 +1476,8 @@ So, use our own archived version.
     </target>
 
     <target name="download-jdk" description="Downloads jdk7.jar and jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
-        <get src="https://checkerframework.org/dev-jdk/jdk7.jar" dest="jdk/jdk7.jar"/>
-        <get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"/>
+        <get src="https://github.com/panacekcz/checker-framework/releases/download/fix-matcher-lowerbound-1/jdk7.jar" dest="jdk/jdk7.jar"/>
+        <get src="https://github.com/panacekcz/checker-framework/releases/download/fix-matcher-lowerbound-1/jdk8.jar" dest="jdk/jdk8.jar"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
         <copy file="jdk/jdk7.jar" tofile="dist/jdk7.jar"/>

--- a/checker/jdk/index/src/java/util/regex/Matcher.java
+++ b/checker/jdk/index/src/java/util/regex/Matcher.java
@@ -338,7 +338,7 @@ public final class Matcher implements MatchResult {
      *          If no match has yet been attempted,
      *          or if the previous match operation failed
      */
-    public int start() {
+    public @NonNegative int start() {
         if (first < 0)
             throw new IllegalStateException("No match available");
         return first;
@@ -385,7 +385,7 @@ public final class Matcher implements MatchResult {
      *          If no match has yet been attempted,
      *          or if the previous match operation failed
      */
-    public @GTENegativeOne int end() {
+    public @NonNegative int end() {
         if (first < 0)
             throw new IllegalStateException("No match available");
         return last;
@@ -1005,7 +1005,7 @@ public final class Matcher implements MatchResult {
      * @return  The starting point of this matcher's region
      * @since 1.5
      */
-    public @GTENegativeOne int regionStart() {
+    public @NonNegative int regionStart() {
         return from;
     }
 
@@ -1018,7 +1018,7 @@ public final class Matcher implements MatchResult {
      * @return  the ending point of this matcher's region
      * @since 1.5
      */
-    public @GTENegativeOne int regionEnd() {
+    public @NonNegative int regionEnd() {
         return to;
     }
 

--- a/checker/tests/index/RegexMatcher.java
+++ b/checker/tests/index/RegexMatcher.java
@@ -3,6 +3,7 @@
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.checkerframework.checker.index.qual.NonNegative;
 
 public class RegexMatcher {
     static void m(String p, String s) {

--- a/checker/tests/index/RegexMatcher.java
+++ b/checker/tests/index/RegexMatcher.java
@@ -1,0 +1,15 @@
+// Test case for Issue panacekcz#8:
+// https://github.com/panacekcz/checker-framework/issues/8
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexMatcher {
+    static void m(String p, String s) {
+        Matcher matcher = Pattern.compile(p).matcher(s);
+
+        s.substring(matcher.start(), matcher.end());
+        //:: error: (argument.type.incompatible)
+        s.substring(matcher.start(1), matcher.end(1));
+    }
+}

--- a/checker/tests/index/RegexMatcher.java
+++ b/checker/tests/index/RegexMatcher.java
@@ -7,9 +7,18 @@ import java.util.regex.Pattern;
 public class RegexMatcher {
     static void m(String p, String s) {
         Matcher matcher = Pattern.compile(p).matcher(s);
+        // The following line cannot be used as a test,
+        // because the relation of matcher to p is not tracked,
+        // so the upper bound is not known.
 
-        s.substring(matcher.start(), matcher.end());
-        //:: error: (argument.type.incompatible)
-        s.substring(matcher.start(1), matcher.end(1));
+        // s.substring(matcher.start(), matcher.end());
+
+        @NonNegative int i;
+        i = matcher.start();
+        i = matcher.end();
+        //:: error: (assignment.type.incompatible)
+        i = matcher.start(1);
+        //:: error: (assignment.type.incompatible)
+        i = matcher.end(1);
     }
 }


### PR DESCRIPTION
This PR strengthens the index annotations on return values of functions in `java.util.regex.Matcher`.
The methods `start()`, `end()`, `regionStart()`, and `regionEnd()` all return `@NonNegative`.
This should eliminate some false positives.
Fixes panacekcz#8.
checker/build.xml is edited to download an annotated jdk with the change.