### PR TITLE
Clean up AnnotatedTypeMirror: remove commented out code and actually

### DIFF
--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -469,16 +469,16 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         public Void visitMethod(MethodTree node, AnnotatedTypeMirror type) {
             AnnotatedTypeMirror.AnnotatedExecutableType methType =
                     (AnnotatedTypeMirror.AnnotatedExecutableType) type;
-            Effect e = getDeclaredEffect(methType.getElement());
+            // Effect e = getDeclaredEffect(methType.getElement());
             TypeElement cls = (TypeElement) methType.getElement().getEnclosingElement();
 
             // STEP 1: Get the method effect annotation
-            if (!hasExplicitEffect(methType.getElement())) {
-                // TODO: This line does nothing!
-                // AnnotatedTypeMirror.addAnnotation silently ignores non-qualifier annotations!
-                // We should be digging up the /declaration/ of the method, and annotating that.
-                methType.addAnnotation(e.getAnnot());
-            }
+            // if (!hasExplicitEffect(methType.getElement())) {
+            // TODO: This line does nothing!
+            // AnnotatedTypeMirror.addAnnotation silently ignores non-qualifier annotations!
+            // We should be digging up the /declaration/ of the method, and annotating that.
+            // methType.addAnnotation(e.getAnnot());
+            // }
 
             // STEP 2: Fix up the method receiver annotation
             AnnotatedTypeMirror.AnnotatedDeclaredType receiverType = methType.getReceiverType();

--- a/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -228,20 +228,20 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
         Effect.EffectRange range =
                 atypeFactory.findInheritedEffectRange(
                         ((TypeElement) methElt.getEnclosingElement()), methElt, true, node);
-        if (targetUIP == null && targetSafeP == null && targetPolyP == null) {
-            // implicitly annotate this method with the LUB of the effects of the methods it
-            // overrides
-            // atypeFactory.fromElement(methElt).addAnnotation(range != null ? range.min.getAnnot()
-            // : (isUIType(((TypeElement)methElt.getEnclosingElement())) ? UI.class :
-            // AlwaysSafe.class));
-            // TODO: This line does nothing! AnnotatedTypeMirror.addAnnotation
-            // silently ignores non-qualifier annotations!
-            // System.err.println("ERROR: TREE ANNOTATOR SHOULD HAVE ADDED EXPLICIT ANNOTATION! ("
-            //     +node.getName()+")");
-            atypeFactory
-                    .fromElement(methElt)
-                    .addAnnotation(atypeFactory.getDeclaredEffect(methElt).getAnnot());
-        }
+        // if (targetUIP == null && targetSafeP == null && targetPolyP == null) {
+        // implicitly annotate this method with the LUB of the effects of the methods it
+        // overrides
+        // atypeFactory.fromElement(methElt).addAnnotation(range != null ? range.min.getAnnot()
+        // : (isUIType(((TypeElement)methElt.getEnclosingElement())) ? UI.class :
+        // AlwaysSafe.class));
+        // TODO: This line does nothing! AnnotatedTypeMirror.addAnnotation
+        // silently ignores non-qualifier annotations!
+        // System.err.println("ERROR: TREE ANNOTATOR SHOULD HAVE ADDED EXPLICIT ANNOTATION! ("
+        //     +node.getName()+")");
+        // atypeFactory
+        //         .fromElement(methElt)
+        //         .addAnnotation(atypeFactory.getDeclaredEffect(methElt).getAnnot());
+        // }
 
         // We hang onto the current method here for ease.  We back up the old
         // current method because this code is reentrant when we traverse methods of an inner class

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -1001,29 +1001,6 @@ public abstract class AnnotatedTypeMirror {
             }
         }
 
-        /* Using this equals method resulted in an infinite recursion
-         * with type variables. TODO: Keep track of visited type variables?
-        @Override
-        public boolean equals(Object o) {
-            boolean res = super.equals(o);
-
-            if (res && (o instanceof AnnotatedDeclaredType)) {
-                AnnotatedDeclaredType dt = (AnnotatedDeclaredType) o;
-
-                List<AnnotatedTypeMirror> mytas = this.getTypeArguments();
-                List<AnnotatedTypeMirror> othertas = dt.getTypeArguments();
-                for (int i = 0; i < mytas.size(); ++i) {
-                    if (!mytas.get(i).equals(othertas.get(i))) {
-                        System.out.println("in AnnotatedDeclaredType; this: " + this + " and " + o);
-                        res = false;
-                        break;
-                    }
-                }
-            }
-            return res;
-        }
-        */
-
         /** Sets the enclosing type */
         /*default-visibility*/ void setEnclosingType(AnnotatedDeclaredType enclosingType) {
             this.enclosingType = enclosingType;
@@ -1073,41 +1050,14 @@ public abstract class AnnotatedTypeMirror {
             return (ExecutableType) this.actualType;
         }
 
-        /* TODO: it never makes sense to add annotations to an executable type -
-         * instead, they should be added to the right component.
-         * For simpler, more regular use, we might want to allow querying for annotations.
-         *
-        @Override
-        public void addAnnotations(Iterable<? extends AnnotationMirror> annotations) {
-            // Thread.dumpStack();
-            super.addAnnotations(annotations);
-        }
+        /**
+         * It never makes sense to add annotations to an executable type - instead, they should be
+         * added to the right component.
+         */
         @Override
         public void addAnnotation(AnnotationMirror a) {
-            // Thread.dumpStack();
-            super.addAnnotation(a);
+            assert false : "AnnotatedExecutableType.addAnnotation should never be called";
         }
-        @Override
-        public void addAnnotation(Class<? extends Annotation> a) {
-            // Thread.dumpStack();
-            super.addAnnotation(a);
-        }
-
-        @Override
-        public Set<AnnotationMirror> getAnnotations() {
-            Thread.dumpStack();
-            return null;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (!(o instanceof AnnotatedExecutableType)) {
-                return false;
-                }
-            // TODO compare components
-            return true;
-        }
-        */
 
         /**
          * Sets the parameter types of this executable type

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -794,7 +794,7 @@ public class QualifierDefaults {
         private static void addAnnotation(AnnotatedTypeMirror type, AnnotationMirror qual) {
             // Add the default annotation, but only if no other
             // annotation is present.
-            if (!type.isAnnotatedInHierarchy(qual)) {
+            if (!type.isAnnotatedInHierarchy(qual) && type.getKind() != TypeKind.EXECUTABLE) {
                 type.addAnnotation(qual);
             }
 


### PR DESCRIPTION
prevent adding annotations to AnnotatedExecutableType.