### PR TITLE
Manual instructions for annotating a custom fixed-size collection

### DIFF
--- a/checker/tests/index/ArrayWrapper.java
+++ b/checker/tests/index/ArrayWrapper.java
@@ -1,0 +1,43 @@
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.LengthOf;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.SameLen;
+
+/**
+ * A test for https://github.com/kelloggm/checker-framework/issues/154
+ *
+ * <p>This class wraps an array, but doesn't expose the array in its public interface. This test
+ * ensures that indexes for this new collection can be annotated as if the collection were an array.
+ *
+ * <p>ArrayWrapper is a fixed-size, weakly typed generic collection.
+ */
+@SuppressWarnings("unchecked")
+public class ArrayWrapper<T> {
+    private final Object @SameLen("this") [] internalRep;
+
+    ArrayWrapper(@NonNegative int size) {
+        @SuppressWarnings(
+                "index") // use the SameLen checker to ensure that anything that's an index for "this" is an
+        // index for the internal array representation. This suppress warnings asserts this fact.
+        final Object @SameLen("this") [] tmp = new Object[size];
+        internalRep = tmp;
+    }
+
+    public @LengthOf("this") int size() {
+        return internalRep.length;
+    }
+
+    public void set(@IndexFor("this") int index, T obj) {
+        internalRep[index] = obj;
+    }
+
+    public T get(@IndexFor("this") int index) {
+        return (T) internalRep[index];
+    }
+
+    public static void clearIndex(ArrayWrapper a, @NonNegative int i) {
+        if (i < a.size()) {
+            a.set(i, null);
+        }
+    }
+}

--- a/checker/tests/index/ArrayWrapper.java
+++ b/checker/tests/index/ArrayWrapper.java
@@ -2,12 +2,15 @@
 // This class wraps an array, but doesn't expose the array in its public interface. This test
 // ensures that indexes for this new collection can be annotated as if the collection were an array.
 
+// Note that there is a copy of this code in the manual in index-checker.tex. If this code is
+// updated, you MUST update that copy, as well.
+
 import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.SameLen;
 
-/** ArrayWrapper is a fixed-size, weakly-typed generic collection. */
+/** ArrayWrapper is a fixed-size generic collection. */
 public class ArrayWrapper<T> {
     private final Object @SameLen("this") [] delegate;
 

--- a/checker/tests/index/ArrayWrapper.java
+++ b/checker/tests/index/ArrayWrapper.java
@@ -1,41 +1,45 @@
+// Test case for https://github.com/kelloggm/checker-framework/issues/154
+// This class wraps an array, but doesn't expose the array in its public interface. This test
+// ensures that indexes for this new collection can be annotated as if the collection were an array.
+
 import org.checkerframework.checker.index.qual.IndexFor;
 import org.checkerframework.checker.index.qual.LengthOf;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.SameLen;
 
-/**
- * A test for https://github.com/kelloggm/checker-framework/issues/154
- *
- * <p>This class wraps an array, but doesn't expose the array in its public interface. This test
- * ensures that indexes for this new collection can be annotated as if the collection were an array.
- *
- * <p>ArrayWrapper is a fixed-size, weakly typed generic collection.
- */
-@SuppressWarnings("unchecked")
+/** ArrayWrapper is a fixed-size, weakly-typed generic collection. */
 public class ArrayWrapper<T> {
-    private final Object @SameLen("this") [] internalRep;
+    private final Object @SameLen("this") [] delegate;
 
+    @SuppressWarnings("index") // constructor creates object of size @SameLen(this) by definition
     ArrayWrapper(@NonNegative int size) {
-        @SuppressWarnings(
-                "index") // use the SameLen checker to ensure that anything that's an index for "this" is an
-        // index for the internal array representation. This suppress warnings asserts this fact.
-        final Object @SameLen("this") [] tmp = new Object[size];
-        internalRep = tmp;
+        delegate = new Object[size];
     }
 
     public @LengthOf("this") int size() {
-        return internalRep.length;
+        return delegate.length;
     }
 
     public void set(@IndexFor("this") int index, T obj) {
-        internalRep[index] = obj;
+        delegate[index] = obj;
     }
 
+    @SuppressWarnings("unchecked") // required for normal Java compilation due to unchecked cast
     public T get(@IndexFor("this") int index) {
-        return (T) internalRep[index];
+        return (T) delegate[index];
     }
 
-    public static void clearIndex(ArrayWrapper a, @NonNegative int i) {
+    public static void clearIndex1(ArrayWrapper<? extends Object> a, @IndexFor("#1") int i) {
+        a.set(i, null);
+    }
+
+    public static void clearIndex2(ArrayWrapper<? extends Object> a, int i) {
+        if (0 <= i && i < a.size()) {
+            a.set(i, null);
+        }
+    }
+
+    public static void clearIndex3(ArrayWrapper<? extends Object> a, @NonNegative int i) {
         if (i < a.size()) {
             a.set(i, null);
         }

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -46,6 +46,12 @@ if a method's formal parameter is used as an index for
 write an \refqualclasswithparams{checker/index/qual}{IndexFor}{myArray}
 annotation on the formal parameter's types.
 
+The Index Checker checks fixed-size data structures, whose size is never
+changed after creation.  For example, a fixed-size data structure has no
+\<add()> or \<remove> operation.  Examples are strings and arrays, and you
+can add support for other fixed-size data structures (see
+Section~\ref{index-annotating-fixed-size}).
+
 To run the Index Checker, run the command
 
 \begin{alltt}
@@ -611,103 +617,51 @@ the example type-check without false positives, a new annotation such as
 is necessary.
 
 
-\section{Annotating your own fixed-size data structures\label{index-annotating-fixed-size}}
+\section{Annotating fixed-size data structures\label{index-annotating-fixed-size}}
 
-The Index Checker, by default, checks the bounds of Strings and
-of arrays. But, often the data structures actually in use in a
-program are \emph{wrappers} for these types. This section will
-explain how to annotate a fixed-size data structure, backed
-by a String or array, that you are writing, so that the Index
-Checker can check it just like any array or String. Note that
-the Index Checker only supports fixed-size data structures---that is,
-only those data structures whose size is set when they are created,
-and cannot be changed.
+The Index Checker has built-in support for Strings and arrays.
+You can add support for additional fixed-size data structures by writing
+annotations.
+This allows the Index Checker to both typecheck the data structure's
+implementation
+and also typecheck uses of the class.
 
-Consider the following weakly-typed, fixed-length collection:
+This section gives an example:  a fixed-length collection.
+
 \begin{Verbatim}
-/*
- * ArrayWrapper is a fixed-size, weakly typed generic collection.
- */
+/** ArrayWrapper is a fixed-size, weakly-typed generic collection. */
 public class ArrayWrapper<T> {
-    private final Object [] internalRep;
+    private final Object @SameLen("this") [] delegate;
 
-    ArrayWrapper(int size) {
-        internalRep = new Object[size];
+    @SuppressWarnings("index") // constructor creates object of size @SameLen(this) by definition
+    ArrayWrapper(@NonNegative int size) {
+        delegate = new Object[size];
     }
 
-    public int size() {
-        return internalRep.length;
+    public @LengthOf("this") int size() {
+        return delegate.length;
     }
 
-    public void set(int index, T obj) {
-        internalRep[index] = obj;
+    public void set(@IndexFor("this") int index, T obj) {
+        delegate[index] = obj;
     }
 
-    @SuppressWarnings("unchecked")
-    public T get(int index) {
-        return (T) internalRep[index];
+    @SuppressWarnings("unchecked") // required for normal Java compilation due to unchecked cast
+    public T get(@IndexFor("this") int index) {
+        return (T) delegate[index];
     }
 }
 \end{Verbatim}
 
-To allow the Index Checker to both typecheck this class and to typecheck uses
-of this class as if this class were, itself, an array, we need to add several
-annotations.
-
-Starting at the top of the class, the first annotation needed is on
-the internal field \code{internalRep}. To establish the relationship
-between the internal representation (an array) and this class,
-a \code{@SameLen("this")} annotation is added to the field. The resulting
-definition is:
+With these annotations, client code like the following typechecks with no
+warnings:
 \begin{Verbatim}
-    private final Object @SameLen("this") [] internalRep;
-\end{Verbatim}
-
-Next, some annotations are needed on the constructor. Since the \code{size}
-parameter is used to create an array, it must be \code{@NonNegative}.
-However, the assignment to \code{internalRep} still does not typecheck, as
-the SameLen Checker reports that \code{new Object[size]} is not
-\code{@SameLen("this")}. This warning must be suppressed; suppressing it
-indicates to the typechecker what the relationship between the external
-representation of the class (\code{"this"}) and the internal representation
-(\code{internalRep}) is. Because of the limitations of Java annotations,
-the resulting constructor looks like this:
-\begin{Verbatim}
-    ArrayWrapper(@NonNegative int size) {
-        @SuppressWarnings("index") // use the SameLen checker to ensure that anything that's an index for "this" is an
-        // index for the internal array representation. This suppress warnings asserts this fact.
-        final Object @SameLen("this") [] tmp = new Object[size];
-        internalRep = tmp;
-    }
-\end{Verbatim}
-
-An annotation must also be written on the \code{size} method. The return type should be
-annotated as \code{@LengthOf("this")}; the SameLen annotation above allows
-this to typecheck with no other annotations. The resulting method is:
-\begin{Verbatim}
-    public @LengthOf("this") int size() {
-        return internalRep.length;
-    }
-\end{Verbatim}
-
-Finally, annotations must be added to the \code{set} and \code{get} methods.
-These annotations, too, need only reference \code{this}:
-\begin{Verbatim}
-    public void set(@IndexFor("this") int index, T obj) {
-        internalRep[index] = obj;
+    public static void clearIndex1(ArrayWrapper<? extends Object> a, @IndexFor("#1") int i) {
+        a.set(i, null);
     }
 
-    @SuppressWarnings("unchecked")
-    public T get(@IndexFor("this") int index) {
-        return (T) internalRep[index];
-    }
-\end{Verbatim}
-
-With these annotations, users can treat \code{ArrayWrapper} as if it were an
-array; code like the following typechecks with no warnings:
-\begin{Verbatim}
-    public static void clearIndex(ArrayWrapper a, @NonNegative int i) {
-        if (i < a.size()) {
+    public static void clearIndex2(ArrayWrapper<? extends Object> a, int i) {
+        if (0 <= i && i < a.size()) {
             a.set(i, null);
         }
     }

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -610,7 +610,8 @@ the example type-check without false positives, a new annotation such as
 \<@SubstringIndexFor\allowbreak(value = "receiver", offset = "substring.length()-1")>
 is necessary.
 
-\section{Annotating your own fixed-size data structures}
+
+\section{Annotating your own fixed-size data structures\label{index-annotating-fixed-size}}
 
 The Index Checker, by default, checks the bounds of Strings and
 of arrays. But, often the data structures actually in use in a

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -610,7 +610,107 @@ the example type-check without false positives, a new annotation such as
 \<@SubstringIndexFor\allowbreak(value = "receiver", offset = "substring.length()-1")>
 is necessary.
 
+\section{Annotating your own fixed-size data structures}
 
+The Index Checker, by default, checks the bounds of Strings and
+of arrays. But, often the data structures actually in use in a
+program are \texit{wrappers} for these types. This section will
+explain how to annotate a fixed-size data structure, backed
+by a String or array, that you are writing, so that the Index
+Checker can check it just like any array or String. Note that
+the Index Checker only supports fixed-size data structures---that is,
+only those data structures whose size is set when they are created,
+and cannot be changed.
+
+Consider the following weakly-typed, fixed-length collection:
+\begin{Verbatim}
+/*
+ * ArrayWrapper is a fixed-size, weakly typed generic collection.
+ */
+public class ArrayWrapper<T> {
+    private final Object [] internalRep;
+
+    ArrayWrapper(int size) {
+        internalRep = new Object[size];
+    }
+
+    public int size() {
+        return internalRep.length;
+    }
+
+    public void set(int index, T obj) {
+        internalRep[index] = obj;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T get(int index) {
+        return (T) internalRep[index];
+    }
+}
+\end{Verbatim}
+
+To allow the Index Checker to both typecheck this class and to typecheck uses
+of this class as if this class were, itself, an array, we need to add several
+annotations.
+
+Starting at the top of the class, the first annotation needed is on
+the internal field \code{internalRep}. To establish the relationship
+between the internal representation (an array) and this class,
+a \code{@SameLen("this")} annotation is added to the field. The resulting
+definition is:
+\begin{Verbatim}
+    private final Object @SameLen("this") [] internalRep;
+\end{Verbatim}
+
+Next, some annotations are needed on the constructor. Since the \code{size}
+parameter is used to create an array, it must be \code{@NonNegative}.
+However, the assignment to \code{internalRep} still does not typecheck, as
+the SameLen Checker reports that \code{new Object[size]} is not
+\code{@SameLen("this")}. This warning must be suppressed; suppressing it
+indicates to the typechecker what the relationship between the external
+representation of the class (\code{"this"}) and the internal representation
+(\code{internalRep}) is. Because of the limitations of Java annotations,
+the resulting constructor looks like this:
+\begin{Verbatim}
+    ArrayWrapper(@NonNegative int size) {
+        @SuppressWarnings("index") // use the SameLen checker to ensure that anything that's an index for "this" is an
+        // index for the internal array representation. This suppress warnings asserts this fact.
+        final Object @SameLen("this") [] tmp = new Object[size];
+        internalRep = tmp;
+    }
+\end{Verbatim}
+
+An annotation must also be written on the \code{size} method. The return type should be
+annotated as \code{@LengthOf("this")}; the SameLen annotation above allows
+this to typecheck with no other annotations. The resulting method is:
+\begin{Verbatim}
+    public @LengthOf("this") int size() {
+        return internalRep.length;
+    }
+\end{Verbatim}
+
+Finally, annotations must be added to the \code{set} and \code{get} methods.
+These annotations, too, need only reference \code{this}:
+\begin{Verbatim}
+    public void set(@IndexFor("this") int index, T obj) {
+        internalRep[index] = obj;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T get(@IndexFor("this") int index) {
+        return (T) internalRep[index];
+    }
+\end{Verbatim}
+
+With these annotations, users can treat \code{ArrayWrapper} as if it were an
+array; code like the following typechecks with no warnings:
+\begin{Verbatim}
+    public static void clearIndex(ArrayWrapper a, @NonNegative int i) {
+        if (i < a.size()) {
+            a.set(i, null);
+        }
+    }
+\end{Verbatim}
 
 %%  LocalWords:  NegativeArraySizeException pre myArray IndexFor someArray
 %%  LocalWords:  MyJavaFile LTLengthOf LTEqLengthOf GTENegativeOne GTE

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -47,9 +47,9 @@ write an \refqualclasswithparams{checker/index/qual}{IndexFor}{myArray}
 annotation on the formal parameter's types.
 
 The Index Checker checks fixed-size data structures, whose size is never
-changed after creation.  For example, a fixed-size data structure has no
-\<add()> or \<remove> operation.  Examples are strings and arrays, and you
-can add support for other fixed-size data structures (see
+changed after creation.  A fixed-size data structure has no \<add()> or
+\<remove> operation.  Examples are strings and arrays, and you can add
+support for other fixed-size data structures (see
 Section~\ref{index-annotating-fixed-size}).
 
 To run the Index Checker, run the command
@@ -622,9 +622,8 @@ is necessary.
 The Index Checker has built-in support for Strings and arrays.
 You can add support for additional fixed-size data structures by writing
 annotations.
-This allows the Index Checker to both typecheck the data structure's
-implementation
-and also typecheck uses of the class.
+This allows the Index Checker to typecheck the data structure's
+implementation and to typecheck uses of the class.
 
 This section gives an example:  a fixed-length collection.
 

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -627,6 +627,9 @@ implementation and to typecheck uses of the class.
 
 This section gives an example:  a fixed-length collection.
 
+%% The code that follows is copied from checker/tests/index/ArrayWrapper.java.
+%% If this code is updated, please update that file, too.
+
 \begin{Verbatim}
 /** ArrayWrapper is a fixed-size generic collection. */
 public class ArrayWrapper<T> {

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -615,7 +615,7 @@ is necessary.
 
 The Index Checker, by default, checks the bounds of Strings and
 of arrays. But, often the data structures actually in use in a
-program are \texit{wrappers} for these types. This section will
+program are \emph{wrappers} for these types. This section will
 explain how to annotate a fixed-size data structure, backed
 by a String or array, that you are writing, so that the Index
 Checker can check it just like any array or String. Note that

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -47,7 +47,7 @@ write an \refqualclasswithparams{checker/index/qual}{IndexFor}{myArray}
 annotation on the formal parameter's types.
 
 The Index Checker checks fixed-size data structures, whose size is never
-changed after creation.  A fixed-size data structure has no \<add()> or
+changed after creation.  A fixed-size data structure has no \<add> or
 \<remove> operation.  Examples are strings and arrays, and you can add
 support for other fixed-size data structures (see
 Section~\ref{index-annotating-fixed-size}).

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -628,7 +628,7 @@ implementation and to typecheck uses of the class.
 This section gives an example:  a fixed-length collection.
 
 \begin{Verbatim}
-/** ArrayWrapper is a fixed-size, weakly-typed generic collection. */
+/** ArrayWrapper is a fixed-size generic collection. */
 public class ArrayWrapper<T> {
     private final Object @SameLen("this") [] delegate;
 


### PR DESCRIPTION
Users of the Index Checker will likely want to annotate their own collections so that the Index Checker treats them as if they were arrays or Strings. Since it's not obvious how to do that, this PR includes an example of doing so (and the associated test case) as a new manual section.