### PR TITLE
Add index upper bound annotations to Math.max

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1429,7 +1429,7 @@ So, use our own archived version.
     </target>
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
-        <get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"/>
+        <get src="https://github.com/panacekcz/checker-framework/releases/download/strings-mathmax-2/jdk8.jar" dest="jdk/jdk8.jar"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
         <copy file="jdk/jdk8.jar" tofile="dist/jdk8.jar"/>

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1429,7 +1429,7 @@ So, use our own archived version.
     </target>
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/strings-mathmax-2/jdk8.jar" dest="jdk/jdk8.jar"/>
+        <get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
         <copy file="jdk/jdk8.jar" tofile="dist/jdk8.jar"/>

--- a/checker/jdk/index/src/java/lang/Math.java
+++ b/checker/jdk/index/src/java/lang/Math.java
@@ -798,7 +798,7 @@ public final class Math {
      * @param   b   another argument.
      * @return  the larger of {@code a} and {@code b}.
      */
-    public static int max(int a, int b) {
+    public static @PolyUpperBound int max(@PolyUpperBound int a, @PolyUpperBound int b) {
         return (a >= b) ? a : b;
     }
 
@@ -812,7 +812,7 @@ public final class Math {
      * @param   b   another argument.
      * @return  the larger of {@code a} and {@code b}.
      */
-    public static long max(long a, long b) {
+    public static @PolyUpperBound long max(@PolyUpperBound long a, @PolyUpperBound long b) {
         return (a >= b) ? a : b;
     }
 

--- a/checker/tests/index/MinMaxIndex.java
+++ b/checker/tests/index/MinMaxIndex.java
@@ -1,0 +1,29 @@
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+
+class MinMaxIndex {
+
+    void indexFor(char[] array, @IndexFor("#1") int i1, @IndexFor("#1") int i2) {
+        char c = array[Math.max(i1, i2)];
+        char d = array[Math.min(i1, i2)];
+    }
+
+    void indexOrHigh(String str, @IndexOrHigh("#1") int i1, @IndexOrHigh("#1") int i2) {
+        str.substring(Math.max(i1, i2));
+        str.substring(Math.min(i1, i2));
+    }
+
+    void indexForOrHigh(String str, @IndexFor("#1") int i1, @IndexOrHigh("#1") int i2) {
+        str.substring(Math.max(i1, i2));
+        str.substring(Math.min(i1, i2));
+        //:: error: (argument.type.incompatible)
+        str.charAt(Math.max(i1, i2));
+        str.charAt(Math.min(i1, i2));
+    }
+
+    void twoSequences(String str1, String str2, @IndexFor("#1") int i1, @IndexFor("#2") int i2) {
+        //:: error: (argument.type.incompatible)
+        str1.charAt(Math.max(i1, i2));
+        str1.charAt(Math.min(i1, i2));
+    }
+}

--- a/checker/tests/index/MinMaxIndex.java
+++ b/checker/tests/index/MinMaxIndex.java
@@ -1,18 +1,22 @@
+// Tests handling Math.min and Math.max methods.
+// The upper bound of Math.max is issue panacekcz#20:
+// https://github.com/panacekcz/checker-framework/issues/20
+
 import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.IndexOrHigh;
 
 class MinMaxIndex {
-
+    // Both min and max preserve IndexFor
     void indexFor(char[] array, @IndexFor("#1") int i1, @IndexFor("#1") int i2) {
         char c = array[Math.max(i1, i2)];
         char d = array[Math.min(i1, i2)];
     }
-
+    // Both min and max preserve IndexOrHigh
     void indexOrHigh(String str, @IndexOrHigh("#1") int i1, @IndexOrHigh("#1") int i2) {
         str.substring(Math.max(i1, i2));
         str.substring(Math.min(i1, i2));
     }
-
+    // Combining IndexFor and IndexOrHigh
     void indexForOrHigh(String str, @IndexFor("#1") int i1, @IndexOrHigh("#1") int i2) {
         str.substring(Math.max(i1, i2));
         str.substring(Math.min(i1, i2));
@@ -20,7 +24,7 @@ class MinMaxIndex {
         str.charAt(Math.max(i1, i2));
         str.charAt(Math.min(i1, i2));
     }
-
+    // max does not work with different sequences, min does
     void twoSequences(String str1, String str2, @IndexFor("#1") int i1, @IndexFor("#2") int i2) {
         //:: error: (argument.type.incompatible)
         str1.charAt(Math.max(i1, i2));


### PR DESCRIPTION
This PR adds `@PolyUpperBound` annotations to `Math.max` methods, similar to `@PolyLowerBound` annotations that are on `Math.min`.
If both arguments satisfy a certain upper bound, then the result does too.

Fixes panacekcz#20.
The file build.xml is changed to download the modified jdk.