### PR TITLE
Fix NPE on CFGBuilder$[...]PhaseOne.visitReturn() when code has lambdas.

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1450,6 +1450,9 @@ public class CFGBuilder {
             this.annotationProvider = annotationProvider;
             elements = env.getElementUtils();
             types = env.getTypeUtils();
+            if (trees == null) {
+                trees = Trees.instance(env);
+            }
 
             // initialize lists and maps
             treeLookupMap = new IdentityHashMap<>();


### PR DESCRIPTION
Whenever CFGBuilder$CFGTranslationPhaseOne.process is called with a
TreePath, rather than a CompilationUnitTree, then this.trees might not
be set.

Eventually, this field is dereferenced inside visitReturn(...), while
processing a lambda return expression. This will result in an NPE when
building a CFG from a TreePath that includes a returned lambda expression.

This patch simply sets CFGBuilder$CFGTranslationPhaseOne.trees to the
same value, regardless of the version of the process(...) method
invoked.