### PR TITLE
Install binutil into dockers.

### DIFF
--- a/checker/bin-devel/Dockerfile-ubuntu-jdk8
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk8
@@ -20,5 +20,6 @@ RUN apt-get -qqy update && apt-get -qqy install \
   unzip \
   wget \
   default-jdk \
+  binutils \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk8
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk8
@@ -10,6 +10,7 @@ MAINTAINER Michael Ernst <mernst@cs.washington.edu>
 #  * Do not run "apt-get upgrade"; instead get upstream to update.
 RUN apt-get -qqy update && apt-get -qqy install \
   ant \
+  binutils \
   cpp \
   git \
   gradle \
@@ -20,6 +21,5 @@ RUN apt-get -qqy update && apt-get -qqy install \
   unzip \
   wget \
   default-jdk \
-  binutils \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*

--- a/checker/bin-devel/Dockerfile-ubuntu-jdkany
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdkany
@@ -15,6 +15,7 @@ RUN apt-get -qqy update && apt-get -qqy install \
 && add-apt-repository ppa:openjdk-r/ppa \
 && apt-get -qqy update && apt-get -qqy install \
   ant \
+  binutils \
   cpp \
   git \
   gradle \
@@ -25,7 +26,6 @@ RUN apt-get -qqy update && apt-get -qqy install \
   unzip \
   wget \
   default-jdk \
-  binutils \
 && apt-get -qqy install \
   dia \
   hevea \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdkany
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdkany
@@ -25,6 +25,7 @@ RUN apt-get -qqy update && apt-get -qqy install \
   unzip \
   wget \
   default-jdk \
+  binutils \
 && apt-get -qqy install \
   dia \
   hevea \


### PR DESCRIPTION
Currently we are working on integrating Z3 as a new solver to CF Inference, which requires `ar` tool be installed during building phase. Since CF Inference uses the same dockers here to running it's travis test, could we have `binutils` (this is the package provide `ar` tool) be installed in these dockers?

I've tested updated DockerFiles locally and it works.

Thanks a lot!