### PR TITLE
Fold compile-time constants (integer literals and lengths of string literals) in offsets

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -257,6 +257,7 @@ public class OffsetEquation {
                 return (Integer) value;
             }
         } else if (termReceiver instanceof FlowExpressions.MethodCall) {
+            // TODO: generalize
             // Length of string literal
             FlowExpressions.MethodCall call = (FlowExpressions.MethodCall) termReceiver;
             if (call.getElement().getSimpleName().toString().equals("length")) {

--- a/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -246,6 +246,65 @@ public class OffsetEquation {
     }
 
     /**
+     * Evaluates an offset term. If the term is an integer constant, returns its value. Otherwise,
+     * returns null.
+     */
+    private Integer evalConstantTerm(Receiver termReceiver) {
+        if (termReceiver instanceof FlowExpressions.ValueLiteral) {
+            // Integer literal
+            Object value = ((FlowExpressions.ValueLiteral) termReceiver).getValue();
+            if (value instanceof Integer) {
+                return (Integer) value;
+            }
+        } else if (termReceiver instanceof FlowExpressions.MethodCall) {
+            // Length of string literal
+            FlowExpressions.MethodCall call = (FlowExpressions.MethodCall) termReceiver;
+            if (call.getElement().getSimpleName().toString().equals("length")) {
+                Receiver callReceiver = call.getReceiver();
+                if (callReceiver instanceof FlowExpressions.ValueLiteral) {
+                    Object value = ((FlowExpressions.ValueLiteral) callReceiver).getValue();
+                    if (value instanceof String) {
+                        return ((String) value).length();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Standardizes and viewpoint-adapts string terms in the list based on the supplied context.
+     * Terms that evaluate to a integer constant are removed from the list, and the constants are
+     * added to or subtracted from the intValue field.
+     */
+    private void standardizeAndViewpointAdaptExpressions(
+            List<String> terms,
+            boolean subtract,
+            FlowExpressionContext context,
+            TreePath scope,
+            boolean useLocalScope)
+            throws FlowExpressionParseException {
+        // Standardize all terms and remove constants
+        int length = terms.size(), j = 0;
+        for (int i = 0; i < length; ++i) {
+            String term = terms.get(i);
+            Receiver receiver = FlowExpressionParseUtil.parse(term, context, scope, useLocalScope);
+            Integer termConstant = evalConstantTerm(receiver);
+            if (termConstant == null) {
+                terms.set(j, receiver.toString());
+                ++j;
+            } else if (subtract) {
+                intValue -= termConstant;
+            } else {
+                intValue += termConstant;
+            }
+        }
+        // Remove remaining elements from the end of the list
+        terms.subList(j, length).clear();
+    }
+
+    /**
      * Standardizes and viewpoint-adapts the string terms based us the supplied context.
      *
      * @param context FlowExpressionContext
@@ -257,24 +316,10 @@ public class OffsetEquation {
     public void standardizeAndViewpointAdaptExpressions(
             FlowExpressionContext context, TreePath scope, boolean useLocalScope)
             throws FlowExpressionParseException {
-        List<String> newAddterms = new ArrayList<>();
-        for (String term : addedTerms) {
-            String standardizedTerm =
-                    FlowExpressionParseUtil.parse(term, context, scope, useLocalScope).toString();
-            newAddterms.add(standardizedTerm);
-        }
 
-        List<String> newSubTerms = new ArrayList<>();
-        for (String term : subtractedTerms) {
-            String standardizedTerm =
-                    FlowExpressionParseUtil.parse(term, context, scope, useLocalScope).toString();
-            newSubTerms.add(standardizedTerm);
-        }
-
-        addedTerms.clear();
-        addedTerms.addAll(newAddterms);
-        subtractedTerms.clear();
-        subtractedTerms.addAll(newSubTerms);
+        standardizeAndViewpointAdaptExpressions(addedTerms, false, context, scope, useLocalScope);
+        standardizeAndViewpointAdaptExpressions(
+                subtractedTerms, true, context, scope, useLocalScope);
     }
 
     /**

--- a/checker/tests/index/Index176.java
+++ b/checker/tests/index/Index176.java
@@ -1,0 +1,16 @@
+// Test case for Issue 176:
+// https://github.com/kelloggm/checker-framework/issues/176
+
+import org.checkerframework.checker.index.qual.IndexFor;
+
+public class Index176 {
+    void test(String arglist, @IndexFor("#1") int pos) {
+        int semi_pos = arglist.indexOf(";");
+        if (semi_pos == -1) {
+            throw new Error("Malformed arglist: " + arglist);
+        }
+        arglist.substring(pos, semi_pos + 1);
+        // :: error: (argument.type.incompatible)
+        arglist.substring(pos, semi_pos + 2);
+    }
+}


### PR DESCRIPTION
This PR makes the Upper Bound Checker recognize integer literals and length of string literals in offset expressions as constants.
Fixes kelloggm#176.

This PR uses a simple name comparison to recognize the string length, not `IndexMethodIdentifier` which would mean passing it as a parameter through all the expression standardization methods.