### PR TITLE
Changing the Key For default for explicit upper bounds to UnkownKeyFor.

### DIFF
--- a/checker/src/org/checkerframework/checker/nullness/qual/KeyForBottom.java
+++ b/checker/src/org/checkerframework/checker/nullness/qual/KeyForBottom.java
@@ -25,6 +25,6 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @InvisibleQualifier
 @SubtypeOf(KeyFor.class)
-@DefaultFor({TypeUseLocation.LOWER_BOUND})
+@DefaultFor({TypeUseLocation.IMPLICIT_LOWER_BOUND})
 @ImplicitFor(literals = LiteralKind.NULL, typeNames = java.lang.Void.class)
 public @interface KeyForBottom {}

--- a/checker/tests/nullness/Issue1712.java
+++ b/checker/tests/nullness/Issue1712.java
@@ -1,0 +1,26 @@
+// Test case for Issue 1712
+// https://github.com/typetools/checker-framework/issues/1712
+
+abstract class Issue1712 {
+
+    abstract <T> T match(
+            Function<? super SubclassA, T> visitA, Function<? super SubclassB, T> visitB);
+
+    class SubclassA extends Issue1712 {
+        @Override
+        <T> T match(Function<? super SubclassA, T> visitA, Function<? super SubclassB, T> visitB) {
+            return visitA.apply(this); // line 11
+        }
+    }
+
+    class SubclassB extends Issue1712 {
+        @Override
+        <T> T match(Function<? super SubclassA, T> visitA, Function<? super SubclassB, T> visitB) {
+            return visitB.apply(this); // line 18
+        }
+    }
+
+    abstract class Function<T1, T2> {
+        abstract T2 apply(T1 arg);
+    }
+}


### PR DESCRIPTION
Fixes #1712.