### PR TITLE
Add support for @PolyUI Java 8 lambdas to guichecker

### DIFF
--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.guieffect;
 
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import java.util.HashSet;
@@ -247,23 +250,72 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         return new Effect(SafeEffect.class);
     }
 
+    public Effect getComputedEffectAtCallsite(
+            MethodInvocationTree node,
+            AnnotatedTypeMirror.AnnotatedDeclaredType callerReceiver,
+            ExecutableElement methodElt) {
+        Effect targetEffect = getDeclaredEffect(methodElt);
+        if (targetEffect.isPoly()) {
+            AnnotatedTypeMirror srcType = null;
+            assert (node.getMethodSelect().getKind() == Tree.Kind.IDENTIFIER
+                    || node.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT);
+            if (node.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT) {
+                ExpressionTree src = ((MemberSelectTree) node.getMethodSelect()).getExpression();
+                srcType = getAnnotatedType(src);
+            } else {
+                // Tree.Kind.IDENTIFIER, e.g. a direct call like "super()"
+                if (callerReceiver == null) {
+                    // Not enought information provided to instantiate this type-polymorphic effects
+                    return targetEffect;
+                }
+                srcType = callerReceiver;
+            }
+
+            // Instantiate type-polymorphic effects
+            if (srcType.hasAnnotation(AlwaysSafe.class)) {
+                targetEffect = new Effect(SafeEffect.class);
+            } else if (srcType.hasAnnotation(UI.class)) {
+                targetEffect = new Effect(UIEffect.class);
+            }
+            // Poly substitution would be a noop.
+        }
+        return targetEffect;
+    }
+
     public Effect getInferedEffectForLambdaExpression(LambdaExpressionTree lambdaTree) {
+        // @UI type if annotated on the lambda expression explicitly
+        //System.err.println(lambdaTree + " " + this.type(lambdaTree).toString(true));
+        if (uiLambdas.contains(lambdaTree)) {
+            return new Effect(UIEffect.class);
+        }
+        if (this.type(lambdaTree).getAnnotation(UI.class) != null) {
+            return new Effect(UIEffect.class);
+        }
         ExecutableElement functionalInterfaceMethodElt =
                 TreeUtils.getFunctionalInterfaceMethod(lambdaTree);
         if (debugSpew) {
             System.err.println("functionalInterfaceMethodElt found for lambda");
         }
-        Effect lambdaEffect = getDeclaredEffect(functionalInterfaceMethodElt);
-        if (lambdaEffect.isPoly()) {
-            if (uiLambdas.contains(lambdaTree)) {
-                // This lambda expression was inferred to be @UIEffect, based on usage.
-                lambdaEffect = new Effect(UIEffect.class);
-            } else {
-                // Infer safe
-                lambdaEffect = new Effect(SafeEffect.class);
-            }
+        return getDeclaredEffect(functionalInterfaceMethodElt);
+    }
+
+    public AnnotatedTypeMirror getInferedTypeForLambdaExpression(LambdaExpressionTree lambdaTree) {
+        AnnotatedTypeMirror typeMirror = getAnnotatedType(lambdaTree);
+        if (uiLambdas.contains(lambdaTree) && !typeMirror.hasAnnotation(UI.class)) {
+            typeMirror.addAnnotation(UI.class);
         }
-        return lambdaEffect;
+        return typeMirror;
+    }
+
+    @Override
+    public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
+        AnnotatedTypeMirror typeMirror = super.getAnnotatedType(tree);
+        if (tree.getKind() == Tree.Kind.LAMBDA_EXPRESSION
+                && uiLambdas.contains((LambdaExpressionTree) tree)
+                && !typeMirror.hasAnnotation(UI.class)) {
+            typeMirror.addAnnotation(UI.class);
+        }
+        return typeMirror;
     }
 
     // Only the visitMethod call should pass true for warnings
@@ -466,8 +518,11 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     public void constrainLambdaToUI(LambdaExpressionTree lambdaExpressionTree) {
-        //System.err.println("Lambda is constrained to be @UI: " + lambdaExpressionTree);
-        this.uiLambdas.add(lambdaExpressionTree);
+        // ToDo: Would expect the following two lines to annotate the type inside the AST and persist it, but they do
+        // not, needing the uiLambdas set structure.
+        //AnnotatedTypeMirror typeMirror = getAnnotatedType(lambdaExpressionTree);
+        //typeMirror.addAnnotation(UI.class);
+        uiLambdas.add(lambdaExpressionTree);
     }
 
     /** A class for adding annotations based on tree. */
@@ -497,6 +552,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public Void visitMethod(MethodTree node, AnnotatedTypeMirror type) {
+
             AnnotatedTypeMirror.AnnotatedExecutableType methType =
                     (AnnotatedTypeMirror.AnnotatedExecutableType) type;
             // Effect e = getDeclaredEffect(methType.getElement());

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -6,6 +6,8 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
@@ -291,8 +293,11 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         if (this.type(lambdaTree).getAnnotation(UI.class) != null) {
             return new Effect(UIEffect.class);
         }
+        JavacProcessingEnvironment javacEnv =
+                (JavacProcessingEnvironment) checker.getProcessingEnvironment();
+        Types types = Types.instance(javacEnv.getContext());
         ExecutableElement functionalInterfaceMethodElt =
-                TreeUtils.getFunctionalInterfaceMethod(lambdaTree);
+                TreeUtils.getFunctionalInterfaceMethod(lambdaTree, types);
         if (debugSpew) {
             System.err.println("functionalInterfaceMethodElt found for lambda");
         }
@@ -302,7 +307,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
     public AnnotatedTypeMirror getInferedTypeForLambdaExpression(LambdaExpressionTree lambdaTree) {
         AnnotatedTypeMirror typeMirror = getAnnotatedType(lambdaTree);
         if (uiLambdas.contains(lambdaTree) && !typeMirror.hasAnnotation(UI.class)) {
-            typeMirror.replaceAnnotation(AnnotationUtils.fromClass(elements, UI.class));
+            typeMirror.replaceAnnotation(AnnotationBuilder.fromClass(elements, UI.class));
         }
         return typeMirror;
     }
@@ -313,7 +318,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         if (tree.getKind() == Tree.Kind.LAMBDA_EXPRESSION
                 && uiLambdas.contains((LambdaExpressionTree) tree)
                 && !typeMirror.hasAnnotation(UI.class)) {
-            typeMirror.replaceAnnotation(AnnotationUtils.fromClass(elements, UI.class));
+            typeMirror.replaceAnnotation(AnnotationBuilder.fromClass(elements, UI.class));
         }
         return typeMirror;
     }

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -259,7 +259,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
      * @param node The method invocation as an AST node.
      * @param callerReceiver The type of the receiver object if available. Used to resolve direct
      *     calls like "super()"
-     * @param methodElt The element of the callee method.s
+     * @param methodElt The element of the callee method.
      * @return The computed effect (SafeEffect or UIEffect) for the method call.
      */
     public Effect getComputedEffectAtCallsite(
@@ -570,7 +570,6 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public Void visitMethod(MethodTree node, AnnotatedTypeMirror type) {
-
             AnnotatedTypeMirror.AnnotatedExecutableType methType =
                     (AnnotatedTypeMirror.AnnotatedExecutableType) type;
             // Effect e = getDeclaredEffect(methType.getElement());

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -302,7 +302,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
     public AnnotatedTypeMirror getInferedTypeForLambdaExpression(LambdaExpressionTree lambdaTree) {
         AnnotatedTypeMirror typeMirror = getAnnotatedType(lambdaTree);
         if (uiLambdas.contains(lambdaTree) && !typeMirror.hasAnnotation(UI.class)) {
-            typeMirror.addAnnotation(UI.class);
+            typeMirror.replaceAnnotation(AnnotationUtils.fromClass(elements, UI.class));
         }
         return typeMirror;
     }
@@ -313,7 +313,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         if (tree.getKind() == Tree.Kind.LAMBDA_EXPRESSION
                 && uiLambdas.contains((LambdaExpressionTree) tree)
                 && !typeMirror.hasAnnotation(UI.class)) {
-            typeMirror.addAnnotation(UI.class);
+            typeMirror.replaceAnnotation(AnnotationUtils.fromClass(elements, UI.class));
         }
         return typeMirror;
     }

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -334,10 +334,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
             // Perform lambda polymorphic effect inference: @PolyUI lambda, calling @UIEffect => @UI lambda
             if (targetEffect.isUI() && callerEffect.isPoly()) {
                 atypeFactory.constrainLambdaToUI((LambdaExpressionTree) callerTree);
-                callerEffect =
-                        atypeFactory.getInferedEffectForLambdaExpression(
-                                (LambdaExpressionTree) callerTree);
-                assert callerEffect.isUI();
+                callerEffect = new Effect(UIEffect.class);
             }
         }
         assert callerEffect != null;
@@ -365,7 +362,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
         List<AnnotatedTypeMirror> argsTypes =
                 AnnotatedTypes.expandVarArgs(atypeFactory, invokedMethod, node.getArguments());
         for (int i = 0; i < args.size(); ++i) {
-            if (args.get(i) instanceof LambdaExpressionTree) {
+            if (args.get(i).getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
                 lambdaAssignmentCheck(
                         argsTypes.get(i),
                         (LambdaExpressionTree) args.get(i),

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -18,6 +18,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
+import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.guieffect.qual.AlwaysSafe;
 import org.checkerframework.checker.guieffect.qual.PolyUI;
 import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
@@ -210,7 +211,9 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
     // For assignments and local variable initialization:
     // Check for @UI annotations on the lhs, use them to infer @UI types on lambda expressions in the rhs
     private void lambdaAssignmentCheck(
-            AnnotatedTypeMirror varType, LambdaExpressionTree lambdaExp, String errorKey) {
+            AnnotatedTypeMirror varType,
+            LambdaExpressionTree lambdaExp,
+            @CompilerMessageKey String errorKey) {
         AnnotatedTypeMirror lambdaType = atypeFactory.getAnnotatedType(lambdaExp);
         assert lambdaType != null : "null type for expression: " + lambdaExp;
         commonAssignmentCheck(varType, lambdaType, lambdaExp, errorKey);

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -32,7 +32,9 @@ import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
 
 /** Require that only UI code invokes code with the UI effect. */

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -250,9 +250,6 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
     @Override
     public Void visitReturn(ReturnTree node, Void p) {
         Void result = super.visitReturn(node, p);
-        /*if (node.getExpression() != null && TreeUtils.enclosingClass(getCurrentPath()).toString().contains("Java8"))
-        System.err.println(TreeUtils.enclosingMethodOrLambda(getCurrentPath()) + " returns: " + node.getExpression() + " with type " +
-            atypeFactory.getAnnotatedType(node.getExpression()));*/
         if (node.getExpression() != null
                 && node.getExpression().getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
 
@@ -365,14 +362,12 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
                 atypeFactory.methodFromUse(node);
         AnnotatedExecutableType invokedMethod = mfuPair.first;
         List<? extends VariableElement> parameters = methodElt.getParameters();
-        List<AnnotatedTypeMirror> typeargs =
+        List<AnnotatedTypeMirror> argsTypes =
                 AnnotatedTypes.expandVarArgs(atypeFactory, invokedMethod, node.getArguments());
         for (int i = 0; i < args.size(); ++i) {
             if (args.get(i) instanceof LambdaExpressionTree) {
-                // !! This doesn't work, because BaseTypeVisitor.shouldSkipUses(...) always returns true from lambdas
-                //commonAssignmentCheck(typeargs.get(i), args.get(i), "argument.type.incompatible");
                 lambdaAssignmentCheck(
-                        typeargs.get(i),
+                        argsTypes.get(i),
                         (LambdaExpressionTree) args.get(i),
                         "argument.type.incompatible");
             }

--- a/checker/tests/guieffect/Java8Lambdas.java
+++ b/checker/tests/guieffect/Java8Lambdas.java
@@ -1,0 +1,150 @@
+import org.checkerframework.checker.guieffect.qual.PolyUI;
+import org.checkerframework.checker.guieffect.qual.PolyUIEffect;
+import org.checkerframework.checker.guieffect.qual.PolyUIType;
+import org.checkerframework.checker.guieffect.qual.UI;
+import org.checkerframework.checker.guieffect.qual.UIEffect;
+
+public class Java8Lambdas {
+
+    private interface SafeFunctionalInterface<T> {
+        public void executeAlwaysSafe(T arg);
+    }
+
+    private interface UIFunctionalInterface<T> {
+        @UIEffect
+        public void executeUI(T arg);
+    }
+
+    @PolyUIType
+    private interface PolymorphicFunctionalInterface<T> {
+        @PolyUIEffect
+        public void executePolymorphic(T arg);
+    }
+
+    private static class LambdaRunner {
+        private final UIElement arg;
+
+        public LambdaRunner(UIElement arg) {
+            this.arg = arg;
+        }
+
+        public void doSafe(SafeFunctionalInterface<UIElement> func) {
+            func.executeAlwaysSafe(this.arg);
+        }
+
+        @UIEffect
+        public void doUI(UIFunctionalInterface<UIElement> func) {
+            func.executeUI(this.arg);
+        }
+
+        // Needs to be @UIEffect, because the functional interface method is @UIEffect
+        public void unsafeDoUI(UIFunctionalInterface<UIElement> func) {
+            //:: error: (call.invalid.ui)
+            func.executeUI(this.arg);
+        }
+
+        public void doEither(@PolyUI PolymorphicFunctionalInterface<UIElement> func) {
+            // In a real program some intelligent dispatch could be done here to avoid running on UI thread unless
+            // needed.
+            arg.runOnUIThread(
+                    new IAsyncUITask() {
+                        final UIElement e2 = arg;
+
+                        @Override
+                        public void doStuff() { // should inherit UI effect
+                            func.executePolymorphic(e2); // should be okay
+                        }
+                    });
+        }
+
+        public void doUISafely(@UI PolymorphicFunctionalInterface<UIElement> func) {
+            // In a real program some intelligent dispatch could be done here to avoid running on UI thread unless
+            // needed.
+            arg.runOnUIThread(
+                    new IAsyncUITask() {
+                        final UIElement e2 = arg;
+
+                        @Override
+                        public void doStuff() { // should inherit UI effect
+                            func.executePolymorphic(e2); // should be okay
+                        }
+                    });
+        }
+    }
+
+    @PolyUIType
+    private static class PolymorphicLambdaRunner {
+        private final UIElement arg;
+
+        public PolymorphicLambdaRunner(UIElement arg) {
+            this.arg = arg;
+        }
+
+        @PolyUIEffect
+        public void doEither(@PolyUI PolymorphicFunctionalInterface<UIElement> func) {
+            func.executePolymorphic(this.arg);
+        }
+    }
+
+    public static void safeContextTestCases(UIElement elem) {
+        LambdaRunner runner = new LambdaRunner(elem);
+        runner.doSafe(e -> e.repaint());
+        //:: error: (call.invalid.ui)
+        runner.doSafe(e -> e.dangerous()); // Not allowed in doSafe
+        //:: error: (call.invalid.ui)
+        runner.doUI(e -> e.repaint()); // Not allowed in safe context
+        //:: error: (call.invalid.ui)
+        runner.doUI(e -> e.dangerous()); // Not allowed in safe context
+        runner.doEither(e -> e.repaint());
+        runner.doEither(e -> e.dangerous());
+        runner.doUISafely(e -> e.dangerous());
+        PolymorphicLambdaRunner safePolymorphicLambdaRunner = new PolymorphicLambdaRunner(elem);
+        safePolymorphicLambdaRunner.doEither(e -> e.repaint());
+        //:: error: (call.invalid.ui)
+        safePolymorphicLambdaRunner.doEither(e -> e.dangerous());
+        @UI PolymorphicLambdaRunner uiPolymorphicLambdaRunner = new @UI PolymorphicLambdaRunner(elem);
+        //:: error: (call.invalid.ui)
+        uiPolymorphicLambdaRunner.doEither(
+                e -> e.repaint()); // Safe at runtime, but not by the type system!
+        //:: error: (call.invalid.ui)
+        uiPolymorphicLambdaRunner.doEither(e -> e.dangerous());
+        PolymorphicFunctionalInterface<UIElement> func1 = e -> e.repaint();
+        //:: error: (call.invalid.ui)
+        PolymorphicFunctionalInterface<UIElement> func2 = e -> e.dangerous(); // Incompatible types!
+        @UI PolymorphicFunctionalInterface<UIElement> func3 = e -> e.dangerous();
+        safePolymorphicLambdaRunner.doEither(func1);
+        safePolymorphicLambdaRunner.doEither(func2);
+        //:: error: (call.invalid.ui)
+        uiPolymorphicLambdaRunner.doEither(func1);
+        //:: error: (call.invalid.ui)
+        uiPolymorphicLambdaRunner.doEither(func2);
+        //:: error: (call.invalid.ui)
+        uiPolymorphicLambdaRunner.doEither(func3);
+    }
+
+    @UIEffect
+    public static void uiContextTestCases(UIElement elem) {
+        LambdaRunner runner = new LambdaRunner(elem);
+        //:: error: (call.invalid.ui)
+        runner.doSafe(e -> e.dangerous());
+        runner.doUI(e -> e.repaint());
+        runner.doUI(e -> e.dangerous());
+        PolymorphicLambdaRunner safePolymorphicLambdaRunner = new PolymorphicLambdaRunner(elem);
+        //:: error: (call.invalid.ui)
+        safePolymorphicLambdaRunner.doEither(e -> e.dangerous());
+        @UI PolymorphicLambdaRunner uiPolymorphicLambdaRunner = new @UI PolymorphicLambdaRunner(elem);
+        uiPolymorphicLambdaRunner.doEither(e -> e.dangerous());
+    }
+
+    public @UI PolymorphicFunctionalInterface<UIElement> returnLambdasTest1() {
+        return e -> e.dangerous();
+    }
+
+    public PolymorphicFunctionalInterface<UIElement> returnLambdasTest2() {
+        return (e -> {
+            //:: error: (call.invalid.ui)
+            e.dangerous();
+        }); // This lambda will be inferred to be safe and thus calling dangerous() is an
+        // error.
+    }
+}

--- a/checker/tests/guieffect/Java8Lambdas.java
+++ b/checker/tests/guieffect/Java8Lambdas.java
@@ -118,7 +118,7 @@ public class Java8Lambdas {
         //:: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(e -> e.dangerous());
         PolymorphicFunctionalInterface<UIElement> func1 = e -> e.repaint();
-        // No error, why? //:: error: (assignment.type.incompatible)
+        //:: error: (assignment.type.incompatible)
         PolymorphicFunctionalInterface<UIElement> func2 = e -> e.dangerous(); // Incompatible types!
         PolymorphicFunctionalInterface<UIElement> func2p =
                 //:: error: (assignment.type.incompatible)
@@ -158,7 +158,7 @@ public class Java8Lambdas {
 
     // This should be an error without an @UI annotation on the return type. No?
     public PolymorphicFunctionalInterface<UIElement> returnLambdasTest2() {
-        // No error, why? :: error: (return.type.incompatible)
+        //:: error: (return.type.incompatible)
         return e -> {
             e.dangerous();
         };

--- a/checker/tests/guieffect/Java8Lambdas.java
+++ b/checker/tests/guieffect/Java8Lambdas.java
@@ -40,7 +40,7 @@ public class Java8Lambdas {
 
         // Needs to be @UIEffect, because the functional interface method is @UIEffect
         public void unsafeDoUI(UIFunctionalInterface<UIElement> func) {
-            //:: error: (call.invalid.ui)
+            // :: error: (call.invalid.ui)
             func.executeUI(this.arg);
         }
 
@@ -90,11 +90,11 @@ public class Java8Lambdas {
     public static void safeContextTestCases(UIElement elem) {
         LambdaRunner runner = new LambdaRunner(elem);
         runner.doSafe(e -> e.repaint());
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         runner.doSafe(e -> e.dangerous()); // Not allowed in doSafe
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         runner.doUI(e -> e.repaint()); // Not allowed in safe context
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         runner.doUI(e -> e.dangerous()); // Not allowed in safe context
         runner.doEither(e -> e.repaint());
         runner.doEither(e -> e.dangerous());
@@ -112,16 +112,16 @@ public class Java8Lambdas {
                     }
                 });
         @UI PolymorphicLambdaRunner uiPolymorphicLambdaRunner = new @UI PolymorphicLambdaRunner(elem);
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(
                 e -> e.repaint()); // Safe at runtime, but not by the type system!
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(e -> e.dangerous());
         PolymorphicFunctionalInterface<UIElement> func1 = e -> e.repaint();
-        //:: error: (assignment.type.incompatible)
+        // :: error: (assignment.type.incompatible)
         PolymorphicFunctionalInterface<UIElement> func2 = e -> e.dangerous(); // Incompatible types!
         PolymorphicFunctionalInterface<UIElement> func2p =
-                //:: error: (assignment.type.incompatible)
+                // :: error: (assignment.type.incompatible)
                 (new @UI PolymorphicFunctionalInterface<UIElement>() {
                     public void executePolymorphic(UIElement arg) {
                         arg.dangerous();
@@ -130,18 +130,18 @@ public class Java8Lambdas {
         @UI PolymorphicFunctionalInterface<UIElement> func3 = e -> e.dangerous();
         safePolymorphicLambdaRunner.doEither(func1);
         safePolymorphicLambdaRunner.doEither(func2);
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(func1);
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(func2);
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         uiPolymorphicLambdaRunner.doEither(func3);
     }
 
     @UIEffect
     public static void uiContextTestCases(UIElement elem) {
         LambdaRunner runner = new LambdaRunner(elem);
-        //:: error: (call.invalid.ui)
+        // :: error: (call.invalid.ui)
         runner.doSafe(e -> e.dangerous());
         runner.doUI(e -> e.repaint());
         runner.doUI(e -> e.dangerous());
@@ -158,7 +158,7 @@ public class Java8Lambdas {
 
     // This should be an error without an @UI annotation on the return type. No?
     public PolymorphicFunctionalInterface<UIElement> returnLambdasTest2() {
-        //:: error: (return.type.incompatible)
+        // :: error: (return.type.incompatible)
         return e -> {
             e.dangerous();
         };
@@ -166,7 +166,7 @@ public class Java8Lambdas {
 
     // Just to check
     public PolymorphicFunctionalInterface<UIElement> returnLambdasTest3() {
-        //:: error: (return.type.incompatible)
+        // :: error: (return.type.incompatible)
         return (new @UI PolymorphicFunctionalInterface<UIElement>() {
             public void executePolymorphic(UIElement arg) {
                 arg.dangerous();

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1529,6 +1529,9 @@ public class CFGBuilder {
                 TreeBuilder treeBuilder,
                 AnnotationProvider annotationProvider) {
             this.env = env;
+            if (trees == null) {
+                trees = Trees.instance(env);
+            }
             this.tryStack = new TryStack(exceptionalExitLabel);
             this.treeBuilder = treeBuilder;
             this.annotationProvider = annotationProvider;
@@ -1575,7 +1578,6 @@ public class CFGBuilder {
             // just generate a degenerated control graph case that will be
             // removed in a later phase.
             nodeList.add(new UnconditionalJump(regularExitLabel));
-
             return new PhaseOneResult(
                     underlyingAST,
                     treeLookupMap,

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1529,9 +1529,6 @@ public class CFGBuilder {
                 TreeBuilder treeBuilder,
                 AnnotationProvider annotationProvider) {
             this.env = env;
-            if (trees == null) {
-                trees = Trees.instance(env);
-            }
             this.tryStack = new TryStack(exceptionalExitLabel);
             this.treeBuilder = treeBuilder;
             this.annotationProvider = annotationProvider;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1575,6 +1575,7 @@ public class CFGBuilder {
             // just generate a degenerated control graph case that will be
             // removed in a later phase.
             nodeList.add(new UnconditionalJump(regularExitLabel));
+
             return new PhaseOneResult(
                     underlyingAST,
                     treeLookupMap,

--- a/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
@@ -12,7 +12,6 @@ import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionStatementTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -1279,17 +1278,5 @@ public final class TreeUtils {
         Context ctx = ((JavacProcessingEnvironment) env).getContext();
         Types javacTypes = Types.instance(ctx);
         return javacTypes.findDescriptorSymbol(((Type) typeOf(tree)).asElement());
-    }
-
-    /**
-     * finds the corresponding functional interface method for a lambda expression
-     *
-     * @param tree the lambda expression
-     * @return the functional interface method
-     */
-    public static Symbol.MethodSymbol getFunctionalInterfaceMethod(
-            LambdaExpressionTree tree, Types types) {
-        Type funcInterfaceType = ((JCTree.JCLambda) tree).type;
-        return (Symbol.MethodSymbol) types.findDescriptorSymbol(funcInterfaceType.tsym);
     }
 }

--- a/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
@@ -1300,34 +1300,9 @@ public final class TreeUtils {
      * @param tree the lambda expression
      * @return the functional interface method
      */
-    public static Symbol.MethodSymbol getFunctionalInterfaceMethod(LambdaExpressionTree tree) {
+    public static Symbol.MethodSymbol getFunctionalInterfaceMethod(
+            LambdaExpressionTree tree, Types types) {
         Type funcInterfaceType = ((JCTree.JCLambda) tree).type;
-        // we want the method symbol for the single function inside the interface...hrm
-        List<Symbol> enclosedElements = funcInterfaceType.tsym.getEnclosedElements();
-
-        Symbol.MethodSymbol result = null;
-        for (Symbol s : enclosedElements) {
-            Symbol.MethodSymbol elem = (Symbol.MethodSymbol) s;
-            if (elem.isDefault() || elem.isStatic()) {
-                continue;
-            }
-            String name = elem.getSimpleName().toString();
-            // any methods overridding java.lang.Object methods don't count;
-            // see https://docs.oracle.com/javase/8/docs/api/java/lang/FunctionalInterface.html
-            // we should really be checking method signatures here; hack for now
-            if (OBJECT_METHOD_NAMES.contains(name)) {
-                continue;
-            }
-            if (result != null) {
-                throw new RuntimeException(
-                        "already found an answer! " + result + " " + elem + " " + enclosedElements);
-            }
-            result = elem;
-        }
-        if (result == null) {
-            throw new RuntimeException(
-                    "could not find functional interface method in " + enclosedElements);
-        }
-        return result;
+        return (Symbol.MethodSymbol) types.findDescriptorSymbol(funcInterfaceType.tsym);
     }
 }

--- a/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
@@ -75,18 +75,6 @@ import org.checkerframework.checker.nullness.qual.*;
 // TODO: This class needs significant restructuring
 public final class TreeUtils {
 
-    static final Set<String> OBJECT_METHOD_NAMES =
-            new HashSet<String>(
-                    Arrays.asList(
-                            "equals",
-                            "hashCode",
-                            "toString",
-                            "finalize",
-                            "clone",
-                            "notify",
-                            "notifyAll",
-                            "wait"));
-
     // Class cannot be instantiated.
     private TreeUtils() {
         throw new AssertionError("Class TreeUtils cannot be instantiated.");

--- a/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/TreeUtils.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;


### PR DESCRIPTION
(with limited inference)

**Summary**:

We had some Java 7 code annotated with the guieffect checker's type system, and we are in the process of porting said codebase to Java 8. As part of that process, we are converting multiple anonymous classes into lambdas. It is not clear to us whether is possible to annotate lambdas as being `@UI` when the functional interface is polymorphic on the UI effect types (`@PolyUIType` class and `@PolyUIEffect` method). Assuming we are correct on this, we would like to add support for UI-polymorphic lambda arguments, ideally with some degree of inference that doesn't require us to cast to an `@UI` version of their functional interface at use (e.g. `o.m((@UI Action) () -> { ... })` would not be preferred, instead `o.m(()->{ do_some_ui_effect() })` should be alright as long as o is `@UI`).

The test cases of `checker/tests/guieffect/Java8Lambdas.java` serve as a reasonable documentation of the cases we would like to handle. This patch works for those.

Apologies for the large PR, specially since I wouldn't be surprised to learn this can all be done in a better way, but I thought it better to discuss this over a PoC implementation than just submitting a feature request :) Will be happy to rewrite part or all of this based on feedback. There is a good chance I missed a much easier/cleaner way to do all this, in which case I'd love to hear it!

**Inference**: 

Since `GuiEffectVisitor.java` visits method invocations before the body of any lambda expression passed as an argument, we actually infer `@UI` at use and then allow `@UIEffect` calls in the body of the lambda only if we previously marked the lambda expression as "inferred `@UI`".

As such, we mark lambdas as being `@UI` only when:

1. The corresponding functional interface is an `@UIType` with an `@UIEffect` method.

Or:

1. The corresponding functional interface is an `@PolyUIType` with an `@PolyUIEffect` method.
2. And either:
2.1. The lambda is being passed as an argument to a method and the formal parameter is annotated `@UI`.
2.2. The lambda is being passed as an argument to a method and the formal parameter is annotated `@PolyUI` and the receiver is already instantiated `@UI`.
2.3. Analogous cases to the two above for returning lambdas.
2.4. The lambda is being assigned to an `@UI` local.
2.5. Some client analysis explicitly calls `constrainLambdaToUI()`

**Known bugs in this PR**:

Again, this is a work in progress. There are a few important issues with the behavior of the code below, in particular:

1) It seems this code won't actually read `@PolyUI` annotations from methods annotated in stubs, no matter what I try. The code in lines 247-277 of `GuiEffectVisitor` is already way too redundant and it still doesn't handle that case. The call to `atypeFactory.methodFromUse(node)` finds `@UI` annotations on stub arguments, but not `@PolyUI` annotations in actual source files, `atypeFactory.getAnnotatedType(formalArgElement)` gets either annotation from source but ignores stubs. Neither finds `@PolyUI` in stubs. I am sure I am doing something wrong there, but not sure what the recommended way of getting that info is.

2) We are missing some inference for the case in which lambdas are being passed through `@PolyUI -> @PolyUI` methods. E.g. Assume we have a method `@PolyUI Action id(@PolyUI Action)`, then we have `void m(@UI Action)`. Ideally we would like `m(id(id(id(() -> { do_some_ui_effect() }))))`to be understood as valid. The simplest solution I can think of here is a traversal on arguments, return expressions and assignment left hand sides, going inside method invocations only when they are `(..., @PolyUI,...) -> @PolyUI` and marking all the lambdas found in those argument positions as being inferred-`@UI`. Is there a better way?
