### PR TITLE
Fix #1781: Add an independent TypeKind enum to not create a warning.

### DIFF
--- a/checker/src/org/checkerframework/checker/interning/qual/Interned.java
+++ b/checker/src/org/checkerframework/checker/interning/qual/Interned.java
@@ -5,10 +5,10 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
 
 /**
  * Indicates that a variable has been interned, i.e., that the variable refers to the canonical

--- a/checker/src/org/checkerframework/checker/lock/qual/GuardedBy.java
+++ b/checker/src/org/checkerframework/checker/lock/qual/GuardedBy.java
@@ -18,13 +18,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.JavaExpression;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**

--- a/checker/src/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/checker/src/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -5,13 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**

--- a/checker/src/org/checkerframework/checker/signedness/qual/Signed.java
+++ b/checker/src/org/checkerframework/checker/signedness/qual/Signed.java
@@ -5,9 +5,9 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
 
 /**
  * The value is to be interpreted as signed. That is, if the most significant bit in the bitwise

--- a/checker/src/org/checkerframework/checker/signedness/qual/SignednessBottom.java
+++ b/checker/src/org/checkerframework/checker/signedness/qual/SignednessBottom.java
@@ -2,11 +2,11 @@ package org.checkerframework.checker.signedness.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeKind;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**

--- a/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
+++ b/framework/src/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
@@ -377,10 +377,10 @@ public class WholeProgramInferenceScenesHelper {
         // org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator.
         ImplicitFor implicitFor = elt.getAnnotation(ImplicitFor.class);
         if (implicitFor != null) {
-            TypeKind[] types = implicitFor.types();
+            org.checkerframework.framework.qual.TypeKind[] types = implicitFor.types();
             TypeKind atmKind = atm.getUnderlyingType().getKind();
-            for (TypeKind tk : types) {
-                if (tk == atmKind) return true;
+            if (hasMatchingTypeKind(atmKind, types)) {
+                return true;
             }
 
             try {
@@ -400,6 +400,17 @@ public class WholeProgramInferenceScenesHelper {
             }
         }
 
+        return false;
+    }
+
+    /** Returns true, iff a matching TypeKind is found. */
+    private boolean hasMatchingTypeKind(
+            TypeKind atmKind, org.checkerframework.framework.qual.TypeKind[] types) {
+        for (org.checkerframework.framework.qual.TypeKind tk : types) {
+            if (tk.name().equals(atmKind.name())) {
+                return true;
+            }
+        }
         return false;
     }
 

--- a/framework/src/org/checkerframework/framework/qual/ImplicitFor.java
+++ b/framework/src/org/checkerframework/framework/qual/ImplicitFor.java
@@ -8,7 +8,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 
 /**
  * A meta-annotation that specifies the trees and types for which the framework should automatically

--- a/framework/src/org/checkerframework/framework/qual/TypeKind.java
+++ b/framework/src/org/checkerframework/framework/qual/TypeKind.java
@@ -1,0 +1,72 @@
+package org.checkerframework.framework.qual;
+
+/**
+ * Specifies kinds of types.
+ *
+ * <p>These correspond to the constants in {@link javax.lang.model.type.TypeKind}. However, that
+ * enum is not available on Android and a warning is produced. So this enum is used instead.
+ */
+public enum TypeKind {
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#BOOLEAN} types. */
+    BOOLEAN,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#BYTE} types. */
+    BYTE,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#SHORT} types. */
+    SHORT,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#INT} types. */
+    INT,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#LONG} types. */
+    LONG,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#CHAR} types. */
+    CHAR,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#FLOAT} types. */
+    FLOAT,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#DOUBLE} types. */
+    DOUBLE,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#VOID} types. */
+    VOID,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#NONE} types. */
+    NONE,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#NULL} types. */
+    NULL,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#ARRAY} types. */
+    ARRAY,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#DECLARED} types. */
+    DECLARED,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#ERROR} types. */
+    ERROR,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#TYPEVAR} types. */
+    TYPEVAR,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#WILDCARD} types. */
+    WILDCARD,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#PACKAGE} types. */
+    PACKAGE,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#EXECUTABLE} types. */
+    EXECUTABLE,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#OTHER} types. */
+    OTHER,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#UNION} types. */
+    UNION,
+
+    /** Corresponds to {@link javax.lang.model.type.TypeKind#INTERSECTION} types. */
+    INTERSECTION;
+}

--- a/framework/src/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
+++ b/framework/src/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
@@ -67,18 +67,32 @@ public class ImplicitsTypeAnnotator extends TypeAnnotator {
         // classes and kinds into maps.
         for (Class<? extends Annotation> qual : quals) {
             ImplicitFor implicit = qual.getAnnotation(ImplicitFor.class);
-            if (implicit == null) continue;
+            if (implicit == null) {
+                continue;
+            }
 
             AnnotationMirror theQual =
                     AnnotationBuilder.fromClass(typeFactory.getElementUtils(), qual);
-            for (TypeKind typeKind : implicit.types()) {
-                addTypeKind(typeKind, theQual);
+            for (org.checkerframework.framework.qual.TypeKind typeKind : implicit.types()) {
+                TypeKind mappedTk = mapTypeKinds(typeKind);
+                addTypeKind(mappedTk, theQual);
             }
 
             for (Class<?> typeName : implicit.typeNames()) {
                 addTypeName(typeName, theQual);
             }
         }
+    }
+
+    /**
+     * Map between {@link org.checkerframework.framework.qual.TypeKind} and {@link
+     * javax.lang.model.type.TypeKind}.
+     *
+     * @param typeKind the Checker Framework TypeKind
+     * @return the javax TypeKind
+     */
+    private TypeKind mapTypeKinds(org.checkerframework.framework.qual.TypeKind typeKind) {
+        return TypeKind.valueOf(typeKind.name());
     }
 
     public void addTypeKind(TypeKind typeKind, AnnotationMirror theQual) {

--- a/framework/tests/src/testlib/flowexpression/qual/FEBot.java
+++ b/framework/tests/src/testlib/flowexpression/qual/FEBot.java
@@ -2,10 +2,10 @@ package testlib.flowexpression.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TypeKind;
 
 @SubtypeOf({FlowExp.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})


### PR DESCRIPTION
... on Android.
Downstream tests depend on
https://github.com/typetools/checker-framework-inference/pull/68