### PR TITLE
Use annotations on uninferred wildcards when substituting polymorphic qualifiers

### DIFF
--- a/checker/tests/tainting/Issue1705.java
+++ b/checker/tests/tainting/Issue1705.java
@@ -1,0 +1,26 @@
+// Test case for Issue 1705
+// https://github.com/typetools/checker-framework/issues/1705
+
+import java.util.function.Function;
+import org.checkerframework.checker.tainting.qual.PolyTainted;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+public class Issue1705 {
+    static class MySecondClass<X> {
+        @PolyTainted MySecondClass<X> doOnComplete(@PolyTainted MySecondClass<X> this) {
+            throw new RuntimeException();
+        }
+    }
+
+    <R> @PolyTainted R to(@PolyTainted Issue1705 this, Function<? super Issue1705, R> arg0) {
+        throw new RuntimeException();
+    }
+
+    static <T> Function<? super T, MySecondClass<T>> empty() {
+        throw new RuntimeException();
+    }
+
+    void test(@Untainted Issue1705 a) {
+        @Untainted Object z = a.to(empty()).doOnComplete();
+    }
+}

--- a/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
+++ b/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
@@ -457,21 +457,7 @@ public class QualifierPolymorphism {
             type = AnnotatedTypes.asSuper(atypeFactory, type, dcType);
 
             Map<AnnotationMirror, Set<? extends AnnotationMirror>> result =
-                    new HashMap<AnnotationMirror, Set<? extends AnnotationMirror>>();
-
-            for (Map.Entry<AnnotationMirror, AnnotationMirror> kv : polyQuals.entrySet()) {
-                AnnotationMirror top = kv.getKey();
-                AnnotationMirror poly = kv.getValue();
-
-                if (top == null && dcType.hasAnnotation(POLYALL)) {
-                    // PolyAll qualifier
-                    result.put(poly, type.getAnnotations());
-                } else if (dcType.hasAnnotation(poly)) {
-                    AnnotationMirror typeQual = type.getAnnotationInHierarchy(top);
-                    result.put(poly, Collections.singleton(typeQual));
-                }
-            }
-
+                    mapQualifierToPoly(type, dcType);
             if (!type.wasRaw() && !dcType.wasRaw()) {
                 result = reduce(result, visit(type.getTypeArguments(), dcType.getTypeArguments()));
             }
@@ -482,8 +468,12 @@ public class QualifierPolymorphism {
         @Override
         public Map<AnnotationMirror, Set<? extends AnnotationMirror>> visitPrimitive(
                 AnnotatedPrimitiveType type, AnnotatedTypeMirror actualType) {
-            Map<AnnotationMirror, Set<? extends AnnotationMirror>> result =
-                    new HashMap<AnnotationMirror, Set<? extends AnnotationMirror>>();
+            return mapQualifierToPoly(type, actualType);
+        }
+
+        private Map<AnnotationMirror, Set<? extends AnnotationMirror>> mapQualifierToPoly(
+                AnnotatedTypeMirror type, AnnotatedTypeMirror actualType) {
+            Map<AnnotationMirror, Set<? extends AnnotationMirror>> result = new HashMap<>();
 
             for (Map.Entry<AnnotationMirror, AnnotationMirror> kv : polyQuals.entrySet()) {
                 AnnotationMirror top = kv.getKey();
@@ -497,7 +487,6 @@ public class QualifierPolymorphism {
                     result.put(poly, Collections.singleton(typeQual));
                 }
             }
-
             return result;
         }
 
@@ -506,20 +495,7 @@ public class QualifierPolymorphism {
                 AnnotatedNullType type, AnnotatedTypeMirror actualType) {
 
             Map<AnnotationMirror, Set<? extends AnnotationMirror>> result =
-                    new HashMap<AnnotationMirror, Set<? extends AnnotationMirror>>();
-
-            for (Map.Entry<AnnotationMirror, AnnotationMirror> kv : polyQuals.entrySet()) {
-                AnnotationMirror top = kv.getKey();
-                AnnotationMirror poly = kv.getValue();
-
-                if (top == null) {
-                    // PolyAll qualifier
-                    result.put(poly, type.getAnnotations());
-                } else if (actualType.hasAnnotation(poly)) {
-                    AnnotationMirror typeQual = type.getAnnotationInHierarchy(top);
-                    result.put(poly, Collections.singleton(typeQual));
-                }
-            }
+                    mapQualifierToPoly(type, actualType);
             if (!result.isEmpty()) {
                 return result;
             } else {
@@ -561,26 +537,9 @@ public class QualifierPolymorphism {
             }
 
             assert type.getKind() == actualType.getKind() : actualType;
-            AnnotatedArrayType arType = (AnnotatedArrayType) actualType;
-
             Map<AnnotationMirror, Set<? extends AnnotationMirror>> result =
-                    new HashMap<AnnotationMirror, Set<? extends AnnotationMirror>>();
-
-            for (Map.Entry<AnnotationMirror, AnnotationMirror> kv : polyQuals.entrySet()) {
-                AnnotationMirror top = kv.getKey();
-                AnnotationMirror poly = kv.getValue();
-
-                if (arType.hasAnnotation(poly)) {
-                    Set<AnnotationMirror> typeQuals;
-                    if (top == null) {
-                        // PolyAll qualifier
-                        typeQuals = type.getAnnotations();
-                    } else {
-                        typeQuals = Collections.singleton(type.getAnnotationInHierarchy(top));
-                    }
-                    result.put(poly, typeQuals);
-                }
-            }
+                    mapQualifierToPoly(type, actualType);
+            AnnotatedArrayType arType = (AnnotatedArrayType) actualType;
             result = reduce(result, visit(type.getComponentType(), arType.getComponentType()));
             return result;
         }
@@ -634,7 +593,7 @@ public class QualifierPolymorphism {
             if (type.isUninferredTypeArgument()
                     || !TypesUtils.isErasedSubtype(
                             type.getUnderlyingType(), actualType.getUnderlyingType(), types)) {
-                return Collections.emptyMap();
+                return mapQualifierToPoly(type, actualType);
             }
             AnnotatedTypeMirror typeSuper = AnnotatedTypes.asSuper(atypeFactory, type, actualType);
             if (typeSuper.getKind() != TypeKind.WILDCARD) {

--- a/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
+++ b/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
@@ -471,6 +471,11 @@ public class QualifierPolymorphism {
             return mapQualifierToPoly(type, actualType);
         }
 
+        /**
+         * If the primary annotation of {@code actualType} is a polymorphic qualifier, then it is
+         * mapped to the primary annotation of {@code type} and the map is returned. Otherwise, an
+         * empty map is returned.
+         */
         private Map<AnnotationMirror, Set<? extends AnnotationMirror>> mapQualifierToPoly(
                 AnnotatedTypeMirror type, AnnotatedTypeMirror actualType) {
             Map<AnnotationMirror, Set<? extends AnnotationMirror>> result = new HashMap<>();

--- a/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
+++ b/framework/src/org/checkerframework/framework/util/QualifierPolymorphism.java
@@ -598,7 +598,7 @@ public class QualifierPolymorphism {
             if (type.isUninferredTypeArgument()
                     || !TypesUtils.isErasedSubtype(
                             type.getUnderlyingType(), actualType.getUnderlyingType(), types)) {
-                return mapQualifierToPoly(type, actualType);
+                return mapQualifierToPoly(type.getExtendsBound(), actualType);
             }
             AnnotatedTypeMirror typeSuper = AnnotatedTypes.asSuper(atypeFactory, type, actualType);
             if (typeSuper.getKind() != TypeKind.WILDCARD) {


### PR DESCRIPTION
Also, reduces code duplication.

Fixes #1705