### PR TITLE
Add index subcheckers to count-suppressions [ci skip]

### DIFF
--- a/checker/bin-devel/count-suppressions
+++ b/checker/bin-devel/count-suppressions
@@ -23,7 +23,7 @@ if [ "$regex" = "nullness" ]; then
     regex="\(nullness\|initialization\|rawness\|keyfor\)"
 fi
 if [ "$regex" = "index" ]; then
-    regex="\(index\|lowerbound\|upperbound\|samelen\|searchindex\|substringindex\)"
+    regex="\(index\|lowerbound\|samelen\|searchindex\|substringindex\|upperbound\)"
 fi
 
 # Implementation notes:

--- a/checker/bin-devel/count-suppressions
+++ b/checker/bin-devel/count-suppressions
@@ -23,7 +23,7 @@ if [ "$regex" = "nullness" ]; then
     regex="\(nullness\|initialization\|rawness\|keyfor\)"
 fi
 if [ "$regex" = "index" ]; then
-    regex="\(index\|lowerbound\|upperbound\)"
+    regex="\(index\|lowerbound\|upperbound\|samelen\|searchindex\|substringindex\)"
 fi
 
 # Implementation notes:


### PR DESCRIPTION
Adds `samelen`, `searchindex` and `substringindex` to the count-suppressions script.