### PR TITLE
Work around some restrictions imposed by the lgtm build environment

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -5,7 +5,21 @@
 extraction:
   java:
     before_index:
-      - bash .travis-build-without-test.sh downloadjdk
-      - ant -f checker/build.xml clean-nocleanjdk
+    - mkdir ${LGTM_WORKSPACE}/downloads
+    - wget -O ${LGTM_WORKSPACE}/downloads/jsr308-langtools.zip https://bitbucket.org/typetools/jsr308-langtools/get/tip.zip
+    - unzip -q -d ${LGTM_WORKSPACE} ${LGTM_WORKSPACE}/downloads/jsr308-langtools.zip
+    - mv ${LGTM_WORKSPACE}/*jsr308-langtools* ${LGTM_WORKSPACE}/jsr308-langtools
+    - (cd ${LGTM_WORKSPACE}/jsr308-langtools/make; ant)
+    - wget -O ${LGTM_WORKSPACE}/downloads/stubparser.zip https://github.com/typetools/stubparser/archive/master.zip
+    - unzip -q -d ${LGTM_WORKSPACE} ${LGTM_WORKSPACE}/downloads/stubparser.zip
+    - mv ${LGTM_WORKSPACE}/*stubparser* ${LGTM_WORKSPACE}/stubparser
+    - (cd ${LGTM_WORKSPACE}/stubparser; mvn -q package -Dmaven.test.skip=true)
+    - wget -O ${LGTM_WORKSPACE}/downloads/annotation-tools.zip https://github.com/typetools/annotation-tools/archive/master.zip
+    - unzip -q -d ${LGTM_WORKSPACE} ${LGTM_WORKSPACE}/downloads/annotation-tools.zip
+    - mv ${LGTM_WORKSPACE}/*annotation-tools* ${LGTM_WORKSPACE}/annotation-tools
+    - (cd ${LGTM_WORKSPACE}/annotation-tools; ant compile)
     index:
-      build_command: ant dist-nobuildjdk
+      build_command:
+      - cd checker
+      - ant -Djsr308.langtools=${LGTM_WORKSPACE}/jsr308-langtools -Dannotation.tools=${LGTM_WORKSPACE}/annotation-tools\
+        \ -Dstubparser.loc=${LGTM_WORKSPACE}/stubparser dist-downloadjdk


### PR DESCRIPTION
* The parent folder of the source checkout is not writeable in the lgtm build environment
* The lgtm build environment limits network access and permits only HTTP GET operations; as
  a result git/hg clone commands fail.

To workaround these restrictions the dependencies are downloaded in the form of a source zip, and
stored in the $LGTM_WORKSPACE folder

@wmdietl