### PR TITLE
Ensure only non-null types are scanned by AnnotatedTypeScanner.

### DIFF
--- a/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
+++ b/checker/src/org/checkerframework/checker/initialization/InitializationStore.java
@@ -102,10 +102,6 @@ public class InitializationStore<V extends CFAbstractValue<V>, S extends Initial
     @Override
     public void updateForMethodCall(
             MethodInvocationNode n, AnnotatedTypeFactory atypeFactory, V val) {
-        AnnotationMirror fieldInvariantAnnotation =
-                ((InitializationAnnotatedTypeFactory<?, ?, ?, ?>) atypeFactory)
-                        .getFieldInvariantAnnotation();
-
         // Remove invariant annotated fields to avoid performance issue reported in #1438.
         for (FieldAccess invariantField : invariantFields.keySet()) {
             fieldValues.remove(invariantField);

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -305,9 +305,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         protected Void scan(AnnotatedTypeMirror type, Void aVoid) {
-            if (type != null) {
-                replaceWithNewAnnoInSpecialCases(type);
-            }
+            replaceWithNewAnnoInSpecialCases(type);
             return super.scan(type, aVoid);
         }
 

--- a/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
+++ b/framework/src/org/checkerframework/framework/type/SupertypeFinder.java
@@ -396,7 +396,9 @@ class SupertypeFinder {
                     return visitedNodes.get(type);
                 }
                 visitedNodes.put(type, null);
-                scan(type.getEnclosingType(), mapping);
+                if (type.getEnclosingType() != null) {
+                    scan(type.getEnclosingType(), mapping);
+                }
 
                 List<AnnotatedTypeMirror> args = new ArrayList<AnnotatedTypeMirror>();
                 for (AnnotatedTypeMirror arg : type.getTypeArguments()) {

--- a/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -139,7 +139,6 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
             // the type of a class literal is the type of the "class" element.
             return f.getAnnotatedType(elt);
         }
-        String kind = elt.getKind().toString();
         switch (elt.getKind()) {
             case METHOD:
             case PACKAGE: // "java.lang" in new java.lang.Short("2")

--- a/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
+++ b/framework/src/org/checkerframework/framework/type/TypesIntoElements.java
@@ -313,9 +313,6 @@ public class TypesIntoElements {
                 ErrorReporter.errorAbort(
                         "TypesIntoElements: invalid usage, null pos with type: " + type);
             }
-            if (type == null) {
-                return List.nil();
-            }
             List<TypeCompound> res = super.scan(type, pos);
             return res;
         }

--- a/framework/src/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
+++ b/framework/src/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
@@ -125,10 +125,6 @@ public class ImplicitsTypeAnnotator extends TypeAnnotator {
 
     @Override
     protected Void scan(AnnotatedTypeMirror type, Void p) {
-
-        if (type == null) // on bounds, etc.
-        return super.scan(type, p);
-
         // If the type's fully-qualified name is in the appropriate map, annotate
         // the type. Do this before looking at kind or class, as this information
         // is more specific.

--- a/framework/src/org/checkerframework/framework/type/typeannotator/IrrelevantTypeAnnotator.java
+++ b/framework/src/org/checkerframework/framework/type/typeannotator/IrrelevantTypeAnnotator.java
@@ -71,9 +71,6 @@ public class IrrelevantTypeAnnotator extends TypeAnnotator {
 
     @Override
     protected Void scan(AnnotatedTypeMirror type, Void aVoid) {
-        if (type == null) {
-            return aVoid;
-        }
         switch (type.getKind()) {
             case TYPEVAR:
             case WILDCARD:
@@ -124,7 +121,9 @@ public class IrrelevantTypeAnnotator extends TypeAnnotator {
     public Void visitExecutable(AnnotatedExecutableType t, Void p) {
         // super skips the receiver
         scan(t.getReturnType(), p);
-        scanAndReduce(t.getReceiverType(), p, null);
+        if (t.getReceiverType() != null) {
+            scanAndReduce(t.getReceiverType(), p, null);
+        }
         scanAndReduce(t.getParameterTypes(), p, null);
         scanAndReduce(t.getThrownTypes(), p, null);
         scanAndReduce(t.getTypeVariables(), p, null);

--- a/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
@@ -61,11 +61,6 @@ public abstract class AnnotatedTypeComparer<R>
     }
 
     @Override
-    public R scanAndReduce(AnnotatedTypeMirror type, AnnotatedTypeMirror p, R r) {
-        return reduce(scan(type, p), r);
-    }
-
-    @Override
     protected R scanAndReduce(
             Iterable<? extends AnnotatedTypeMirror> types, AnnotatedTypeMirror p, R r) {
         ErrorReporter.errorAbort(
@@ -84,9 +79,13 @@ public abstract class AnnotatedTypeComparer<R>
     public final R visitDeclared(AnnotatedDeclaredType type, AnnotatedTypeMirror p) {
         assert p instanceof AnnotatedDeclaredType : p;
         R r = scan(type.getTypeArguments(), ((AnnotatedDeclaredType) p).getTypeArguments());
-        r =
-                scanAndReduce(
-                        type.getEnclosingType(), ((AnnotatedDeclaredType) p).getEnclosingType(), r);
+        if (type.getEnclosingType() != null) {
+            r =
+                    scanAndReduce(
+                            type.getEnclosingType(),
+                            ((AnnotatedDeclaredType) p).getEnclosingType(),
+                            r);
+        }
         return r;
     }
 
@@ -102,7 +101,9 @@ public abstract class AnnotatedTypeComparer<R>
         assert p instanceof AnnotatedExecutableType : p;
         AnnotatedExecutableType ex = (AnnotatedExecutableType) p;
         R r = scan(type.getReturnType(), ex.getReturnType());
-        r = scanAndReduce(type.getReceiverType(), ex.getReceiverType(), r);
+        if (type.getReceiverType() != null) {
+            r = scanAndReduce(type.getReceiverType(), ex.getReceiverType(), r);
+        }
         r = scanAndReduce(type.getParameterTypes(), ex.getParameterTypes(), r);
         r = scanAndReduce(type.getThrownTypes(), ex.getThrownTypes(), r);
         r = scanAndReduce(type.getTypeVariables(), ex.getTypeVariables(), r);

--- a/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeScanner.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeScanner.java
@@ -1,9 +1,5 @@
 package org.checkerframework.framework.type.visitor;
 
-/*>>>
-import org.checkerframework.checker.nullness.qual.Nullable;
-*/
-
 import java.util.IdentityHashMap;
 import java.util.Map;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -100,12 +96,12 @@ public class AnnotatedTypeScanner<R, P> implements AnnotatedTypeVisitor<R, P> {
      * Scan {@code type} by calling {@code type.accept(this, p)}; this method may be overridden by
      * subclasses.
      *
-     * @param type the possibly null type to scan
+     * @param type type to scan
      * @param p the parameter to use
      * @return the result of visiting {@code type}
      */
-    protected R scan(/*@Nullable*/ AnnotatedTypeMirror type, P p) {
-        return (type == null ? null : type.accept(this, p));
+    protected R scan(AnnotatedTypeMirror type, P p) {
+        return type.accept(this, p);
     }
 
     /**
@@ -140,7 +136,7 @@ public class AnnotatedTypeScanner<R, P> implements AnnotatedTypeVisitor<R, P> {
      * @param r result to combine with the result of scanning {@code type}
      * @return the combination of {@code r} with the result of scanning {@code type}
      */
-    public R scanAndReduce(/*@Nullable*/ AnnotatedTypeMirror type, P p, R r) {
+    protected R scanAndReduce(AnnotatedTypeMirror type, P p, R r) {
         return reduce(scan(type, p), r);
     }
 
@@ -165,7 +161,10 @@ public class AnnotatedTypeScanner<R, P> implements AnnotatedTypeVisitor<R, P> {
             return visitedNodes.get(type);
         }
         visitedNodes.put(type, null);
-        R r = scan(type.getEnclosingType(), p);
+        R r = null;
+        if (type.getEnclosingType() != null) {
+            scan(type.getEnclosingType(), p);
+        }
         r = scanAndReduce(type.getTypeArguments(), p, r);
         return r;
     }
@@ -199,7 +198,9 @@ public class AnnotatedTypeScanner<R, P> implements AnnotatedTypeVisitor<R, P> {
     @Override
     public R visitExecutable(AnnotatedExecutableType type, P p) {
         R r = scan(type.getReturnType(), p);
-        r = scanAndReduce(type.getReceiverType(), p, r);
+        if (type.getReceiverType() != null) {
+            r = scanAndReduce(type.getReceiverType(), p, r);
+        }
         r = scanAndReduce(type.getParameterTypes(), p, r);
         r = scanAndReduce(type.getThrownTypes(), p, r);
         r = scanAndReduce(type.getTypeVariables(), p, r);

--- a/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
+++ b/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
@@ -288,15 +288,13 @@ public class QualifierPolymorphism {
                         public Void scan(
                                 AnnotatedTypeMirror type,
                                 Map<AnnotationMirror, Set<? extends AnnotationMirror>> matches) {
-                            if (type != null) {
-                                for (Map.Entry<AnnotationMirror, Set<? extends AnnotationMirror>>
-                                        pqentry : matches.entrySet()) {
-                                    AnnotationMirror poly = pqentry.getKey();
-                                    if (poly != null && type.hasAnnotation(poly)) {
-                                        type.removeAnnotation(poly);
-                                        Set<? extends AnnotationMirror> quals = pqentry.getValue();
-                                        type.replaceAnnotations(quals);
-                                    }
+                            for (Map.Entry<AnnotationMirror, Set<? extends AnnotationMirror>>
+                                    pqentry : matches.entrySet()) {
+                                AnnotationMirror poly = pqentry.getKey();
+                                if (poly != null && type.hasAnnotation(poly)) {
+                                    type.removeAnnotation(poly);
+                                    Set<? extends AnnotationMirror> quals = pqentry.getValue();
+                                    type.replaceAnnotations(quals);
                                 }
                             }
                             return super.scan(type, matches);
@@ -310,21 +308,19 @@ public class QualifierPolymorphism {
     class Completer extends AnnotatedTypeScanner<Void, Void> {
         @Override
         protected Void scan(AnnotatedTypeMirror type, Void p) {
-            if (type != null) {
-                for (Map.Entry<AnnotationMirror, AnnotationMirror> pqentry : polyQuals.entrySet()) {
-                    AnnotationMirror top = pqentry.getKey();
-                    AnnotationMirror poly = pqentry.getValue();
+            for (Map.Entry<AnnotationMirror, AnnotationMirror> pqentry : polyQuals.entrySet()) {
+                AnnotationMirror top = pqentry.getKey();
+                AnnotationMirror poly = pqentry.getValue();
 
-                    if (type.hasAnnotation(poly)) {
-                        type.removeAnnotation(poly);
-                        if (top == null) {
-                            // poly is PolyAll -> add all tops not explicitly given
-                            type.addMissingAnnotations(topQuals);
-                        } else if (type.getKind() != TypeKind.TYPEVAR
-                                && type.getKind() != TypeKind.WILDCARD) {
-                            // Do not add the top qualifiers to type variables and wildcards
-                            type.addAnnotation(top);
-                        }
+                if (type.hasAnnotation(poly)) {
+                    type.removeAnnotation(poly);
+                    if (top == null) {
+                        // poly is PolyAll -> add all tops not explicitly given
+                        type.addMissingAnnotations(topQuals);
+                    } else if (type.getKind() != TypeKind.TYPEVAR
+                            && type.getKind() != TypeKind.WILDCARD) {
+                        // Do not add the top qualifiers to type variables and wildcards
+                        type.addAnnotation(top);
                     }
                 }
             }

--- a/framework/src/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -517,9 +517,6 @@ public class DependentTypesHelper {
 
         @Override
         protected Void scan(AnnotatedTypeMirror type, Void aVoid) {
-            if (type == null) {
-                return null;
-            }
             List<AnnotationMirror> newAnnos = new ArrayList<>();
             for (AnnotationMirror anno : type.getAnnotations()) {
                 AnnotationMirror annotationMirror =
@@ -634,9 +631,6 @@ public class DependentTypesHelper {
 
         @Override
         protected List<DependentTypesError> scan(AnnotatedTypeMirror type, Void aVoid) {
-            if (type == null) {
-                return super.scan(type, aVoid);
-            }
             List<DependentTypesError> errors = new ArrayList<>();
             for (AnnotationMirror am : type.getAnnotations()) {
                 if (isExpressionAnno(am)) {
@@ -753,9 +747,6 @@ public class DependentTypesHelper {
     private class ContainsDependentType extends AnnotatedTypeScanner<Boolean, Void> {
         @Override
         protected Boolean scan(AnnotatedTypeMirror type, Void aVoid) {
-            if (type == null) {
-                return false;
-            }
             for (AnnotationMirror am : type.getAnnotations()) {
                 if (isExpressionAnno(am)) {
                     return true;


### PR DESCRIPTION
Simplify some code accordingly.