### PR TITLE
Update Maven example to use annotationProcessorPaths

### DIFF
--- a/docs/examples/MavenExample/pom.xml
+++ b/docs/examples/MavenExample/pom.xml
@@ -34,11 +34,6 @@
       <!-- <artifactId>checker-qual7</artifactId> -->
       <version>${checkerFrameworkVersion}</version>
     </dependency>
-    <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker</artifactId>
-      <version>${checkerFrameworkVersion}</version>
-    </dependency>
     <!-- The Type Annotations compiler. Uncomment if using annotations in comments. -->
     <!--<dependency>
       <groupId>org.checkerframework</groupId>
@@ -88,6 +83,13 @@
               <!-- Uncomment to use the Type Annotations compiler. -->
               <!--<fork>true</fork>-->
               <showWarnings>true</showWarnings>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>org.checkerframework</groupId>
+                  <artifactId>checker</artifactId>
+                  <version>${checkerFrameworkVersion}</version>
+                </path>
+              </annotationProcessorPaths>
               <annotationProcessors>
                   <!-- Add all the checkers you want to enable here -->
                   <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -359,11 +359,6 @@ checker as an annotation processor directly.
        <!-- <artifactId>checker-qual7</artifactId> -->
       <version>\ReleaseVersion{}</version>
     </dependency>
-    <dependency>
-      <groupId>org.checkerframework</groupId>
-      <artifactId>checker</artifactId>
-      <version>\ReleaseVersion{}</version>
-    </dependency>
     <!-- The Type Annotations compiler. Uncomment if using annotations in comments. -->
     <!-- <dependency>
       <groupId>org.checkerframework</groupId>
@@ -489,6 +484,13 @@ For example, to use the \code{org.checkerframework.checker.nullness.NullnessChec
         <Xmaxerrs>10000</Xmaxerrs>
         <Xmaxwarns>10000</Xmaxwarns>
       </compilerArguments>
+      <annotationProcessorPaths>
+        <path>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker</artifactId>
+          <version>\ReleaseVersion{}</version>
+        </path>
+      </annotationProcessorPaths>
       <annotationProcessors>
         <!-- Add all the checkers you want to enable here -->
         <annotationProcessor>org.checkerframework.checker.nullness.NullnessChecker</annotationProcessor>


### PR DESCRIPTION
This way checker.jar is not a runtime dependency.

Fixes #1734.