### PR TITLE
lgtm.yml: fix ant command

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -21,5 +21,4 @@ extraction:
     index:
       build_command:
       - cd checker
-      - ant -Djsr308.langtools=${LGTM_WORKSPACE}/jsr308-langtools -Dannotation.tools=${LGTM_WORKSPACE}/annotation-tools\
-        \ -Dstubparser.loc=${LGTM_WORKSPACE}/stubparser dist-downloadjdk
+      - ant -Djsr308.langtools=${LGTM_WORKSPACE}/jsr308-langtools -Dannotation.tools=${LGTM_WORKSPACE}/annotation-tools -Dstubparser.loc=${LGTM_WORKSPACE}/stubparser dist-downloadjdk


### PR DESCRIPTION
A last minute edit to break a long line into two was done wrongly. As a result
the 'ant' command line ended up contain some spurious \ symbols causing the build
to fail.

@wmdietl Apologies for the mistake, I really shouldn't edit  yaml files without validating them.