### PR TITLE
Fully qualify javadoc links to remove import.

### DIFF
--- a/checker/src/org/checkerframework/checker/formatter/qual/ReturnsFormat.java
+++ b/checker/src/org/checkerframework/checker/formatter/qual/ReturnsFormat.java
@@ -5,7 +5,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.checker.formatter.FormatUtil;
 
 /**
  * Attach this annotation to a method with the following properties:
@@ -18,7 +17,7 @@ import org.checkerframework.checker.formatter.FormatUtil;
  *   <li>On success, the method returns the passed format string unmodified.
  * </ul>
  *
- * An example is {@link FormatUtil#asFormat}.
+ * An example is {@link org.checkerframework.checker.formatter.FormatUtil#asFormat}.
  *
  * @checker_framework.manual #formatter-checker Format String Checker
  */

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nChecksFormat.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nChecksFormat.java
@@ -5,11 +5,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.checker.i18nformatter.I18nFormatUtil;
 
 /**
- * This annotation is used internally to annotate {@link I18nFormatUtil#hasFormat} (and will
- * potentially be used to annotate more such functions in the future).
+ * This annotation is used internally to annotate {@link
+ * org.checkerframework.checker.i18nformatter.I18nFormatUtil#hasFormat} (and will potentially be
+ * used to annotate more such functions in the future).
  *
  * <p>Attach this annotation to a method with the following properties:
  *

--- a/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nValidFormat.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/qual/I18nValidFormat.java
@@ -5,10 +5,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.checker.i18nformatter.I18nFormatUtil;
 
 /**
- * This annotation is used internally to annotate {@link I18nFormatUtil#isFormat}
+ * This annotation is used internally to annotate {@link
+ * org.checkerframework.checker.i18nformatter.I18nFormatUtil#isFormat}
  *
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  * @author Siwakorn Srisakaokul


### PR DESCRIPTION
The reason is so I can build a Qualifier only JAR using a regex like "**/qual/*.java".  I'm using Bazel to build from source and Guava requires the checker framework annotations.