### PR TITLE
StubParser: Check that an annotation is a declaration annotation

### DIFF
--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -234,20 +234,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Set<AnnotationMirror> getDeclAnnotations(Element elt) {
-        // Work around for Issue #1356
-        // https://github.com/typetools/checker-framework/issues/1356
-        Set<AnnotationMirror> annos = super.getDeclAnnotations(elt);
-        Set<AnnotationMirror> newSet = AnnotationUtils.createAnnotationSet();
-        for (AnnotationMirror anno : annos) {
-            if (!isSupportedQualifier(aliasedAnnotation(anno))) {
-                newSet.add(anno);
-            }
-        }
-        return newSet;
-    }
-
-    @Override
     public CFTransfer createFlowTransferFunction(
             CFAbstractAnalysis<CFValue, CFStore, CFTransfer> analysis) {
         return new ValueTransfer(analysis);

--- a/framework/src/org/checkerframework/common/value/qual/StaticallyExecutable.java
+++ b/framework/src/org/checkerframework/common/value/qual/StaticallyExecutable.java
@@ -13,5 +13,5 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface StaticallyExecutable {}

--- a/framework/src/org/checkerframework/framework/stub/StubParser.java
+++ b/framework/src/org/checkerframework/framework/stub/StubParser.java
@@ -1019,7 +1019,7 @@ public class StubParser {
             if (annoMirror != null) {
                 Target target =
                         annoMirror.getAnnotationType().asElement().getAnnotation(Target.class);
-                // Only add the declaration annotation if the annotation applies ot the element.
+                // Only add the declaration annotation if the annotation applies to the element.
                 if (AnnotationUtils.getElementKindsForTarget(target).contains(elt.getKind())) {
                     annos.add(annoMirror);
                 }

--- a/framework/src/org/checkerframework/framework/stub/StubParser.java
+++ b/framework/src/org/checkerframework/framework/stub/StubParser.java
@@ -43,6 +43,7 @@ import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.type.WildcardType;
 import java.io.InputStream;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1016,7 +1017,12 @@ public class StubParser {
         for (AnnotationExpr annotation : annotations) {
             AnnotationMirror annoMirror = getAnnotation(annotation, supportedAnnotations);
             if (annoMirror != null) {
-                annos.add(annoMirror);
+                Target target =
+                        annoMirror.getAnnotationType().asElement().getAnnotation(Target.class);
+                // Only add the declaration annotation if the annotation applies ot the element.
+                if (AnnotationUtils.getElementKindsForTarget(target).contains(elt.getKind())) {
+                    annos.add(annoMirror);
+                }
             }
         }
         String key = ElementUtils.getVerboseName(elt);

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -393,7 +393,9 @@ public class AnnotationUtils {
             case TYPE_PARAMETER:
                 return EnumSet.of(ElementKind.TYPE_PARAMETER);
             case TYPE_USE:
+                return EnumSet.noneOf(ElementKind.class);
             default:
+                ErrorReporter.errorAbort("New ElementType: %s", elementType);
                 return EnumSet.noneOf(ElementKind.class);
         }
     }

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -12,11 +12,14 @@ import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.model.JavacElements;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -26,6 +29,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
@@ -345,6 +349,53 @@ public class AnnotationUtils {
     /** Returns true if the given annotation has a @Inherited meta-annotation. */
     public static boolean hasInheritedMeta(AnnotationMirror anno) {
         return anno.getAnnotationType().asElement().getAnnotation(Inherited.class) != null;
+    }
+
+    /** @return the set of {@link ElementKind}s to which {@code target} applies */
+    public static EnumSet<ElementKind> getElementKindsForTarget(/*@Nullable*/ Target target) {
+        if (target == null) {
+            // A missing @Target implies that the annotation can be written everywhere.
+            return EnumSet.allOf(ElementKind.class);
+        }
+        EnumSet<ElementKind> eleKinds = EnumSet.noneOf(ElementKind.class);
+        for (ElementType elementType : target.value()) {
+            eleKinds.addAll(getElementKindsForElementType(elementType));
+        }
+        return eleKinds;
+    }
+
+    /** @return the set of {@link ElementKind}s corresponding to {@code elementType} */
+    public static EnumSet<ElementKind> getElementKindsForElementType(ElementType elementType) {
+        switch (elementType) {
+            case TYPE:
+                return EnumSet.of(
+                        ElementKind.CLASS,
+                        ElementKind.INTERFACE,
+                        ElementKind.ANNOTATION_TYPE,
+                        ElementKind.ENUM);
+            case FIELD:
+                return EnumSet.of(ElementKind.FIELD, ElementKind.ENUM_CONSTANT);
+            case METHOD:
+                return EnumSet.of(ElementKind.METHOD);
+            case PARAMETER:
+                return EnumSet.of(ElementKind.PARAMETER);
+            case CONSTRUCTOR:
+                return EnumSet.of(ElementKind.CONSTRUCTOR);
+            case LOCAL_VARIABLE:
+                return EnumSet.of(
+                        ElementKind.LOCAL_VARIABLE,
+                        ElementKind.RESOURCE_VARIABLE,
+                        ElementKind.EXCEPTION_PARAMETER);
+            case ANNOTATION_TYPE:
+                return EnumSet.of(ElementKind.ANNOTATION_TYPE);
+            case PACKAGE:
+                return EnumSet.of(ElementKind.PACKAGE);
+            case TYPE_PARAMETER:
+                return EnumSet.of(ElementKind.TYPE_PARAMETER);
+            case TYPE_USE:
+            default:
+                return EnumSet.noneOf(ElementKind.class);
+        }
     }
 
     // **********************************************************************

--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -355,7 +355,9 @@ public class AnnotationUtils {
         return anno.getAnnotationType().asElement().getAnnotation(Inherited.class) != null;
     }
 
-    /** @return the set of {@link ElementKind}s to which {@code target} applies */
+    /**
+     * @return the set of {@link ElementKind}s to which {@code target} applies, ignoring TYPE_USE
+     */
     public static EnumSet<ElementKind> getElementKindsForTarget(/*@Nullable*/ Target target) {
         if (target == null) {
             // A missing @Target implies that the annotation can be written everywhere.
@@ -368,7 +370,13 @@ public class AnnotationUtils {
         return eleKinds;
     }
 
-    /** @return the set of {@link ElementKind}s corresponding to {@code elementType} */
+    /**
+     * Returns the set of {@link ElementKind}s corresponding to {@code elementType}. If the element
+     * type is TYPE_USE, then ElementKinds returned should be the same as those returned for TYPE
+     * and TYPE_PARAMETER, but this method returns the empty set instead.
+     *
+     * @return the set of {@link ElementKind}s corresponding to {@code elementType}
+     */
     public static EnumSet<ElementKind> getElementKindsForElementType(ElementType elementType) {
         switch (elementType) {
             case TYPE:


### PR DESCRIPTION
This fixes #1356, so the workaround for that issue is removed. 

This fix also found that `@StaticallyExecutable` was missing the `CONSTRUCTOR` target.