### PR TITLE
Clean up StubParser

### DIFF
--- a/checker/jtreg/stubs/Issue1542Driver.java
+++ b/checker/jtreg/stubs/Issue1542Driver.java
@@ -1,10 +1,9 @@
 /*
  * @test
  * @summary Test case for Issue 1542 https://github.com/typetools/checker-framework/issues/1542
- * @compile -XDrawDiagnostics issue1542/NeedsIntRange.java issue1542/UsesIntRange.java
- * @compile -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.tainting.TaintingChecker -AprintErrorStack -Anomsgtext Issue1542Driver.java -Astubs=issue1542/ -AstubWarnIfNotFound
+ *
+ * @compile -XDrawDiagnostics issue1542/NeedsIntRange.java issue1542/Stub.java issue1542/ExampleAnno.java
+ * @compile -XDrawDiagnostics -processor org.checkerframework.common.value.ValueChecker issue1542/UsesIntRange.java -Astubs=issue1542/ -AprintErrorStack -AstubWarnIfNotFound
  */
-
-package issue1542;
 
 public class Issue1542Driver {}

--- a/checker/jtreg/stubs/issue1542/ExampleAnno.java
+++ b/checker/jtreg/stubs/issue1542/ExampleAnno.java
@@ -1,0 +1,81 @@
+package issue1542;
+
+public class ExampleAnno {
+    public enum MyEnum {
+        A,
+        B,
+        C;
+    }
+
+    @interface DoubleExample {
+        double value();
+    }
+
+    @interface FloatExample {
+        float value();
+    }
+
+    @interface ShortExample {
+        short value();
+    }
+
+    @interface IntExample {
+        int value();
+    }
+
+    @interface LongExample {
+        long value();
+    }
+
+    @interface CharExample {
+        char value();
+    }
+
+    @interface StringExample {
+        String value();
+    }
+
+    @interface ClassExample {
+        Class<?> value();
+    }
+
+    @interface MyEnumExample {
+        MyEnum value();
+    }
+
+    @interface DoubleArrayExample {
+        double[] value();
+    }
+
+    @interface FloatArrayExample {
+        float[] value();
+    }
+
+    @interface ShortArrayExample {
+        short[] value();
+    }
+
+    @interface IntArrayExample {
+        int[] value();
+    }
+
+    @interface LongArrayExample {
+        long[] value();
+    }
+
+    @interface CharArrayExample {
+        char[] value();
+    }
+
+    @interface StringArrayExample {
+        String[] value();
+    }
+
+    @interface ClassArrayExample {
+        Class<?>[] value();
+    }
+
+    @interface MyEnumArrayExample {
+        MyEnum[] value();
+    }
+}

--- a/checker/jtreg/stubs/issue1542/Stub.astub
+++ b/checker/jtreg/stubs/issue1542/Stub.astub
@@ -1,0 +1,38 @@
+package issue1542;
+
+import issue1542.ExampleAnno.CharArrayExample;
+import issue1542.ExampleAnno.DoubleArrayExample;
+import issue1542.ExampleAnno.DoubleExample;
+import issue1542.ExampleAnno.LongArrayExample;
+import issue1542.ExampleAnno.LongExample;
+import issue1542.ExampleAnno.MyEnum;
+import static issue1542.ExampleAnno.MyEnum.*;
+import issue1542.ExampleAnno.MyEnumArrayExample;
+import issue1542.ExampleAnno.MyEnumExample;
+import issue1542.ExampleAnno.ClassArrayExample;
+import issue1542.ExampleAnno.ClassExample;
+
+public class Stub {
+    @CharArrayExample({1, 'a'}) int x1;
+    @CharArrayExample('a') int x2;
+    @CharArrayExample(1) int x3;
+    @LongExample(1) int x4;
+    @LongExample(1L) int x5;
+    @LongArrayExample(1L) int x6;
+    @LongArrayExample({1L, 1}) int x7;
+
+    @MyEnumArrayExample(MyEnum.A) int x8;
+    @MyEnumArrayExample(A) int x9;
+    @MyEnumArrayExample({MyEnum.A, B}) int x10;
+    @MyEnumExample(A) int x11;
+
+    @DoubleExample(0) int x12;
+    @DoubleExample(0L) int x13;
+    @DoubleExample(0.0) int x14;
+    @DoubleExample(0.0f) int x15;
+    @DoubleArrayExample({0, 0L, 0.0, 0.0F}) int x16;
+
+    @ClassExample(ClassExample.class) int x17;
+    @ClassArrayExample(ClassExample.class) int x18;
+    @ClassArrayExample({ClassExample.class, java.lang.String.class}) int x19;
+}

--- a/checker/jtreg/stubs/issue1542/Stub.java
+++ b/checker/jtreg/stubs/issue1542/Stub.java
@@ -1,0 +1,23 @@
+package issue1542;
+
+public class Stub {
+    int x1;
+    int x2;
+    int x3;
+    int x4;
+    int x5;
+    int x6;
+    int x7;
+    int x8;
+    int x9;
+    int x10;
+    int x11;
+    int x12;
+    int x13;
+    int x14;
+    int x15;
+    int x16;
+    int x17;
+    int x18;
+    int x19;
+}


### PR DESCRIPTION
This addresses some of the TODOs leftover from #1547. 

1. If an annotation expressions can't be parsed because an element can't be found, don't ErrorAbort, but rather issue a stubparser warning.

2.  Also, adds more tests for the different types of annotation values. 

3. One minor bug fix in the case:  `@DoubleValue( value = 1L)` where the type of value is double.  The `1L` must be converted to a double.