### PR TITLE
Generalize index upper bound refinement by !=

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -195,12 +195,13 @@ public abstract class UBQualifier {
     }
 
     /**
-     * Returns whether or not this qualifier has sequence with offset of -1.
+     * Returns whether or not this qualifier has sequence with the specified offset.
      *
      * @param sequence sequence expression
-     * @return whether or not this qualifier has sequence with offset of -1
+     * @param offset the offset being looked for
+     * @return whether or not this qualifier has sequence with the specified offset
      */
-    public boolean hasSequenceWithOffsetNeg1(String sequence) {
+    public boolean hasSequenceWithOffset(String sequence, int offset) {
         return false;
     }
 
@@ -224,12 +225,12 @@ public abstract class UBQualifier {
         }
 
         @Override
-        public boolean hasSequenceWithOffsetNeg1(String sequence) {
+        public boolean hasSequenceWithOffset(String sequence, int offset) {
             Set<OffsetEquation> offsets = map.get(sequence);
             if (offsets == null) {
                 return false;
             }
-            return offsets.contains(OffsetEquation.NEG_1);
+            return offsets.contains(OffsetEquation.createOffsetForInt(offset));
         }
 
         /**
@@ -240,7 +241,7 @@ public abstract class UBQualifier {
          */
         @Override
         public boolean isLessThanOrEqualTo(String sequence) {
-            return isLessThanLengthOf(sequence) || hasSequenceWithOffsetNeg1(sequence);
+            return isLessThanLengthOf(sequence) || hasSequenceWithOffset(sequence, -1);
         }
 
         /**

--- a/checker/tests/index/RefineNeqLength.java
+++ b/checker/tests/index/RefineNeqLength.java
@@ -1,0 +1,64 @@
+// Test case for Issue panacekcz#12:
+// https://github.com/panacekcz/checker-framework/issues/12
+
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+import org.checkerframework.checker.index.qual.LTLengthOf;
+import org.checkerframework.checker.index.qual.LTOMLengthOf;
+import org.checkerframework.checker.index.qual.NonNegative;
+
+class RefineNeqLength {
+    void refineNeqLength(int[] array, @IndexOrHigh("#1") int i) {
+        // Refines i <= array.length to i < array.length
+        if (i != array.length) {
+            refineNeqLengthMOne(array, i);
+        }
+        // No refinement
+        if (i != array.length - 1) {
+            //:: error: (argument.type.incompatible)
+            refineNeqLengthMOne(array, i);
+        }
+    }
+
+    void refineNeqLengthMOne(int[] array, @IndexFor("#1") int i) {
+        // Refines i < array.length to i < array.length - 1
+        if (i != array.length - 1) {
+            refineNeqLengthMTwo(array, i);
+            //:: error: (argument.type.incompatible)
+            refineNeqLengthMThree(array, i);
+        }
+    }
+
+    void refineNeqLengthMTwo(int[] array, @NonNegative @LTOMLengthOf("#1") int i) {
+        // Refines i < array.length - 1 to i < array.length - 2
+        if (i != array.length - 2) {
+            refineNeqLengthMThree(array, i);
+        }
+        // No refinement
+        if (i != array.length - 1) {
+            //:: error: (argument.type.incompatible)
+            refineNeqLengthMThree(array, i);
+        }
+    }
+
+    @LTLengthOf(value = "#1", offset = "3") int refineNeqLengthMThree(
+            int[] array, @NonNegative @LTLengthOf(value = "#1", offset = "2") int i) {
+        // Refines i < array.length - 2 to i < array.length - 3
+        if (i != array.length - 3) {
+            return i;
+        }
+        //:: error: (return.type.incompatible)
+        return i;
+    }
+
+    // The same test for a string.
+    @LTLengthOf(value = "#1", offset = "3") int refineNeqLengthMThree(
+            String str, @NonNegative @LTLengthOf(value = "#1", offset = "2") int i) {
+        // Refines i < str.length() - 2 to i < str.length() - 3
+        if (i != str.length() - 3) {
+            return i;
+        }
+        //:: error: (return.type.incompatible)
+        return i;
+    }
+}

--- a/checker/tests/index/RefineNeqLength.java
+++ b/checker/tests/index/RefineNeqLength.java
@@ -6,6 +6,7 @@ import org.checkerframework.checker.index.qual.IndexOrHigh;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 import org.checkerframework.checker.index.qual.LTOMLengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.common.value.qual.IntVal;
 
 class RefineNeqLength {
     void refineNeqLength(int[] array, @IndexOrHigh("#1") int i) {
@@ -36,6 +37,22 @@ class RefineNeqLength {
         }
         // No refinement
         if (i != array.length - 1) {
+            //:: error: (argument.type.incompatible)
+            refineNeqLengthMThree(array, i);
+        }
+    }
+
+    void refineNeqLengthMTwoNonLiteral(
+            int[] array,
+            @NonNegative @LTOMLengthOf("#1") int i,
+            @IntVal(3) int c3,
+            @IntVal({2, 3}) int c23) {
+        // Refines i < array.length - 1 to i < array.length - 2
+        if (i != array.length - (5 - c3)) {
+            refineNeqLengthMThree(array, i);
+        }
+        // No refinement
+        if (i != array.length - c23) {
             //:: error: (argument.type.incompatible)
             refineNeqLengthMThree(array, i);
         }


### PR DESCRIPTION
This PR generalizes the refinement of upper bounds in the index checker by the `!=` operator.
Currently, if `i` is `@LTEqLengthOf("receiver")` or equivalently `@LTLengthOf(value="receiver",offset="-1")`, then after checking `i != receiver.length`, it is refined to `@LTLengthOf(value="receiver")`.
With this change, if `i` is `@LTLengthOf(value="receiver",offset=c-1)` then after checking `i != receiver.length - c`, it is refined to `@LTLengthOf(value="receiver", offset=c)` for any ~literal~ constant `c`.

Fixes panacekcz#12.
Should not be merged before #1469. ~Tests fail because of kelloggm#167 and should pass after that is merged.~