### PR TITLE
Show stack trace to ease debugging

### DIFF
--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -242,7 +242,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             return (Factory) new BaseAnnotatedTypeFactory(checker);
         } catch (Throwable t) {
             t.printStackTrace();
-            return null;
+            throw t;
         }
     }
 

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -219,30 +219,35 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     @SuppressWarnings("unchecked") // unchecked cast to type variable
     protected Factory createTypeFactory() {
-        try {
-            // Try to reflectively load the type factory.
-            Class<?> checkerClass = checker.getClass();
-            while (checkerClass != BaseTypeChecker.class) {
-                final String classToLoad =
-                        checkerClass
-                                .getName()
-                                .replace("Checker", "AnnotatedTypeFactory")
-                                .replace("Subchecker", "AnnotatedTypeFactory");
+        // Try to reflectively load the type factory.
+        Class<?> checkerClass = checker.getClass();
+        while (checkerClass != BaseTypeChecker.class) {
+            final String classToLoad =
+                    checkerClass
+                            .getName()
+                            .replace("Checker", "AnnotatedTypeFactory")
+                            .replace("Subchecker", "AnnotatedTypeFactory");
 
-                AnnotatedTypeFactory result =
-                        BaseTypeChecker.invokeConstructorFor(
-                                classToLoad,
-                                new Class<?>[] {BaseTypeChecker.class},
-                                new Object[] {checker});
-                if (result != null) {
-                    return (Factory) result;
-                }
-                checkerClass = checkerClass.getSuperclass();
+            AnnotatedTypeFactory result =
+                    BaseTypeChecker.invokeConstructorFor(
+                            classToLoad,
+                            new Class<?>[] {BaseTypeChecker.class},
+                            new Object[] {checker});
+            if (result != null) {
+                return (Factory) result;
             }
+            checkerClass = checkerClass.getSuperclass();
+        }
+        try {
             return (Factory) new BaseAnnotatedTypeFactory(checker);
         } catch (Throwable t) {
-            t.printStackTrace();
-            throw t;
+            ErrorReporter.errorAbort(
+                    "Unexpected "
+                            + t.getClass().getSimpleName()
+                            + " when invoking BaseAnnotatedTypeFactory for checker "
+                            + t.getClass().getSimpleName(),
+                    t);
+            return null; // dead code
         }
     }
 

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -219,26 +219,31 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     @SuppressWarnings("unchecked") // unchecked cast to type variable
     protected Factory createTypeFactory() {
-        // Try to reflectively load the type factory.
-        Class<?> checkerClass = checker.getClass();
-        while (checkerClass != BaseTypeChecker.class) {
-            final String classToLoad =
-                    checkerClass
-                            .getName()
-                            .replace("Checker", "AnnotatedTypeFactory")
-                            .replace("Subchecker", "AnnotatedTypeFactory");
+        try {
+            // Try to reflectively load the type factory.
+            Class<?> checkerClass = checker.getClass();
+            while (checkerClass != BaseTypeChecker.class) {
+                final String classToLoad =
+                        checkerClass
+                                .getName()
+                                .replace("Checker", "AnnotatedTypeFactory")
+                                .replace("Subchecker", "AnnotatedTypeFactory");
 
-            AnnotatedTypeFactory result =
-                    BaseTypeChecker.invokeConstructorFor(
-                            classToLoad,
-                            new Class<?>[] {BaseTypeChecker.class},
-                            new Object[] {checker});
-            if (result != null) {
-                return (Factory) result;
+                AnnotatedTypeFactory result =
+                        BaseTypeChecker.invokeConstructorFor(
+                                classToLoad,
+                                new Class<?>[] {BaseTypeChecker.class},
+                                new Object[] {checker});
+                if (result != null) {
+                    return (Factory) result;
+                }
+                checkerClass = checkerClass.getSuperclass();
             }
-            checkerClass = checkerClass.getSuperclass();
+            return (Factory) new BaseAnnotatedTypeFactory(checker);
+        } catch (Throwable t) {
+            t.printStackTrace();
+            return null;
         }
-        return (Factory) new BaseAnnotatedTypeFactory(checker);
     }
 
     public final Factory getTypeFactory() {

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -245,7 +245,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     "Unexpected "
                             + t.getClass().getSimpleName()
                             + " when invoking BaseAnnotatedTypeFactory for checker "
-                            + t.getClass().getSimpleName(),
+                            + checker.getClass().getSimpleName(),
                     t);
             return null; // dead code
         }


### PR DESCRIPTION
When an exception is thrown while setting up the Checker Framework (say, in a checker's constructor or while reading a stub file), it can be difficult to know what happened, much less where.  This outputs a wordy stack trace.  This should only happen when there is a bug in the Checker Framework itself, so it seems acceptable.  I'm not sure whether there is a better way, however.