### PR TITLE
Refine unsigned shift right when this range is non-negative

### DIFF
--- a/framework/src/org/checkerframework/common/value/util/Range.java
+++ b/framework/src/org/checkerframework/common/value/util/Range.java
@@ -591,8 +591,16 @@ public class Range {
         }
     }
 
-    /** We give up the analysis for unsigned shift right operation */
+    /**
+     * When this range only contains non-negative values, the refined result should be the same as
+     * {@link #signedShiftRight(Range)}. We give up the analysis when this range contains negative
+     * value(s).
+     */
     public Range unsignedShiftRight(Range right) {
+        if (this.from >= 0) {
+            return signedShiftRight(right);
+        }
+
         if (this.isNothing() || right.isNothing()) {
             return NOTHING;
         }

--- a/framework/tests/src/tests/RangeTest.java
+++ b/framework/tests/src/tests/RangeTest.java
@@ -446,6 +446,28 @@ public class RangeTest {
     }
 
     @Test
+    public void testUnsignedShiftRight() {
+        for (RangeAndElement re1 : rangeAndElements()) {
+            for (RangeAndElement re2 : rangeAndElements()) {
+                Range result = re1.range.unsignedShiftRight(re2.range);
+                if (re1.range.from >= 0) {
+                    assert result.contains(re1.element >>> re2.element)
+                            : String.format(
+                                    "Range.unsignedShiftRight failure: %s %s => %s; witnesses %s >> %s => %s",
+                                    re1.range,
+                                    re2.range,
+                                    result,
+                                    re1.element,
+                                    re2.element,
+                                    re1.element >> re2.element);
+                } else {
+                    assert result == Range.EVERYTHING;
+                }
+            }
+        }
+    }
+
+    @Test
     public void testUnaryPlus() {
         for (RangeAndElement re : rangeAndElements()) {
             Range result = re.range.unaryPlus();

--- a/framework/tests/value/Issue1655.java
+++ b/framework/tests/value/Issue1655.java
@@ -1,0 +1,12 @@
+// Test case for Issue 1655
+// https://github.com/typetools/checker-framework/issues/1655
+import org.checkerframework.common.value.qual.IntRange;
+
+public class Issue1655 {
+
+    public void test(int a) {
+        @IntRange(from = 0, to = 255) int b = a & 0xff;
+        @IntRange(from = 0, to = 15) int c1 = b >> 4;
+        @IntRange(from = 0, to = 15) int c2 = b >>> 4;
+    }
+}


### PR DESCRIPTION
Hi @panacekcz, @mernst,

This partially fixes #1655. As discussed, I simply added the case when this range only contains non-negative values. It reuses `Range#signedShiftRight` to do the calculation. We can think about the cases when this range contains negative values if necessary.

Please kindly review. Thanks!

Jason
