### PR TITLE
Unskip test that was fixed.

### DIFF
--- a/checker/tests/initialization/fbc/TryFinallyBreak.java
+++ b/checker/tests/initialization/fbc/TryFinallyBreak.java
@@ -1,6 +1,5 @@
 // Test case for Issue 548:
 // https://github.com/typetools/checker-framework/issues/548
-// @skip-test
 
 class TryFinallyBreak {
     String foo() {


### PR DESCRIPTION
https://github.com/typetools/checker-framework/commit/0712903c13910dbd7d228730a7232a325b0ad337 also fixed #548. 