### PR TITLE
Avoid NPE in Regex Checker.

### DIFF
--- a/checker/src/org/checkerframework/checker/regex/RegexVisitor.java
+++ b/checker/src/org/checkerframework/checker/regex/RegexVisitor.java
@@ -91,9 +91,17 @@ public class RegexVisitor extends BaseTypeVisitor<RegexAnnotatedTypeFactory> {
                 LiteralTree literal = (LiteralTree) group;
                 int paramGroups = (Integer) literal.getValue();
                 ExpressionTree receiver = TreeUtils.getReceiverTree(node);
+                if (receiver == null) {
+                    // When checking java.util.regex.Matcher, calls to group (and other methods) don't
+                    // have a receiver tree.  So, just do the regular checking.  Verifying Matcher
+                    // or any other subclass of MatcherResult (where group is declared) is out of
+                    // scope for this checker.
+                    return super.visitMethodInvocation(node, p);
+                }
                 int annoGroups = 0;
                 AnnotatedTypeMirror receiverType = atypeFactory.getAnnotatedType(receiver);
-                if (receiverType.hasAnnotation(Regex.class)) {
+
+                if (receiverType != null && receiverType.hasAnnotation(Regex.class)) {
                     annoGroups =
                             atypeFactory.getGroupCount(receiverType.getAnnotation(Regex.class));
                 }

--- a/checker/src/org/checkerframework/checker/regex/RegexVisitor.java
+++ b/checker/src/org/checkerframework/checker/regex/RegexVisitor.java
@@ -92,10 +92,10 @@ public class RegexVisitor extends BaseTypeVisitor<RegexAnnotatedTypeFactory> {
                 int paramGroups = (Integer) literal.getValue();
                 ExpressionTree receiver = TreeUtils.getReceiverTree(node);
                 if (receiver == null) {
-                    // When checking java.util.regex.Matcher, calls to group (and other methods) don't
-                    // have a receiver tree.  So, just do the regular checking.  Verifying Matcher
-                    // or any other subclass of MatcherResult (where group is declared) is out of
-                    // scope for this checker.
+                    // When checking implementations of java.util.regex.MatcherResult, calls to
+                    // group (and other methods) don't have a receiver tree.  So, just do the
+                    // regular checking. Verifying an implemenation of a subclass of MatcherResult
+                    // is out of the scope of this checker.
                     return super.visitMethodInvocation(node, p);
                 }
                 int annoGroups = 0;

--- a/checker/tests/regex/MyMatchResult.java
+++ b/checker/tests/regex/MyMatchResult.java
@@ -1,0 +1,49 @@
+import java.util.regex.MatchResult;
+
+// Outside of scope of the Regex Checker to verify an implementation of MatchResult,
+// so just check for crashes.
+@SuppressWarnings("regex")
+public class MyMatchResult implements MatchResult {
+
+    @Override
+    public int start() {
+        group(0);
+        group();
+        end();
+        end(1);
+        groupCount();
+        start();
+        start(19);
+        return 0;
+    }
+
+    @Override
+    public int start(int group) {
+        return 0;
+    }
+
+    @Override
+    public int end() {
+        return 0;
+    }
+
+    @Override
+    public int end(int group) {
+        return 0;
+    }
+
+    @Override
+    public String group() {
+        return null;
+    }
+
+    @Override
+    public String group(int group) {
+        return null;
+    }
+
+    @Override
+    public int groupCount() {
+        return 0;
+    }
+}


### PR DESCRIPTION
It only occurs for implementations of java.util.regex.MatchResult.