### PR TITLE
Work around a bug where Travis truncates logs and fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 
 # Using travis_wait here seems to cause the job to terminate after 1 minute
 # with no error (!).
-# The fcntl lines work around a bug where Travis truncates logs and fails.
+# The fcntl line works around a bug where Travis truncates logs and fails.
 script:
 - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 - REMOTE_ORIGIN_URL=`git config --get remote.origin.url`

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
 # Using travis_wait here seems to cause the job to terminate after 1 minute
 # with no error (!).
 script:
+- python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 - REMOTE_ORIGIN_URL=`git config --get remote.origin.url`
 - echo "THIS_REPO=${THIS_REPO}"
 - echo "JDKVER=${JDKVER}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
 
 # Using travis_wait here seems to cause the job to terminate after 1 minute
 # with no error (!).
+# The fcntl lines work around a bug where Travis truncates logs and fails.
 script:
 - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 - REMOTE_ORIGIN_URL=`git config --get remote.origin.url`


### PR DESCRIPTION
The workaround is to set fcntl, taken from travis-ci/travis-ci#8920

