### PR TITLE
Fix flow2 test readme [ci skip]

### DIFF
--- a/framework/tests/flow2/README
+++ b/framework/tests/flow2/README
@@ -2,4 +2,4 @@ To add a new file to the test suite, see
   ../README
 
 To run the tests, do
-  ant -e -find build.xml flow2-tests
+  ant -e -find build.xml flow-tests


### PR DESCRIPTION
The command stated in the README for flow2 tests does not work.