### PR TITLE
Remove visitBinary from Lower Bound Checker Annotated Type Factory; move functionality to Lower Bound Transfer

### DIFF
--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.index.lowerbound;
 
-import static org.checkerframework.checker.index.IndexUtil.getExactValue;
 import static org.checkerframework.checker.index.IndexUtil.getPossibleValues;
 
 import com.sun.source.tree.BinaryTree;
@@ -8,7 +7,6 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
-import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.UnaryTree;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -39,6 +37,7 @@ import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.common.value.qual.BottomVal;
 import org.checkerframework.common.value.util.Range;
+import org.checkerframework.dataflow.cfg.node.NumericalMultiplicationNode;
 import org.checkerframework.framework.qual.PolyAll;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -193,7 +192,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /** Determine the annotation that should be associated with a literal. */
-    private AnnotationMirror anmFromVal(long val) {
+    AnnotationMirror anmFromVal(long val) {
         if (val >= 1) {
             return POS;
         } else if (val >= 0) {
@@ -220,6 +219,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          * Sets typeDst to the immediate supertype of typeSrc, unless typeSrc is already Positive.
          * Implements the following transitions:
          *
+         * <p>
+         *
          * <pre>
          *      pos &rarr; pos
          *      nn &rarr; pos
@@ -242,6 +243,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         /**
          * Sets typeDst to the immediate subtype of typeSrc, unless typeSrc is already
          * LowerBoundUnknown. Implements the following transitions:
+         *
+         * <p>
          *
          * <pre>
          *       pos &rarr; nn
@@ -319,28 +322,6 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         /**
-         * Looks up the minlen of a member select tree. Returns null if the tree doesn't represent
-         * an array's length field.
-         */
-        private Integer getMinLenFromMemberSelectTree(MemberSelectTree tree) {
-            if (TreeUtils.isArrayLengthAccess(tree)) {
-                return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
-            }
-            return null;
-        }
-
-        /**
-         * Looks up the minlen of a method invocation tree. Returns null if the tree doesn't
-         * represent an string length method.
-         */
-        private Integer getMinLenFromMethodInvocationTree(MethodInvocationTree tree) {
-            if (imf.isStringLength(tree, processingEnv)) {
-                return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
-            }
-            return null;
-        }
-
-        /**
          * For dealing with array length expressions. Looks for array length accesses specifically,
          * then dispatches to the MinLen checker to determine the length of the relevant array. If
          * it's found, use it to give the expression a type.
@@ -355,458 +336,78 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         /**
-         * Dispatch to binary operator helper methods. The Lower Bound Checker currently handles
-         * addition, subtraction, multiplication, division, and remainder.
+         * Does not dispatch to binary operator helper methods. The Lower Bound Checker handles
+         * binary operations via its transfer function.
          */
         @Override
         public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
-            // Check if this is a string concatenation. If so, bail.
-            if (TreeUtils.isStringConcatenation(tree)) {
-                type.addAnnotation(UNKNOWN);
-                return super.visitBinary(tree, type);
-            }
-
-            // Dispatch according to the operation.
-            ExpressionTree left = tree.getLeftOperand();
-            ExpressionTree right = tree.getRightOperand();
-            // Every "addAnnotationForX" method is stateful and modifies the variable "type".
-            switch (tree.getKind()) {
-                case PLUS:
-                    addAnnotationForPlus(left, right, type);
-                    break;
-                case MINUS:
-                    addAnnotationForMinus(left, right, type);
-                    break;
-                case MULTIPLY:
-                    addAnnotationForMultiply(left, right, type);
-                    break;
-                case DIVIDE:
-                    addAnnotationForDivide(left, right, type);
-                    break;
-                case REMAINDER:
-                    addAnnotationForRemainder(left, right, type);
-                    break;
-                case AND:
-                    addAnnotationForAnd(left, right, type);
-                    break;
-                case RIGHT_SHIFT:
-                    addAnnotationForRightShift(left, right, type);
-                    break;
-                default:
-                    break;
-            }
+            type.addAnnotation(UNKNOWN);
             return super.visitBinary(tree, type);
         }
-
-        /**
-         * Helper method for addAnnotationForPlus. Handles addition of constants.
-         *
-         * @param val the integer value of the constant
-         * @param nonLiteralType the type of the side of the expression that isn't a constant
-         * @param type the type of the result expression
-         */
-        private void addAnnotationForLiteralPlus(
-                int val, AnnotatedTypeMirror nonLiteralType, AnnotatedTypeMirror type) {
-            if (val == -2) {
-                if (nonLiteralType.hasAnnotation(POS)) {
-                    type.addAnnotation(GTEN1);
-                    return;
-                }
-            } else if (val == -1) {
-                demoteType(nonLiteralType, type);
-                return;
-            } else if (val == 0) {
-                // This gets the type of nonLiteralType in our hierarchy (in which POS is the
-                // bottom type).
-                type.addAnnotation(nonLiteralType.getAnnotationInHierarchy(POS));
-                return;
-            } else if (val == 1) {
-                promoteType(nonLiteralType, type);
-                return;
-            } else if (val >= 2) {
-                if (!nonLiteralType.hasAnnotation(UNKNOWN)) {
-                    // 2 + a positive, or a non-negative, or a non-negative-1 is a positive
-                    type.addAnnotation(POS);
-                    return;
-                }
-            }
-            type.addAnnotation(UNKNOWN);
-        }
-
-        /**
-         * addAnnotationForPlus handles the following cases:
-         *
-         * <pre>
-         *      lit -2 + pos &rarr; gte-1
-         *      lit -1 + * &rarr; call demote
-         *      lit 0 + * &rarr; *
-         *      lit 1 + * &rarr; call promote
-         *      lit &ge; 2 + {gte-1, nn, or pos} &rarr; pos
-         *      let all other lits, including sets, fall through:
-         *      pos + pos &rarr; pos
-         *      nn + * &rarr; *
-         *      pos + gte-1 &rarr; nn
-         *      * + * &rarr; lbu
-         *  </pre>
-         */
-        private void addAnnotationForPlus(
-                ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-
-            // Adding two literals is handled by visitBinary, so that
-            // case can be ignored.
-            AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-            // Check if the right side's value is known at compile time.
-
-            Long valRight = getExactValue(rightExpr, getValueAnnotatedTypeFactory());
-            if (valRight != null) {
-                addAnnotationForLiteralPlus(valRight.intValue(), leftType, type);
-                return;
-            }
-
-            AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-            // Check if the left side's value is known at compile time.
-
-            Long valLeft = getExactValue(leftExpr, getValueAnnotatedTypeFactory());
-            if (valLeft != null) {
-                addAnnotationForLiteralPlus(valLeft.intValue(), rightType, type);
-                return;
-            }
-
-            /* This section is handling the generic cases:
-             *      pos + pos -> pos
-             *      nn + * -> *
-             *      pos + gte-1 -> nn
-             */
-            if (leftType.hasAnnotation(POS) && rightType.hasAnnotation(POS)) {
-                type.addAnnotation(POS);
-                return;
-            }
-
-            if (leftType.hasAnnotation(NN)) {
-                type.addAnnotation(rightType.getAnnotationInHierarchy(POS));
-                return;
-            }
-            if (rightType.hasAnnotation(NN)) {
-                type.addAnnotation(leftType.getAnnotationInHierarchy(POS));
-                return;
-            }
-
-            if ((leftType.hasAnnotation(POS) && rightType.hasAnnotation(GTEN1))
-                    || (leftType.hasAnnotation(GTEN1) && rightType.hasAnnotation(POS))) {
-                type.addAnnotation(NN);
-                return;
-            }
-
-            // * + * -> lbu.
-            type.addAnnotation(UNKNOWN);
-        }
-
-        /**
-         * addAnnotationForMinus handles the following cases:
-         *
-         * <pre>
-         *      * - lit &rarr; call plus(*, -1 * the value of the lit)
-         *      * - * &rarr; lbu
-         *  </pre>
-         */
-        private void addAnnotationForMinus(
-                ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-
-            // Check if the right side's value is known at compile time.
-            Long valRight = getExactValue(rightExpr, getValueAnnotatedTypeFactory());
-            if (valRight != null) {
-                AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-                // Instead of a separate method for subtraction, add the negative of a constant.
-                addAnnotationForLiteralPlus(-1 * valRight.intValue(), leftType, type);
-
-                Integer minLen = null;
-                // Check if the left side is a field access of an array's length,
-                // or invocation of String.length. If so,
-                // try to look up the MinLen of the array, and potentially keep
-                // this either NN or POS instead of GTEN1 or LBU.
-                if (leftExpr.getKind() == Kind.MEMBER_SELECT) {
-                    MemberSelectTree mstree = (MemberSelectTree) leftExpr;
-                    minLen = getMinLenFromMemberSelectTree(mstree);
-                } else if (leftExpr.getKind() == Kind.METHOD_INVOCATION) {
-                    MethodInvocationTree mitree = (MethodInvocationTree) leftExpr;
-                    minLen = getMinLenFromMethodInvocationTree(mitree);
-                }
-
-                if (minLen != null) {
-                    type.replaceAnnotation(anmFromVal(minLen - valRight));
-                }
-
-                return;
-            }
-
-            // The checker can't reason about arbitrary (i.e. non-literal)
-            // things that are being subtracted, so it gives up.
-            type.addAnnotation(UNKNOWN);
-        }
-
-        /**
-         * Helper function for addAnnotationForMultiply. Handles compile-time known constants.
-         *
-         * @param val the integer value of the constant
-         * @param nonLiteralType the type of the side of the expression that isn't a constant
-         * @param type the type of the result expression
-         */
-        private void addAnnotationForLiteralMultiply(
-                int val, AnnotatedTypeMirror nonLiteralType, AnnotatedTypeMirror type) {
-            if (val == 0) {
-                type.addAnnotation(NN);
-                return;
-            } else if (val == 1) {
-                // Make the result type equal to nonLiteralType.
-                type.addAnnotation(nonLiteralType.getAnnotationInHierarchy(POS));
-                return;
-            } else if (val > 1) {
-                if (nonLiteralType.hasAnnotation(POS) || nonLiteralType.hasAnnotation(NN)) {
-                    type.addAnnotation(nonLiteralType.getAnnotationInHierarchy(POS));
-                    return;
-                }
-            }
-            type.addAnnotation(UNKNOWN);
-        }
-
-        private boolean checkForMathRandomSpecialCase(
-                ExpressionTree randTree, ExpressionTree arrLenTree, AnnotatedTypeMirror type) {
-            if (randTree.getKind() == Kind.METHOD_INVOCATION
-                    && TreeUtils.isArrayLengthAccess(arrLenTree)) {
-                MethodInvocationTree miTree = (MethodInvocationTree) randTree;
-
-                if (imf.isMathRandom(miTree, processingEnv)) {
-                    // This is Math.random() * array.length, which must be NonNegative
-                    type.addAnnotation(NN);
-                    return true;
-                }
-
-                if (imf.isRandomNextDouble(miTree, processingEnv)) {
-                    // This is Random.nextDouble() * array.length, which must be NonNegative
-                    type.addAnnotation(NN);
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        /**
-         * addAnnotationForMultiply handles the following cases:
-         *
-         * <pre>
-         *        * * lit 0 &rarr; nn (=0)
-         *        * * lit 1 &rarr; *
-         *        pos * pos &rarr; pos
-         *        pos * nn &rarr; nn
-         *        nn * nn &rarr; nn
-         *        * * * &rarr; lbu
-         *  </pre>
-         */
-        private void addAnnotationForMultiply(
-                ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-
-            // Special handling for multiplying an array length by a Math.random().
-            if (checkForMathRandomSpecialCase(rightExpr, leftExpr, type)
-                    || checkForMathRandomSpecialCase(leftExpr, rightExpr, type)) {
-                return;
-            }
-
-            AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-            // Check if the right side's value is known at compile time.
-
-            Long valRight = getExactValue(rightExpr, getValueAnnotatedTypeFactory());
-            if (valRight != null) {
-                addAnnotationForLiteralMultiply(valRight.intValue(), leftType, type);
-                return;
-            }
-
-            AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-            // Check if the left side's value is known at compile time.
-            Long valLeft = getExactValue(leftExpr, getValueAnnotatedTypeFactory());
-            if (valLeft != null) {
-                addAnnotationForLiteralMultiply(valLeft.intValue(), rightType, type);
-                return;
-            }
-
-            /* This section handles generic annotations:
-             *   pos * pos -> pos
-             *   nn * pos -> nn
-             *   nn * nn -> nn
-             */
-            if (leftType.hasAnnotation(POS) && rightType.hasAnnotation(POS)) {
-                type.addAnnotation(POS);
-                return;
-            }
-            if ((leftType.hasAnnotation(POS) && rightType.hasAnnotation(NN))
-                    || (leftType.hasAnnotation(NN) && rightType.hasAnnotation(POS))) {
-                type.addAnnotation(NN);
-                return;
-            }
-            if (leftType.hasAnnotation(NN) && rightType.hasAnnotation(NN)) {
-                type.addAnnotation(NN);
-                return;
-            }
-            type.addAnnotation(UNKNOWN);
-        }
-
-        /** When the value on the left is known at compile time. */
-        private void addAnnotationForLiteralDivideLeft(
-                int val, AnnotatedTypeMirror rightType, AnnotatedTypeMirror type) {
-            if (val == 0) {
-                type.addAnnotation(NN);
-            } else if (val == 1) {
-                if (rightType.hasAnnotation(NN) || rightType.hasAnnotation(POS)) {
-                    type.addAnnotation(NN);
-                } else {
-                    // (1 / x) can't be outside the range [-1, 1] when x is an integer.
-                    type.addAnnotation(GTEN1);
-                }
-            }
-        }
-
-        /** When the value on the right is known at compile time. */
-        private void addAnnotationForLiteralDivideRight(
-                int val, AnnotatedTypeMirror leftType, AnnotatedTypeMirror type) {
-            if (val == 0) {
-                // Reaching this indicates a divide by zero error. If the value is zero, then this is
-                // division by zero. Division by zero is treated as bottom so that users
-                // aren't warned about dead code that's dividing by zero. This code assumes that non-dead
-                // code won't include literal divide by zeros...
-                type.addAnnotation(BOTTOM);
-            } else if (val == 1) {
-                type.addAnnotation(leftType.getAnnotationInHierarchy(POS));
-            } else if (val >= 2) {
-                if (leftType.hasAnnotation(NonNegative.class)
-                        || leftType.hasAnnotation(Positive.class)) {
-                    type.addAnnotation(NN);
-                }
-            }
-        }
-
-        /**
-         * addAnnotationForDivide handles these cases:
-         *
-         * <pre>
-         * lit 0 / * &rarr; nn (=0)
-         *      * / lit 0 &rarr; pos
-         *      lit 1 / {pos, nn} &rarr; nn
-         *      lit 1 / * &rarr; gten1
-         *      * / lit 1 &rarr; *
-         *      {pos, nn} / lit &gt;1 &rarr; nn
-         *      pos / {pos, nn} &rarr; nn (can round to zero)
-         *      * / {pos, nn} &rarr; *
-         *      * / * &rarr; lbu
-         *  </pre>
-         */
-        private void addAnnotationForDivide(
-                ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-
-            AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-            // Check if the right side's value is known at compile time.
-
-            Long valRight = getExactValue(rightExpr, getValueAnnotatedTypeFactory());
-            if (valRight != null) {
-                addAnnotationForLiteralDivideRight(valRight.intValue(), leftType, type);
-                return;
-            }
-
-            AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-            // Check if the left side's value is known at compile time.
-            Long valLeft = getExactValue(leftExpr, getValueAnnotatedTypeFactory());
-            if (valLeft != null) {
-                addAnnotationForLiteralDivideLeft(valLeft.intValue(), leftType, type);
-                return;
-            }
-
-            /* This section handles generic annotations:
-             *    pos / {pos, nn} -> nn (can round to zero)
-             *    * / {pos, nn} -> *
-             */
-            if (leftType.hasAnnotation(POS)
-                    && (rightType.hasAnnotation(POS) || rightType.hasAnnotation(NN))) {
-                type.addAnnotation(NN);
-                return;
-            }
-            if (rightType.hasAnnotation(POS) || rightType.hasAnnotation(NN)) {
-                type.addAnnotation(leftType.getAnnotationInHierarchy(POS));
-                return;
-            }
-            // Everything else is unknown.
-            type.addAnnotation(UNKNOWN);
-        }
-
-        /** A remainder with 1 or -1 as the divisor always results in zero. */
-        private void addAnnotationForLiteralRemainder(int val, AnnotatedTypeMirror type) {
-            if (val == 1 || val == -1) {
-                type.addAnnotation(NN);
-            }
-        }
-
-        /**
-         * addAnnotationForRemainder handles these cases: * % 1/-1 &rarr; nn pos/nn % * &rarr; nn
-         * gten1 % * &rarr; gten1 * % * &rarr; lbu
-         */
-        public void addAnnotationForRemainder(
-                ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-            AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-            AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-
-            // Check if the right side's value is known at compile time.
-            Long valRight = getExactValue(rightExpr, getValueAnnotatedTypeFactory());
-            if (valRight != null) {
-                addAnnotationForLiteralRemainder(valRight.intValue(), type);
-            }
-
-            /* This section handles generic annotations:
-               pos/nn % * -> nn
-               gten1 % * -> gten1
-            */
-            if (leftType.hasAnnotation(POS) || leftType.hasAnnotation(NN)) {
-                type.addAnnotation(NN);
-                return;
-            }
-            if (leftType.hasAnnotation(GTEN1)) {
-                type.addAnnotation(GTEN1);
-                return;
-            }
-
-            // Everything else is unknown.
-            type.addAnnotation(UNKNOWN);
-        }
-    }
-
-    /** Handles shifts. * &gt;&gt; NonNegative &rarr; NonNegative */
-    private void addAnnotationForRightShift(
-            ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-        AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-        AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-        if (leftType.hasAnnotation(NN) || leftType.hasAnnotation(POS)) {
-            if (rightType.hasAnnotation(NN) || rightType.hasAnnotation(POS)) {
-                type.addAnnotation(NN);
-                return;
-            }
-        }
-        type.addAnnotation(UNKNOWN);
     }
 
     /**
-     * Handles masking. Particularly, handles the following cases: * &amp; NonNegative &rarr;
-     * NonNegative
+     * Looks up the minlen of a member select tree. Returns null if the tree doesn't represent an
+     * array's length field.
      */
-    private void addAnnotationForAnd(
-            ExpressionTree leftExpr, ExpressionTree rightExpr, AnnotatedTypeMirror type) {
-        AnnotatedTypeMirror rightType = getAnnotatedType(rightExpr);
-        if (rightType.hasAnnotation(NN) || rightType.hasAnnotation(POS)) {
-            type.addAnnotation(NN);
-            return;
+    Integer getMinLenFromMemberSelectTree(MemberSelectTree tree) {
+        if (TreeUtils.isArrayLengthAccess(tree)) {
+            return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
         }
+        return null;
+    }
 
-        AnnotatedTypeMirror leftType = getAnnotatedType(leftExpr);
-        if (leftType.hasAnnotation(NN) || leftType.hasAnnotation(POS)) {
-            type.addAnnotation(NN);
-            return;
+    /**
+     * Looks up the minlen of a method invocation tree. Returns null if the tree doesn't represent
+     * an string length method.
+     */
+    Integer getMinLenFromMethodInvocationTree(MethodInvocationTree tree) {
+        if (imf.isStringLength(tree, processingEnv)) {
+            return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
         }
+        return null;
+    }
 
-        type.addAnnotation(UNKNOWN);
+    /**
+     * Determines whether the multiplication includes a call to Math.random that requires
+     * special-casing by the LBC. In particular, the LBC must special cases calls to Math.random *
+     * array.length and Random.nextDouble() * array.length.
+     *
+     * @param node a multiplication node that may need special casing
+     * @return an AnnotationMirror representing the result if the special case is valid, or null if
+     *     not
+     */
+    AnnotationMirror checkForMathRandomSpecialCase(NumericalMultiplicationNode node) {
+        AnnotationMirror forwardRes =
+                checkForMathRandomSpecialCase(
+                        node.getLeftOperand().getTree(), node.getRightOperand().getTree());
+        if (forwardRes != null) {
+            return forwardRes;
+        }
+        AnnotationMirror backwardsRes =
+                checkForMathRandomSpecialCase(
+                        node.getRightOperand().getTree(), node.getLeftOperand().getTree());
+        if (backwardsRes != null) {
+            return backwardsRes;
+        }
+        return null;
+    }
+
+    private AnnotationMirror checkForMathRandomSpecialCase(Tree randTree, Tree arrLenTree) {
+        if (randTree.getKind() == Tree.Kind.METHOD_INVOCATION
+                && TreeUtils.isArrayLengthAccess(arrLenTree)) {
+            MethodInvocationTree miTree = (MethodInvocationTree) randTree;
+
+            if (imf.isMathRandom(miTree, processingEnv)) {
+                // This is Math.random() * array.length, which must be NonNegative
+                return NN;
+            }
+
+            if (imf.isRandomNextDouble(miTree, processingEnv)) {
+                // This is Random.nextDouble() * array.length, which must be NonNegative
+                return NN;
+            }
+        }
+        return null;
     }
 }

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -1,19 +1,33 @@
 package org.checkerframework.checker.index.lowerbound;
 
+import static org.checkerframework.checker.index.IndexUtil.getExactValue;
+
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
 import org.checkerframework.checker.index.IndexRefinementInfo;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
 import org.checkerframework.checker.index.qual.LowerBoundUnknown;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
+import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
+import org.checkerframework.dataflow.cfg.node.BinaryOperationNode;
+import org.checkerframework.dataflow.cfg.node.BitwiseAndNode;
+import org.checkerframework.dataflow.cfg.node.IntegerDivisionNode;
+import org.checkerframework.dataflow.cfg.node.IntegerRemainderNode;
 import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.dataflow.cfg.node.NumericalAdditionNode;
+import org.checkerframework.dataflow.cfg.node.NumericalMultiplicationNode;
+import org.checkerframework.dataflow.cfg.node.NumericalSubtractionNode;
+import org.checkerframework.dataflow.cfg.node.SignedRightShiftNode;
+import org.checkerframework.dataflow.cfg.node.UnsignedRightShiftNode;
 import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
@@ -21,6 +35,8 @@ import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * Implements dataflow refinement rules based on tests: &lt;, &gt;, ==, and their derivatives.
+ *
+ * <p>Also implements the logic for binary operations: +, -, *, /, and %.
  *
  * <p>&gt;, &lt;, &ge;, &le;, ==, and != nodes are represented as combinations of &gt; and &ge;
  * (e.g. == is &ge; in both directions in the then branch), and implement refinements based on these
@@ -126,8 +142,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
             Node mLiteral, Node otherNode, AnnotationMirror otherAnno, CFStore store) {
 
         Long integerLiteral =
-                IndexUtil.getExactValue(
-                        mLiteral.getTree(), aTypeFactory.getValueAnnotatedTypeFactory());
+                getExactValue(mLiteral.getTree(), aTypeFactory.getValueAnnotatedTypeFactory());
 
         if (integerLiteral == null) {
             return;
@@ -241,5 +256,507 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
                 aTypeFactory.getQualifierHierarchy().greatestLowerBound(rightAnno, leftAnno);
 
         store.insertValue(leftRec, newLBType);
+    }
+
+    /** Inserts the type below oldAnm in the hierarchy into the store as the value of rec. */
+    private AnnotationMirror demoteType(AnnotationMirror oldAnm) {
+        if (isPositive(oldAnm)) {
+            return NN;
+        } else if (isNonNegative(oldAnm)) {
+            return GTEN1;
+        } else {
+            return UNKNOWN;
+        }
+    }
+
+    /** Inserts the type above oldAnm in the hierarchy into the store as the value of rec. */
+    private AnnotationMirror promoteType(AnnotationMirror oldAnm) {
+        if (isNonNegative(oldAnm)) {
+            return POS;
+        } else if (isGTEN1(oldAnm)) {
+            return NN;
+        } else {
+            return UNKNOWN;
+        }
+    }
+
+    /**
+     * Helper method for getAnnotationForPlus. Handles addition of constants.
+     *
+     * @param val the integer value of the constant
+     * @param nonLiteralType the type of the side of the expression that isn't a constant
+     */
+    private AnnotationMirror getAnnotationForLiteralPlus(int val, AnnotationMirror nonLiteralType) {
+        if (val == -2) {
+            if (isPositive(nonLiteralType)) {
+                return GTEN1;
+            }
+        } else if (val == -1) {
+            return demoteType(nonLiteralType);
+        } else if (val == 0) {
+            return nonLiteralType;
+        } else if (val == 1) {
+            return promoteType(nonLiteralType);
+        } else if (val >= 2) {
+            if (isGTEN1(nonLiteralType)) {
+                // 2 + a positive, or a non-negative, or a non-negative-1 is a positive
+                return POS;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * getAnnotationForPlus handles the following cases:
+     *
+     * <pre>
+     *      lit -2 + pos &rarr; gte-1
+     *      lit -1 + * &rarr; call demote
+     *      lit 0 + * &rarr; *
+     *      lit 1 + * &rarr; call promote
+     *      lit &ge; 2 + {gte-1, nn, or pos} &rarr; pos
+     *      let all other lits, including sets, fall through:
+     *      pos + pos &rarr; pos
+     *      nn + * &rarr; *
+     *      pos + gte-1 &rarr; nn
+     *      * + * &rarr; lbu
+     *  </pre>
+     */
+    private AnnotationMirror getAnnotationForPlus(
+            BinaryOperationNode binaryOpNode, TransferInput<CFValue, CFStore> p) {
+
+        Node leftExprNode = binaryOpNode.getLeftOperand();
+        Node rightExprNode = binaryOpNode.getRightOperand();
+
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(leftExprNode, p);
+
+        // Check if the right side's value is known at compile time.
+        Long valRight =
+                getExactValue(rightExprNode.getTree(), aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valRight != null) {
+            return getAnnotationForLiteralPlus(valRight.intValue(), leftAnno);
+        }
+
+        AnnotationMirror rightAnno = getLowerBoundAnnotation(rightExprNode, p);
+
+        // Check if the left side's value is known at compile time.
+        Long valLeft =
+                getExactValue(leftExprNode.getTree(), aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valLeft != null) {
+            return getAnnotationForLiteralPlus(valLeft.intValue(), rightAnno);
+        }
+
+        /* This section is handling the generic cases:
+         *      pos + pos -> pos
+         *      nn + * -> *
+         *      pos + gte-1 -> nn
+         */
+        if (AnnotationUtils.areSameByClass(leftAnno, Positive.class)
+                && AnnotationUtils.areSameByClass(rightAnno, Positive.class)) {
+            return POS;
+        }
+
+        if (AnnotationUtils.areSameByClass(leftAnno, NonNegative.class)) {
+            return rightAnno;
+        }
+
+        if (AnnotationUtils.areSameByClass(rightAnno, NonNegative.class)) {
+            return leftAnno;
+        }
+
+        if ((isPositive(leftAnno) && isGTEN1(rightAnno))
+                || (isGTEN1(leftAnno) && isPositive(rightAnno))) {
+            return NN;
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * getAnnotationForMinus handles the following cases:
+     *
+     * <pre>
+     *      * - lit &rarr; call plus(*, -1 * the value of the lit)
+     *      * - * &rarr; lbu
+     *  </pre>
+     */
+    private AnnotationMirror getAnnotationForMinus(
+            BinaryOperationNode minusNode, TransferInput<CFValue, CFStore> p) {
+
+        // Check if the right side's value is known at compile time.
+        Long valRight =
+                getExactValue(
+                        minusNode.getRightOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valRight != null) {
+            AnnotationMirror leftAnno = getLowerBoundAnnotation(minusNode.getLeftOperand(), p);
+            // Instead of a separate method for subtraction, add the negative of a constant.
+            AnnotationMirror result =
+                    getAnnotationForLiteralPlus(-1 * valRight.intValue(), leftAnno);
+
+            Tree leftExpr = minusNode.getLeftOperand().getTree();
+            Integer minLen = null;
+            // Check if the left side is a field access of an array's length,
+            // or invocation of String.length. If so,
+            // try to look up the MinLen of the array, and potentially keep
+            // this either NN or POS instead of GTEN1 or LBU.
+            if (leftExpr.getKind() == Tree.Kind.MEMBER_SELECT) {
+                MemberSelectTree mstree = (MemberSelectTree) leftExpr;
+                minLen = aTypeFactory.getMinLenFromMemberSelectTree(mstree);
+            } else if (leftExpr.getKind() == Tree.Kind.METHOD_INVOCATION) {
+                MethodInvocationTree mitree = (MethodInvocationTree) leftExpr;
+                minLen = aTypeFactory.getMinLenFromMethodInvocationTree(mitree);
+            }
+
+            if (minLen != null) {
+                result = aTypeFactory.anmFromVal(minLen - valRight);
+            }
+            return result;
+        }
+
+        // The checker can't reason about arbitrary (i.e. non-literal)
+        // things that are being subtracted, so it gives up.
+        return UNKNOWN;
+    }
+
+    /**
+     * Helper function for getAnnotationForMultiply. Handles compile-time known constants.
+     *
+     * @param val the integer value of the constant
+     * @param nonLiteralType the type of the side of the expression that isn't a constant
+     */
+    private AnnotationMirror getAnnotationForLiteralMultiply(
+            int val, AnnotationMirror nonLiteralType) {
+        if (val == 0) {
+            return NN;
+        } else if (val == 1) {
+            return nonLiteralType;
+        } else if (val > 1) {
+            if (isNonNegative(nonLiteralType)) {
+                return nonLiteralType;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * getAnnotationForMultiply handles the following cases:
+     *
+     * <pre>
+     *        * * lit 0 &rarr; nn (=0)
+     *        * * lit 1 &rarr; *
+     *        pos * pos &rarr; pos
+     *        pos * nn &rarr; nn
+     *        nn * nn &rarr; nn
+     *        * * * &rarr; lbu
+     *  </pre>
+     */
+    private AnnotationMirror getAnnotationForMultiply(
+            NumericalMultiplicationNode node, TransferInput<CFValue, CFStore> p) {
+
+        // Special handling for multiplying an array length by a Math.random().
+        AnnotationMirror randomSpecialCaseResult = aTypeFactory.checkForMathRandomSpecialCase(node);
+        if (randomSpecialCaseResult != null) {
+            return randomSpecialCaseResult;
+        }
+
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
+
+        // Check if the right side's value is known at compile time.
+        Long valRight =
+                getExactValue(
+                        node.getRightOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valRight != null) {
+            return getAnnotationForLiteralMultiply(valRight.intValue(), leftAnno);
+        }
+
+        AnnotationMirror rightAnno = getLowerBoundAnnotation(node.getRightOperand(), p);
+        // Check if the left side's value is known at compile time.
+        Long valLeft =
+                getExactValue(
+                        node.getLeftOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valLeft != null) {
+            return getAnnotationForLiteralMultiply(valLeft.intValue(), rightAnno);
+        }
+
+        /* This section handles generic annotations:
+         *   pos * pos -> pos
+         *   nn * pos -> nn (elided, since positives are also non-negative)
+         *   nn * nn -> nn
+         */
+        if (isPositive(leftAnno) && isPositive(rightAnno)) {
+            return POS;
+        }
+        if (isNonNegative(leftAnno) && isNonNegative(rightAnno)) {
+            return NN;
+        }
+        return UNKNOWN;
+    }
+
+    /** When the value on the left is known at compile time. */
+    private AnnotationMirror addAnnotationForLiteralDivideLeft(
+            int val, AnnotationMirror rightAnno) {
+        if (val == 0) {
+            return NN;
+        } else if (val == 1) {
+            if (isNonNegative(rightAnno)) {
+                return NN;
+            } else {
+                // (1 / x) can't be outside the range [-1, 1] when x is an integer.
+                return GTEN1;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /** When the value on the right is known at compile time. */
+    private AnnotationMirror addAnnotationForLiteralDivideRight(
+            int val, AnnotationMirror leftAnno) {
+        if (val == 0) {
+            // Reaching this indicates a divide by zero error. If the value is zero, then this is
+            // division by zero. Division by zero is treated as bottom so that users
+            // aren't warned about dead code that's dividing by zero. This code assumes that non-dead
+            // code won't include literal divide by zeros...
+            return aTypeFactory.BOTTOM;
+        } else if (val == 1) {
+            return leftAnno;
+        } else if (val >= 2) {
+            if (isNonNegative(leftAnno)) {
+                return NN;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * getAnnotationForDivide handles these cases:
+     *
+     * <pre>
+     * lit 0 / * &rarr; nn (=0)
+     *      * / lit 0 &rarr; pos
+     *      lit 1 / {pos, nn} &rarr; nn
+     *      lit 1 / * &rarr; gten1
+     *      * / lit 1 &rarr; *
+     *      {pos, nn} / lit &gt;1 &rarr; nn
+     *      pos / {pos, nn} &rarr; nn (can round to zero)
+     *      * / {pos, nn} &rarr; *
+     *      * / * &rarr; lbu
+     *  </pre>
+     */
+    private AnnotationMirror getAnnotationForDivide(
+            IntegerDivisionNode node, TransferInput<CFValue, CFStore> p) {
+
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
+
+        // Check if the right side's value is known at compile time.
+        Long valRight =
+                getExactValue(
+                        node.getRightOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valRight != null) {
+            return addAnnotationForLiteralDivideRight(valRight.intValue(), leftAnno);
+        }
+
+        AnnotationMirror rightAnno = getLowerBoundAnnotation(node.getRightOperand(), p);
+
+        // Check if the left side's value is known at compile time.
+        Long valLeft =
+                getExactValue(
+                        node.getLeftOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valLeft != null) {
+            return addAnnotationForLiteralDivideLeft(valLeft.intValue(), leftAnno);
+        }
+
+        /* This section handles generic annotations:
+         *    pos / {pos, nn} -> nn (can round to zero)
+         *    * / {pos, nn} -> *
+         */
+        if (isPositive(leftAnno) && isNonNegative(rightAnno)) {
+            return NN;
+        }
+        if (isNonNegative(rightAnno)) {
+            return leftAnno;
+        }
+        // Everything else is unknown.
+        return UNKNOWN;
+    }
+
+    /** A remainder with 1 or -1 as the divisor always results in zero. */
+    private AnnotationMirror addAnnotationForLiteralRemainder(int val) {
+        if (val == 1 || val == -1) {
+            return NN;
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * getAnnotationForRemainder handles these cases: * % 1/-1 &rarr; nn pos/nn % * &rarr; nn gten1
+     * % * &rarr; gten1 * % * &rarr; lbu
+     */
+    public AnnotationMirror getAnnotationForRemainder(
+            IntegerRemainderNode node, TransferInput<CFValue, CFStore> p) {
+
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
+
+        // Check if the right side's value is known at compile time.
+        Long valRight =
+                getExactValue(
+                        node.getRightOperand().getTree(),
+                        aTypeFactory.getValueAnnotatedTypeFactory());
+        if (valRight != null) {
+            return addAnnotationForLiteralRemainder(valRight.intValue());
+        }
+
+        /* This section handles generic annotations:
+              pos/nn % * -> nn
+              gten1 % * -> gten1
+        */
+        if (isNonNegative(leftAnno)) {
+            return NN;
+        }
+        if (isGTEN1(leftAnno)) {
+            return GTEN1;
+        }
+
+        // Everything else is unknown.
+        return UNKNOWN;
+    }
+
+    /** Handles shifts. * &gt;&gt; NonNegative &rarr; NonNegative */
+    private AnnotationMirror getAnnotationForRightShift(
+            BinaryOperationNode node, TransferInput<CFValue, CFStore> p) {
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
+        AnnotationMirror rightAnno = getLowerBoundAnnotation(node.getRightOperand(), p);
+
+        if (isNonNegative(leftAnno)) {
+            if (isNonNegative(rightAnno)) {
+                return NN;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    /**
+     * Handles masking. Particularly, handles the following cases: * &amp; NonNegative &rarr;
+     * NonNegative
+     */
+    private AnnotationMirror getAnnotationForAnd(
+            BitwiseAndNode node, TransferInput<CFValue, CFStore> p) {
+
+        AnnotationMirror rightAnno = getLowerBoundAnnotation(node.getRightOperand(), p);
+        if (isNonNegative(rightAnno)) {
+            return NN;
+        }
+
+        AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
+        if (isNonNegative(leftAnno)) {
+            return NN;
+        }
+        return UNKNOWN;
+    }
+
+    private boolean isPositive(AnnotationMirror anm) {
+        return AnnotationUtils.areSameByClass(anm, Positive.class);
+    }
+
+    private boolean isNonNegative(AnnotationMirror anm) {
+        return AnnotationUtils.areSameByClass(anm, NonNegative.class) || isPositive(anm);
+    }
+
+    private boolean isGTEN1(AnnotationMirror anm) {
+        return AnnotationUtils.areSameByClass(anm, GTENegativeOne.class) || isNonNegative(anm);
+    }
+
+    private AnnotationMirror getLowerBoundAnnotation(
+            Node subNode, TransferInput<CFValue, CFStore> p) {
+        CFValue value = p.getValueOfSubNode(subNode);
+        return getLowerBoundAnnotation(value);
+    }
+
+    private AnnotationMirror getLowerBoundAnnotation(CFValue cfValue) {
+        return aTypeFactory
+                .getQualifierHierarchy()
+                .findAnnotationInHierarchy(cfValue.getAnnotations(), aTypeFactory.UNKNOWN);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitNumericalAddition(
+            NumericalAdditionNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> result = super.visitNumericalAddition(n, p);
+        AnnotationMirror newAnno = getAnnotationForPlus(n, p);
+        return createNewResult(result, newAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitNumericalSubtraction(
+            NumericalSubtractionNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> result = super.visitNumericalSubtraction(n, p);
+        AnnotationMirror newAnno = getAnnotationForMinus(n, p);
+        return createNewResult(result, newAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitNumericalMultiplication(
+            NumericalMultiplicationNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> result = super.visitNumericalMultiplication(n, p);
+        AnnotationMirror newAnno = getAnnotationForMultiply(n, p);
+        return createNewResult(result, newAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitIntegerDivision(
+            IntegerDivisionNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> result = super.visitIntegerDivision(n, p);
+        AnnotationMirror newAnno = getAnnotationForDivide(n, p);
+        return createNewResult(result, newAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitIntegerRemainder(
+            IntegerRemainderNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> transferResult = super.visitIntegerRemainder(n, p);
+        AnnotationMirror resultAnno = getAnnotationForRemainder(n, p);
+        return createNewResult(transferResult, resultAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitSignedRightShift(
+            SignedRightShiftNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> transferResult = super.visitSignedRightShift(n, p);
+        AnnotationMirror resultAnno = getAnnotationForRightShift(n, p);
+        return createNewResult(transferResult, resultAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitUnsignedRightShift(
+            UnsignedRightShiftNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> transferResult = super.visitUnsignedRightShift(n, p);
+        AnnotationMirror resultAnno = getAnnotationForRightShift(n, p);
+        return createNewResult(transferResult, resultAnno);
+    }
+
+    @Override
+    public TransferResult<CFValue, CFStore> visitBitwiseAnd(
+            BitwiseAndNode n, TransferInput<CFValue, CFStore> p) {
+        TransferResult<CFValue, CFStore> transferResult = super.visitBitwiseAnd(n, p);
+        AnnotationMirror resultAnno = getAnnotationForAnd(n, p);
+        return createNewResult(transferResult, resultAnno);
+    }
+
+    /**
+     * Create a new transfer result based on the original result and the new annotation.
+     *
+     * @param result the original result
+     * @param resultAnno the new annotation
+     * @return the new transfer result
+     */
+    private TransferResult<CFValue, CFStore> createNewResult(
+            TransferResult<CFValue, CFStore> result, AnnotationMirror resultAnno) {
+        CFValue newResultValue =
+                analysis.createSingleAnnotationValue(
+                        resultAnno, result.getResultValue().getUnderlyingType());
+        return new RegularTransferResult<>(newResultValue, result.getRegularStore());
     }
 }

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -258,8 +258,10 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         store.insertValue(leftRec, newLBType);
     }
 
-    /** Inserts the type below oldAnm in the hierarchy into the store as the value of rec. */
-    private AnnotationMirror demoteType(AnnotationMirror oldAnm) {
+    /**
+     * Returns an annotation mirror representing the result of subtracting one from {@code oldAnm}.
+     */
+    private AnnotationMirror anmAfterSubtractingOne(AnnotationMirror oldAnm) {
         if (isPositive(oldAnm)) {
             return NN;
         } else if (isNonNegative(oldAnm)) {
@@ -269,8 +271,8 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         }
     }
 
-    /** Inserts the type above oldAnm in the hierarchy into the store as the value of rec. */
-    private AnnotationMirror promoteType(AnnotationMirror oldAnm) {
+    /** Returns an annotation mirror representing the result of adding one to {@code oldAnm}. */
+    private AnnotationMirror anmAfterAddingOne(AnnotationMirror oldAnm) {
         if (isNonNegative(oldAnm)) {
             return POS;
         } else if (isGTEN1(oldAnm)) {
@@ -292,11 +294,11 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
                 return GTEN1;
             }
         } else if (val == -1) {
-            return demoteType(nonLiteralType);
+            return anmAfterSubtractingOne(nonLiteralType);
         } else if (val == 0) {
             return nonLiteralType;
         } else if (val == 1) {
-            return promoteType(nonLiteralType);
+            return anmAfterAddingOne(nonLiteralType);
         } else if (val >= 2) {
             if (isGTEN1(nonLiteralType)) {
                 // 2 + a positive, or a non-negative, or a non-negative-1 is a positive


### PR DESCRIPTION
The Index Checker is known to suffer performance issues. This is the first step towards resolving that problem.

This PR removes code from `LowerBoundTreeAnnotator#visitBinary` and replaces the functionality with code in the transfer function. The previous version of `visitBinary` required calls to `getAnnotatedType`, which is known to be exponentially slow when processing nested binary expressions.

Running `ant index-tests` on my laptop takes 2 minutes 1 second with this PR, and 2 min 29 seconds without it (~18% faster).

Running `javac -processor lowerbound tests/index/BigBinaryExpr.java` with this PR takes 11.2 seconds, while master takes 16.0 seconds (~30% faster). Note that this test is currently commented out. I uncommented it to get these numbers.