### PR TITLE
Avoid int overflow in UBQualifier.isValuePlusOffsetLessThanMinLen

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -779,14 +779,14 @@ public abstract class UBQualifier {
             return UpperBoundUnknownQualifier.UNKNOWN;
         }
 
-        public boolean isValuePlusOffsetLessThanMinLen(String sequence, int value, int minlen) {
+        public boolean isValuePlusOffsetLessThanMinLen(String sequence, long value, int minlen) {
             Set<OffsetEquation> offsets = map.get(sequence);
             if (offsets == null) {
                 return false;
             }
             for (OffsetEquation offset : offsets) {
                 if (offset.isInt()) {
-                    return minlen > value + offset.getInt();
+                    return (long) minlen - offset.getInt() > value;
                 }
             }
             return false;

--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -786,6 +786,7 @@ public abstract class UBQualifier {
             }
             for (OffsetEquation offset : offsets) {
                 if (offset.isInt()) {
+                    // This expression must not overflow
                     return (long) minlen - offset.getInt() > value;
                 }
             }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -287,6 +287,6 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
         if (value == null) {
             return false;
         }
-        return varQual.isValuePlusOffsetLessThanMinLen(arrayName, value.intValue(), minLen);
+        return varQual.isValuePlusOffsetLessThanMinLen(arrayName, value, minLen);
     }
 }

--- a/checker/tests/index/Index167.java
+++ b/checker/tests/index/Index167.java
@@ -1,0 +1,27 @@
+// Test case for Issue 167:
+// https://github.com/kelloggm/checker-framework/issues/167
+
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.LTOMLengthOf;
+import org.checkerframework.checker.index.qual.NonNegative;
+
+public class Index167 {
+    static void fn1(int[] arr, @IndexFor("#1") int i) {
+        if (i >= 33) {
+            //:: error: (argument.type.incompatible)
+            fn2(arr, i);
+        }
+        if (i > 33) {
+            //:: error: (argument.type.incompatible)
+            fn2(arr, i);
+        }
+        if (i != 33) {
+            //:: error: (argument.type.incompatible)
+            fn2(arr, i);
+        }
+    }
+
+    static void fn2(int[] arr, @NonNegative @LTOMLengthOf("#1") int i) {
+        int c = arr[i + 1];
+    }
+}


### PR DESCRIPTION
This PR avoids `int` overflow in `UBQualifier.isValuePlusOffsetLessThanMinLen`. An overflow in this method caused `relaxedCommonAssignmentCheck` to return true in cases where it shouldn't. This resulted in missed upper bound warnings (see kelloggm#167).
The exposing code doesn't even contain any large integers or overflowing operations. The large integer value causing the overflow comes as a range bound from the value checker.

Fixes kelloggm#167.