### PR TITLE
Don't issue methodref.inference.unimplemented warnings

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2468,9 +2468,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         return overrideChecker.checkOverride();
     }
 
-    // Only issue the methodref.inference.unimplemented message once
-    private static boolean typeArgumentInferenceCheck = false;
-
     /**
      * Check that a method reference is allowed. Using the OverrideChecker class.
      *
@@ -2589,11 +2586,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                 }
             }
             if (requiresInference) {
-                if (!typeArgumentInferenceCheck) {
+                if (checker.hasOption("conservativeUninferredTypeArguments")) {
                     checker.report(
                             Result.warning("methodref.inference.unimplemented"),
                             memberReferenceTree);
-                    typeArgumentInferenceCheck = true;
                 }
                 return true;
             }

--- a/framework/tests/all-systems/java8/memberref/MemberReferences.java
+++ b/framework/tests/all-systems/java8/memberref/MemberReferences.java
@@ -1,3 +1,6 @@
+// If conservativeUninferredTypeArguments option is used, then the lines marked
+// "TODO: ISsue 802", will issue a methodref.inference.unimplemented warning.
+
 interface Supplier<R> {
     R supply();
 }
@@ -30,7 +33,6 @@ class Super {
         void context() {
             FunctionMR<Object, Object> f1 = super::func1;
             // TODO: Issue 802: type argument inference
-            // TODO: should expect warning: (methodref.inference.unimplemented)
             FunctionMR f2 = super::func2;
             // Top level wildcards are ignored when type checking
             FunctionMR<? extends String, ? extends String> f3 = super::<String>func2;

--- a/framework/tests/all-systems/java8/memberref/MemberReferences.java
+++ b/framework/tests/all-systems/java8/memberref/MemberReferences.java
@@ -1,5 +1,5 @@
 // If conservativeUninferredTypeArguments option is used, then the lines marked
-// "TODO: ISsue 802", will issue a methodref.inference.unimplemented warning.
+// "TODO: Issue 802", will issue a methodref.inference.unimplemented warning.
 
 interface Supplier<R> {
     R supply();


### PR DESCRIPTION
If conservativeUninferredTypeArguments is used; otherwise, never issue the warning.