### PR TITLE
Warn if declaration annotation is interpreted as an array component type qualifier

### DIFF
--- a/checker/tests/nullness/Issue1667.java
+++ b/checker/tests/nullness/Issue1667.java
@@ -1,0 +1,19 @@
+import javax.annotation.CheckForNull;
+
+class Issue1667 {
+    @com.sun.istack.internal.NotNull Object[] foo(Object[] bar) {
+        // :: error: (return.type.incompatible)
+        return null;
+    }
+
+    @CheckForNull
+    Object[] foo2(@CheckForNull Object[] bar) {
+        // :: error: (return.type.incompatible)
+        return null;
+    }
+
+    void test() {
+        // :: error: (argument.type.incompatible)
+        foo2(null);
+    }
+}

--- a/checker/tests/nullness/Issue1667.java
+++ b/checker/tests/nullness/Issue1667.java
@@ -1,3 +1,5 @@
+// warning: Interpreting @com.sun.istack.internal.NotNull as a type annotation on an array component type.
+// warning: Interpreting @javax.annotation.CheckForNull as a type annotation on an array component type.
 import javax.annotation.CheckForNull;
 
 class Issue1667 {

--- a/framework/src/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/org/checkerframework/framework/source/SourceChecker.java
@@ -698,6 +698,21 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         return swString.split(",");
     }
 
+    @Override
+    public void warn(String format, Object... args) {
+        String msg = String.format(format, args);
+        this.messager.printMessage(Kind.MANDATORY_WARNING, msg);
+    }
+
+    private Set<String> warnedBefore = new HashSet<>();
+
+    @Override
+    public void warnOnce(String format, Object... args) {
+        if (warnedBefore.add(String.format(format, args))) {
+            warn(format, args);
+        }
+    }
+
     /**
      * Exception type used only internally to abort processing. Only public to allow
      * tests.AnnotationBuilderTest; this class should be private.

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -525,19 +525,20 @@ public abstract class AnnotatedTypeMirror {
      *
      * @param a the annotation to add
      */
-    public void addAnnotation(AnnotationMirror a) {
+    public boolean addAnnotation(AnnotationMirror a) {
         if (a == null) {
             ErrorReporter.errorAbort(
                     "AnnotatedTypeMirror.addAnnotation: null is not a valid annotation.");
         }
         if (atypeFactory.isSupportedQualifier(a)) {
-            this.annotations.add(a);
+            return this.annotations.add(a);
         } else {
             AnnotationMirror aliased = atypeFactory.aliasedAnnotation(a);
             if (atypeFactory.isSupportedQualifier(aliased)) {
-                addAnnotation(aliased);
+                return addAnnotation(aliased);
             }
         }
+        return false;
     }
 
     /**
@@ -1038,8 +1039,9 @@ public abstract class AnnotatedTypeMirror {
          * added to the right component.
          */
         @Override
-        public void addAnnotation(AnnotationMirror a) {
+        public boolean addAnnotation(AnnotationMirror a) {
             assert false : "AnnotatedExecutableType.addAnnotation should never be called";
+            return false;
         }
 
         /**
@@ -1357,9 +1359,10 @@ public abstract class AnnotatedTypeMirror {
         }
 
         @Override
-        public void addAnnotation(AnnotationMirror a) {
-            super.addAnnotation(a);
+        public boolean addAnnotation(AnnotationMirror a) {
+            boolean result = super.addAnnotation(a);
             fixupBoundAnnotations();
+            return result;
         }
 
         /**
@@ -1775,9 +1778,10 @@ public abstract class AnnotatedTypeMirror {
         }
 
         @Override
-        public void addAnnotation(AnnotationMirror a) {
-            super.addAnnotation(a);
+        public boolean addAnnotation(AnnotationMirror a) {
+            boolean result = super.addAnnotation(a);
             fixupBoundAnnotations();
+            return result;
         }
 
         /**

--- a/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -87,7 +87,17 @@ public class ElementAnnotationUtil {
     static void addAnnotationsFromElement(
             final AnnotatedTypeMirror type, final List<? extends AnnotationMirror> annotations) {
         AnnotatedTypeMirror innerType = AnnotatedTypes.innerMostType(type);
-        innerType.addAnnotations(annotations);
+        if (innerType != type) {
+            for (AnnotationMirror annotation : annotations) {
+                if (innerType.addAnnotation(annotation)) {
+                    ErrorReporter.warnOnce(
+                            "Interpreting %s as a type annotation on an array component type.",
+                            annotation);
+                }
+            }
+        } else {
+            innerType.addAnnotations(annotations);
+        }
     }
 
     /**

--- a/javacutil/src/org/checkerframework/javacutil/ErrorHandler.java
+++ b/javacutil/src/org/checkerframework/javacutil/ErrorHandler.java
@@ -11,7 +11,23 @@ public interface ErrorHandler {
      *
      * @param msg the error message to log
      */
-    public void errorAbort(String msg);
+    void errorAbort(String msg);
 
-    public void errorAbort(String msg, Throwable cause);
+    void errorAbort(String msg, Throwable cause);
+
+    /**
+     * Log a warning.
+     *
+     * @param format format string
+     * @param args arguments to the format string
+     */
+    void warn(String format, Object... args);
+
+    /**
+     * If the warning has not been logged before, log it.
+     *
+     * @param format format string
+     * @param args arguments to the format string
+     */
+    void warnOnce(String format, Object... args);
 }

--- a/javacutil/src/org/checkerframework/javacutil/ErrorReporter.java
+++ b/javacutil/src/org/checkerframework/javacutil/ErrorReporter.java
@@ -51,4 +51,35 @@ public class ErrorReporter {
             throw new RuntimeException(msg, cause);
         }
     }
+
+    /**
+     * Log a warning message use {@link String#format(String, Object...)}}.
+     *
+     * @param format a format string
+     * @param args arguments to the format string
+     */
+    public static void warn(String format, Object... args) {
+        if (handler != null) {
+            handler.warn(format, args);
+        } else {
+            String formattedMsg = String.format(format, args);
+            throw new RuntimeException(formattedMsg, new Throwable());
+        }
+    }
+
+    /**
+     * If this is the first time this warning is issued, then log a waring message using {@link
+     * String#format(String, Object...)}}. Otherwise, do nothing.
+     *
+     * @param format a format string
+     * @param args arguments to the format string
+     */
+    public static void warnOnce(String format, Object... args) {
+        if (handler != null) {
+            handler.warnOnce(format, args);
+        } else {
+            String formattedMsg = String.format(format, args);
+            throw new RuntimeException(formattedMsg, new Throwable());
+        }
+    }
 }


### PR DESCRIPTION
The warning is issued once per annotation that is used as a component type qualifier.

An example of the new warning:
```
javacheck -processor nullness -cp $CHECKERFRAMEWORK/checker/dist/checker.jar  $CHECKERFRAMEWORK/checker/tests/nullness/Issue1667.java
warning: Interpreting @com.sun.istack.internal.NotNull as a type annotation on an array component type.
warning: Interpreting @javax.annotation.CheckForNull as a type annotation on an array component type.
... (Nullness Checker warnings.) ...
2 warnings
```
This pull request also adds `warn` and `warnOnce` methods to `ErrorReporter`. 