### PR TITLE
Fix #1500: Incorrect initialization and nullness in finally block

### DIFF
--- a/checker/tests/initialization/fbc/TryFinally2.java
+++ b/checker/tests/initialization/fbc/TryFinally2.java
@@ -1,8 +1,6 @@
 // Test case for Issue 1500:
 // https://github.com/typetools/checker-framework/issues/1500
 
-// @skip-test until the issue is fixed
-
 import java.io.InputStream;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -881,20 +881,27 @@ public class CFGBuilder {
             }
 
             // collect all reachable trees
-            final Set<Tree> allReeachableTrees = new HashSet<>();
+            final Set<Tree> allReachableTrees =
+                    Collections.newSetFromMap(new IdentityHashMap<Tree, Boolean>());
             for (Block b : cfg.getAllBlocks()) {
                 if (b instanceof RegularBlock) {
                     for (Node n : ((RegularBlock) b).getContents()) {
-                        allReeachableTrees.add(n.getTree());
+                        Tree tree = n.getTree();
+                        if (tree != null) {
+                            allReachableTrees.add(tree);
+                        }
                     }
                 } else if (b instanceof ExceptionBlock) {
-                    allReeachableTrees.add(((ExceptionBlock) b).getNode().getTree());
+                    Tree tree = ((ExceptionBlock) b).getNode().getTree();
+                    if (tree != null) {
+                        allReachableTrees.add(tree);
+                    }
                 }
             }
 
             // remove a generated tree if any child tree of it is unreachable because such tree is
             // not analyzed by dataflow framework and cause of false errors.
-            ContainsAnyScanner s = new ContainsAnyScanner(allReeachableTrees);
+            ContainsAnyScanner s = new ContainsAnyScanner(allReachableTrees);
             for (List<Tree> generatedTrees : cfg.generatedTreesLookupMap.values()) {
                 Iterator<Tree> generatedTreesIterator = generatedTrees.iterator();
                 while (generatedTreesIterator.hasNext()) {
@@ -924,6 +931,10 @@ public class CFGBuilder {
 
             @Override
             public Void scan(Tree node, Void aVoid) {
+                if (node == null) {
+                    return null;
+                }
+
                 if (trees.contains(node)) {
                     contains = true;
                 }


### PR DESCRIPTION
When both of `allReachableTrees` and the generated trees contain `null`, unreachable generated trees are not removed and it becomes a cause of the false positive.