### PR TITLE
Improve refinement of minimum string length after startsWith and endsWith

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -1339,32 +1339,15 @@ public class ValueTransfer extends CFTransfer {
         ValueMethodIdentifier methodIdentifier = atypefactory.getMethodIdentifier();
         if (methodIdentifier.isStartsWithMethod(methodElement)
                 || methodIdentifier.isEndsWithMethod(methodElement)) {
-            Receiver argument = FlowExpressions.internalReprOf(atypefactory, n.getArgument(0));
-            Receiver receiver =
-                    FlowExpressions.internalReprOf(atypefactory, n.getTarget().getReceiver());
 
-            Integer minLength = null;
-
-            if (argument instanceof FlowExpressions.ValueLiteral) {
-                // starts/ends with literal
-                FlowExpressions.ValueLiteral argumentLiteral =
-                        (FlowExpressions.ValueLiteral) argument;
-                Object argumentValue = argumentLiteral.getValue();
-                if (argumentValue instanceof String) {
-                    minLength = ((String) argumentValue).length();
-                }
-            } else if (CFStore.canInsertReceiver(argument)) {
-                // use annotation stored for the argument
-                CFValue argumentCFValue = thenStore.getValue(argument);
-                if (argumentCFValue != null) {
-                    AnnotationMirror argumentAnno = getValueAnnotation(argumentCFValue);
-                    if (argumentAnno != null) {
-                        minLength = atypefactory.getMinLenValue(argumentAnno);
-                    }
-                }
-            }
+            Node argumentNode = n.getArgument(0);
+            AnnotationMirror argumentAnno = getArrayOrStringAnnotation(argumentNode);
+            Integer minLength = atypefactory.getMinLenValue(argumentAnno);
             // Update the annotation of the receiver
             if (minLength != null && minLength != 0) {
+                Receiver receiver =
+                        FlowExpressions.internalReprOf(atypefactory, n.getTarget().getReceiver());
+
                 AnnotationMirror minLenAnno =
                         atypefactory.createArrayLenRangeAnnotation(minLength, Integer.MAX_VALUE);
                 thenStore.insertValue(receiver, minLenAnno);

--- a/framework/tests/value/StartsEndsWith.java
+++ b/framework/tests/value/StartsEndsWith.java
@@ -49,4 +49,20 @@ class StartsEndsWith {
             @ArrayLen(10) String s10 = str;
         }
     }
+
+    void refineStartsStaticFinal(String str) {
+        if (str.startsWith(StartsEndsWithExternal.staticFinalField)) {
+            @MinLen(3) String s3 = str;
+        }
+    }
+
+    void refineStartsConditional(String str, String prefix) {
+        if (prefix.length() > 10 && str.startsWith(prefix)) {
+            @MinLen(11) String s11 = str;
+        }
+    }
+}
+
+class StartsEndsWithExternal {
+    public static final String staticFinalField = "str";
 }


### PR DESCRIPTION
This PR improves the feature added in #1432. That implementation worked with string literals, but not with static final fields. This PR changes the way of retrieving the value annotation of the argument so that it works with static final fields as well.
Fixes panacekcz#9.