### PR TITLE
Make sure jdk exists before running tests that use it.

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -827,7 +827,7 @@
         </antcall>
     </target>
 
-    <target name="index-tests" depends="jar,build-tests"
+    <target name="index-tests" depends="jar,jdk.jar.exists,build-tests"
             description="Run tests for the Index Checker">
         <antcall target="-run-tests">
             <param name="param" value="tests.IndexTest"/>
@@ -841,7 +841,7 @@
         </antcall>
     </target>
 
-    <target name="lock-tests" depends="jar,build-tests"
+    <target name="lock-tests" depends="jar,jdk.jar.exists,build-tests"
             description="Run tests for the Lock Checker">
         <antcall target="-run-tests">
             <param name="param" value="tests.LockTest"/>
@@ -1508,6 +1508,8 @@
          <env key="LT_BIN" value="${LT_BIN}"/>
       </exec>
       <move file="jdk/jdk.jar" tofile="jdk/${jdkName}"/>
+        <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
+        <copy file="jdk/${jdkName}" tofile="dist/${jdkName}"/>
 
     </target>
 

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1508,8 +1508,8 @@
          <env key="LT_BIN" value="${LT_BIN}"/>
       </exec>
       <move file="jdk/jdk.jar" tofile="jdk/${jdkName}"/>
-        <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
-        <copy file="jdk/${jdkName}" tofile="dist/${jdkName}"/>
+      <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
+      <copy file="jdk/${jdkName}" tofile="dist/${jdkName}"/>
 
     </target>
 
@@ -1543,9 +1543,6 @@
 
         <copy tofile="dist/javac.jar" file="${javac.lib}"
               overwrite="true" failonerror="true" />
-
-        <copy file="jdk/jdk8.jar" tofile="dist/jdk8.jar" overwrite="true" failonerror="false" />
-        <copy file="jdk/jdk9.jar" tofile="dist/jdk9.jar" overwrite="true" failonerror="false" />
     </target>
 
     <target name="jdk.jar.exists"


### PR DESCRIPTION
Also, copy jdk.jar to dist after it is created.