### PR TITLE
Always recalculate direct super types for AnnotatedDeclaredTypes

### DIFF
--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -130,14 +130,6 @@ public class AnnotatedTypeCopier
             copy.setTypeArguments(copyTypeArgs);
         }
 
-        if (original.supertypes != null) {
-            final List<AnnotatedDeclaredType> copySupertypes = new ArrayList<>();
-            for (final AnnotatedDeclaredType supertype : original.supertypes) {
-                copySupertypes.add((AnnotatedDeclaredType) visit(supertype, originalToCopy));
-            }
-            copy.supertypes = Collections.unmodifiableList(copySupertypes);
-        }
-
         return copy;
     }
 

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -829,8 +829,6 @@ public abstract class AnnotatedTypeMirror {
         /** The enclosing Type */
         protected AnnotatedDeclaredType enclosingType;
 
-        protected List<AnnotatedDeclaredType> supertypes = null;
-
         private boolean declaration;
 
         /**
@@ -989,21 +987,7 @@ public abstract class AnnotatedTypeMirror {
 
         @Override
         public List<AnnotatedDeclaredType> directSuperTypes() {
-            if (supertypes == null) {
-                supertypes = Collections.unmodifiableList(SupertypeFinder.directSuperTypes(this));
-            }
-            return supertypes;
-        }
-
-        /*
-         * Return the direct super types field without lazy initialization;
-         * originally to prevent infinite recursion in IGJATF.postDirectSuperTypes.
-         *
-         * TODO: find a nicer way, see the single caller in QualifierDefaults
-         * for comment.
-         */
-        public List<AnnotatedDeclaredType> directSuperTypesField() {
-            return supertypes;
+            return Collections.unmodifiableList(SupertypeFinder.directSuperTypes(this));
         }
 
         @Override


### PR DESCRIPTION
If the annotations on the AnnotatedDeclaredType or enclosing type changes or if the type arguments change, then the super types must be recomputed.  Instead of keeping track of these changes, just recompute.  

Fixes #1605.

I'm not sure if this is the best fix. It's not clear to me why the super types were stored for the AnnotatedDeclaredTypes in the first place.  (The only other types they are stored for is AnnotatedIntersectionTypes which makes sense because the super types can be directly annotated.) My guess is for performance.  I'll run this branch on ~Guava and~ the JDK to see if there is any difference.  There was no impact with Guava.
