### PR TITLE
Correct handling of enclosing type in more places

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1490,8 +1490,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         Map<TypeVariable, AnnotatedTypeMirror> mapping = new HashMap<>();
 
-        for (int i = 0; i < targs.size(); ++i) {
-            mapping.put(((AnnotatedTypeVariable) tvars.get(i)).getUnderlyingType(), targs.get(i));
+        AnnotatedDeclaredType enclosing = type;
+        while (enclosing != null) {
+            List<AnnotatedTypeMirror> enclosingTArgs = enclosing.getTypeArguments();
+            AnnotatedDeclaredType declaredType =
+                    getAnnotatedType((TypeElement) enclosing.getUnderlyingType().asElement());
+            List<AnnotatedTypeMirror> enclosingTVars = declaredType.getTypeArguments();
+            for (int i = 0; i < enclosingTArgs.size(); i++) {
+                AnnotatedTypeVariable enclosingTVar = (AnnotatedTypeVariable) enclosingTVars.get(i);
+                mapping.put(enclosingTVar.getUnderlyingType(), enclosingTArgs.get(i));
+            }
+            enclosing = enclosing.getEnclosingType();
         }
 
         List<AnnotatedTypeParameterBounds> res = new LinkedList<>();

--- a/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
@@ -84,6 +84,9 @@ public abstract class AnnotatedTypeComparer<R>
     public final R visitDeclared(AnnotatedDeclaredType type, AnnotatedTypeMirror p) {
         assert p instanceof AnnotatedDeclaredType : p;
         R r = scan(type.getTypeArguments(), ((AnnotatedDeclaredType) p).getTypeArguments());
+        r =
+                scanAndReduce(
+                        type.getEnclosingType(), ((AnnotatedDeclaredType) p).getEnclosingType(), r);
         return r;
     }
 

--- a/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeScanner.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeScanner.java
@@ -129,7 +129,8 @@ public class AnnotatedTypeScanner<R, P> implements AnnotatedTypeVisitor<R, P> {
             return visitedNodes.get(type);
         }
         visitedNodes.put(type, null);
-        R r = scan(type.getTypeArguments(), p);
+        R r = scan(type.getEnclosingType(), p);
+        r = scanAndReduce(type.getTypeArguments(), p, r);
         return r;
     }
 

--- a/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -362,8 +362,10 @@ public class ElementAnnotationUtil {
             AnnotatedTypeMirror type, List<TypeAnnotationPosition.TypePathEntry> location) {
 
         if (location.isEmpty() && type.getKind() != TypeKind.DECLARED) {
-            // The annotation on a declared type might apply to the enclosing type, so that case is
-            // covered in getLocationTypeADT.
+            // An annotation with an empty type path on a declared type applies to the outermost
+            // enclosing type. This logic is handled together with non-empty type paths in
+            // getLocationTypeADT. For other kinds of types, no work is required for an empty
+            // type path.
             return type;
         } else if (type.getKind() == TypeKind.NULL) {
             return getLocationTypeANT((AnnotatedNullType) type, location);

--- a/framework/tests/all-systems/Issue1431.java
+++ b/framework/tests/all-systems/Issue1431.java
@@ -1,6 +1,6 @@
 // Test case for Issue 1431
 // https://github.com/typetools/checker-framework/issues/1431
-
+@SuppressWarnings("initialization.fields.uninitialized")
 public class Issue1431 {
     static class Outer<V> {
         class Inner<T extends V> {}

--- a/framework/tests/all-systems/Issue1431.java
+++ b/framework/tests/all-systems/Issue1431.java
@@ -1,0 +1,10 @@
+// Test case for Issue 1431
+// https://github.com/typetools/checker-framework/issues/1431
+
+public class Issue1431 {
+    static class Outer<V> {
+        class Inner<T extends V> {}
+    }
+
+    Outer<Object>.Inner<int[]> ic;
+}


### PR DESCRIPTION
1.  `AnnotatedTypeFactory#typeVariablesFromUse` must substitute type parameters of the enclosing type, too.  This fixes #1431. 
2.  AnnotatedTypeVisitors must also visit enclosing types.  This fixes #724 by applying defaults to enclosing types.
3.  Correct how annotations on inner types are applied.

(1 caused a crash that required 2.  2 caused a crash that required 3.)


Downsteam test will pass once https://github.com/typetools/checker-framework-inference/pull/59 is merged.