### PR TITLE
Stop infinite recursion in sameAnnotationValue.

### DIFF
--- a/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/org/checkerframework/javacutil/AnnotationUtils.java
@@ -510,6 +510,8 @@ public class AnnotationUtils {
                 }
             }
             return true;
+        } else if ((val1 instanceof AnnotationMirror) && (val2 instanceof AnnotationMirror)) {
+            return areSame((AnnotationMirror) val1, (AnnotationMirror) val2);
         } else if ((val1 instanceof AnnotationValue) && (val2 instanceof AnnotationValue)) {
             return sameAnnotationValue((AnnotationValue) val1, (AnnotationValue) val2);
         } else if ((val1 instanceof Type.ClassType) && (val2 instanceof Type.ClassType)) {


### PR DESCRIPTION
This fixes the current sparta build failure. (https://travis-ci.org/typetools/sparta/builds/305055418) 

When the AnnotationValue is an annotation, the underlying object is a `com.sun.tools.javac.code.Attribute.Compound`which extends `Attribute` which extends `AnnotationValue`. `Compound#getValue` returns itself, so an infinite recursion occurs.  Since `Compound` also implements `AnnotationMirror`, use `areSame` instead.