### PR TITLE
Update jdk8.jar in annotated-libraries

### DIFF
--- a/checker/build.xml
+++ b/checker/build.xml
@@ -1399,7 +1399,7 @@
 
     <target name="download-jdk" description="Downloads jdk8.jar from checkerframework.org/dev-jdk to checker/jdk and checker/dist">
         <!-- See instructions for updating the jdk.jar at https://github.com/typetools/annotated-libraries/blob/master/README.jdk -->
-        <get src="https://github.com/panacekcz/checker-framework/releases/download/upperbound-annotate-collections-2/jdk8.jar" dest="jdk/jdk8.jar"
+        <get src="https://github.com/typetools/annotated-libraries/raw/36f721f6529be400ef64c309d7658ed62564af7d/jdk8.jar" dest="jdk/jdk8.jar"
              usetimestamp="true"/>
 
         <!-- Copy jars to dist. If dist doesn't exist then the copy task creates it.-->


### PR DESCRIPTION
jdk8.jar in annotated-libraries was not updated after PR #1716. This PR applies the updated location.