### PR TITLE
Refine upper bound of a subtrahend with offset

### DIFF
--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -226,7 +226,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             propagateToOperands((LessThanLengthOf) largerQualPlus1, smaller, in, store);
         }
 
-        refineSubtrahendWithOffset(larger, smaller, 1, in, store);
+        refineSubtrahendWithOffset(larger, smaller, true, in, store);
 
         Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), smaller);
         store.insertValue(rightRec, atypeFactory.convertUBQualifierToAnnotation(refinedRight));
@@ -255,7 +255,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             propagateToOperands((LessThanLengthOf) leftQualifier, right, in, store);
         }
 
-        refineSubtrahendWithOffset(left, right, 0, in, store);
+        refineSubtrahendWithOffset(left, right, false, in, store);
 
         Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), right);
         store.insertValue(rightRec, atypeFactory.convertUBQualifierToAnnotation(refinedRight));
@@ -268,18 +268,18 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * <p>This is based on the fact that if {@code (minuend - subtrahend) >= offset}, and {@code
      * minuend + o < l}, then {@code subtrahend + o + offset < l}.
      *
-     * <p>If gtNode is not a subtraction, the method does nothing.
+     * <p>If {@code gtNode} is not a {@link NumericalSubtractionNode}, the method does nothing.
      *
      * @param gtNode the node that is greater or equal to the offset
      * @param offsetNode a node part of the offset
-     * @param offsetVal a constant part of the offset
+     * @param offsetAddOne whether to add one to the offset
      * @param in input of the transfer function
      * @param store location to store the refined types
      */
     private void refineSubtrahendWithOffset(
             Node gtNode,
             Node offsetNode,
-            int offsetVal,
+            boolean offsetAddOne,
             TransferInput<CFValue, CFStore> in,
             CFStore store) {
         if (gtNode instanceof NumericalSubtractionNode) {
@@ -292,7 +292,9 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
 
             UBQualifier newQual =
                     subtrahendQual.glb(
-                            minuendQual.plusOffset(offsetNode, atypeFactory).plusOffset(offsetVal));
+                            minuendQual
+                                    .plusOffset(offsetNode, atypeFactory)
+                                    .plusOffset(offsetAddOne ? 1 : 0));
             Receiver subtrahendRec = FlowExpressions.internalReprOf(atypeFactory, subtrahend);
             store.insertValue(subtrahendRec, atypeFactory.convertUBQualifierToAnnotation(newQual));
         }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -225,6 +225,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             propagateToOperands((LessThanLengthOf) largerQualPlus1, smaller, in, store);
         }
 
+        refineSubtrahendWithOffset(larger, smaller, 1, in, store);
+
         Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), smaller);
         store.insertValue(rightRec, atypeFactory.convertUBQualifierToAnnotation(refinedRight));
     }
@@ -252,8 +254,47 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             propagateToOperands((LessThanLengthOf) leftQualifier, right, in, store);
         }
 
+        refineSubtrahendWithOffset(left, right, 0, in, store);
+
         Receiver rightRec = FlowExpressions.internalReprOf(analysis.getTypeFactory(), right);
         store.insertValue(rightRec, atypeFactory.convertUBQualifierToAnnotation(refinedRight));
+    }
+
+    /**
+     * Refines the subtrahend in a subtraction which is greater than a certain offset. The type of
+     * the subtrahend is refined to the type of the minuend with the offset added.
+     *
+     * <p>This is based on the fact that if {@code (minuend - subtrahend) >= offset}, and {@code
+     * minuend + o < l}, then {@code subtrahend + o + offset < l}.
+     *
+     * <p>If gtNode is not a subtraction, the method does nothing.
+     *
+     * @param gtNode the node that is greater or equal to the offset
+     * @param offsetNode a node part of the offset
+     * @param offsetVal a constant part of the offset
+     * @param in input of the transfer function
+     * @param store location to store the refined types
+     */
+    private void refineSubtrahendWithOffset(
+            Node gtNode,
+            Node offsetNode,
+            int offsetVal,
+            TransferInput<CFValue, CFStore> in,
+            CFStore store) {
+        if (gtNode instanceof NumericalSubtractionNode) {
+            NumericalSubtractionNode subtractionNode = (NumericalSubtractionNode) gtNode;
+
+            Node minuend = subtractionNode.getLeftOperand();
+            UBQualifier minuendQual = getUBQualifier(minuend, in);
+            Node subtrahend = subtractionNode.getRightOperand();
+            UBQualifier subtrahendQual = getUBQualifier(subtrahend, in);
+
+            UBQualifier newQual =
+                    subtrahendQual.glb(
+                            minuendQual.plusOffset(offsetNode, atypeFactory).plusOffset(offsetVal));
+            Receiver subtrahendRec = FlowExpressions.internalReprOf(atypeFactory, subtrahend);
+            store.insertValue(subtrahendRec, atypeFactory.convertUBQualifierToAnnotation(newQual));
+        }
     }
 
     @Override

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -694,7 +694,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         Node caseNode = n.getCaseOperand();
         AssignmentNode assign = (AssignmentNode) n.getSwitchOperand();
         Node switchNode = assign.getExpression();
-        refineSubtrahendWithOffset(switchNode, caseNode, 0, in, result.getThenStore());
+        refineSubtrahendWithOffset(switchNode, caseNode, false, in, result.getThenStore());
         return result;
     }
 }

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -261,8 +261,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * Refines the subtrahend in a subtraction which is greater than a certain offset. The type of
-     * the subtrahend is refined to the type of the minuend with the offset added.
+     * Refines the subtrahend in a subtraction which is greater than or equal to a certain offset.
+     * The type of the subtrahend is refined to the type of the minuend with the offset added.
      *
      * <p>This is based on the fact that if {@code (minuend - subtrahend) >= offset}, and {@code
      * minuend + o < l}, then {@code subtrahend + o + offset < l}.

--- a/checker/tests/index/RefineSubtrahend.java
+++ b/checker/tests/index/RefineSubtrahend.java
@@ -37,4 +37,15 @@ public class RefineSubtrahend {
             }
         }
     }
+
+    void cases(int[] a, @NonNegative int l) {
+        switch (a.length - l) {
+            case 1:
+                int x = a[l];
+                break;
+            case 2:
+                int y = a[l + 1];
+                break;
+        }
+    }
 }

--- a/checker/tests/index/RefineSubtrahend.java
+++ b/checker/tests/index/RefineSubtrahend.java
@@ -1,0 +1,40 @@
+// Test case for kelloggm 215
+// https://github.com/kelloggm/checker-framework/issues/215
+import org.checkerframework.checker.index.qual.NonNegative;
+
+public class RefineSubtrahend {
+    void withConstant(int[] a, @NonNegative int l) {
+        if (a.length - l > 10) {
+            int x = a[l + 10];
+        }
+        if (a.length - 10 > l) {
+            int x = a[l + 10];
+        }
+        if (a.length - l >= 10) {
+            // :: error: (array.access.unsafe.high)
+            int x = a[l + 10];
+            int x1 = a[l + 9];
+        }
+    }
+
+    void withVariable(int[] a, @NonNegative int l, @NonNegative int j, @NonNegative int k) {
+        if (a.length - l > j) {
+            if (k <= j) {
+                int x = a[l + k];
+            }
+        }
+        if (a.length - j > l) {
+            if (k <= j) {
+                int x = a[l + k];
+            }
+        }
+        if (a.length - j >= l) {
+            if (k <= j) {
+                // :: error: (array.access.unsafe.high)
+                int x = a[l + k];
+                // :: error: (array.access.unsafe.low)
+                int x1 = a[l + k - 1];
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds refinement to the transfer of the Upper Bound Checker, to refine the upper bound of a subtrahend in a condition such as `a.length - i > j`. Currently `j` is refined to `@LTLengthOf(value="a", offset="i")`. This refines `i` to `@LTLengthOf(value="a", offset="j")` as well.

The rules are:
- if `minuend` is `@LTLengthOf(value="a", offset="o")` and `minuend-subtrahend>offset`, then `subtrahend` is `@LTLengthOf(value="a", offset="o+offset+1")` 
- if `minuend` is `@LTLengthOf(value="a", offset="o")` and `minuend-subtrahend>=offset`, then `subtrahend` is `@LTLengthOf(value="a", offset="o+offset")` 

Fixes kelloggm#215