### PR TITLE
Assume that minimum length of sequences is always at least 0

### DIFF
--- a/checker/src/org/checkerframework/checker/index/IndexUtil.java
+++ b/checker/src/org/checkerframework/checker/index/IndexUtil.java
@@ -104,10 +104,9 @@ public class IndexUtil {
 
     /**
      * Queries the Value Checker to determine if there is a known minimum length for the array
-     * represented by {@code tree}. If not, returns null.
+     * represented by {@code tree}. If not, returns 0.
      */
-    public static Integer getMinLen(
-            Tree tree, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
+    public static int getMinLen(Tree tree, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
         AnnotatedTypeMirror minLenType = valueAnnotatedTypeFactory.getAnnotatedType(tree);
         return valueAnnotatedTypeFactory.getMinLenValue(minLenType);
     }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -92,8 +92,8 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
         }
 
         // Check against the minlen of the array itself.
-        Integer minLen = IndexUtil.getMinLen(arrTree, atypeFactory.getValueAnnotatedTypeFactory());
-        if (valMax != null && minLen != null && valMax < minLen) {
+        int minLen = IndexUtil.getMinLen(arrTree, atypeFactory.getValueAnnotatedTypeFactory());
+        if (valMax != null && valMax < minLen) {
             return;
         }
 

--- a/checker/tests/index/NegativeIndex.java
+++ b/checker/tests/index/NegativeIndex.java
@@ -1,0 +1,10 @@
+// Test case for kelloggm#216
+// https://github.com/kelloggm/checker-framework/issues/216
+import org.checkerframework.common.value.qual.*;
+
+public class NegativeIndex {
+    @SuppressWarnings("lowerbound")
+    void m(int[] a) {
+        int x = a[-100];
+    }
+}

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -202,12 +202,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public AnnotationMirror aliasedAnnotation(AnnotationMirror anno) {
         if (AnnotationUtils.areSameByClass(anno, MinLen.class)) {
-            Integer from = getMinLenValue(anno);
-            if (from != null && from >= 0) {
-                return createArrayLenRangeAnnotation(from, Integer.MAX_VALUE);
-            } else {
-                return createArrayLenRangeAnnotation(0, Integer.MAX_VALUE);
-            }
+            int from = getMinLenValue(anno);
+            return createArrayLenRangeAnnotation(from, Integer.MAX_VALUE);
         }
 
         return super.aliasedAnnotation(anno);
@@ -2098,7 +2094,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 || AnnotationUtils.areSameByClass(anm, IntRangeFromGTENegativeOne.class);
     }
 
-    public Integer getMinLenValue(AnnotatedTypeMirror atm) {
+    public int getMinLenValue(AnnotatedTypeMirror atm) {
         return getMinLenValue(atm.getAnnotationInHierarchy(UNKNOWNVAL));
     }
 
@@ -2123,14 +2119,14 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Used to find the minimum length of an array, which is useful for array bounds checking.
-     * Returns null if there is no minimum length known, or if the passed annotation is null.
+     * Finds a minimum length of an array specified by the provided annotation. Returns 0 if there
+     * is no minimum length known, or if the passed annotation is null.
      *
      * <p>Note that this routine handles actual {@link MinLen} annotations, because it is called by
      * {@link ValueAnnotatedTypeFactory#aliasedAnnotation(AnnotationMirror)}, which transforms
      * {@link MinLen} annotations into {@link ArrayLenRange} annotations.
      */
-    public Integer getMinLenValue(AnnotationMirror annotation) {
+    private Integer getSpecifiedMinLenValue(AnnotationMirror annotation) {
         if (annotation == null) {
             return null;
         }
@@ -2145,6 +2141,23 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     ValueCheckerUtils.getLengthsForStringValues(getStringValues(annotation)));
         } else {
             return null;
+        }
+    }
+
+    /**
+     * Used to find the minimum length of an array, which is useful for array bounds checking.
+     * Returns 0 if there is no minimum length known, or if the passed annotation is null.
+     *
+     * <p>Note that this routine handles actual {@link MinLen} annotations, because it is called by
+     * {@link ValueAnnotatedTypeFactory#aliasedAnnotation(AnnotationMirror)}, which transforms
+     * {@link MinLen} annotations into {@link ArrayLenRange} annotations.
+     */
+    public int getMinLenValue(AnnotationMirror annotation) {
+        Integer minLen = getSpecifiedMinLenValue(annotation);
+        if (minLen == null || minLen < 0) {
+            return 0;
+        } else {
+            return minLen;
         }
     }
 
@@ -2203,7 +2216,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return 0;
         }
 
-        Integer minLenValue = getMinLenValue(lengthAnno);
-        return minLenValue == null ? 0 : minLenValue;
+        return getMinLenValue(lengthAnno);
     }
 }

--- a/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -2119,8 +2119,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     /**
-     * Finds a minimum length of an array specified by the provided annotation. Returns 0 if there
-     * is no minimum length known, or if the passed annotation is null.
+     * Finds a minimum length of an array specified by the provided annotation. Returns null if
+     * there is no minimum length known, or if the passed annotation is null.
      *
      * <p>Note that this routine handles actual {@link MinLen} annotations, because it is called by
      * {@link ValueAnnotatedTypeFactory#aliasedAnnotation(AnnotationMirror)}, which transforms

--- a/framework/src/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/org/checkerframework/common/value/ValueTransfer.java
@@ -1358,9 +1358,9 @@ public class ValueTransfer extends CFTransfer {
 
             Node argumentNode = n.getArgument(0);
             AnnotationMirror argumentAnno = getArrayOrStringAnnotation(argumentNode);
-            Integer minLength = atypefactory.getMinLenValue(argumentAnno);
+            int minLength = atypefactory.getMinLenValue(argumentAnno);
             // Update the annotation of the receiver
-            if (minLength != null && minLength != 0) {
+            if (minLength != 0) {
                 Receiver receiver =
                         FlowExpressions.internalReprOf(atypefactory, n.getTarget().getReceiver());
 


### PR DESCRIPTION
The method `ValueAnnotatedTypeFactory.getMinLenValue(AnnotationMirror)` currently returns `null` if there is no information about the minimum length of an array. However, the minimum length is always at least 0. Callers of  this method must usually check for `null` and treat it as 0. However, in the upper bound check of array element access, it treated it differently, causing unnecessary upper bound warning on negative constant indices.

This PR changes the method and several related method to never return `null` and return 0 if the minimum length is not known. This reduces the burden on callers of this method and fixes the upper bound check.
Fixes kelloggm#216.