### PR TITLE
Update error prone

### DIFF
--- a/build-common.properties
+++ b/build-common.properties
@@ -82,7 +82,7 @@ checker.jdk8orhigher.sources=org/checkerframework/checker/nullness/Opt.java
 # TODO: currently you have to copy this .jar to ~/.ant/lib
 # How can we set this from here?
 # See the check-errorprone target in checker/build.xml
-errorprone.version=2.1.0
+errorprone.version=2.1.3
 # The location of errorprone
 errorprone.home=${checkerframework}/../error-prone-${errorprone.version}
 errorprone.lib=${errorprone.home}/ant/target/error_prone_ant-${errorprone.version}.jar

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1390,13 +1390,14 @@
         compression="gzip" />
 
       <exec executable="mvn" dir="${errorprone.home}" failonerror="true">
+        <arg value="-q"/>
         <arg value="package"/>
         <arg value="-Dmaven.test.skip=true"/>
       </exec>
     </target>
 
-    <!-- Depend on dist-nobuildjdk to make sure everything compiles. -->
-    <target name="check-errorprone" depends="dist-nobuildjdk, clean-nojar, -errorprone.download"
+    <!-- Depend on jar to make sure everything compiles. -->
+    <target name="check-errorprone" depends="jar, clean-nojar, -errorprone.download"
             description="Run the error-prone compiler on the Checker Framework">
         <mkdir dir="${build}"/>
 

--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1420,8 +1420,6 @@
             <compilerarg value="-Xep:ReferenceEquality:OFF"/>
             <!-- These might be worth fixing. -->
             <compilerarg value="-Xep:DefaultCharset:OFF"/>
-            <!-- Disable until https://github.com/google/error-prone/issues/725 is fixed. -->
-            <compilerarg value="-Xep:NamedParameters:OFF"/>
             <compilerarg value="-Werror"/>
         </javac>
     </target>

--- a/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -1139,7 +1139,7 @@ public class FlowExpressions {
 
         @Override
         public String toString() {
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append("new " + type);
             if (!dimensions.isEmpty()) {
                 boolean needComma = false;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -67,6 +67,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.util.Context;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -74,7 +75,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -231,7 +231,7 @@ public class CFGBuilder {
      * Class declarations that have been encountered when building the control-flow graph for a
      * method.
      */
-    protected final List<ClassTree> declaredClasses = new LinkedList<>();
+    protected final List<ClassTree> declaredClasses = new ArrayList<>();
 
     public List<ClassTree> getDeclaredClasses() {
         return declaredClasses;
@@ -241,7 +241,7 @@ public class CFGBuilder {
      * Lambdas encountered when building the control-flow graph for a method, variable initializer,
      * or initializer.
      */
-    protected final List<LambdaExpressionTree> declaredLambdas = new LinkedList<>();
+    protected final List<LambdaExpressionTree> declaredLambdas = new ArrayList<>();
 
     public List<LambdaExpressionTree> getDeclaredLambdas() {
         return declaredLambdas;
@@ -726,11 +726,11 @@ public class CFGBuilder {
      */
     protected static class TryStack {
         protected Label exitLabel;
-        protected LinkedList<TryFrame> frames;
+        protected ArrayDeque<TryFrame> frames;
 
         public TryStack(Label exitLabel) {
             this.exitLabel = exitLabel;
-            this.frames = new LinkedList<>();
+            this.frames = new ArrayDeque<>();
         }
 
         public void pushFrame(TryFrame frame) {

--- a/dataflow/src/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
@@ -8,11 +8,12 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.UnaryTree;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
@@ -125,7 +126,7 @@ public class ControlFlowGraph {
     /** @return the set of all basic block in this control flow graph */
     public Set<Block> getAllBlocks() {
         Set<Block> visited = new HashSet<>();
-        Queue<Block> worklist = new LinkedList<>();
+        Queue<Block> worklist = new ArrayDeque<>();
         Block cur = entryBlock;
         visited.add(entryBlock);
 
@@ -135,7 +136,7 @@ public class ControlFlowGraph {
                 break;
             }
 
-            Queue<Block> succs = new LinkedList<>();
+            Queue<Block> succs = new ArrayDeque<>();
             if (cur.getType() == BlockType.CONDITIONAL_BLOCK) {
                 ConditionalBlock ccur = ((ConditionalBlock) cur);
                 succs.add(ccur.getThenSuccessor());
@@ -174,9 +175,9 @@ public class ControlFlowGraph {
      *     <p>Blocks may appear more than once in the sequence.
      */
     public List<Block> getDepthFirstOrderedBlocks() {
-        List<Block> dfsOrderResult = new LinkedList<>();
+        List<Block> dfsOrderResult = new ArrayList<>();
         Set<Block> visited = new HashSet<>();
-        Deque<Block> worklist = new LinkedList<>();
+        Deque<Block> worklist = new ArrayDeque<>();
         worklist.add(entryBlock);
         while (!worklist.isEmpty()) {
             Block cur = worklist.getLast();
@@ -201,7 +202,7 @@ public class ControlFlowGraph {
      * @return a Deque of successor Blocks
      */
     private Deque<Block> getSuccessors(Block cur) {
-        Deque<Block> succs = new LinkedList<>();
+        Deque<Block> succs = new ArrayDeque<>();
         if (cur.getType() == BlockType.CONDITIONAL_BLOCK) {
             ConditionalBlock ccur = ((ConditionalBlock) cur);
             succs.add(ccur.getThenSuccessor());

--- a/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -8,11 +8,11 @@ import com.sun.tools.javac.tree.JCTree;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -116,7 +116,7 @@ public class DOTCFGVisualizer<
         this.sbDigraph.append("digraph {\n");
 
         Block cur = entry;
-        Queue<Block> worklist = new LinkedList<>();
+        Queue<Block> worklist = new ArrayDeque<>();
         visited.add(entry);
         // traverse control flow graph and define all arrows
         while (true) {
@@ -285,7 +285,7 @@ public class DOTCFGVisualizer<
         this.sbBlock.setLength(0);
 
         // loop over contents
-        List<Node> contents = new LinkedList<>();
+        List<Node> contents = new ArrayList<>();
         switch (bb.getType()) {
             case REGULAR_BLOCK:
                 contents.addAll(((RegularBlock) bb).getContents());

--- a/dataflow/src/org/checkerframework/dataflow/cfg/block/RegularBlockImpl.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/block/RegularBlockImpl.java
@@ -1,7 +1,7 @@
 package org.checkerframework.dataflow.cfg.block;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import org.checkerframework.dataflow.cfg.node.Node;
 
@@ -21,7 +21,7 @@ public class RegularBlockImpl extends SingleSuccessorBlockImpl implements Regula
      */
     public RegularBlockImpl() {
         super(BlockType.REGULAR_BLOCK);
-        contents = new LinkedList<>();
+        contents = new ArrayList<>();
     }
 
     /** Add a node to the contents of this basic block. */

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
@@ -2,8 +2,8 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.ArrayAccessTree;
 import com.sun.source.tree.Tree;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
@@ -73,7 +73,7 @@ public class ArrayAccessNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getArray());
         list.add(getIndex());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ArrayCreationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ArrayCreationNode.java
@@ -6,8 +6,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.Tree;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.dataflow.util.HashCodeUtils;
@@ -74,7 +74,7 @@ public class ArrayCreationNode extends Node {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("new " + type);
         if (!dimensions.isEmpty()) {
             boolean needComma = false;
@@ -128,7 +128,7 @@ public class ArrayCreationNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(dimensions.size() + initializers.size());
         list.addAll(dimensions);
         list.addAll(initializers);
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/AssertionErrorNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/AssertionErrorNode.java
@@ -2,8 +2,8 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 
@@ -72,7 +72,7 @@ public class AssertionErrorNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getCondition());
         list.add(getDetail());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/AssignmentNode.java
@@ -5,8 +5,8 @@ import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.cfg.node.AssignmentContext.AssignmentLhsContext;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.TreeUtils;
@@ -85,7 +85,7 @@ public class AssignmentNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getTarget());
         list.add(getExpression());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/BinaryOperationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/BinaryOperationNode.java
@@ -1,8 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.BinaryTree;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -44,7 +44,7 @@ public abstract class BinaryOperationNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getLeftOperand());
         list.add(getRightOperand());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/CaseNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/CaseNode.java
@@ -2,8 +2,8 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.Tree.Kind;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.Types;
 import org.checkerframework.dataflow.util.HashCodeUtils;
@@ -73,7 +73,7 @@ public class CaseNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getSwitchOperand());
         list.add(getCaseOperand());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/FunctionalInterfaceNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/FunctionalInterfaceNode.java
@@ -4,7 +4,7 @@ import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.Tree;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Collections;
 import org.checkerframework.javacutil.ErrorReporter;
 import org.checkerframework.javacutil.TreeUtils;
 
@@ -84,7 +84,6 @@ public class FunctionalInterfaceNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
-        return list;
+        return Collections.emptyList();
     }
 }

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/MarkerNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/MarkerNode.java
@@ -47,9 +47,10 @@ public class MarkerNode extends Node {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
-        sb.append("marker ");
-        sb.append("(" + message + ")");
+        StringBuilder sb = new StringBuilder();
+        sb.append("marker (");
+        sb.append(message);
+        sb.append(")");
         return sb.toString();
     }
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/MethodInvocationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/MethodInvocationNode.java
@@ -3,8 +3,8 @@ package org.checkerframework.dataflow.cfg.node;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreePath;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import org.checkerframework.dataflow.cfg.node.AssignmentContext.MethodParameterContext;
 import org.checkerframework.dataflow.util.HashCodeUtils;
@@ -81,7 +81,7 @@ public class MethodInvocationNode extends Node {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(target);
         sb.append("(");
         boolean needComma = false;
@@ -118,7 +118,7 @@ public class MethodInvocationNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        List<Node> list = new LinkedList<Node>();
+        List<Node> list = new ArrayList<Node>(1 + arguments.size());
         list.add(target);
         list.addAll(arguments);
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/Node.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/Node.java
@@ -5,8 +5,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 import com.sun.source.tree.Tree;
+import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.LinkedList;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.dataflow.cfg.CFGBuilder;
 import org.checkerframework.dataflow.cfg.block.Block;
@@ -132,8 +132,8 @@ public abstract class Node {
      *     well as (transitively) the operands of its operands
      */
     public Collection<Node> getTransitiveOperands() {
-        LinkedList<Node> operands = new LinkedList<>(getOperands());
-        LinkedList<Node> transitiveOperands = new LinkedList<>();
+        ArrayDeque<Node> operands = new ArrayDeque<>(getOperands());
+        ArrayDeque<Node> transitiveOperands = new ArrayDeque<>(operands.size());
         while (!operands.isEmpty()) {
             Node next = operands.removeFirst();
             operands.addAll(next.getOperands());

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
@@ -1,8 +1,8 @@
 package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.NewClassTree;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.TreeUtils;
@@ -54,7 +54,7 @@ public class ObjectCreationNode extends Node {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append("new " + constructor + "(");
         boolean needComma = false;
         for (Node arg : arguments) {
@@ -93,7 +93,7 @@ public class ObjectCreationNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(1 + arguments.size());
         list.add(constructor);
         list.addAll(arguments);
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
@@ -2,8 +2,8 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.Tree.Kind;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -49,7 +49,7 @@ public class StringConcatenateAssignmentNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(2);
         list.add(getLeftOperand());
         list.add(getRightOperand());
         return list;

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/SynchronizedNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/SynchronizedNode.java
@@ -51,9 +51,10 @@ public class SynchronizedNode extends Node {
 
     @Override
     public String toString() {
-        StringBuffer sb = new StringBuffer();
-        sb.append("synchronized ");
-        sb.append("(" + expression + ")");
+        StringBuilder sb = new StringBuilder();
+        sb.append("synchronized (");
+        sb.append(expression);
+        sb.append(")");
         return sb.toString();
     }
 

--- a/dataflow/src/org/checkerframework/dataflow/cfg/node/TernaryExpressionNode.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/node/TernaryExpressionNode.java
@@ -2,8 +2,8 @@ package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.Tree.Kind;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import org.checkerframework.dataflow.util.HashCodeUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
@@ -85,7 +85,7 @@ public class TernaryExpressionNode extends Node {
 
     @Override
     public Collection<Node> getOperands() {
-        LinkedList<Node> list = new LinkedList<Node>();
+        ArrayList<Node> list = new ArrayList<Node>(3);
         list.add(getConditionOperand());
         list.add(getThenOperand());
         list.add(getElseOperand());

--- a/eclipse/checker-framework-eclipse-plugin/src/org/checkerframework/eclipse/util/PluginUtil.java
+++ b/eclipse/checker-framework-eclipse-plugin/src/org/checkerframework/eclipse/util/PluginUtil.java
@@ -155,7 +155,7 @@ public class PluginUtil {
     public static <T> String join(final String delimiter, final T[] objs) {
 
         boolean notFirst = false;
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
 
         for (final Object obj : objs) {
             if (notFirst) {
@@ -171,13 +171,13 @@ public class PluginUtil {
     public static String join(String delimiter, Iterable<?> values) {
         StringBuilder sb = new StringBuilder();
 
-        boolean isntFirst = false;
+        boolean notFirst = false;
         for (Object value : values) {
-            if (isntFirst) {
+            if (notFirst) {
                 sb.append(delimiter);
             }
             sb.append(value);
-            isntFirst = true;
+            notFirst = true;
         }
 
         return sb.toString();

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -659,8 +658,9 @@ public abstract class BaseTypeChecker extends SourceChecker implements BaseTypeC
     @Override
     protected Object processArg(Object arg) {
         if (arg instanceof Collection) {
-            List<Object> newList = new LinkedList<>();
-            for (Object o : ((Collection<?>) arg)) {
+            Collection<?> carg = (Collection<?>) arg;
+            List<Object> newList = new ArrayList<>(carg.size());
+            for (Object o : carg) {
                 newList.add(processArg(o));
             }
             return newList;

--- a/framework/src/org/checkerframework/common/reflection/DefaultReflectionResolver.java
+++ b/framework/src/org/checkerframework/common/reflection/DefaultReflectionResolver.java
@@ -29,7 +29,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -488,7 +487,7 @@ public class DefaultReflectionResolver implements ReflectionResolver {
         Resolve resolve = Resolve.instance(context);
         Names names = Names.instance(context);
 
-        List<Symbol> result = new LinkedList<>();
+        List<Symbol> result = new ArrayList<>();
         try {
             Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class);
             loadClass.setAccessible(true);
@@ -544,7 +543,7 @@ public class DefaultReflectionResolver implements ReflectionResolver {
         Resolve resolve = Resolve.instance(context);
         Names names = Names.instance(context);
 
-        List<Symbol> result = new LinkedList<>();
+        List<Symbol> result = new ArrayList<>();
         try {
             Method loadClass = Resolve.class.getDeclaredMethod("loadClass", Env.class, Name.class);
             loadClass.setAccessible(true);

--- a/framework/src/org/checkerframework/common/util/debug/TreeDebug.java
+++ b/framework/src/org/checkerframework/common/util/debug/TreeDebug.java
@@ -47,10 +47,10 @@ public class TreeDebug extends AbstractProcessor {
 
     public static class Visitor extends TreePathScanner<Void, Void> {
 
-        private final StringBuffer buf;
+        private final StringBuilder buf;
 
         public Visitor() {
-            buf = new StringBuffer();
+            buf = new StringBuilder();
         }
 
         @Override

--- a/framework/src/org/checkerframework/framework/source/Result.java
+++ b/framework/src/org/checkerframework/framework/source/Result.java
@@ -5,10 +5,10 @@ import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.nullness.qual.*;
 */
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
@@ -76,7 +76,7 @@ public final class Result {
 
     private Result(Type type, Collection<DiagMessage> messagePairs) {
         this.type = type;
-        this.messages = new LinkedList<DiagMessage>();
+        this.messages = new ArrayList<DiagMessage>();
         if (messagePairs != null) {
             for (DiagMessage msg : messagePairs) {
                 String message = msg.getMessageKey();
@@ -106,7 +106,8 @@ public final class Result {
             return SUCCESS;
         }
 
-        List<DiagMessage> messages = new LinkedList<DiagMessage>();
+        List<DiagMessage> messages =
+                new ArrayList<DiagMessage>(this.messages.size() + r.messages.size());
         messages.addAll(this.messages);
         messages.addAll(r.messages);
         return new Result(Type.merge(r.type, this.type), messages);
@@ -129,7 +130,7 @@ public final class Result {
 
     /** @return the message keys associated with the result */
     public List<String> getMessageKeys() {
-        List<String> msgKeys = new LinkedList<String>();
+        List<String> msgKeys = new ArrayList<String>(getDiagMessages().size());
         for (DiagMessage msg : getDiagMessages()) {
             msgKeys.add(msg.getMessageKey());
         }

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -20,18 +20,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryPoolMXBean;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.Stack;
 import java.util.TreeSet;
 import java.util.regex.Pattern;
 import javax.annotation.processing.AbstractProcessor;
@@ -529,17 +528,17 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         }
 
         this.messages = new Properties();
-        Stack<Class<?>> checkers = new Stack<Class<?>>();
+        ArrayDeque<Class<?>> checkers = new ArrayDeque<Class<?>>();
 
         Class<?> currClass = this.getClass();
         while (currClass != SourceChecker.class) {
-            checkers.push(currClass);
+            checkers.addFirst(currClass);
             currClass = currClass.getSuperclass();
         }
-        checkers.push(SourceChecker.class);
+        checkers.addFirst(SourceChecker.class);
 
-        while (!checkers.empty()) {
-            messages.putAll(getProperties(checkers.pop(), MSGS_FILE));
+        while (!checkers.isEmpty()) {
+            messages.putAll(getProperties(checkers.removeFirst(), MSGS_FILE));
         }
         return this.messages;
     }
@@ -1789,7 +1788,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         // {@link org.checkerframework.framework.source.SupportedOptions}
         // we additionally add
         Class<?> clazz = this.getClass();
-        List<Class<?>> clazzPrefixes = new LinkedList<>();
+        List<Class<?>> clazzPrefixes = new ArrayList<>();
 
         do {
             clazzPrefixes.add(clazz);

--- a/framework/src/org/checkerframework/framework/test/TypecheckResult.java
+++ b/framework/src/org/checkerframework/framework/test/TypecheckResult.java
@@ -2,7 +2,6 @@ package org.checkerframework.framework.test;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import javax.tools.Diagnostic;
@@ -153,7 +152,7 @@ public class TypecheckResult {
         unexpectedDiagnostics.addAll(actualDiagnostics);
         unexpectedDiagnostics.removeAll(expectedDiagnostics);
 
-        final List<TestDiagnostic> missingDiagnostics = new LinkedList<>(expectedDiagnostics);
+        final List<TestDiagnostic> missingDiagnostics = new ArrayList<>(expectedDiagnostics);
         missingDiagnostics.removeAll(actualDiagnostics);
 
         boolean testFailed = !unexpectedDiagnostics.isEmpty() || !missingDiagnostics.isEmpty();
@@ -181,7 +180,7 @@ public class TypecheckResult {
         unexpectedDiagnostics.addAll(actualDiagnostics);
         unexpectedDiagnostics.removeAll(expectedDiagnostics);
 
-        final List<TestDiagnostic> missingDiagnostics = new LinkedList<>(expectedDiagnostics);
+        final List<TestDiagnostic> missingDiagnostics = new ArrayList<>(expectedDiagnostics);
         missingDiagnostics.removeAll(actualDiagnostics);
 
         boolean testFailed = !unexpectedDiagnostics.isEmpty() || !missingDiagnostics.isEmpty();

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -406,8 +405,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 }
             }
             if (!otherElementTypes.isEmpty()) {
-                StringBuffer buf =
-                        new StringBuffer("The @Target meta-annotation on type qualifier ");
+                StringBuilder buf =
+                        new StringBuilder("The @Target meta-annotation on type qualifier ");
                 buf.append(annotationClass.toString());
                 buf.append(" must not contain ");
                 for (int i = 0; i < otherElementTypes.size(); i++) {
@@ -1526,7 +1525,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             enclosing = enclosing.getEnclosingType();
         }
 
-        List<AnnotatedTypeParameterBounds> res = new LinkedList<>();
+        List<AnnotatedTypeParameterBounds> res = new ArrayList<>(tvars.size());
 
         for (AnnotatedTypeMirror atm : tvars) {
             AnnotatedTypeVariable atv = (AnnotatedTypeVariable) atm;
@@ -2001,7 +2000,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         AnnotatedExecutableType methodType =
                 AnnotatedTypes.asMemberOf(types, this, receiverType, methodElt);
-        List<AnnotatedTypeMirror> typeargs = new LinkedList<AnnotatedTypeMirror>();
+        List<AnnotatedTypeMirror> typeargs = new ArrayList<>(methodType.getTypeVariables().size());
 
         Map<TypeVariable, AnnotatedTypeMirror> typeVarMapping =
                 AnnotatedTypes.findTypeArguments(processingEnv, this, tree, methodElt, methodType);
@@ -2124,7 +2123,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             con.setParameterTypes(actualParams);
         }
 
-        List<AnnotatedTypeMirror> typeargs = new LinkedList<AnnotatedTypeMirror>();
+        List<AnnotatedTypeMirror> typeargs = new ArrayList<>(con.getTypeVariables().size());
 
         Map<TypeVariable, AnnotatedTypeMirror> typeVarMapping =
                 AnnotatedTypes.findTypeArguments(processingEnv, this, tree, ctor, con);

--- a/framework/src/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/org/checkerframework/framework/type/BoundsInitializer.java
@@ -780,9 +780,10 @@ public class BoundsInitializer {
         }
 
         public AnnotatedTypeMirror traverseToParent(
-                final AnnotatedTypeMirror start, final List<BoundPathNode> path) {
+                final AnnotatedTypeMirror start, final BoundPath path) {
             AnnotatedTypeMirror current = start;
             for (int i = 0; i < path.size() - 1; i++) {
+                // Note that the last element in path isn't inspected.
                 current = path.get(i).next(current);
             }
 
@@ -890,8 +891,8 @@ public class BoundsInitializer {
         }
     }
 
-    /** An array list of BoundPathNodes whose equals method is a referential equality check */
-    @SuppressWarnings("serial")
+    /** A linked list of BoundPathNodes whose equals method is a referential equality check */
+    @SuppressWarnings({"serial", "JdkObsolete"})
     private static class BoundPath extends LinkedList<BoundPathNode> {
 
         @Override

--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -21,6 +21,7 @@ import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.VariableTree;
 import com.sun.source.util.TreePath;
 import java.lang.annotation.Annotation;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +30,6 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -194,7 +194,7 @@ public abstract class GenericAnnotatedTypeFactory<
         this.everUseFlow = useFlow;
         this.shouldDefaultTypeVarLocals = useFlow;
         this.useFlow = useFlow;
-        this.analyses = new LinkedList<>();
+        this.analyses = new ArrayDeque<>();
         this.scannedClasses = new HashMap<>();
         this.flowResult = null;
         this.regularExitStores = null;
@@ -939,7 +939,7 @@ public abstract class GenericAnnotatedTypeFactory<
             return;
         }
 
-        Queue<ClassTree> queue = new LinkedList<>();
+        Queue<ClassTree> queue = new ArrayDeque<>();
         List<Pair<VariableElement, Value>> fieldValues = new ArrayList<>();
         queue.add(classTree);
         while (!queue.isEmpty()) {
@@ -960,7 +960,7 @@ public abstract class GenericAnnotatedTypeFactory<
             initializationStaticStore = null;
             initializationStore = null;
 
-            Queue<Pair<LambdaExpressionTree, Store>> lambdaQueue = new LinkedList<>();
+            Queue<Pair<LambdaExpressionTree, Store>> lambdaQueue = new ArrayDeque<>();
 
             try {
                 List<CFGMethod> methods = new ArrayList<>();

--- a/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -17,7 +17,6 @@ import com.sun.source.tree.UnionTypeTree;
 import com.sun.source.tree.WildcardTree;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
@@ -92,7 +91,7 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
     public AnnotatedTypeMirror visitParameterizedType(
             ParameterizedTypeTree node, AnnotatedTypeFactory f) {
 
-        List<AnnotatedTypeMirror> args = new LinkedList<AnnotatedTypeMirror>();
+        List<AnnotatedTypeMirror> args = new ArrayList<>(node.getTypeArguments().size());
         for (Tree t : node.getTypeArguments()) {
             args.add(visit(t, f));
         }
@@ -117,7 +116,7 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
     @Override
     public AnnotatedTypeMirror visitTypeParameter(TypeParameterTree node, AnnotatedTypeFactory f) {
 
-        List<AnnotatedTypeMirror> bounds = new LinkedList<AnnotatedTypeMirror>();
+        List<AnnotatedTypeMirror> bounds = new ArrayList<>(node.getBounds().size());
         for (Tree t : node.getBounds()) {
             AnnotatedTypeMirror bound;
             if (visitedBounds.containsKey(t) && f == visitedBounds.get(t).atypeFactory) {

--- a/framework/src/org/checkerframework/framework/type/typeannotator/PropagationTypeAnnotator.java
+++ b/framework/src/org/checkerframework/framework/type/typeannotator/PropagationTypeAnnotator.java
@@ -1,8 +1,8 @@
 package org.checkerframework.framework.type.typeannotator;
 
 import com.sun.tools.javac.code.Type.WildcardType;
+import java.util.ArrayDeque;
 import java.util.Set;
-import java.util.Stack;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
@@ -33,7 +33,7 @@ public class PropagationTypeAnnotator extends TypeAnnotator {
     // TypeAnnotatorUtil.eraseBoundsThenAnnotate.
     // This flag prevents infinite recursion.
     private boolean pause = false;
-    private Stack<AnnotatedDeclaredType> parents = new Stack<>();
+    private ArrayDeque<AnnotatedDeclaredType> parents = new ArrayDeque<>();
 
     public PropagationTypeAnnotator(AnnotatedTypeFactory typeFactory) {
         super(typeFactory);
@@ -73,9 +73,9 @@ public class PropagationTypeAnnotator extends TypeAnnotator {
         if (pause) {
             return null;
         }
-        parents.push(declaredType);
+        parents.addFirst(declaredType);
         super.visitDeclared(declaredType, aVoid);
-        parents.pop();
+        parents.removeFirst();
         return null;
     }
 
@@ -96,9 +96,9 @@ public class PropagationTypeAnnotator extends TypeAnnotator {
         Element typeParamElement = TypesUtils.wildcardToTypeParam(wildcard);
         if (typeParamElement == null) {
             typeParamElement =
-                    (parents.empty())
+                    (parents.isEmpty())
                             ? null
-                            : getTypeParamFromEnclosingClass(wildcardAtm, parents.peek());
+                            : getTypeParamFromEnclosingClass(wildcardAtm, parents.peekFirst());
         }
 
         if (typeParamElement != null) {

--- a/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -777,7 +776,7 @@ public class AnnotatedTypes {
      * @return whether the type contains the modifier
      */
     public static boolean containsModifier(AnnotatedTypeMirror type, AnnotationMirror modifier) {
-        return containsModifierImpl(type, modifier, new LinkedList<AnnotatedTypeMirror>());
+        return containsModifierImpl(type, modifier, new ArrayList<AnnotatedTypeMirror>());
     }
 
     /*

--- a/framework/src/org/checkerframework/framework/util/Heuristics.java
+++ b/framework/src/org/checkerframework/framework/util/Heuristics.java
@@ -9,8 +9,8 @@ import com.sun.source.tree.Tree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.util.SimpleTreeVisitor;
 import com.sun.source.util.TreePath;
+import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.LinkedList;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -42,19 +42,21 @@ public class Heuristics {
         TreePath parentPath = path.getParentPath();
         boolean result = true;
 
-        LinkedList<Tree.Kind> queue = new LinkedList<Tree.Kind>(Arrays.asList(kinds));
+        ArrayDeque<Tree.Kind> queue = new ArrayDeque<Tree.Kind>(Arrays.asList(kinds));
 
         Tree tree;
         while ((tree = parentPath.getLeaf()) != null) {
 
-            if (queue.isEmpty()) break;
+            if (queue.isEmpty()) {
+                break;
+            }
 
             if (tree.getKind() == Tree.Kind.BLOCK || tree.getKind() == Tree.Kind.PARENTHESIZED) {
                 parentPath = parentPath.getParentPath();
                 continue;
             }
 
-            result &= queue.poll() == parentPath.getLeaf().getKind();
+            result &= queue.removeFirst() == parentPath.getLeaf().getKind();
             parentPath = parentPath.getParentPath();
         }
 

--- a/framework/src/org/checkerframework/framework/util/PluginUtil.java
+++ b/framework/src/org/checkerframework/framework/util/PluginUtil.java
@@ -155,7 +155,7 @@ public class PluginUtil {
     public static <T> String join(final String delimiter, final T[] objs) {
 
         boolean notFirst = false;
-        final StringBuffer sb = new StringBuffer();
+        final StringBuilder sb = new StringBuilder();
 
         for (final Object obj : objs) {
             if (notFirst) {
@@ -171,13 +171,13 @@ public class PluginUtil {
     public static String join(String delimiter, Iterable<?> values) {
         StringBuilder sb = new StringBuilder();
 
-        boolean isntFirst = false;
+        boolean notFirst = false;
         for (Object value : values) {
-            if (isntFirst) {
+            if (notFirst) {
                 sb.append(delimiter);
             }
             sb.append(value);
-            isntFirst = true;
+            notFirst = true;
         }
 
         return sb.toString();

--- a/framework/src/org/checkerframework/framework/util/dependenttypes/DependentTypesError.java
+++ b/framework/src/org/checkerframework/framework/util/dependenttypes/DependentTypesError.java
@@ -33,7 +33,7 @@ public class DependentTypesError {
     }
 
     public DependentTypesError(String expression, FlowExpressionParseException e) {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         List<Result.DiagMessage> msgs = e.getResult().getDiagMessages();
 
         for (Result.DiagMessage msg : msgs) {

--- a/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -7,6 +7,7 @@ import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.TypeAnnotationPosition;
 import com.sun.tools.javac.code.TypeAnnotationPosition.TypePathEntry;
 import com.sun.tools.javac.code.TypeAnnotationPosition.TypePathEntryKind;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -405,7 +406,7 @@ public class ElementAnnotationUtil {
             AnnotatedDeclaredType type, List<TypeAnnotationPosition.TypePathEntry> location) {
 
         // List order by outer most type to inner most type.
-        LinkedList<AnnotatedDeclaredType> outerToInner = new LinkedList<>();
+        ArrayDeque<AnnotatedDeclaredType> outerToInner = new ArrayDeque<>();
         AnnotatedDeclaredType enclosing = type;
         while (enclosing != null) {
             outerToInner.addFirst(enclosing);
@@ -413,6 +414,8 @@ public class ElementAnnotationUtil {
         }
 
         // Create a linked list of the location, so removing the first element is easier.
+        // Also, the `tail` operation wouldn't work with a Deque.
+        @SuppressWarnings("JdkObsolete")
         LinkedList<TypePathEntry> tailOfLocations = new LinkedList<>(location);
         boolean error = false;
         while (!tailOfLocations.isEmpty()) {

--- a/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -3,13 +3,13 @@ package org.checkerframework.framework.util.typeinference;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -494,7 +494,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
         }
 
         final int numberOfParams = paramTypes.size();
-        final LinkedList<AFConstraint> afConstraints = new LinkedList<>();
+        final ArrayDeque<AFConstraint> afConstraints = new ArrayDeque<>(numberOfParams);
         for (int i = 0; i < numberOfParams; i++) {
             if (!useNullArguments && argTypes.get(i).getKind() == TypeKind.NULL) {
                 continue;
@@ -568,7 +568,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
         if (assignedTo != null) {
             final Set<AFConstraint> reducedConstraints = new LinkedHashSet<>();
 
-            final Queue<AFConstraint> constraints = new LinkedList<>();
+            final Queue<AFConstraint> constraints = new ArrayDeque<>();
             constraints.add(new F2A(boxedReturnType, assignedTo));
 
             reduceAfConstraints(typeFactory, reducedConstraints, constraints, targets);
@@ -603,7 +603,9 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             final Set<TypeVariable> targets,
             final AnnotatedTypeFactory typeFactory) {
 
-        final LinkedList<AFConstraint> assignmentAfs = new LinkedList<>();
+        final ArrayDeque<AFConstraint> assignmentAfs =
+                new ArrayDeque<>(
+                        2 * methodType.getTypeVariables().size() + afArgumentConstraints.size());
         for (AnnotatedTypeVariable typeParam : methodType.getTypeVariables()) {
             final TypeVariable target = typeParam.getUnderlyingType();
             final AnnotatedTypeMirror inferredType = inferredArgs.get(target);
@@ -624,7 +626,8 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             }
         }
 
-        LinkedList<AFConstraint> substitutedAssignmentConstraints = new LinkedList<>();
+        ArrayDeque<AFConstraint> substitutedAssignmentConstraints =
+                new ArrayDeque<>(assignmentAfs.size() + 1);
         for (AFConstraint afConstraint : assignmentAfs) {
             substitutedAssignmentConstraints.add(afConstraint.substitute(inferredArgs));
         }
@@ -829,7 +832,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             boolean asSubtype,
             AnnotatedTypeFactory typeFactory) {
         final Types types = typeFactory.getProcessingEnv().getTypeUtils();
-        final List<TypeVariable> targetList = new LinkedList<>(targets);
+        final List<TypeVariable> targetList = new ArrayList<>(targets);
 
         final Map<TypeVariable, AnnotatedTypeVariable> paramDeclarations = new HashMap<>();
 


### PR DESCRIPTION
Increment error-prone version.
Make error-prone build quieter and don't require a built JDK.
Prefer ArrayList/ArrayDeque over LinkedList and Stack; prefer StringBuilder over StringBuffer.