### PR TITLE
Allow @IgnoreInWholeProgramInference to apply to fields

### DIFF
--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -32,6 +32,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.InternalUtils;
 
@@ -420,6 +421,9 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
         // @IgnoreInWholeProgramInference meta-annotation, exit this routine.
         for (AnnotationMirror declAnno :
                 atf.getDeclAnnotations(InternalUtils.symbol(lhs.getTree()))) {
+            if (AnnotationUtils.areSameByClass(declAnno, IgnoreInWholeProgramInference.class)) {
+                return;
+            }
             Element elt = declAnno.getAnnotationType().asElement();
             if (elt.getAnnotation(IgnoreInWholeProgramInference.class) != null) {
                 return;

--- a/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
+++ b/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
@@ -8,11 +8,11 @@ import java.lang.annotation.Target;
 
 /**
  * A meta-annotation indicating that an annotation type prevents whole-program inference. For
- * example, if the definition of {@code &#064;Inject} is meta-annotated with {@code
- * &#064;IgnoreInWholeProgramInference}:<br>
+ * example, if the definition of {@code @Inject} is meta-annotated with
+ * {@code @IgnoreInWholeProgramInference}:<br>
  * <tt>@IgnoreInWholeProgramInference</tt><br>
  * <tt>@interface Inject { }</tt><br>
- * then no type qualifier will be inferred for any field annotated by {@code &#064;Inject}.
+ * then no type qualifier will be inferred for any field annotated by {@code @Inject}.
  *
  * <p>This is appropriate for fields that are set reflectively, so there are no calls in client code
  * that type inference can learn from. Examples of qualifiers that should be meta-annotated with

--- a/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
+++ b/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
@@ -7,8 +7,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A meta-annotation indicating that an annotation type prevents whole-program inference. For
- * example, if the definition of {@code @Inject} is meta-annotated with
+ * This annotation can be used two ways:
+ *
+ * <p>1. As a meta-annotation indicating that an annotation type prevents whole-program inference.
+ * For example, if the definition of {@code @Inject} is meta-annotated with
  * {@code @IgnoreInWholeProgramInference}:<br>
  * <tt>@IgnoreInWholeProgramInference</tt><br>
  * <tt>@interface Inject { }</tt><br>
@@ -21,6 +23,9 @@ import java.lang.annotation.Target;
  * href="https://docs.oracle.com/javaee/7/api/javax/inject/Singleton.html">{@code @Singleton}</a>,
  * and <a
  * href="https://types.cs.washington.edu/plume-lib/api/plume/Option.html">{@code @Option}</a>.
+ *
+ * <p>2. As a field annotation indicating that no type qualifier will be inferred for the field it
+ * annotates.
  *
  * <p>See {@link
  * org.checkerframework.common.wholeprograminference.WholeProgramInferenceScenes#updateInferredFieldType}

--- a/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
+++ b/framework/src/org/checkerframework/framework/qual/IgnoreInWholeProgramInference.java
@@ -27,5 +27,5 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.ANNOTATION_TYPE)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD})
 public @interface IgnoreInWholeProgramInference {}

--- a/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
+++ b/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
@@ -1,5 +1,5 @@
 import java.lang.reflect.Field;
-import org.checerframework.framework.qual.IgnoreInWholeProgramInference;
+import org.checkerframework.framework.qual.IgnoreInWholeProgramInference;
 import testlib.wholeprograminference.qual.*;
 /**
  * This file contains expected errors that should exist even after the jaif type inference occurs.

--- a/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
+++ b/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
@@ -1,4 +1,5 @@
 import java.lang.reflect.Field;
+import org.checerframework.framework.qual.IgnoreInWholeProgramInference;
 import testlib.wholeprograminference.qual.*;
 /**
  * This file contains expected errors that should exist even after the jaif type inference occurs.
@@ -221,14 +222,18 @@ public class ExpectedErrors {
 
     class IgnoreMetaAnnotationTest2 {
         @ToIgnore int field;
+        @IgnoreInWholeProgramInference int field2;
 
         void foo() {
             field = getSibling1();
+            field2 = getSibling1();
         }
 
         void test() {
             //:: error: (argument.type.incompatible)
             expectsSibling1(field);
+            //:: error: (argument.type.incompatible)
+            expectsSibling1(field2);
         }
     }
 }


### PR DESCRIPTION
Also, implement the functionality of apply `@IgnoreInWholeProgramInference` to fields.

Fixes #1535 . 