### PR TITLE
Fix contract override checks

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3140,15 +3140,15 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             Set<Pair<Receiver, AnnotationMirror>> mustSubset,
             Set<Pair<Receiver, AnnotationMirror>> set,
             /*@CompilerMessageKey*/ String messageKey) {
-        for (Pair<Receiver, AnnotationMirror> a : mustSubset) {
+        for (Pair<Receiver, AnnotationMirror> weak : mustSubset) {
             boolean found = false;
 
-            for (Pair<Receiver, AnnotationMirror> b : set) {
+            for (Pair<Receiver, AnnotationMirror> strong : set) {
                 // are we looking at a contract of the same receiver?
-                if (a.first.equals(b.first)) {
+                if (weak.first.equals(strong.first)) {
                     // check subtyping relationship of annotations
                     QualifierHierarchy qualifierHierarchy = atypeFactory.getQualifierHierarchy();
-                    if (qualifierHierarchy.isSubtype(a.second, b.second)) {
+                    if (qualifierHierarchy.isSubtype(strong.second, weak.second)) {
                         found = true;
                         break;
                     }
@@ -3164,8 +3164,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                                 overriderTyp,
                                 overriddenMeth,
                                 overriddenTyp,
-                                a.second,
-                                a.first),
+                                weak.second,
+                                weak.first),
                         method);
             }
         }

--- a/framework/src/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/org/checkerframework/common/basetype/messages.properties
@@ -75,13 +75,13 @@ contracts.conditional.postcondition.not.satisfied=the conditional postcondition 
 contracts.conditional.postcondition.invalid.returntype=this annotation is only valid for methods with return type 'boolean'
 # Same text for "override" and "methodref", but different key.
 contracts.precondition.override.invalid=Precondition must be no stronger than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition is too strong: '%s' for '%s'
-contracts.postcondition.override.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition is too weak: '%s' for '%s'
-contracts.conditional.postcondition.true.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=true is too weak: '%s' for '%s'
-contracts.conditional.postcondition.false.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=false is too weak: '%s' for '%s'
+contracts.postcondition.override.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition is too strong: '%s' for '%s'
+contracts.conditional.postcondition.true.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition with result=true is too strong: '%s' for '%s'
+contracts.conditional.postcondition.false.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition with result=false is too strong: '%s' for '%s'
 contracts.precondition.methodref.invalid=Precondition must be no stronger than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition is too strong: '%s' for '%s'
-contracts.postcondition.methodref.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition is too weak: '%s' for '%s'
-contracts.conditional.postcondition.true.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=true is too weak: '%s' for '%s'
-contracts.conditional.postcondition.false.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=false is too weak: '%s' for '%s'
+contracts.postcondition.methodref.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition is too strong: '%s' for '%s'
+contracts.conditional.postcondition.true.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition with result=true is too strong: '%s' for '%s'
+contracts.conditional.postcondition.false.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nBase postcondition with result=false is too strong: '%s' for '%s'
 
 lambda.unimplemented=This version of the Checker Framework does not type-check lambda expressions.
 methodref.inference.unimplemented=This version of the Checker Framework does not type-check method references with implicit type arguments.

--- a/framework/src/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/org/checkerframework/common/basetype/messages.properties
@@ -75,13 +75,13 @@ contracts.conditional.postcondition.not.satisfied=the conditional postcondition 
 contracts.conditional.postcondition.invalid.returntype=this annotation is only valid for methods with return type 'boolean'
 # Same text for "override" and "methodref", but different key.
 contracts.precondition.override.invalid=Precondition must be no stronger than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition is too strong: '%s' for '%s'
-contracts.postcondition.override.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPosncondition is too weak: '%s' for '%s'
-contracts.conditional.postcondition.true.override.invalid=Conditional precondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition with result=true is too weak: '%s' for '%s'
-contracts.conditional.postcondition.false.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPosncondition with result=false is too weak: '%s' for '%s'
+contracts.postcondition.override.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition is too weak: '%s' for '%s'
+contracts.conditional.postcondition.true.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=true is too weak: '%s' for '%s'
+contracts.conditional.postcondition.false.override.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=false is too weak: '%s' for '%s'
 contracts.precondition.methodref.invalid=Precondition must be no stronger than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition is too strong: '%s' for '%s'
-contracts.postcondition.methodref.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPosncondition is too weak: '%s' for '%s'
-contracts.conditional.postcondition.true.methodref.invalid=Conditional precondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPrecondition with result=true is too weak: '%s' for '%s'
-contracts.conditional.postcondition.false.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPosncondition with result=false is too weak: '%s' for '%s'
+contracts.postcondition.methodref.invalid=Postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition is too weak: '%s' for '%s'
+contracts.conditional.postcondition.true.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=true is too weak: '%s' for '%s'
+contracts.conditional.postcondition.false.methodref.invalid=Conditional postcondition must be no weaker than in superclass.\nMethod\n  %s in %s\n  cannot override\n  %s in %s\nPostcondition with result=false is too weak: '%s' for '%s'
 
 lambda.unimplemented=This version of the Checker Framework does not type-check lambda expressions.
 methodref.inference.unimplemented=This version of the Checker Framework does not type-check method references with implicit type arguments.

--- a/framework/tests/flow2/ContractsOverridingSubtyping.java
+++ b/framework/tests/flow2/ContractsOverridingSubtyping.java
@@ -1,0 +1,77 @@
+import org.checkerframework.framework.qual.EnsuresQualifier;
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+import org.checkerframework.framework.qual.RequiresQualifier;
+import org.checkerframework.framework.qual.Unqualified;
+import testlib.util.Odd;
+
+class ContractsOverridingSubtyping {
+    static class Base {
+        String f;
+        @Odd String g;
+
+        @RequiresQualifier(expression = "f", qualifier = Odd.class)
+        void requiresOdd() {}
+
+        @RequiresQualifier(expression = "f", qualifier = Unqualified.class)
+        void requiresUnqual() {}
+
+        @EnsuresQualifier(expression = "f", qualifier = Odd.class)
+        void ensuresOdd() {
+            f = g;
+        }
+
+        @EnsuresQualifier(expression = "f", qualifier = Unqualified.class)
+        void ensuresUnqual() {}
+
+        @EnsuresQualifierIf(expression = "f", result = true, qualifier = Odd.class)
+        boolean ensuresIfOdd() {
+            f = g;
+            return true;
+        }
+
+        @EnsuresQualifierIf(expression = "f", result = true, qualifier = Unqualified.class)
+        boolean ensuresIfUnqual() {
+            return true;
+        }
+    }
+
+    static class Derived extends Base {
+
+        @Override
+        @RequiresQualifier(expression = "f", qualifier = Unqualified.class)
+        void requiresOdd() {}
+
+        @Override
+        @RequiresQualifier(expression = "f", qualifier = Odd.class)
+        // :: error: (contracts.precondition.override.invalid)
+        void requiresUnqual() {}
+
+        @Override
+        @EnsuresQualifier(expression = "f", qualifier = Unqualified.class)
+        // :: error: (contracts.postcondition.override.invalid)
+        void ensuresOdd() {
+            f = g;
+        }
+
+        @Override
+        @EnsuresQualifier(expression = "f", qualifier = Odd.class)
+        void ensuresUnqual() {
+            f = g;
+        }
+
+        @Override
+        @EnsuresQualifierIf(expression = "f", result = true, qualifier = Unqualified.class)
+        // :: error: (contracts.conditional.postcondition.true.override.invalid)
+        boolean ensuresIfOdd() {
+            f = g;
+            return true;
+        }
+
+        @Override
+        @EnsuresQualifierIf(expression = "f", result = true, qualifier = Odd.class)
+        boolean ensuresIfUnqual() {
+            f = g;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1724.

- swaps the order of arguments to `isSubtype`
- fixes warning messages