### PR TITLE
Add additional override in ValueVisitor to avoid spurious errors

### DIFF
--- a/checker/tests/value-index-interaction/MethodOverrides3.java
+++ b/checker/tests/value-index-interaction/MethodOverrides3.java
@@ -1,5 +1,5 @@
 // This class should not issues any errors, since these annotations are identical to the ones
-// on the class in java.io.PrintWriter.
+// on java.io.PrintWriter in the Index JDK.
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/checker/tests/value-index-interaction/MethodOverrides3.java
+++ b/checker/tests/value-index-interaction/MethodOverrides3.java
@@ -1,0 +1,17 @@
+// This class should not issues any errors, since these annotations are identical to the ones
+// on the class in java.io.PrintWriter.
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+
+public class MethodOverrides3 extends PrintWriter {
+    public MethodOverrides3(File file) throws FileNotFoundException {
+        super(file);
+    }
+
+    @Override
+    public void write(char[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {}
+}

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2417,6 +2417,31 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // Get the type of the overriding method.
         AnnotatedExecutableType overrider = atypeFactory.getAnnotatedType(overriderTree);
 
+        // Call the other version of the method, which takes overrider. The split is
+        // for compatibility reasons - the other method used to include this call.
+        return checkOverride(
+                overriderTree, overrider, overridingType, overridden, overriddenType, p);
+    }
+
+    /**
+     * Type checks that a method may override another method. Uses an OverrideChecker subclass as
+     * created by createOverrideChecker().
+     *
+     * @param overriderTree declaration tree of overriding method
+     * @param overrider type of the overriding method
+     * @param overridingType type of overriding class
+     * @param overridden type of overridden method
+     * @param overriddenType type of overridden class
+     * @return true if the override is allowed
+     */
+    protected boolean checkOverride(
+            MethodTree overriderTree,
+            AnnotatedExecutableType overrider,
+            AnnotatedDeclaredType overridingType,
+            AnnotatedExecutableType overridden,
+            AnnotatedDeclaredType overriddenType,
+            Void p) {
+
         // This needs to be done before overrider.getReturnType() and overridden.getReturnType()
         if (overrider.getTypeVariables().isEmpty() && !overridden.getTypeVariables().isEmpty()) {
             overridden = overridden.getErased();

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2401,8 +2401,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * Type checks that a method may override another method. Uses an OverrideChecker subclass as
      * created by createOverrideChecker(). This version of the method uses the annotated type
      * factory to get the annotated type of the overriding method, and does NOT expose that type.
-     * @see #checkOverride(MethodTree, AnnotatedExecutableType, AnnotatedDeclaredType, AnnotatedExecutableType, AnnotatedDeclaredType, Void)
      *
+     * @see #checkOverride(MethodTree, AnnotatedExecutableType, AnnotatedDeclaredType,
+     *     AnnotatedExecutableType, AnnotatedDeclaredType, Void)
      * @param overriderTree declaration tree of overriding method
      * @param overridingType type of overriding class
      * @param overridden type of overridden method
@@ -2420,17 +2421,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         AnnotatedExecutableType overrider = atypeFactory.getAnnotatedType(overriderTree);
 
         // Call the other version of the method, which takes overrider. Both versions
-	// exist to allow checkers to override one or the other depending on their needs.
+        // exist to allow checkers to override one or the other depending on their needs.
         return checkOverride(
                 overriderTree, overrider, overridingType, overridden, overriddenType, p);
     }
 
     /**
      * Type checks that a method may override another method. Uses an OverrideChecker subclass as
-     * created by createOverrideChecker(). This version of the method exposes AnnotatedExecutableType
-     * of the overriding method. Override this version of the method if you need to access that type.
-     * @see #checkOverride(MethodTree, AnnotatedDeclaredType, AnnotatedExecutableType, AnnotatedDeclaredType, Void)
+     * created by createOverrideChecker(). This version of the method exposes
+     * AnnotatedExecutableType of the overriding method. Override this version of the method if you
+     * need to access that type.
      *
+     * @see #checkOverride(MethodTree, AnnotatedDeclaredType, AnnotatedExecutableType,
+     *     AnnotatedDeclaredType, Void)
      * @param overriderTree declaration tree of overriding method
      * @param overrider type of the overriding method
      * @param overridingType type of overriding class

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2399,7 +2399,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     /**
      * Type checks that a method may override another method. Uses an OverrideChecker subclass as
-     * created by createOverrideChecker().
+     * created by createOverrideChecker(). This version of the method uses the annotated type
+     * factory to get the annotated type of the overriding method, and does NOT expose that type.
+     * @see #checkOverride(MethodTree, AnnotatedExecutableType, AnnotatedDeclaredType, AnnotatedExecutableType, AnnotatedDeclaredType, Void)
      *
      * @param overriderTree declaration tree of overriding method
      * @param overridingType type of overriding class
@@ -2417,15 +2419,17 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // Get the type of the overriding method.
         AnnotatedExecutableType overrider = atypeFactory.getAnnotatedType(overriderTree);
 
-        // Call the other version of the method, which takes overrider. The split is
-        // for compatibility reasons - the other method used to include this call.
+        // Call the other version of the method, which takes overrider. Both versions
+	// exist to allow checkers to override one or the other depending on their needs.
         return checkOverride(
                 overriderTree, overrider, overridingType, overridden, overriddenType, p);
     }
 
     /**
      * Type checks that a method may override another method. Uses an OverrideChecker subclass as
-     * created by createOverrideChecker().
+     * created by createOverrideChecker(). This version of the method exposes AnnotatedExecutableType
+     * of the overriding method. Override this version of the method if you need to access that type.
+     * @see #checkOverride(MethodTree, AnnotatedDeclaredType, AnnotatedExecutableType, AnnotatedDeclaredType, Void)
      *
      * @param overriderTree declaration tree of overriding method
      * @param overrider type of the overriding method

--- a/framework/src/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/org/checkerframework/common/value/ValueVisitor.java
@@ -89,12 +89,17 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
     @Override
     protected boolean checkOverride(
             MethodTree overriderTree,
+            AnnotatedTypeMirror.AnnotatedExecutableType overrider,
             AnnotatedTypeMirror.AnnotatedDeclaredType overridingType,
             AnnotatedTypeMirror.AnnotatedExecutableType overridden,
             AnnotatedTypeMirror.AnnotatedDeclaredType overriddenType,
             Void p) {
+
+        replaceSpecialIntRangeAnnotations(overrider);
         replaceSpecialIntRangeAnnotations(overridden);
-        return super.checkOverride(overriderTree, overridingType, overridden, overriddenType, p);
+
+        return super.checkOverride(
+                overriderTree, overrider, overridingType, overridden, overriddenType, p);
     }
 
     /**


### PR DESCRIPTION
See kelloggm#171 for a description of this issue: basically, overrides of JDK methods aren't being handled correctly wrt `@IntRangeFromX` annotations.

`BaseTypeVisitor` doesn't actually expose the interface needed to fix the problem, so I made a backwards-compatible change to `BaseTypeVisitor` that splits the `checkOverride` method so that there are two entry points, one of which `ValueVisitor` needs.