### PR TITLE
Fix crash in Guava

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -943,10 +943,9 @@ public abstract class AnnotatedTypeMirror {
                             (AnnotatedTypeVariable) declaration.getTypeArguments().get(i);
                     TypeVariableSubstitutor varSubstitutor = atypeFactory.getTypeVarSubstitutor();
                     // The upper bound of a type parameter may refer to other type parameters.
-                    // Substitute those references with the type argument, but make a copy so that
-                    // the merge happens without a concurrent modification exception.
+                    // Substitute those references with the type argument.
                     AnnotatedTypeMirror typeParamUpperBound =
-                            varSubstitutor.substitute(map, typeParam.getUpperBound()).deepCopy();
+                            varSubstitutor.substitute(map, typeParam.getUpperBound());
 
                     AnnotatedWildcardType wct = (AnnotatedWildcardType) typeArgs.get(i);
                     AnnotatedTypeMerger.merge(typeParamUpperBound, wct.getExtendsBound());

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -943,9 +943,10 @@ public abstract class AnnotatedTypeMirror {
                             (AnnotatedTypeVariable) declaration.getTypeArguments().get(i);
                     TypeVariableSubstitutor varSubstitutor = atypeFactory.getTypeVarSubstitutor();
                     // The upper bound of a type parameter may refer to other type parameters.
-                    // Substitute those references with the type argument.
+                    // Substitute those references with the type argument, but make a copy so that
+                    // the merge happens without a concurrent modification exception.
                     AnnotatedTypeMirror typeParamUpperBound =
-                            varSubstitutor.substitute(map, typeParam.getUpperBound());
+                            varSubstitutor.substitute(map, typeParam.getUpperBound()).deepCopy();
 
                     AnnotatedWildcardType wct = (AnnotatedWildcardType) typeArgs.get(i);
                     AnnotatedTypeMerger.merge(typeParamUpperBound, wct.getExtendsBound());

--- a/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeVariableSubstitutor.java
@@ -42,11 +42,11 @@ public class TypeVariableSubstitutor {
      *
      * @param argument the argument to declaration (this will be a value in typeParamToArg)
      * @param use the use that is being replaced
-     * @return a shallow copy of argument with the appropriate annotations applied
+     * @return a deep copy of argument with the appropriate annotations applied
      */
     protected AnnotatedTypeMirror substituteTypeVariable(
             final AnnotatedTypeMirror argument, final AnnotatedTypeVariable use) {
-        final AnnotatedTypeMirror substitute = argument.shallowCopy(false);
+        final AnnotatedTypeMirror substitute = argument.deepCopy(true);
         substitute.addAnnotations(argument.getAnnotationsField());
 
         if (!use.getAnnotationsField().isEmpty()) {

--- a/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeMerger.java
+++ b/framework/src/org/checkerframework/framework/type/visitor/AnnotatedTypeMerger.java
@@ -58,6 +58,7 @@ public class AnnotatedTypeMerger extends AnnotatedTypeComparer<Void> {
 
     @Override
     protected Void compare(AnnotatedTypeMirror one, AnnotatedTypeMirror two) {
+        assert one != two;
         if (one != null && two != null) {
             replaceAnnotations(one, two);
         }

--- a/framework/tests/all-systems/Issue1587.java
+++ b/framework/tests/all-systems/Issue1587.java
@@ -14,4 +14,15 @@ abstract class Issue1587 {
     }
 
     abstract Iterable<MyObject> g(Iterable<MyObject> r);
+
+    interface Class2<C, D extends Class2<C, D>> {}
+
+    static class Class1<A, B extends Class2<A, B>> {
+
+        static void test() {}
+
+        void use() {
+            Class1.test();
+        }
+    }
 }


### PR DESCRIPTION
The fix for #1587 caused another crash when type-checking Guava.  This pull request fixes that crash.