### PR TITLE
Fix typo in javadoc.astub and add testing infrastructure

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -827,10 +827,17 @@
         </antcall>
     </target>
 
-    <target name="index-tests" depends="jar,build-tests"
+    <target name="index-tests" depends="jar,build-tests, index-javadoc-astub-tests"
             description="Run tests for the Index Checker">
         <antcall target="-run-tests">
             <param name="param" value="tests.IndexTest"/>
+        </antcall>
+    </target>
+
+    <target name="index-javadoc-astub-tests" depends="jar,build-tests"
+            description="Run javadoc astub test with the Index Checker">
+        <antcall target="-run-tests">
+            <param name="param" value="tests.JavadocAstubTest"/>
         </antcall>
     </target>
 

--- a/checker/lib/javadoc.astub
+++ b/checker/lib/javadoc.astub
@@ -1,4 +1,4 @@
-import org.checkerframework.common.value.MinLen;
+import org.checkerframework.common.value.qual.MinLen;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;

--- a/checker/tests/index-javadoc-astub/IndexJavadocAnnos.java
+++ b/checker/tests/index-javadoc-astub/IndexJavadocAnnos.java
@@ -1,0 +1,10 @@
+import com.sun.javadoc.RootDoc;
+import org.checkerframework.common.value.qual.MinLen;
+
+public class IndexJavadocAnnos {
+    void test(IndexJavadocAnnos o, RootDoc root) {
+        o.setOptions(root.options());
+    }
+
+    void setOptions(Object @MinLen(1) [] objs) {}
+}

--- a/checker/tests/src/tests/JavadocAstubTest.java
+++ b/checker/tests/src/tests/JavadocAstubTest.java
@@ -1,0 +1,26 @@
+package tests;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/** JUnit tests for the javadoc astub for the Index Checker. */
+public class JavadocAstubTest extends CheckerFrameworkPerDirectoryTest {
+
+    public JavadocAstubTest(List<File> testFiles) {
+        super(
+                testFiles,
+                org.checkerframework.checker.index.IndexChecker.class,
+                "index",
+                "-Anomsgtext",
+                "-AprintErrorStack",
+                "-AstubWarnIfNotFound",
+                "-Astubs=" + "lib/javadoc.astub");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"index-javadoc-astub"};
+    }
+}


### PR DESCRIPTION
I did a bad thing. In typetools#1613, I added a javadoc.astub file but I didn't add automated tests for it. This PR fixes that problem, and also removes a typo in the javadoc.astub file itself that the testing regime would have caught.