### PR TITLE
All characters are NonNegative (JLS 4.2)

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1452,8 +1452,11 @@
     </target>
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
-        <get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"
+        <get src="https://github.com/kelloggm/checker-framework/releases/download/character-nn/jdk8.jar" dest="jdk/jdk8.jar"
              usetimestamp="true"/>
+
+        <!--get src="https://checkerframework.org/dev-jdk/jdk8.jar" dest="jdk/jdk8.jar"
+             usetimestamp="true"/-->
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->
         <copy file="jdk/jdk8.jar" tofile="dist/jdk8.jar"/>

--- a/checker/jdk/index/src/java/lang/Character.java
+++ b/checker/jdk/index/src/java/lang/Character.java
@@ -121,7 +121,7 @@ import java.util.Locale;
  * @since   1.0
  */
 public final
-class Character implements java.io.Serializable, Comparable<Character> {
+@NonNegative class Character implements java.io.Serializable, Comparable<Character> {
     /**
      * The minimum radix available for conversion to and from strings.
      * The constant value of this field is the smallest value permitted

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -141,6 +141,15 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
     }
 
+    /** chars are unsigned implies chars are non-negative. See JLS 4.2. */
+    private void ensureCharNonNegative(AnnotatedTypeMirror type) {
+        if (type.getUnderlyingType().getKind() == TypeKind.CHAR) {
+            if (qualHierarchy.isSubtype(NN, type.getAnnotationInHierarchy(UNKNOWN))) {
+                type.replaceAnnotation(NN);
+            }
+        }
+    }
+
     @Override
     public void addComputedTypeAnnotations(Element element, AnnotatedTypeMirror type) {
         super.addComputedTypeAnnotations(element, type);
@@ -149,11 +158,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     getValueAnnotatedTypeFactory().getAnnotatedType(element);
             addLowerBoundTypeFromValueType(valueType, type);
         }
-        // chars are unsigned -> chars are non-negative. See JLS 4.2.
-        if (type.getUnderlyingType().getKind() == TypeKind.CHAR
-                && type.getAnnotation(Positive.class) == null) {
-            type.replaceAnnotation(NN);
-        }
+        ensureCharNonNegative(type);
     }
 
     @Override
@@ -166,11 +171,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addLowerBoundTypeFromValueType(valueType, type);
         }
-        // chars are unsigned -> chars are non-negative. See JLS 4.2.
-        if (type.getUnderlyingType().getKind() == TypeKind.CHAR
-                && type.getAnnotation(Positive.class) == null) {
-            type.replaceAnnotation(NN);
-        }
+        ensureCharNonNegative(type);
     }
 
     /** Returns the Value Checker's annotated type factory. */

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.index.IndexMethodIdentifier;
 import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
@@ -148,6 +149,11 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     getValueAnnotatedTypeFactory().getAnnotatedType(element);
             addLowerBoundTypeFromValueType(valueType, type);
         }
+        // chars are unsigned -> chars are non-negative. See JLS 4.2.
+        if (type.getUnderlyingType().getKind() == TypeKind.CHAR
+                && type.getAnnotation(Positive.class) == null) {
+            type.replaceAnnotation(NN);
+        }
     }
 
     @Override
@@ -159,6 +165,11 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (iUseFlow && tree != null && TreeUtils.isExpressionTree(tree)) {
             AnnotatedTypeMirror valueType = getValueAnnotatedTypeFactory().getAnnotatedType(tree);
             addLowerBoundTypeFromValueType(valueType, type);
+        }
+        // chars are unsigned -> chars are non-negative. See JLS 4.2.
+        if (type.getUnderlyingType().getKind() == TypeKind.CHAR
+                && type.getAnnotation(Positive.class) == null) {
+            type.replaceAnnotation(NN);
         }
     }
 

--- a/checker/tests/index/IndexByChar.java
+++ b/checker/tests/index/IndexByChar.java
@@ -1,0 +1,25 @@
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.Positive;
+
+public class IndexByChar {
+
+    // adapted from Guava
+    public int m(char c) {
+        int[] i = new int[128];
+        if (c < 128) return i[c]; // line 5
+        else return -1;
+    }
+
+    public void basicTest(char c) {
+        @NonNegative int x = c;
+    }
+
+    public void boxedTest(Character c) {
+        @NonNegative int x = c.charValue();
+        @NonNegative int y = c;
+    }
+
+    public void ensurePositiveNotReplaced(@Positive char c) {
+        @Positive int x = c;
+    }
+}

--- a/checker/tests/index/NonnegativeChar.java
+++ b/checker/tests/index/NonnegativeChar.java
@@ -1,0 +1,37 @@
+import java.util.ArrayList;
+import org.checkerframework.checker.index.qual.LowerBoundBottom;
+import org.checkerframework.checker.index.qual.PolyLowerBound;
+
+public class NonnegativeChar {
+    void foreach(char[] array) {
+        for (char value : array) ; // line 7
+    }
+
+    char constant() {
+        return Character.MAX_VALUE; // line 11
+    }
+
+    char conversion(int i) {
+        return (char) i; // line 15
+    }
+
+    public void takeList(ArrayList<Character> z) {}
+
+    public void passList() {
+        takeList(new ArrayList<Character>()); //line 20
+    }
+
+    static class CustomList extends ArrayList<Character> {}
+
+    public void passCustomList() {
+        takeList(new CustomList()); // line 25
+    }
+
+    public @LowerBoundBottom char bottomLB(@LowerBoundBottom char c) {
+        return c; // line 29
+    }
+
+    public @PolyLowerBound char polyLB(@PolyLowerBound char c) {
+        return c; // line 32
+    }
+}


### PR DESCRIPTION
By JLS 4.2, characters are unsigned 16 bit integers. This means that the Index Checker can treat them as `@NonNegative` implicitly, removing some false positives. See kelloggm#192 and [JLS 4.2](https://docs.oracle.com/javase/specs/jls/se7/html/jls-4.html#jls-4.2)