### PR TITLE
Change index jdk annotations on position and range indices

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1453,7 +1453,7 @@
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
         <!-- See instructions for updating the jdk.jar https://github.com/typetools/annotated-libraries/blob/master/README.jdk -->
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/index-ranges-1/jdk8.jar" dest="jdk/jdk8.jar"
+        <get src="https://github.com/panacekcz/checker-framework/releases/download/index-range-annotations-1/jdk8.jar" dest="jdk/jdk8.jar"
              usetimestamp="true"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1453,7 +1453,7 @@
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
         <!-- See instructions for updating the jdk.jar https://github.com/typetools/annotated-libraries/blob/master/README.jdk -->
-        <get src="https://github.com/typetools/annotated-libraries/raw/4ddafa7109b/jdk8.jar" dest="jdk/jdk8.jar"
+        <get src="https://github.com/panacekcz/checker-framework/releases/download/index-ranges-1/jdk8.jar" dest="jdk/jdk8.jar"
              usetimestamp="true"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1453,7 +1453,7 @@
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
         <!-- See instructions for updating the jdk.jar https://github.com/typetools/annotated-libraries/blob/master/README.jdk -->
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/index-range-annotations-1/jdk8.jar" dest="jdk/jdk8.jar"
+        <get src="https://github.com/typetools/annotated-libraries/raw/4620ac469e186e42585fd19c8dea6a4160c93811/jdk8.jar" dest="jdk/jdk8.jar"
              usetimestamp="true"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->

--- a/checker/jdk/index/src/java/io/BufferedInputStream.java
+++ b/checker/jdk/index/src/java/io/BufferedInputStream.java
@@ -320,7 +320,7 @@ class BufferedInputStream extends FilterInputStream {
      *                          invoking its {@link #close()} method,
      *                          or an I/O error occurs.
      */
-    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         getBufIfOpen(); // Check for closed stream

--- a/checker/jdk/index/src/java/io/BufferedInputStream.java
+++ b/checker/jdk/index/src/java/io/BufferedInputStream.java
@@ -320,7 +320,7 @@ class BufferedInputStream extends FilterInputStream {
      *                          invoking its {@link #close()} method,
      *                          or an I/O error occurs.
      */
-    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         getBufIfOpen(); // Check for closed stream

--- a/checker/jdk/index/src/java/io/BufferedOutputStream.java
+++ b/checker/jdk/index/src/java/io/BufferedOutputStream.java
@@ -114,7 +114,7 @@ class BufferedOutputStream extends FilterOutputStream {
      * @param      len   the number of bytes to write.
      * @exception  IOException  if an I/O error occurs.
      */
-    public synchronized void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public synchronized void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (len >= buf.length) {
             /* If the request length exceeds the size of the output buffer,
                flush the output buffer and then write the data directly.

--- a/checker/jdk/index/src/java/io/BufferedReader.java
+++ b/checker/jdk/index/src/java/io/BufferedReader.java
@@ -267,7 +267,7 @@ public class BufferedReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/BufferedReader.java
+++ b/checker/jdk/index/src/java/io/BufferedReader.java
@@ -267,7 +267,7 @@ public class BufferedReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/ByteArrayInputStream.java
+++ b/checker/jdk/index/src/java/io/ByteArrayInputStream.java
@@ -174,7 +174,7 @@ class ByteArrayInputStream extends InputStream {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/ByteArrayInputStream.java
+++ b/checker/jdk/index/src/java/io/ByteArrayInputStream.java
@@ -121,7 +121,7 @@ class ByteArrayInputStream extends InputStream {
      * @param   offset   the offset in the buffer of the first byte to read.
      * @param   length   the maximum number of bytes to read from the buffer.
      */
-    public ByteArrayInputStream(byte buf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) {
+    public ByteArrayInputStream(byte buf[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length) {
         this.buf = buf;
         this.pos = offset;
         this.count = Math.min(offset + length, buf.length);
@@ -174,7 +174,7 @@ class ByteArrayInputStream extends InputStream {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/ByteArrayOutputStream.java
+++ b/checker/jdk/index/src/java/io/ByteArrayOutputStream.java
@@ -133,7 +133,7 @@ public class ByteArrayOutputStream extends OutputStream {
      * @param   off   the start offset in the data.
      * @param   len   the number of bytes to write.
      */
-    public synchronized void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if ((off < 0) || (off > b.length) || (len < 0) ||
             ((off + len) - b.length > 0)) {
             throw new IndexOutOfBoundsException();

--- a/checker/jdk/index/src/java/io/CharArrayReader.java
+++ b/checker/jdk/index/src/java/io/CharArrayReader.java
@@ -76,7 +76,7 @@ public class CharArrayReader extends Reader {
      * @param offset    Offset of the first char to read
      * @param length    Number of chars to read
      */
-    public CharArrayReader(char buf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) {
+    public CharArrayReader(char buf[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length) {
         if ((offset < 0) || (offset > buf.length) || (length < 0) ||
             ((offset + length) < 0)) {
             throw new IllegalArgumentException();
@@ -118,7 +118,7 @@ public class CharArrayReader extends Reader {
      *
      * @exception   IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/CharArrayReader.java
+++ b/checker/jdk/index/src/java/io/CharArrayReader.java
@@ -118,7 +118,7 @@ public class CharArrayReader extends Reader {
      *
      * @exception   IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/CharArrayWriter.java
+++ b/checker/jdk/index/src/java/io/CharArrayWriter.java
@@ -201,7 +201,7 @@ class CharArrayWriter extends Writer {
      *
      * @since  1.5
      */
-    public CharArrayWriter append(CharSequence csq, @IndexFor("#1") int start, @IndexOrHigh("#1") int end) {
+    public CharArrayWriter append(CharSequence csq, @IndexOrHigh("#1") int start, @IndexOrHigh("#1") int end) {
         String s = (csq == null ? "null" : csq).subSequence(start, end).toString();
         write(s, 0, s.length());
         return this;

--- a/checker/jdk/index/src/java/io/Console.java
+++ b/checker/jdk/index/src/java/io/Console.java
@@ -417,7 +417,7 @@ public final class Console implements Flushable
             return in.ready();
         }
 
-        public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+        public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length)
             throws IOException
         {
             int off = offset;

--- a/checker/jdk/index/src/java/io/Console.java
+++ b/checker/jdk/index/src/java/io/Console.java
@@ -417,7 +417,7 @@ public final class Console implements Flushable
             return in.ready();
         }
 
-        public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+        public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
             throws IOException
         {
             int off = offset;

--- a/checker/jdk/index/src/java/io/DataInputStream.java
+++ b/checker/jdk/index/src/java/io/DataInputStream.java
@@ -97,7 +97,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final @IndexOrLow("#1") int read(byte b[]) throws IOException {
+    public final @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException {
         return in.read(b, 0, b.length);
     }
 
@@ -146,7 +146,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public final @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/DataInputStream.java
+++ b/checker/jdk/index/src/java/io/DataInputStream.java
@@ -146,7 +146,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      * @see        java.io.FilterInputStream#in
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public final @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public final @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 
@@ -188,7 +188,7 @@ class DataInputStream extends FilterInputStream implements DataInput {
      *             another I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public final void readFully(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public final void readFully(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (len < 0)
             throw new IndexOutOfBoundsException();
         int n = 0;

--- a/checker/jdk/index/src/java/io/DataOutputStream.java
+++ b/checker/jdk/index/src/java/io/DataOutputStream.java
@@ -102,7 +102,7 @@ class DataOutputStream extends FilterOutputStream implements DataOutput {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterOutputStream#out
      */
-    public synchronized void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         out.write(b, off, len);

--- a/checker/jdk/index/src/java/io/FileInputStream.java
+++ b/checker/jdk/index/src/java/io/FileInputStream.java
@@ -206,7 +206,7 @@ class FileInputStream extends InputStream
      *             the file has been reached.
      * @exception  IOException  if an I/O error occurs.
      */
-    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException {
         return readBytes(b, 0, b.length);
     }
 
@@ -228,7 +228,7 @@ class FileInputStream extends InputStream
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FileInputStream.java
+++ b/checker/jdk/index/src/java/io/FileInputStream.java
@@ -228,7 +228,7 @@ class FileInputStream extends InputStream
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FileOutputStream.java
+++ b/checker/jdk/index/src/java/io/FileOutputStream.java
@@ -300,7 +300,7 @@ class FileOutputStream extends OutputStream
      * @param      len   the number of bytes to write.
      * @exception  IOException  if an I/O error occurs.
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         writeBytes(b, off, len, append);
     }
 

--- a/checker/jdk/index/src/java/io/FilterInputStream.java
+++ b/checker/jdk/index/src/java/io/FilterInputStream.java
@@ -104,7 +104,7 @@ class FilterInputStream extends InputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#read(byte[], int, int)
      */
-    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -130,7 +130,7 @@ class FilterInputStream extends InputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FilterInputStream.java
+++ b/checker/jdk/index/src/java/io/FilterInputStream.java
@@ -130,7 +130,7 @@ class FilterInputStream extends InputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterInputStream#in
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FilterOutputStream.java
+++ b/checker/jdk/index/src/java/io/FilterOutputStream.java
@@ -118,7 +118,7 @@ class FilterOutputStream extends OutputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.FilterOutputStream#write(int)
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if ((off | len | (b.length - (len + off)) | (off + len)) < 0)
             throw new IndexOutOfBoundsException();
 

--- a/checker/jdk/index/src/java/io/FilterReader.java
+++ b/checker/jdk/index/src/java/io/FilterReader.java
@@ -71,7 +71,7 @@ public abstract class FilterReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(cbuf, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/FilterReader.java
+++ b/checker/jdk/index/src/java/io/FilterReader.java
@@ -71,7 +71,7 @@ public abstract class FilterReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return in.read(cbuf, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/InputStream.java
+++ b/checker/jdk/index/src/java/io/InputStream.java
@@ -98,7 +98,7 @@ public abstract class InputStream implements Closeable {
      * @exception  NullPointerException  if <code>b</code> is <code>null</code>.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException {
         return read(b, 0, b.length);
     }
 
@@ -159,7 +159,7 @@ public abstract class InputStream implements Closeable {
      * <code>b.length - off</code>
      * @see        java.io.InputStream#read()
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/InputStream.java
+++ b/checker/jdk/index/src/java/io/InputStream.java
@@ -159,7 +159,7 @@ public abstract class InputStream implements Closeable {
      * <code>b.length - off</code>
      * @see        java.io.InputStream#read()
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/InputStreamReader.java
+++ b/checker/jdk/index/src/java/io/InputStreamReader.java
@@ -181,7 +181,7 @@ public class InputStreamReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
         return sd.read(cbuf, offset, length);
     }
 

--- a/checker/jdk/index/src/java/io/InputStreamReader.java
+++ b/checker/jdk/index/src/java/io/InputStreamReader.java
@@ -181,7 +181,7 @@ public class InputStreamReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length) throws IOException {
         return sd.read(cbuf, offset, length);
     }
 

--- a/checker/jdk/index/src/java/io/LineNumberInputStream.java
+++ b/checker/jdk/index/src/java/io/LineNumberInputStream.java
@@ -127,7 +127,7 @@ class LineNumberInputStream extends FilterInputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.LineNumberInputStream#read()
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/LineNumberInputStream.java
+++ b/checker/jdk/index/src/java/io/LineNumberInputStream.java
@@ -127,7 +127,7 @@ class LineNumberInputStream extends FilterInputStream {
      * @exception  IOException  if an I/O error occurs.
      * @see        java.io.LineNumberInputStream#read()
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/LineNumberReader.java
+++ b/checker/jdk/index/src/java/io/LineNumberReader.java
@@ -160,7 +160,7 @@ public class LineNumberReader extends BufferedReader {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             int n = super.read(cbuf, off, len);
 

--- a/checker/jdk/index/src/java/io/LineNumberReader.java
+++ b/checker/jdk/index/src/java/io/LineNumberReader.java
@@ -160,7 +160,7 @@ public class LineNumberReader extends BufferedReader {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             int n = super.read(cbuf, off, len);
 

--- a/checker/jdk/index/src/java/io/ObjectInput.java
+++ b/checker/jdk/index/src/java/io/ObjectInput.java
@@ -80,7 +80,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @exception IOException If an I/O error has occurred.
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /**
      * Skips n bytes of input.

--- a/checker/jdk/index/src/java/io/ObjectInput.java
+++ b/checker/jdk/index/src/java/io/ObjectInput.java
@@ -68,7 +68,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @exception IOException If an I/O error has occurred.
      */
-    public @IndexOrLow("#1") int read(byte b[]) throws IOException;
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException;
 
     /**
      * Reads into an array of bytes.  This method will
@@ -80,7 +80,7 @@ public interface ObjectInput extends DataInput, AutoCloseable {
      *          returned when the end of the stream is reached.
      * @exception IOException If an I/O error has occurred.
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /**
      * Skips n bytes of input.

--- a/checker/jdk/index/src/java/io/ObjectInputStream.java
+++ b/checker/jdk/index/src/java/io/ObjectInputStream.java
@@ -852,7 +852,7 @@ public class ObjectInputStream
      * @throws  IOException If an I/O error has occurred.
      * @see java.io.DataInputStream#readFully(byte[],int,int)
      */
-    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (buf == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/io/ObjectInputStream.java
+++ b/checker/jdk/index/src/java/io/ObjectInputStream.java
@@ -852,7 +852,7 @@ public class ObjectInputStream
      * @throws  IOException If an I/O error has occurred.
      * @see java.io.DataInputStream#readFully(byte[],int,int)
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (buf == null) {
             throw new NullPointerException();
         }
@@ -1022,7 +1022,7 @@ public class ObjectInputStream
      * @throws  EOFException If end of file is reached.
      * @throws  IOException If other I/O error has occurred.
      */
-    public void readFully(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void readFully(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         int endoff = off + len;
         if (off < 0 || len < 0 || endoff > buf.length || endoff < 0) {
             throw new IndexOutOfBoundsException();

--- a/checker/jdk/index/src/java/io/ObjectOutput.java
+++ b/checker/jdk/index/src/java/io/ObjectOutput.java
@@ -72,7 +72,7 @@ public interface ObjectOutput extends DataOutput, AutoCloseable {
      * @param len       the number of bytes that are written
      * @exception IOException If an I/O error has occurred.
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /**
      * Flushes the stream. This will write any buffered

--- a/checker/jdk/index/src/java/io/ObjectOutputStream.java
+++ b/checker/jdk/index/src/java/io/ObjectOutputStream.java
@@ -695,7 +695,7 @@ public class ObjectOutputStream
      * @param   len the number of bytes that are written
      * @throws  IOException If an I/O error has occurred.
      */
-    public void write(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (buf == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/io/OutputStream.java
+++ b/checker/jdk/index/src/java/io/OutputStream.java
@@ -104,7 +104,7 @@ public abstract class OutputStream implements Closeable, Flushable {
      *             an <code>IOException</code> is thrown if the output
      *             stream is closed.
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/PipedInputStream.java
+++ b/checker/jdk/index/src/java/io/PipedInputStream.java
@@ -366,7 +366,7 @@ public class PipedInputStream extends InputStream {
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
      *           closed, or if an I/O error occurs.
      */
-    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/PipedInputStream.java
+++ b/checker/jdk/index/src/java/io/PipedInputStream.java
@@ -366,7 +366,7 @@ public class PipedInputStream extends InputStream {
      *           {@link #connect(java.io.PipedOutputStream) unconnected},
      *           closed, or if an I/O error occurs.
      */
-    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (b == null) {
             throw new NullPointerException();
         } else if (off < 0 || len < 0 || len > b.length - off) {

--- a/checker/jdk/index/src/java/io/PipedOutputStream.java
+++ b/checker/jdk/index/src/java/io/PipedOutputStream.java
@@ -136,7 +136,7 @@ class PipedOutputStream extends OutputStream {
      *          {@link #connect(java.io.PipedInputStream) unconnected},
      *          closed, or if an I/O error occurs.
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (sink == null) {
             throw new IOException("Pipe not connected");
         } else if (b == null) {

--- a/checker/jdk/index/src/java/io/PipedReader.java
+++ b/checker/jdk/index/src/java/io/PipedReader.java
@@ -289,7 +289,7 @@ public class PipedReader extends Reader {
      *                  {@link #connect(java.io.PipedWriter) unconnected}, closed,
      *                  or an I/O error occurs.
      */
-    public synchronized @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (!connected) {
             throw new IOException("Pipe not connected");
         } else if (closedByReader) {

--- a/checker/jdk/index/src/java/io/PipedReader.java
+++ b/checker/jdk/index/src/java/io/PipedReader.java
@@ -289,7 +289,7 @@ public class PipedReader extends Reader {
      *                  {@link #connect(java.io.PipedWriter) unconnected}, closed,
      *                  or an I/O error occurs.
      */
-    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)  throws IOException {
         if (!connected) {
             throw new IOException("Pipe not connected");
         } else if (closedByReader) {

--- a/checker/jdk/index/src/java/io/PrintStream.java
+++ b/checker/jdk/index/src/java/io/PrintStream.java
@@ -475,7 +475,7 @@ import org.checkerframework.checker.index.qual.*;
      * @param  off   Offset from which to start taking bytes
      * @param  len   Number of bytes to write
      */
-    public void write(byte buf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void write(byte buf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         try {
             synchronized (this) {
                 ensureOpen();

--- a/checker/jdk/index/src/java/io/PushbackInputStream.java
+++ b/checker/jdk/index/src/java/io/PushbackInputStream.java
@@ -163,7 +163,7 @@ class PushbackInputStream extends FilterInputStream {
      *             or an I/O error occurs.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();

--- a/checker/jdk/index/src/java/io/PushbackInputStream.java
+++ b/checker/jdk/index/src/java/io/PushbackInputStream.java
@@ -163,7 +163,7 @@ class PushbackInputStream extends FilterInputStream {
      *             or an I/O error occurs.
      * @see        java.io.InputStream#read(byte[], int, int)
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();
@@ -227,7 +227,7 @@ class PushbackInputStream extends FilterInputStream {
      *            invoking its {@link #close()} method.
      * @since     JDK1.1
      */
-    public void unread(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void unread(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (len > pos) {
             throw new IOException("Push back buffer is full");

--- a/checker/jdk/index/src/java/io/PushbackReader.java
+++ b/checker/jdk/index/src/java/io/PushbackReader.java
@@ -104,7 +104,7 @@ public class PushbackReader extends FilterReader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             try {

--- a/checker/jdk/index/src/java/io/PushbackReader.java
+++ b/checker/jdk/index/src/java/io/PushbackReader.java
@@ -104,7 +104,7 @@ public class PushbackReader extends FilterReader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             try {
@@ -172,7 +172,7 @@ public class PushbackReader extends FilterReader {
      * @exception  IOException  If there is insufficient room in the pushback
      *                          buffer, or if some other I/O error occurs
      */
-    public void unread(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void unread(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if (len > pos)

--- a/checker/jdk/index/src/java/io/RandomAccessFile.java
+++ b/checker/jdk/index/src/java/io/RandomAccessFile.java
@@ -343,7 +343,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 
@@ -400,7 +400,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *               all the bytes.
      * @exception  IOException   if an I/O error occurs.
      */
-    public final void readFully(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public final void readFully(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         int n = 0;
         do {
             int count = this.read(b, off + n, len - n);
@@ -487,7 +487,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * @param      len   the number of bytes to write.
      * @exception  IOException  if an I/O error occurs.
      */
-    public void write(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         writeBytes(b, off, len);
     }
 

--- a/checker/jdk/index/src/java/io/RandomAccessFile.java
+++ b/checker/jdk/index/src/java/io/RandomAccessFile.java
@@ -343,7 +343,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * <code>len</code> is negative, or <code>len</code> is greater than
      * <code>b.length - off</code>
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         return readBytes(b, off, len);
     }
 
@@ -366,7 +366,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * some other I/O error occurs.
      * @exception  NullPointerException If <code>b</code> is <code>null</code>.
      */
-    public @IndexOrLow("#1") int read(byte b[]) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[]) throws IOException {
         return readBytes(b, 0, b.length);
     }
 

--- a/checker/jdk/index/src/java/io/Reader.java
+++ b/checker/jdk/index/src/java/io/Reader.java
@@ -155,7 +155,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    abstract public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    abstract public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /** Maximum skip-buffer size */
     private static final int maxSkipBufferSize = 8192;

--- a/checker/jdk/index/src/java/io/Reader.java
+++ b/checker/jdk/index/src/java/io/Reader.java
@@ -137,7 +137,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * @exception   IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[]) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[]) throws IOException {
         return read(cbuf, 0, cbuf.length);
     }
 
@@ -155,7 +155,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    abstract public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
+    abstract public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException;
 
     /** Maximum skip-buffer size */
     private static final int maxSkipBufferSize = 8192;

--- a/checker/jdk/index/src/java/io/SequenceInputStream.java
+++ b/checker/jdk/index/src/java/io/SequenceInputStream.java
@@ -195,7 +195,7 @@ class SequenceInputStream extends InputStream {
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (in == null) {
             return -1;
         } else if (b == null) {

--- a/checker/jdk/index/src/java/io/SequenceInputStream.java
+++ b/checker/jdk/index/src/java/io/SequenceInputStream.java
@@ -195,7 +195,7 @@ class SequenceInputStream extends InputStream {
      * <code>b.length - off</code>
      * @exception  IOException  if an I/O error occurs.
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (in == null) {
             return -1;
         } else if (b == null) {

--- a/checker/jdk/index/src/java/io/StringBufferInputStream.java
+++ b/checker/jdk/index/src/java/io/StringBufferInputStream.java
@@ -109,7 +109,7 @@ class StringBufferInputStream extends InputStream {
      *             <code>-1</code> if there is no more data because the end of
      *             the stream has been reached.
      */
-    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/StringBufferInputStream.java
+++ b/checker/jdk/index/src/java/io/StringBufferInputStream.java
@@ -109,7 +109,7 @@ class StringBufferInputStream extends InputStream {
      *             <code>-1</code> if there is no more data because the end of
      *             the stream has been reached.
      */
-    public synchronized @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public synchronized @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         } else if ((off < 0) || (off > b.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/StringReader.java
+++ b/checker/jdk/index/src/java/io/StringReader.java
@@ -86,7 +86,7 @@ public class StringReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @IndexOrLow("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/io/StringReader.java
+++ b/checker/jdk/index/src/java/io/StringReader.java
@@ -86,7 +86,7 @@ public class StringReader extends Reader {
      *
      * @exception  IOException  If an I/O error occurs
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(char cbuf[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         synchronized (lock) {
             ensureOpen();
             if ((off < 0) || (off > cbuf.length) || (len < 0) ||

--- a/checker/jdk/index/src/java/lang/AbstractStringBuilder.java
+++ b/checker/jdk/index/src/java/lang/AbstractStringBuilder.java
@@ -383,7 +383,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      *             {@code dst.length}
      *             </ul>
      */
-    public void getChars(/*!IndexOrHigh("this")*/ int srcBegin, /*!IndexOrHigh("this")*/ int srcEnd, char[] dst, @IndexFor("#3") int dstBegin)
+    public void getChars(/*!IndexOrHigh("this")*/ int srcBegin, /*!IndexOrHigh("this")*/ int srcEnd, char[] dst, @IndexOrHigh("#3") int dstBegin)
     {
         if (srcBegin < 0)
             throw new StringIndexOutOfBoundsException(srcBegin);
@@ -597,7 +597,7 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      *         if {@code offset < 0} or {@code len < 0}
      *         or {@code offset+len > str.length}
      */
-    public AbstractStringBuilder append(char str[], @NonNegative @LTLengthOf(value="#1", offset="#3") int offset, @IndexFor("#1") int len) {
+    public AbstractStringBuilder append(char str[], @NonNegative @LTLengthOf(value="#1", offset="#3 - 1") int offset, @IndexOrHigh("#1") int len) {
         if (len > 0)                // let arraycopy report AIOOBE for len < 0
             ensureCapacityInternal(count + len);
         System.arraycopy(str, offset, value, count, len);
@@ -963,8 +963,8 @@ abstract class AbstractStringBuilder implements Appendable, CharSequence {
      *             {@code (offset+len)} is greater than
      *             {@code str.length}.
      */
-    public AbstractStringBuilder insert(int index, char[] str, @NonNegative @LTLengthOf(value="#2", offset="#4") int offset,
-                                        @IndexFor("#2") int len)
+    public AbstractStringBuilder insert(int index, char[] str, @NonNegative @LTLengthOf(value="#2", offset="#4 - 1") int offset,
+                                        @IndexOrHigh("#2") int len)
     {
         if ((index < 0) || (index > length()))
             throw new StringIndexOutOfBoundsException(index);

--- a/checker/jdk/index/src/java/lang/Character.java
+++ b/checker/jdk/index/src/java/lang/Character.java
@@ -5048,7 +5048,7 @@ class Character implements java.io.Serializable, Comparable<Character> {
      * count} is larger than the length of the given array.
      * @since  1.5
      */
-    public static @NonNegative int codePointCount(char[] a, @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public static @NonNegative int codePointCount(char[] a, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         if (count > a.length - offset || offset < 0 || count < 0) {
             throw new IndexOutOfBoundsException();
         }
@@ -5157,8 +5157,8 @@ class Character implements java.io.Serializable, Comparable<Character> {
      *   {@code codePointOffset} code points.
      * @since 1.5
      */
-    public static @IndexFor("#1") int offsetByCodePoints(char[] a, @IndexFor("#1") int start, @IndexOrHigh("#1") int count,
-                                         @IndexFor("#1") int index, int codePointOffset) {
+    public static @IndexOrHigh("#1") int offsetByCodePoints(char[] a, @IndexOrHigh("#1") int start, @IndexOrHigh("#1") int count,
+                                         @IndexOrHigh("#1") int index, int codePointOffset) {
         if (count > a.length-start || start < 0 || count < 0
             || index < start || index > start+count) {
             throw new IndexOutOfBoundsException();

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -190,7 +190,7 @@ public final class String
      *          If the {@code offset} and {@code count} arguments index
      *          characters outside the bounds of the {@code value} array
      */
-    public String(char value[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public String(char value[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         if (offset < 0) {
             throw new StringIndexOutOfBoundsException(offset);
         }
@@ -238,7 +238,7 @@ public final class String
      *
      * @since  1.5
      */
-    public String(int[] codePoints, @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public String(int[] codePoints, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         if (offset < 0) {
             throw new StringIndexOutOfBoundsException(offset);
         }
@@ -323,7 +323,7 @@ public final class String
      * @see  #String(byte[])
      */
     @Deprecated
-    public String(byte ascii[], int hibyte, @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public String(byte ascii[], int hibyte, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         checkBounds(ascii, offset, count);
         char value[] = new char[count];
 
@@ -421,7 +421,7 @@ public final class String
      *
      * @since  JDK1.1
      */
-    public String(byte bytes[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length, String charsetName)
+    public String(byte bytes[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length, String charsetName)
         throws UnsupportedEncodingException
     {
         if (charsetName == null)
@@ -460,7 +460,7 @@ public final class String
      *
      * @since  1.6
      */
-    public String(byte bytes[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length, Charset charset) {
+    public String(byte bytes[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length, Charset charset) {
         if (charset == null)
             throw new NullPointerException("charset");
         checkBounds(bytes, offset, length);
@@ -545,7 +545,7 @@ public final class String
      *
      * @since  JDK1.1
      */
-    public String(byte bytes[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int length) {
+    public String(byte bytes[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length) {
         checkBounds(bytes, offset, length);
         this.value = StringCoding.decode(bytes, offset, length);
     }
@@ -817,7 +817,7 @@ public final class String
      *            <li>{@code dstBegin+(srcEnd-srcBegin)} is larger than
      *                {@code dst.length}</ul>
      */
-    public void getChars(@IndexOrHigh("this") int srcBegin, @IndexOrHigh("this") int srcEnd, char dst[], @IndexFor("#3") int dstBegin) {
+    public void getChars(@IndexOrHigh("this") int srcBegin, @IndexOrHigh("this") int srcEnd, char dst[], @IndexOrHigh("#3") int dstBegin) {
         if (srcBegin < 0) {
             throw new StringIndexOutOfBoundsException(srcBegin);
         }
@@ -874,7 +874,7 @@ public final class String
      *          </ul>
      */
     @Deprecated
-    public void getBytes(@IndexOrHigh("this") int srcBegin, @IndexOrHigh("this") int srcEnd, byte dst[], @IndexFor("#3") int dstBegin) {
+    public void getBytes(@IndexOrHigh("this") int srcBegin, @IndexOrHigh("this") int srcEnd, byte dst[], @IndexOrHigh("#3") int dstBegin) {
         if (srcBegin < 0) {
             throw new StringIndexOutOfBoundsException(srcBegin);
         }
@@ -3033,7 +3033,7 @@ public final class String
      *          {@code offset+count} is larger than
      *          {@code data.length}.
      */
-    public static String valueOf(char data[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public static String valueOf(char data[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         return new String(data, offset, count);
     }
 
@@ -3050,7 +3050,7 @@ public final class String
      *          {@code offset+count} is larger than
      *          {@code data.length}.
      */
-    public static String copyValueOf(char data[], @IndexFor("#1") int offset, @IndexOrHigh("#1") int count) {
+    public static String copyValueOf(char data[], @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int count) {
         // All public String constructors now copy the data.
         return new String(data, offset, count);
     }

--- a/checker/jdk/index/src/java/lang/StringBuffer.java
+++ b/checker/jdk/index/src/java/lang/StringBuffer.java
@@ -213,8 +213,8 @@ import org.checkerframework.checker.index.qual.*;
      * @throws NullPointerException {@inheritDoc}
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public synchronized void getChars(/* @IndexFor("this")*/ int srcBegin, /*!IndexOrHigh("this")*/ int srcEnd, char[] dst,
-                                      @IndexFor("#3") int dstBegin)
+    public synchronized void getChars(/* @IndexOrHigh("this")*/ int srcBegin, /*!IndexOrHigh("this")*/ int srcEnd, char[] dst,
+                                      @IndexOrHigh("#3") int dstBegin)
     {
         super.getChars(srcBegin, srcEnd, dst, dstBegin);
     }
@@ -319,7 +319,7 @@ import org.checkerframework.checker.index.qual.*;
     /**
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public synchronized StringBuffer append(char[] str, @IndexFor("#1") int offset, @IndexOrHigh("#1") int len) {
+    public synchronized StringBuffer append(char[] str, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int len) {
         super.append(str, offset, len);
         return this;
     }
@@ -417,7 +417,7 @@ import org.checkerframework.checker.index.qual.*;
      * @throws StringIndexOutOfBoundsException {@inheritDoc}
      * @since      1.2
      */
-    public synchronized StringBuffer insert(/*!IndexFor("this")*/ int index, char[] str, @IndexFor("#2") int offset,
+    public synchronized StringBuffer insert(/*!IndexFor("this")*/ int index, char[] str, @IndexOrHigh("#2") int offset,
                                             @IndexOrHigh("#2") int len)
     {
         super.insert(index, str, offset, len);

--- a/checker/jdk/index/src/java/lang/StringBuilder.java
+++ b/checker/jdk/index/src/java/lang/StringBuilder.java
@@ -201,7 +201,7 @@ public final class StringBuilder
     /**
      * @throws IndexOutOfBoundsException {@inheritDoc}
      */
-    public StringBuilder append(char[] str, @IndexFor("#1") int offset, @IndexOrHigh("#1") int len) {
+    public StringBuilder append(char[] str, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int len) {
         super.append(str, offset, len);
         return this;
     }
@@ -271,7 +271,7 @@ public final class StringBuilder
     /**
      * @throws StringIndexOutOfBoundsException {@inheritDoc}
      */
-    public StringBuilder insert(/* !IndexFor("this") */ int index, char[] str, @IndexFor("#2") int offset,
+    public StringBuilder insert(/* !IndexFor("this") */ int index, char[] str, @IndexOrHigh("#2") int offset,
                                 @IndexOrHigh("#2") int len)
     {
         super.insert(index, str, offset, len);

--- a/checker/jdk/index/src/java/nio/channels/FileChannel.java
+++ b/checker/jdk/index/src/java/nio/channels/FileChannel.java
@@ -356,7 +356,7 @@ public abstract class FileChannel
      * read.  Otherwise this method behaves exactly as specified in the {@link
      * ScatteringByteChannel} interface.  </p>
      */
-    public abstract @GTENegativeOne long read(ByteBuffer[] dsts, @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+    public abstract @GTENegativeOne long read(ByteBuffer[] dsts, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length)
         throws IOException;
 
     /**
@@ -396,7 +396,7 @@ public abstract class FileChannel
      * behaves exactly as specified in the {@link GatheringByteChannel}
      * interface.  </p>
      */
-    public abstract @NonNegative long write(ByteBuffer[] srcs, @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+    public abstract @NonNegative long write(ByteBuffer[] srcs, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length)
         throws IOException;
 
     /**

--- a/checker/jdk/index/src/java/sun/nio/ch/FileChannelImpl.java
+++ b/checker/jdk/index/src/java/sun/nio/ch/FileChannelImpl.java
@@ -153,7 +153,7 @@ public class FileChannelImpl
         }
     }
 
-    public @NonNegative long read(ByteBuffer[] dsts, @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+    public @NonNegative long read(ByteBuffer[] dsts, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length)
         throws IOException
     {
         if ((offset < 0) || (length < 0) || (offset > dsts.length - length))
@@ -205,7 +205,7 @@ public class FileChannelImpl
         }
     }
 
-    public @NonNegative long write(ByteBuffer[] srcs, @IndexFor("#1") int offset, @IndexOrHigh("#1") int length)
+    public @NonNegative long write(ByteBuffer[] srcs, @IndexOrHigh("#1") int offset, @IndexOrHigh("#1") int length)
         throws IOException
     {
         if ((offset < 0) || (length < 0) || (offset > srcs.length - length))

--- a/checker/jdk/index/src/java/util/Arrays.java
+++ b/checker/jdk/index/src/java/util/Arrays.java
@@ -97,7 +97,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(int[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(int[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -137,7 +137,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(long[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(long[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -177,7 +177,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(short[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(short[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -217,7 +217,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(char[] a, @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(char[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -257,7 +257,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(byte[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(byte[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -313,7 +313,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(float[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(float[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -369,7 +369,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException
      *     if {@code fromIndex < 0} or {@code toIndex > a.length}
      */
-    public static void sort(double[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(double[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         DualPivotQuicksort.sort(a, fromIndex, toIndex - 1);
     }
@@ -420,7 +420,7 @@ public class Arrays {
 //        sort(a, 0, a.length, NATURAL_ORDER);
 //    }
 //
-//    public static void sort(Object[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+//    public static void sort(Object[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
 //        sort(a, fromIndex, toIndex, NATURAL_ORDER);
 //    }
 
@@ -531,7 +531,7 @@ public class Arrays {
      *         not <i>mutually comparable</i> (for example, strings and
      *         integers).
      */
-    public static void sort(Object[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    public static void sort(Object[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         if (LegacyMergeSort.userRequested)
             legacyMergeSort(a, fromIndex, toIndex);
         else
@@ -540,7 +540,7 @@ public class Arrays {
 
     /** To be removed in a future release. */
     private static void legacyMergeSort(Object[] a,
-                                         @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+                                         @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
         Object[] aux = copyOfRange(a, fromIndex, toIndex);
         mergeSort(aux, a, fromIndex, toIndex, -fromIndex);
@@ -720,7 +720,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if {@code fromIndex < 0} or
      *         {@code toIndex > a.length}
      */
-    public static <T> void sort(T[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static <T> void sort(T[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                 Comparator<? super T> c) {
         if (LegacyMergeSort.userRequested)
             legacyMergeSort(a, fromIndex, toIndex, c);
@@ -729,7 +729,7 @@ public class Arrays {
     }
 
     /** To be removed in a future release. */
-    private static <T> void legacyMergeSort(T[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static <T> void legacyMergeSort(T[] a, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                             Comparator<? super T> c) {
         rangeCheck(a.length, fromIndex, toIndex);
         T[] aux = copyOfRange(a, fromIndex, toIndex);
@@ -790,7 +790,7 @@ public class Arrays {
      * Checks that {@code fromIndex} and {@code toIndex} are in
      * the range and throws an appropriate exception, if they aren't.
      */
-    private static void rangeCheck(int length,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
+    private static void rangeCheck(int length, @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex) {
         if (fromIndex > toIndex) {
             throw new IllegalArgumentException(
                 "fromIndex(" + fromIndex + ") > toIndex(" + toIndex + ")");
@@ -860,14 +860,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(long[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(long[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    long key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(long[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(long[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      long key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -941,14 +941,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(int[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(int[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    int key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static @SearchIndexFor("#1") int binarySearch0(int[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static @SearchIndexFor("#1") int binarySearch0(int[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      int key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1022,14 +1022,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(short[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(short[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    short key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(short[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(short[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      short key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1103,14 +1103,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(char[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(char[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    char key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(char[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(char[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      char key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1184,14 +1184,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(byte[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(byte[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    byte key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(byte[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(byte[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      byte key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1267,14 +1267,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(double[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(double[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    double key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(double[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(double[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      double key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1358,14 +1358,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(float[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(float[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    float key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(float[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(float[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      float key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1464,14 +1464,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static @SearchIndexFor("#1") int binarySearch(Object[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static @SearchIndexFor("#1") int binarySearch(Object[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                    Object key) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key);
     }
 
     // Like public version, but without range checks.
-    private static int binarySearch0(Object[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static int binarySearch0(Object[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                      Object key) {
         int low = fromIndex;
         int high = toIndex - 1;
@@ -1565,14 +1565,14 @@ public class Arrays {
      *         if {@code fromIndex < 0 or toIndex > a.length}
      * @since 1.6
      */
-    public static <T> @SearchIndexFor("#1") int binarySearch(T[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static <T> @SearchIndexFor("#1") int binarySearch(T[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                        T key, Comparator<? super T> c) {
         rangeCheck(a.length, fromIndex, toIndex);
         return binarySearch0(a, fromIndex, toIndex, key, c);
     }
 
     // Like public version, but without range checks.
-    private static <T> int binarySearch0(T[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    private static <T> int binarySearch0(T[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                                          T key, Comparator<? super T> c) {
         if (c == null) {
             return binarySearch0(a, fromIndex, toIndex, key);
@@ -1905,7 +1905,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(long[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, long val) {
+    public static void fill(long[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, long val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -1940,7 +1940,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(int[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, int val) {
+    public static void fill(int[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, int val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -1975,7 +1975,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(short[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, short val) {
+    public static void fill(short[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, short val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2010,7 +2010,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(char[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, char val) {
+    public static void fill(char[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, char val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2045,7 +2045,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(byte[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, byte val) {
+    public static void fill(byte[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, byte val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2080,7 +2080,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(boolean[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
+    public static void fill(boolean[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,
                             boolean val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
@@ -2116,7 +2116,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(double[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,double val){
+    public static void fill(double[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex,double val){
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2151,7 +2151,7 @@ public class Arrays {
      * @throws ArrayIndexOutOfBoundsException if <tt>fromIndex &lt; 0</tt> or
      *         <tt>toIndex &gt; a.length</tt>
      */
-    public static void fill(float[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, float val) {
+    public static void fill(float[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, float val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2190,7 +2190,7 @@ public class Arrays {
      * @throws ArrayStoreException if the specified value is not of a
      *         runtime type that can be stored in the specified array
      */
-    public static void fill(Object[] a,  @IndexFor("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, Object val) {
+    public static void fill(Object[] a,  @IndexOrHigh("#1") int fromIndex, @IndexOrHigh("#1") int toIndex, Object val) {
         rangeCheck(a.length, fromIndex, toIndex);
         for (int i = fromIndex; i < toIndex; i++)
             a[i] = val;
@@ -2471,7 +2471,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static <T> T[] copyOfRange(T[] original, @IndexFor("#1") int from, int to) {
+    public static <T> T[] copyOfRange(T[] original, @IndexOrHigh("#1") int from, int to) {
         return copyOfRange(original, from, to, (Class<T[]>) original.getClass());
     }
 
@@ -2506,7 +2506,7 @@ public class Arrays {
      *     an array of class <tt>newType</tt>.
      * @since 1.6
      */
-    public static <T,U> T[] copyOfRange(U[] original, @IndexFor("#1") int from, int to, Class<? extends T[]> newType) {
+    public static <T,U> T[] copyOfRange(U[] original, @IndexOrHigh("#1") int from, int to, Class<? extends T[]> newType) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2544,7 +2544,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static byte[] copyOfRange(byte[] original, @IndexFor("#1") int from, int to) {
+    public static byte[] copyOfRange(byte[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2580,7 +2580,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static short[] copyOfRange(short[] original, @IndexFor("#1") int from, int to) {
+    public static short[] copyOfRange(short[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2616,7 +2616,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static int[] copyOfRange(int[] original, @IndexFor("#1") int from, int to) {
+    public static int[] copyOfRange(int[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2652,7 +2652,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static long[] copyOfRange(long[] original, @IndexFor("#1") int from, int to) {
+    public static long[] copyOfRange(long[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2688,7 +2688,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static char[] copyOfRange(char[] original, @IndexFor("#1") int from, int to) {
+    public static char[] copyOfRange(char[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2724,7 +2724,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static float[] copyOfRange(float[] original, @IndexFor("#1") int from, int to) {
+    public static float[] copyOfRange(float[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2760,7 +2760,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static double[] copyOfRange(double[] original, @IndexFor("#1") int from, int to) {
+    public static double[] copyOfRange(double[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);
@@ -2796,7 +2796,7 @@ public class Arrays {
      * @throws NullPointerException if <tt>original</tt> is null
      * @since 1.6
      */
-    public static boolean[] copyOfRange(boolean[] original, @IndexFor("#1") int from, int to) {
+    public static boolean[] copyOfRange(boolean[] original, @IndexOrHigh("#1") int from, int to) {
         int newLength = to - from;
         if (newLength < 0)
             throw new IllegalArgumentException(from + " > " + to);

--- a/checker/jdk/index/src/java/util/ComparableTimSort.java
+++ b/checker/jdk/index/src/java/util/ComparableTimSort.java
@@ -147,7 +147,7 @@ class ComparableTimSort {
           sort(a, 0, a.length);
     }
 
-    static void sort(Object[] a, @IndexFor("#1") int lo, @IndexOrHigh("#1") int hi) {
+    static void sort(Object[] a, @IndexOrHigh("#1") int lo, @IndexOrHigh("#1") int hi) {
         rangeCheck(a.length, lo, hi);
         int nRemaining  = hi - lo;
         if (nRemaining < 2)

--- a/checker/jdk/index/src/java/util/DualPivotQuicksort.java
+++ b/checker/jdk/index/src/java/util/DualPivotQuicksort.java
@@ -105,7 +105,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(int[] a, @IndexFor("#1") int left,  @IndexFor("#1") int right) {
+    public static void sort(int[] a, @IndexOrHigh("#1") int left,  @IndexFor("#1") int right) {
         // Use Quicksort on small arrays
         if (right - left < QUICKSORT_THRESHOLD) {
             sort(a, left, right, true);
@@ -545,7 +545,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(long[] a, @IndexFor("#1") int left,  @IndexFor("#1") int right) {
+    public static void sort(long[] a, @IndexOrHigh("#1") int left,  @IndexFor("#1") int right) {
         // Use Quicksort on small arrays
         if (right - left < QUICKSORT_THRESHOLD) {
             sort(a, left, right, true);
@@ -985,7 +985,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(short[] a, @IndexFor("#1") int left, @IndexFor("#1") int right) {
+    public static void sort(short[] a, @IndexOrHigh("#1") int left, @IndexFor("#1") int right) {
         // Use counting sort on large arrays
         if (right - left > COUNTING_SORT_THRESHOLD_FOR_SHORT_OR_CHAR) {
             int[] count = new int[NUM_SHORT_VALUES];
@@ -1457,7 +1457,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(char[] a, @IndexFor("#1") int left, @IndexFor("#1") int right) {
+    public static void sort(char[] a, @IndexOrHigh("#1") int left, @IndexFor("#1") int right) {
         // Use counting sort on large arrays
         if (right - left > COUNTING_SORT_THRESHOLD_FOR_SHORT_OR_CHAR) {
             int[] count = new int[NUM_CHAR_VALUES];
@@ -1932,7 +1932,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(byte[] a, @IndexFor("#1") int left, @IndexFor("#1") int right) {
+    public static void sort(byte[] a, @IndexOrHigh("#1") int left, @IndexFor("#1") int right) {
         // Use counting sort on large arrays
         if (right - left > COUNTING_SORT_THRESHOLD_FOR_BYTE) {
             int[] count = new int[NUM_BYTE_VALUES];
@@ -1979,7 +1979,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(float[] a, @IndexFor("#1") int left, @IndexFor("#1") int right) {
+    public static void sort(float[] a, @IndexOrHigh("#1") int left, @IndexFor("#1") int right) {
         /*
          * Phase 1: Move NaNs to the end of the array.
          */
@@ -2506,7 +2506,7 @@ final class DualPivotQuicksort {
      * @param left the index of the first element, inclusive, to be sorted
      * @param right the index of the last element, inclusive, to be sorted
      */
-    public static void sort(double[] a, @IndexFor("#1") int left, @IndexFor("#1") int right) {
+    public static void sort(double[] a, @IndexOrHigh("#1") int left, @IndexFor("#1") int right) {
         /*
          * Phase 1: Move NaNs to the end of the array.
          */

--- a/checker/jdk/index/src/java/util/GregorianCalendar.java
+++ b/checker/jdk/index/src/java/util/GregorianCalendar.java
@@ -37,10 +37,13 @@
  */
 
 package java.util;
+import org.checkerframework.common.value.qual.*;
 import org.checkerframework.checker.index.qual.*;
+
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+
 import sun.util.calendar.BaseCalendar;
 import sun.util.calendar.CalendarDate;
 import sun.util.calendar.CalendarSystem;
@@ -364,7 +367,7 @@ public class GregorianCalendar extends Calendar {
      *
      * @see #ERA
      */
-    public static final int BC = 0;
+    public static final @IntVal(0) int BC = 0;
 
     /**
      * Value of the {@link #ERA} field indicating
@@ -382,7 +385,7 @@ public class GregorianCalendar extends Calendar {
      *
      * @see #ERA
      */
-    public static final int AD = 1;
+    public static final @IntVal(1) int AD = 1;
 
     /**
      * Value of the {@link #ERA} field indicating

--- a/checker/jdk/index/src/java/util/zip/Adler32.java
+++ b/checker/jdk/index/src/java/util/zip/Adler32.java
@@ -60,7 +60,7 @@ class Adler32 implements Checksum {
     /**
      * Updates the checksum with the specified array of bytes.
      */
-    public void update(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void update(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/util/zip/CRC32.java
+++ b/checker/jdk/index/src/java/util/zip/CRC32.java
@@ -56,7 +56,7 @@ class CRC32 implements Checksum {
     /**
      * Updates the CRC-32 checksum with the specified array of bytes.
      */
-    public void update(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void update(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
@@ -79,7 +79,7 @@ class CheckedInputStream extends FilterInputStream {
      * <code>buf.length - off</code>
      * @exception IOException if an I/O error has occurred
      */
-    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         len = in.read(buf, off, len);
         if (len != -1) {
             cksum.update(buf, off, len);

--- a/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/CheckedInputStream.java
@@ -79,7 +79,7 @@ class CheckedInputStream extends FilterInputStream {
      * <code>buf.length - off</code>
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         len = in.read(buf, off, len);
         if (len != -1) {
             cksum.update(buf, off, len);

--- a/checker/jdk/index/src/java/util/zip/CheckedOutputStream.java
+++ b/checker/jdk/index/src/java/util/zip/CheckedOutputStream.java
@@ -70,7 +70,7 @@ class CheckedOutputStream extends FilterOutputStream {
      * @param len the number of bytes to be written
      * @exception IOException if an I/O error has occurred
      */
-    public void write(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         out.write(b, off, len);
         cksum.update(b, off, len);
     }

--- a/checker/jdk/index/src/java/util/zip/Checksum.java
+++ b/checker/jdk/index/src/java/util/zip/Checksum.java
@@ -46,7 +46,7 @@ interface Checksum {
      * @param off the start offset of the data
      * @param len the number of bytes to use for the update
      */
-    public void update(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len);
+    public void update(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len);
 
     /**
      * Returns the current checksum value.

--- a/checker/jdk/index/src/java/util/zip/Deflater.java
+++ b/checker/jdk/index/src/java/util/zip/Deflater.java
@@ -195,7 +195,7 @@ class Deflater {
      * @param len the length of the data
      * @see Deflater#needsInput
      */
-    public void setInput(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void setInput(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b== null) {
             throw new NullPointerException();
         }
@@ -231,7 +231,7 @@ class Deflater {
      * @see Inflater#inflate
      * @see Inflater#getAdler
      */
-    public void setDictionary(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void setDictionary(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         }
@@ -347,7 +347,7 @@ class Deflater {
      * @return the actual number of bytes of compressed data written to the
      *         output buffer
      */
-    public @GTENegativeOne int deflate(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public @GTENegativeOne int deflate(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         return deflate(b, off, len, NO_FLUSH);
     }
 
@@ -414,7 +414,7 @@ class Deflater {
      * @throws IllegalArgumentException if the flush mode is invalid
      * @since 1.7
      */
-    public @GTENegativeOne int deflate(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len, int flush) {
+    public @GTENegativeOne int deflate(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len, int flush) {
         if (b == null) {
             throw new NullPointerException();
         }

--- a/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
@@ -169,7 +169,7 @@ public class DeflaterInputStream extends FilterInputStream {
      * @throws IOException if an I/O error occurs or if this input stream is
      * already closed
      */
-    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         // Sanity checks
         ensureOpen();
         if (b == null) {

--- a/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/DeflaterInputStream.java
@@ -169,7 +169,7 @@ public class DeflaterInputStream extends FilterInputStream {
      * @throws IOException if an I/O error occurs or if this input stream is
      * already closed
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         // Sanity checks
         ensureOpen();
         if (b == null) {

--- a/checker/jdk/index/src/java/util/zip/DeflaterOutputStream.java
+++ b/checker/jdk/index/src/java/util/zip/DeflaterOutputStream.java
@@ -197,7 +197,7 @@ class DeflaterOutputStream extends FilterOutputStream {
      * @param len the length of the data
      * @exception IOException if an I/O error has occurred
      */
-    public void write(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         if (def.finished()) {
             throw new IOException("write beyond end of stream");
         }

--- a/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
@@ -109,7 +109,7 @@ class GZIPInputStream extends InflaterInputStream {
      * @exception IOException if an I/O error has occurred.
      *
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (eos) {
             return -1;

--- a/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/GZIPInputStream.java
@@ -109,7 +109,7 @@ class GZIPInputStream extends InflaterInputStream {
      * @exception IOException if an I/O error has occurred.
      *
      */
-    public @IndexOrLow("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (eos) {
             return -1;

--- a/checker/jdk/index/src/java/util/zip/GZIPOutputStream.java
+++ b/checker/jdk/index/src/java/util/zip/GZIPOutputStream.java
@@ -141,7 +141,7 @@ class GZIPOutputStream extends DeflaterOutputStream {
      * @param len the length of the data
      * @exception IOException If an I/O error has occurred.
      */
-    public synchronized void write(byte[] buf, @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized void write(byte[] buf, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         super.write(buf, off, len);

--- a/checker/jdk/index/src/java/util/zip/Inflater.java
+++ b/checker/jdk/index/src/java/util/zip/Inflater.java
@@ -118,7 +118,7 @@ class Inflater {
      * @param len the length of the input data
      * @see Inflater#needsInput
      */
-    public void setInput(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void setInput(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         }
@@ -154,7 +154,7 @@ class Inflater {
      * @see Inflater#needsDictionary
      * @see Inflater#getAdler
      */
-    public void setDictionary(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) {
+    public void setDictionary(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) {
         if (b == null) {
             throw new NullPointerException();
         }
@@ -243,7 +243,7 @@ class Inflater {
      * @see Inflater#needsInput
      * @see Inflater#needsDictionary
      */
-    public @GTENegativeOne int inflate(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public @GTENegativeOne int inflate(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)
         throws DataFormatException
     {
         if (b == null) {

--- a/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
@@ -139,7 +139,7 @@ class InflaterInputStream extends FilterInputStream {
      * @exception ZipException if a ZIP format error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();

--- a/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/InflaterInputStream.java
@@ -139,7 +139,7 @@ class InflaterInputStream extends FilterInputStream {
      * @exception ZipException if a ZIP format error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (b == null) {
             throw new NullPointerException();

--- a/checker/jdk/index/src/java/util/zip/InflaterOutputStream.java
+++ b/checker/jdk/index/src/java/util/zip/InflaterOutputStream.java
@@ -219,7 +219,7 @@ public class InflaterOutputStream extends FilterOutputStream {
      * @throws NullPointerException if {@code b} is null
      * @throws ZipException if a compression (ZIP) format error occurs
      */
-    public void write(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public void write(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         // Sanity checks
         ensureOpen();
         if (b == null) {

--- a/checker/jdk/index/src/java/util/zip/ZipFile.java
+++ b/checker/jdk/index/src/java/util/zip/ZipFile.java
@@ -662,7 +662,7 @@ class ZipFile implements ZipConstants, Closeable {
             this.jzentry = jzentry;
         }
 
-       public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+       public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
             if (rem == 0) {
                 return -1;
             }

--- a/checker/jdk/index/src/java/util/zip/ZipFile.java
+++ b/checker/jdk/index/src/java/util/zip/ZipFile.java
@@ -662,7 +662,7 @@ class ZipFile implements ZipConstants, Closeable {
             this.jzentry = jzentry;
         }
 
-       public @IndexOrLow("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+       public @GTENegativeOne @LTEqLengthOf("#1") int read(byte b[], @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
             if (rem == 0) {
                 return -1;
             }

--- a/checker/jdk/index/src/java/util/zip/ZipInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/ZipInputStream.java
@@ -178,7 +178,7 @@ class ZipInputStream extends InflaterInputStream implements ZipConstants {
      * @exception ZipException if a ZIP file error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @IndexOrLow("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (off < 0 || len < 0 || off > b.length - len) {
             throw new IndexOutOfBoundsException();

--- a/checker/jdk/index/src/java/util/zip/ZipInputStream.java
+++ b/checker/jdk/index/src/java/util/zip/ZipInputStream.java
@@ -178,7 +178,7 @@ class ZipInputStream extends InflaterInputStream implements ZipConstants {
      * @exception ZipException if a ZIP file error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
+    public @GTENegativeOne @LTEqLengthOf("#1") int read(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len) throws IOException {
         ensureOpen();
         if (off < 0 || len < 0 || off > b.length - len) {
             throw new IndexOutOfBoundsException();

--- a/checker/jdk/index/src/java/util/zip/ZipOutputStream.java
+++ b/checker/jdk/index/src/java/util/zip/ZipOutputStream.java
@@ -296,7 +296,7 @@ class ZipOutputStream extends DeflaterOutputStream implements ZipConstants {
      * @exception ZipException if a ZIP file error has occurred
      * @exception IOException if an I/O error has occurred
      */
-    public synchronized void write(byte[] b, @IndexFor("#1") int off, @IndexOrHigh("#1") int len)
+    public synchronized void write(byte[] b, @IndexOrHigh("#1") int off, @IndexOrHigh("#1") int len)
         throws IOException
     {
         ensureOpen();


### PR DESCRIPTION
This PR changes index jdk annotations applied to indices that represent a position or a start of a range in an array or a string. Such index can point to the end of the array, so `@IndexOrHigh` or `@LTEqLengthOf` is appropriate for it.

This PR does not add relations between offsets and lengths of ranges.

See panacekcz#5.
Fixes kelloggm#191.

Main changes:
- `@IndexFor` to `@IndexOrHigh` on
  - `off` parameter of `read` and `write`
  - `append`, `insert`, `getChars` (not making `AbstractStringBuilder` and its subclasses consistent)
  - character array handling methods
  - `sort`, `binarySearch`, `fill`, `copyOfRange`
  - offsets in `java.util.zip`
- `@IndexOrLow` to `@GTENegativeOne @LTEqLengthOf` on return value of `read`. This appears often in the jdk, so I would consider adding an alias to these two annotations.