### PR TITLE
 In the JDK, mark static classes as static

### DIFF
--- a/checker/jdk/lock/src/java/util/AbstractMap.java
+++ b/checker/jdk/lock/src/java/util/AbstractMap.java
@@ -5,7 +5,7 @@ import org.checkerframework.checker.lock.qual.*;
 // Subclasses of this interface/class may opt to prohibit null elements.
 public abstract class AbstractMap<K extends Object, V extends Object> implements Map<K, V> {
   protected AbstractMap() {}
-  public class SimpleEntry<K extends Object, V extends Object>
+  public static class SimpleEntry<K extends Object, V extends Object>
       implements Map.Entry<K, V>, java.io.Serializable {
     private static final long serialVersionUID = 0;
     public SimpleEntry(K a1, V a2) { throw new RuntimeException("skeleton method"); }
@@ -17,7 +17,7 @@ public abstract class AbstractMap<K extends Object, V extends Object> implements
      public int hashCode(@GuardSatisfied SimpleEntry<K,V> this) { throw new RuntimeException("skeleton method"); }
      public String toString(@GuardSatisfied SimpleEntry<K,V> this) { throw new RuntimeException("skeleton method"); }
   }
-  public class SimpleImmutableEntry<K extends Object, V extends Object>
+  public static class SimpleImmutableEntry<K extends Object, V extends Object>
       implements Map.Entry<K, V>, java.io.Serializable {
     private static final long serialVersionUID = 0;
     public SimpleImmutableEntry(K a1, V a2) { throw new RuntimeException("skeleton method"); }

--- a/checker/jdk/nullness/src/java/util/AbstractMap.java
+++ b/checker/jdk/nullness/src/java/util/AbstractMap.java
@@ -8,7 +8,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 // Subclasses of this interface/class may opt to prohibit null elements.
 public abstract class AbstractMap<K extends @Nullable Object, V extends @Nullable Object> implements Map<K, V> {
   protected AbstractMap() {}
-  public class SimpleEntry<K extends @Nullable Object, V extends @Nullable Object>
+  public static class SimpleEntry<K extends @Nullable Object, V extends @Nullable Object>
       implements Map.Entry<K, V>, java.io.Serializable {
     private static final long serialVersionUID = 0;
     public SimpleEntry(K a1, V a2) { throw new RuntimeException("skeleton method"); }
@@ -20,7 +20,7 @@ public abstract class AbstractMap<K extends @Nullable Object, V extends @Nullabl
     @Pure public int hashCode() { throw new RuntimeException("skeleton method"); }
     @SideEffectFree public String toString() { throw new RuntimeException("skeleton method"); }
   }
-  public class SimpleImmutableEntry<K extends @Nullable Object, V extends @Nullable Object>
+  public static class SimpleImmutableEntry<K extends @Nullable Object, V extends @Nullable Object>
       implements Map.Entry<K, V>, java.io.Serializable {
     private static final long serialVersionUID = 0;
     public SimpleImmutableEntry(K a1, V a2) { throw new RuntimeException("skeleton method"); }


### PR DESCRIPTION
Otherwise, the jaif files include inner-type locations in for the receivers.

I checked for other static inner classes not marked as static, but these were the only ones.

(I'm rebuilding the jdk, now.)

Fixes #1636 