### PR TITLE
Modernize handling of Vector#copyInto in BaseTypeVisitor

### DIFF
--- a/checker/tests/index/JodaFail.java
+++ b/checker/tests/index/JodaFail.java
@@ -1,0 +1,12 @@
+class Converter {}
+
+class PeriodConverter extends Converter {}
+
+public final class JodaFail {
+
+    void copyInto(Converter[] converters) {}
+
+    public void getPeriodConverters(PeriodConverter[] converters) {
+        copyInto(converters);
+    }
+}

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -179,6 +179,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     /** An instance of the {@link ContractsUtils} helper class. */
     protected final ContractsUtils contractsUtils;
 
+    /** The Vector#copyInto method from java.util.Vector. It is special-cased,
+     * because Java's type system isn't sufficiently powerful to typecheck it. */
+    private final ExecutableElement vectorCopyInto;
+
     /**
      * @param checker the type-checker associated with this visitor (for callbacks to {@link
      *     TypeHierarchy#isSubtype})
@@ -193,6 +197,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         this.visitorState = atypeFactory.getVisitorState();
         this.typeValidator = createTypeValidator();
         this.vectorType = atypeFactory.fromElement(elements.getTypeElement("java.util.Vector"));
+        this.vectorCopyInto = TreeUtils.getMethod("java.util.Vector", "copyInto", 1, atypeFactory.getProcessingEnv());
     }
 
     protected BaseTypeVisitor(BaseTypeChecker checker, Factory typeFactory) {
@@ -205,6 +210,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         this.visitorState = atypeFactory.getVisitorState();
         this.typeValidator = createTypeValidator();
         this.vectorType = atypeFactory.fromElement(elements.getTypeElement("java.util.Vector"));
+        this.vectorCopyInto = TreeUtils.getMethod("java.util.Vector", "copyInto", 1, atypeFactory.getProcessingEnv());
     }
 
     /**
@@ -1129,8 +1135,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     /** Returns true if the method symbol represents {@code Vector.copyInto} */
     protected boolean isVectorCopyInto(AnnotatedExecutableType method) {
         ExecutableElement elt = method.getElement();
-        if (elt.getSimpleName().contentEquals("copyInto") && elt.getParameters().size() == 1)
+        if (ElementUtils.isMethod(elt, vectorCopyInto, atypeFactory.getProcessingEnv())) {
             return true;
+        }
 
         return false;
     }

--- a/framework/tests/all-systems/JodaFail.java
+++ b/framework/tests/all-systems/JodaFail.java
@@ -1,0 +1,12 @@
+class Converter {}
+
+class PeriodConverter extends Converter {}
+
+public final class JodaFail {
+
+    void copyInto(Converter[] converters) {}
+
+    public void getPeriodConverters(PeriodConverter[] converters) {
+        copyInto(converters);
+    }
+}


### PR DESCRIPTION
`BaseTypeVisitor` has special handling for `Vector#copyInto`, because the semantics of that method aren't expressible in Java's type system (as enforced by `javac`). This special case has existed for at least 8 years, based on `git blame`. However, the check used to determine if a given method is actually `Vector#copyInto` just checked if the method was named "copyInto" and that it had one parameter.

Recently, the Index Checker experienced a crash while trying to do a case-study on the JodaTime project that was caused by this bug. JodaTime's `ConverterSet` class contains a method called "copyInto" that takes only one parameter. This caused `BaseTypeVisitor` to trigger the special case, and throw extraneous errors (this other `copyInto` method didn't need special handling...).

This change uses `ElementUtils#isMethod` to check that the method that triggers the special handling is actually either `Vector#copyInto` or a method that overrides it.

**Testing**
A minimized version of the failure from JodaTime is included as both an Index Checker test and an all-systems test. This test fails without this change, but passes with it.