### PR TITLE
Install build-essential in dockers

### DIFF
--- a/checker/bin-devel/Dockerfile-ubuntu-jdk8
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk8
@@ -11,6 +11,7 @@ MAINTAINER Michael Ernst <mernst@cs.washington.edu>
 RUN apt-get -qqy update && apt-get -qqy install \
   ant \
   binutils \
+  build-essential \
   cpp \
   git \
   gradle \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdkany
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdkany
@@ -16,6 +16,7 @@ RUN apt-get -qqy update && apt-get -qqy install \
 && apt-get -qqy update && apt-get -qqy install \
   ant \
   binutils \
+  build-essential \
   cpp \
   git \
   gradle \


### PR DESCRIPTION
Sorry for bothering again. After installed `ar`, I've found `z3` also need c++ compilers be installed in dockers. Could we also install `build-essential` (this provides c++ compiler) into these dockers?

I've tested CFI  travis build script in updated dockers locally, and this time Z3 successfully built. So after merging this PR, I think dockers should be ready for Z3 integration.

Thanks again!