### PR TITLE
Fix method overriding bug in Value Checker

### DIFF
--- a/checker/tests/index/MethodOverrides.java
+++ b/checker/tests/index/MethodOverrides.java
@@ -1,0 +1,20 @@
+// This class should not issues any errors from the value checker.
+// The index checker should issue the errors instead.
+
+// There is a copy of this test at checker/tests/value-index-interaction/MethodOverrides.java,
+// which does not include expected failures.
+
+import org.checkerframework.checker.index.qual.GTENegativeOne;
+
+public class MethodOverrides {
+    @GTENegativeOne int read() {
+        return -1;
+    }
+}
+
+class MethodOverrides2 extends MethodOverrides {
+    //:: error: (override.return.invalid)
+    int read() {
+        return -1;
+    }
+}

--- a/checker/tests/value-index-interaction/MethodOverrides.java
+++ b/checker/tests/value-index-interaction/MethodOverrides.java
@@ -1,0 +1,19 @@
+// This class should not issues any errors from the value checker.
+// The index checker should issue the errors instead.
+
+// There is a copy of this test at checker/tests/index/MethodOverrides.java,
+// which includes expected failures.
+
+import org.checkerframework.checker.index.qual.GTENegativeOne;
+
+public class MethodOverrides {
+    @GTENegativeOne int read() {
+        return -1;
+    }
+}
+
+class MethodOverrides2 extends MethodOverrides {
+    int read() {
+        return -1;
+    }
+}

--- a/framework/src/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/org/checkerframework/common/value/ValueVisitor.java
@@ -81,7 +81,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
     /**
      * Return types for methods that are annotated with {@code @IntRangeFromX} annotations need to
      * be replaced with {@code @UnknownVal}. See the documentation on {@link
-     * this#commonAssignmentCheck(AnnotatedTypeMirror, ExpressionTree, String)}.
+     * #commonAssignmentCheck(AnnotatedTypeMirror, ExpressionTree, String) commonAssignmentCheck}.
      *
      * <p>A separate override is necessary because checkOverride doesn't actually use the
      * commonAssignmentCheck.


### PR DESCRIPTION
This fixes the issue Suzanne discovered in the Daikon build with the Value Checker. The problem existed before for `@Positive` annotations, but became apparent when `@GTENegativeOne` annotations were added, because those appear in JDK methods that Daikon overrides. This change fixes that problem while at the same time reducing code duplication.