### PR TITLE
Make PolyUpperBound work correctly

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -928,7 +928,7 @@ public abstract class UBQualifier {
     }
 
     private static class PolyQualifier extends UBQualifier {
-        static final UBQualifier POLY = new UpperBoundBottomQualifier();
+        static final UBQualifier POLY = new PolyQualifier();
 
         @Override
         public boolean isPoly() {

--- a/checker/tests/index/UBPoly.java
+++ b/checker/tests/index/UBPoly.java
@@ -1,0 +1,21 @@
+// test case for issue 163: https://github.com/kelloggm/checker-framework/issues/163
+
+import org.checkerframework.checker.index.qual.LTLengthOf;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.PolyUpperBound;
+
+public class UBPoly {
+    public static void main(String[] args) {
+        char[] a = new char[10];
+        poly(a, 100);
+    }
+
+    public static void poly(char[] a, @NonNegative @PolyUpperBound int i) {
+        //:: error: (argument.type.incompatible)
+        access(a, i);
+    }
+
+    public static void access(char[] a, @NonNegative @LTLengthOf("#1") int j) {
+        char c = a[j];
+    }
+}


### PR DESCRIPTION
`@PolyUpperBound` annotations were being treated as `@UpperBoundBottom` annotations by `isSubtype`. This caused false negatives, as reported in kelloggm#163.

The problem was that the static variable on the `PolyQualifier` subclass of `UpperBoundQualifier` was incorrectly instantiated as an `UpperBoundBottomQualifier`. This change fixes the error and introduces a new test case.