### PR TITLE
Remove empty defaults from Upper Bound Checker qualifiers

### DIFF
--- a/checker/src/org/checkerframework/checker/index/qual/IndexFor.java
+++ b/checker/src/org/checkerframework/checker/index/qual/IndexFor.java
@@ -31,5 +31,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IndexFor {
     /** Sequences that the annotated expression is a valid index for. */
-    String[] value() default {};
+    String[] value();
 }

--- a/checker/src/org/checkerframework/checker/index/qual/IndexOrHigh.java
+++ b/checker/src/org/checkerframework/checker/index/qual/IndexOrHigh.java
@@ -31,5 +31,5 @@ public @interface IndexOrHigh {
     /**
      * Sequences that the annotated expression is a valid index for or is equal to the lengeth of.
      */
-    String[] value() default {};
+    String[] value();
 }

--- a/checker/src/org/checkerframework/checker/index/qual/IndexOrLow.java
+++ b/checker/src/org/checkerframework/checker/index/qual/IndexOrLow.java
@@ -28,5 +28,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IndexOrLow {
     /** Sequences that the annotated expression is a valid index for (or it's -1). */
-    String[] value() default {};
+    String[] value();
 }

--- a/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
+++ b/checker/src/org/checkerframework/checker/index/qual/LengthOf.java
@@ -15,5 +15,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface LengthOf {
     /** Sequences that the annotated expression is equal to the lengeth of. */
-    String[] value() default {};
+    String[] value();
 }


### PR DESCRIPTION
These empty defaults cause crashes instead of helpful error messages. Upperbound qualifiers are meaningless without an argument, so they shouldn't allow no argument to be passed to them.

Closes kelloggm#173.