### PR TITLE
Fix and disable incorrect Index Checker test

### DIFF
--- a/checker/tests/index/LessThanLen.java
+++ b/checker/tests/index/LessThanLen.java
@@ -42,6 +42,14 @@ public class LessThanLen {
 
     public static void m6(int[] shorter) {
         int[] longer = new int[4 * shorter.length];
+        // TODO: enable when https://github.com/kelloggm/checker-framework/issues/211 is fixed
+        // // :: error: (assignment.type.incompatible)
+        // @LTLengthOf("longer") int x = shorter.length;
+        @LTEqLengthOf("longer") int y = shorter.length;
+    }
+
+    public static void m7(int @MinLen(1) [] shorter) {
+        int[] longer = new int[4 * shorter.length];
         @LTLengthOf("longer") int x = shorter.length;
         @LTEqLengthOf("longer") int y = shorter.length;
     }

--- a/checker/tests/index/LessThanLen.java
+++ b/checker/tests/index/LessThanLen.java
@@ -1,4 +1,5 @@
 import org.checkerframework.checker.index.qual.*;
+import org.checkerframework.common.value.qual.MinLen;
 
 public class LessThanLen {
 


### PR DESCRIPTION
kelloggm#211 describes a test case that currently succeeds but should fail.
This PR disables the incorrect part of the test and adds a fixed version.