### PR TITLE
Add an invalid dependency on a checker annotation.

### DIFF
--- a/framework/tests/all-systems/WildcardSuper.java
+++ b/framework/tests/all-systems/WildcardSuper.java
@@ -1,4 +1,8 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 class WildcardSuper {
+    @Nullable Object foo;
+
     interface Consumer<T> {
         void consume(T object);
     }


### PR DESCRIPTION
DO NOT MERGE.
Test to see whether Travis coverage discovers this invalid test.