### PR TITLE
Preserve upper bound for right shift

### DIFF
--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -409,6 +409,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** Checks if the expression is non-negative, i.e. it has Positive on NonNegative annotation. */
     public boolean isNonNegative(Tree tree) {
+        //TODO: consolidate with the isNonNegative method in LowerBoundTransfer
         AnnotatedTypeMirror treeType = getAnnotatedType(tree);
         return treeType.hasAnnotation(NonNegative.class) || treeType.hasAnnotation(Positive.class);
     }

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -406,4 +406,10 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
         return null;
     }
+
+    /** Checks if the expression is non-negative, i.e. it has Positive on NonNegative annotation. */
+    public boolean isNonNegative(Tree tree) {
+        AnnotatedTypeMirror treeType = getAnnotatedType(tree);
+        return treeType.hasAnnotation(NonNegative.class) || treeType.hasAnnotation(Positive.class);
+    }
 }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -436,23 +436,10 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 case AND:
                     addAnnotationForAnd(left, right, type);
                     break;
-                case RIGHT_SHIFT:
-                case UNSIGNED_RIGHT_SHIFT:
-                    addAnnotationForRightShift(left, right, type);
-                    break;
                 default:
                     break;
             }
             return super.visitBinary(tree, type);
-        }
-
-        /** Infers upper-bound annotation for (left >> right) and (left >>> right) */
-        private void addAnnotationForRightShift(
-                ExpressionTree left, ExpressionTree right, AnnotatedTypeMirror type) {
-            LowerBoundAnnotatedTypeFactory lowerBoundATF = getLowerBoundAnnotatedTypeFactory();
-            if (lowerBoundATF.getAnnotatedType(left).hasAnnotation(NonNegative.class)) {
-                type.addAnnotation(getAnnotatedType(left).getAnnotationInHierarchy(UNKNOWN));
-            }
         }
 
         private void addAnnotationForAnd(

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -450,7 +450,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         private void addAnnotationForRightShift(
                 ExpressionTree left, ExpressionTree right, AnnotatedTypeMirror type) {
             LowerBoundAnnotatedTypeFactory lowerBoundATF = getLowerBoundAnnotatedTypeFactory();
-            if (lowerBoundATF.getAnnotatedType(left).hasAnnotation(NonNegative.class)) {
+            if (lowerBoundATF.isNonNegative(left)) {
                 type.addAnnotation(getAnnotatedType(left).getAnnotationInHierarchy(UNKNOWN));
             }
         }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -436,10 +436,23 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 case AND:
                     addAnnotationForAnd(left, right, type);
                     break;
+                case RIGHT_SHIFT:
+                case UNSIGNED_RIGHT_SHIFT:
+                    addAnnotationForRightShift(left, right, type);
+                    break;
                 default:
                     break;
             }
             return super.visitBinary(tree, type);
+        }
+
+        /** Infers upper-bound annotation for (left >> right) and (left >>> right) */
+        private void addAnnotationForRightShift(
+                ExpressionTree left, ExpressionTree right, AnnotatedTypeMirror type) {
+            LowerBoundAnnotatedTypeFactory lowerBoundATF = getLowerBoundAnnotatedTypeFactory();
+            if (lowerBoundATF.getAnnotatedType(left).hasAnnotation(NonNegative.class)) {
+                type.addAnnotation(getAnnotatedType(left).getAnnotationInHierarchy(UNKNOWN));
+            }
         }
 
         private void addAnnotationForAnd(

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -446,7 +446,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return super.visitBinary(tree, type);
         }
 
-        /** Infers upper-bound annotation for (left >> right) and (left >>> right) */
+        /** Infers upper-bound annotation for {@code left >> right} and {@code left >>> right} */
         private void addAnnotationForRightShift(
                 ExpressionTree left, ExpressionTree right, AnnotatedTypeMirror type) {
             LowerBoundAnnotatedTypeFactory lowerBoundATF = getLowerBoundAnnotatedTypeFactory();

--- a/checker/tests/index/ShiftRight.java
+++ b/checker/tests/index/ShiftRight.java
@@ -1,0 +1,26 @@
+// Test case for kelloggm 214
+// https://github.com/kelloggm/checker-framework/issues/214
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+import org.checkerframework.checker.index.qual.LTLengthOf;
+
+public class ShiftRight {
+    void indexFor(Object[] a, @IndexFor("#1") int i) {
+        @IndexFor("a") int o = i >> 2;
+        @IndexFor("a") int p = i >>> 2;
+    }
+
+    void indexOrHigh(Object[] a, @IndexOrHigh("#1") int i) {
+        @IndexOrHigh("a") int o = i >> 2;
+        @IndexOrHigh("a") int p = i >>> 2;
+        // Not true if a.length == 0
+        // :: error: (assignment.type.incompatible)
+        @IndexFor("a") int q = i >> 2;
+    }
+
+    void negative(Object[] a, @LTLengthOf(value = "#1", offset = "100") int i) {
+        // Not true for some negative i
+        // :: error: (assignment.type.incompatible)
+        @LTLengthOf(value = "#1", offset = "100") int q = i >> 2;
+    }
+}


### PR DESCRIPTION
This PR fixes kelloggm#214 (upper bounds for right shift) by copying the upper bound annotation from the left operand, if it is non-negative.

After this is merged, kelloggm#217 can be implemented.