### PR TITLE
Add support on the dataflow CFG for visiting lambda result expressions

### DIFF
--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -140,6 +140,7 @@ import org.checkerframework.dataflow.cfg.node.InstanceOfNode;
 import org.checkerframework.dataflow.cfg.node.IntegerDivisionNode;
 import org.checkerframework.dataflow.cfg.node.IntegerLiteralNode;
 import org.checkerframework.dataflow.cfg.node.IntegerRemainderNode;
+import org.checkerframework.dataflow.cfg.node.LambdaResultExpressionNode;
 import org.checkerframework.dataflow.cfg.node.LeftShiftNode;
 import org.checkerframework.dataflow.cfg.node.LessThanNode;
 import org.checkerframework.dataflow.cfg.node.LessThanOrEqualNode;
@@ -1551,7 +1552,22 @@ public class CFGBuilder {
             generatedTreesLookupMap = new IdentityHashMap<>();
 
             // traverse AST of the method body
-            scan(bodyPath, null);
+            Node finalNode = scan(bodyPath, null);
+
+            // If we are building the CFG for a lambda with a single expression as the body, then add an extra node
+            // for the result of that lambda
+            if (underlyingAST.getKind() == UnderlyingAST.Kind.LAMBDA) {
+                LambdaExpressionTree lambdaTree =
+                        ((UnderlyingAST.CFGLambda) underlyingAST).getLambdaTree();
+                if (lambdaTree.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION) {
+                    Node resultNode =
+                            new LambdaResultExpressionNode(
+                                    (ExpressionTree) lambdaTree.getBody(),
+                                    finalNode,
+                                    env.getTypeUtils());
+                    extendWithNode(resultNode);
+                }
+            }
 
             // add marker to indicate that the next block will be the exit block
             // Note: if there is a return statement earlier in the method (which

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/AbstractNodeVisitor.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/AbstractNodeVisitor.java
@@ -272,6 +272,11 @@ public abstract class AbstractNodeVisitor<R, P> implements NodeVisitor<R, P> {
     };
 
     @Override
+    public R visitLambdaResultExpression(LambdaResultExpressionNode n, P p) {
+        return visitNode(n, p);
+    };
+
+    @Override
     public R visitStringConversion(StringConversionNode n, P p) {
         return visitNode(n, p);
     };

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -21,20 +21,23 @@ public class LambdaResultExpressionNode extends Node {
     protected ExpressionTree tree;
     protected /*@Nullable*/ Node result;
 
-    public LambdaResultExpressionNode(
-            ExpressionTree t, /*@Nullable*/ Node result, Types types /*,
-            LambdaExpressionTree lambda,
-            Symbol.MethodSymbol methodSymbol*/) {
+    public LambdaResultExpressionNode(ExpressionTree t, /*@Nullable*/ Node result, Types types) {
         super(InternalUtils.typeOf(t));
         this.result = result;
         tree = t;
-        //result.setAssignmentContext(new AssignmentContext.LambdaReturnContext(methodSymbol));
     }
 
+    /**
+     * Returns the final node of the CFG corresponding to the lambda expression body (see {@link
+     * LambdaResultExpressionNode.getTree()}).
+     */
     public Node getResult() {
         return result;
     }
-
+    /**
+     * Returns the {@link ExpressionTree} corresponding to the body of a lambda expression with an
+     * expression body (e.g. X for (o -> X) where X is an expression and not a {...} block).
+     */
     @Override
     public ExpressionTree getTree() {
         return tree;
@@ -55,6 +58,8 @@ public class LambdaResultExpressionNode extends Node {
 
     @Override
     public boolean equals(Object obj) {
+        // No need to compare tree, since in a well-formed LambdaResultExpressionNode, result will be the same only
+        // when tree is the same (this is similar to ReturnNode).
         if (obj == null || !(obj instanceof LambdaResultExpressionNode)) {
             return false;
         }
@@ -67,6 +72,8 @@ public class LambdaResultExpressionNode extends Node {
 
     @Override
     public int hashCode() {
+        // No need to incorporate tree, since in a well-formed LambdaResultExpressionNode, result will be the same only
+        // when tree is the same (this is similar to ReturnNode).
         return HashCodeUtils.hash(result);
     }
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -1,0 +1,81 @@
+package org.checkerframework.dataflow.cfg.node;
+
+import com.sun.source.tree.ExpressionTree;
+import java.util.Collection;
+import java.util.Collections;
+import javax.lang.model.util.Types;
+import org.checkerframework.dataflow.util.HashCodeUtils;
+import org.checkerframework.javacutil.InternalUtils;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
+/**
+ * A node for the single expression body of a single expression lambda
+ *
+ * @author Lazaro Clapp
+ */
+public class LambdaResultExpressionNode extends Node {
+
+    protected ExpressionTree tree;
+    protected /*@Nullable*/ Node result;
+
+    public LambdaResultExpressionNode(
+            ExpressionTree t, /*@Nullable*/ Node result, Types types /*,
+            LambdaExpressionTree lambda,
+            Symbol.MethodSymbol methodSymbol*/) {
+        super(InternalUtils.typeOf(t));
+        this.result = result;
+        tree = t;
+        //result.setAssignmentContext(new AssignmentContext.LambdaReturnContext(methodSymbol));
+    }
+
+    public Node getResult() {
+        return result;
+    }
+
+    @Override
+    public ExpressionTree getTree() {
+        return tree;
+    }
+
+    @Override
+    public <R, P> R accept(NodeVisitor<R, P> visitor, P p) {
+        return visitor.visitLambdaResultExpression(this, p);
+    }
+
+    @Override
+    public String toString() {
+        if (result != null) {
+            return "-> " + result;
+        }
+        return "-> ()";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || !(obj instanceof LambdaResultExpressionNode)) {
+            return false;
+        }
+        LambdaResultExpressionNode other = (LambdaResultExpressionNode) obj;
+        if ((result == null) != (other.result == null)) {
+            return false;
+        }
+        return (result == null || result.equals(other.result));
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeUtils.hash(result);
+    }
+
+    @Override
+    public Collection<Node> getOperands() {
+        if (result == null) {
+            return Collections.emptyList();
+        } else {
+            return Collections.singletonList(result);
+        }
+    }
+}

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -34,6 +34,7 @@ public class LambdaResultExpressionNode extends Node {
     public Node getResult() {
         return result;
     }
+
     /**
      * Returns the {@link ExpressionTree} corresponding to the body of a lambda expression with an
      * expression body (e.g. X for (<code>o -&gt; X</code>) where X is an expression and not a {...}

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -29,14 +29,15 @@ public class LambdaResultExpressionNode extends Node {
 
     /**
      * Returns the final node of the CFG corresponding to the lambda expression body (see {@link
-     * LambdaResultExpressionNode.getTree()}).
+     * #getTree()}).
      */
     public Node getResult() {
         return result;
     }
     /**
      * Returns the {@link ExpressionTree} corresponding to the body of a lambda expression with an
-     * expression body (e.g. X for (o -> X) where X is an expression and not a {...} block).
+     * expression body (e.g. X for (<code>o -&gt; X</code>) where X is an expression and not a {...}
+     * block).
      */
     @Override
     public ExpressionTree getTree() {

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/NodeVisitor.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/NodeVisitor.java
@@ -112,6 +112,8 @@ public interface NodeVisitor<R, P> {
 
     R visitReturn(ReturnNode n, P p);
 
+    R visitLambdaResultExpression(LambdaResultExpressionNode n, P p);
+
     R visitStringConversion(StringConversionNode n, P p);
 
     R visitNarrowingConversion(NarrowingConversionNode n, P p);


### PR DESCRIPTION
This adds a new node to the cfg, LambdaResultExpressionNode, which corresponds
to the result of a lambda expression with a single expression as its body, and
which is added at the end of the cfg when CFGBuilder is passed a CFGLambda of
this kind as the underlaying ast.

This is needed by some analyses to handle the result of a lambda expression in
the case where the body is a single ExpressionTree. The case where the body is
a block is already handled by matching ReturnNode.