### PR TITLE
Handle enclosing types correctly in SuperTypeVisitor.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
+++ b/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
@@ -165,9 +165,12 @@ class SupertypeFinder {
             while (enclosing != null) {
                 TypeElement enclosingTypeElement =
                         (TypeElement) enclosing.getUnderlyingType().asElement();
+                List<AnnotatedTypeMirror> typeArgs = enclosing.getTypeArguments();
+                List<? extends TypeParameterElement> typeParams =
+                        enclosingTypeElement.getTypeParameters();
                 for (int i = 0; i < enclosing.getTypeArguments().size(); ++i) {
-                    AnnotatedTypeMirror typArg = enclosing.getTypeArguments().get(i);
-                    TypeParameterElement ele = enclosingTypeElement.getTypeParameters().get(i);
+                    AnnotatedTypeMirror typArg = typeArgs.get(i);
+                    TypeParameterElement ele = typeParams.get(i);
                     mapping.put(ele, typArg);
                 }
 

--- a/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
+++ b/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
@@ -161,10 +161,17 @@ class SupertypeFinder {
                 }
             }
 
-            for (int i = 0; i < type.getTypeArguments().size(); ++i) {
-                AnnotatedTypeMirror typArg = type.getTypeArguments().get(i);
-                TypeParameterElement ele = typeElement.getTypeParameters().get(i);
-                mapping.put(ele, typArg);
+            AnnotatedDeclaredType enclosing = type;
+            while (enclosing != null) {
+                TypeElement enclosingTypeElement =
+                        (TypeElement) enclosing.getUnderlyingType().asElement();
+                for (int i = 0; i < enclosing.getTypeArguments().size(); ++i) {
+                    AnnotatedTypeMirror typArg = enclosing.getTypeArguments().get(i);
+                    TypeParameterElement ele = enclosingTypeElement.getTypeParameters().get(i);
+                    mapping.put(ele, typArg);
+                }
+
+                enclosing = enclosing.getEnclosingType();
             }
 
             ClassTree classTree = atypeFactory.trees.getTree(typeElement);
@@ -386,6 +393,7 @@ class SupertypeFinder {
                     return visitedNodes.get(type);
                 }
                 visitedNodes.put(type, null);
+                scan(type.getEnclosingType(), mapping);
 
                 List<AnnotatedTypeMirror> args = new ArrayList<AnnotatedTypeMirror>();
                 for (AnnotatedTypeMirror arg : type.getTypeArguments()) {

--- a/framework/tests/all-systems/Issue1442.java
+++ b/framework/tests/all-systems/Issue1442.java
@@ -1,0 +1,34 @@
+// Test case for Issue 1442.
+// https://github.com/typetools/checker-framework/issues/1442
+
+public class Issue1442 {
+    protected void configure(SubConfig<SubMyClass>.SubConfigInner x) {
+        SubMyClass subMyClass = x.getT().getSubConfigInner().outerClassTypeVar();
+    }
+
+    static class MyClass<A extends MyClass<A>> {}
+
+    static class SubMyClass extends MyClass<SubMyClass> {}
+
+    static class Config<B extends MyClass<B>> {
+        class ConfigInner<T> {
+            public T getT() {
+                throw new RuntimeException();
+            }
+        }
+    }
+
+    static class SubConfig<C extends MyClass<C>> extends Config<C> {
+        public class SubConfigInner extends ConfigInner<Thing> {
+            public C outerClassTypeVar() {
+                throw new RuntimeException();
+            }
+        }
+
+        class Thing {
+            public SubConfigInner getSubConfigInner() {
+                throw new RuntimeException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1442.