### PR TITLE
Fix Issue #1809 by determining better type for member references.

### DIFF
--- a/checker/jtreg/nullness/Issue1809.java
+++ b/checker/jtreg/nullness/Issue1809.java
@@ -1,0 +1,40 @@
+/*
+ * @test
+ * @summary Test for Issue 1809: caching issue.
+ *     https://github.com/typetools/checker-framework/issues/1809
+ *     Also see framework/tests/all-systems/Issue1809.java
+ *
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -AprintErrorStack -AatfCacheSize=4 Issue1809.java
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -AprintErrorStack -AatfDoNotCache Issue1809.java
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -AprintErrorStack Issue1809.java
+ */
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@SuppressWarnings("unchecked")
+abstract class Issue1809 {
+
+    abstract <T> Stream<T> concat(Stream<? extends T>... streams);
+
+    abstract Optional<A> f();
+
+    private static class A {}
+
+    interface B {
+        List<C> g();
+    }
+
+    interface C {
+        List<S> h();
+    }
+
+    interface S {}
+
+    private Stream<A> xrefsFor(B b) {
+        return concat(b.g().stream().flatMap(a -> a.h().stream().map(c -> f())))
+                .filter(Optional::isPresent)
+                .map(Optional::get);
+    }
+}

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2504,8 +2504,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // That is handled separately in method receiver check.
 
         // The type of the expression or type use, <expression>::method or <type use>::method.
-        AnnotatedTypeMirror enclosingType =
-                atypeFactory.getAnnotatedType(memberReferenceTree.getQualifierExpression());
+        ExpressionTree qexpTree = memberReferenceTree.getQualifierExpression();
+        AnnotatedTypeMirror enclosingType = atypeFactory.getAnnotatedTypeFromTypeTree(qexpTree);
+        if (qexpTree.getKind() == Tree.Kind.IDENTIFIER) {
+            // This is a hack around the ambiguity between identifiers that could be
+            // types or expressions. Using TreeUtils.isTypeTree unfortunately doesn't
+            // help, as it isn't precise enough.
+            // TODO: determine a nicer way. Is taking the main qualifiers enough?
+            AnnotatedTypeMirror expType = atypeFactory.getAnnotatedType(qexpTree);
+            if (enclosingType != expType) {
+                enclosingType.replaceAnnotations(expType.getEffectiveAnnotations());
+            }
+        }
 
         // ========= Overriding Executable =========
         // The ::method element, see JLS 15.13.1 Compile-Time Declaration of a Method Reference

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -306,10 +306,25 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     private final Map<Tree, AnnotatedTypeMirror> classAndMethodTreeCache;
 
     /**
-     * Mapping from a Tree to its annotated type; before implicits are applied, just what the
-     * programmer wrote.
+     * Mapping from an expression tree to its annotated type; before implicits are applied, just
+     * what the programmer wrote. Might alias the same object as fromMemberTreeCache and
+     * fromTypeTreeCache.
      */
-    protected final Map<Tree, AnnotatedTypeMirror> fromTreeCache;
+    protected final Map<Tree, AnnotatedTypeMirror> fromExpressionTreeCache;
+
+    /**
+     * Mapping from a member tree to its annotated type; before implicits are applied, just what the
+     * programmer wrote. Might alias the same object as fromExpressionTreeCache and
+     * fromTypeTreeCache
+     */
+    protected final Map<Tree, AnnotatedTypeMirror> fromMemberTreeCache;
+
+    /**
+     * Mapping from a type tree to its annotated type; before implicits are applied, just what the
+     * programmer wrote. Might alias the same object as fromExpressionTreeCache and
+     * fromMemberTreeCache.
+     */
+    protected final Map<Tree, AnnotatedTypeMirror> fromTypeTreeCache;
 
     /**
      * Mapping from an Element to its annotated type; before implicits are applied, just what the
@@ -361,12 +376,16 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         if (shouldCache) {
             int cacheSize = getCacheSize();
             this.classAndMethodTreeCache = CollectionUtils.createLRUCache(cacheSize);
-            this.fromTreeCache = CollectionUtils.createLRUCache(cacheSize);
+            this.fromExpressionTreeCache = CollectionUtils.createLRUCache(cacheSize);
+            this.fromMemberTreeCache = CollectionUtils.createLRUCache(cacheSize);
+            this.fromTypeTreeCache = CollectionUtils.createLRUCache(cacheSize);
             this.elementCache = CollectionUtils.createLRUCache(cacheSize);
             this.elementToTreeCache = CollectionUtils.createLRUCache(cacheSize);
         } else {
             this.classAndMethodTreeCache = null;
-            this.fromTreeCache = null;
+            this.fromExpressionTreeCache = null;
+            this.fromMemberTreeCache = null;
+            this.fromTypeTreeCache = null;
             this.elementCache = null;
             this.elementToTreeCache = null;
         }
@@ -530,7 +549,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             // Clear the caches with trees because once the compilation unit changes,
             // the trees may be modified and lose type arguments.
             elementToTreeCache.clear();
-            fromTreeCache.clear();
+            fromExpressionTreeCache.clear();
+            fromMemberTreeCache.clear();
+            fromTypeTreeCache.clear();
             classAndMethodTreeCache.clear();
 
             // There is no need to clear the following cache, it is limited by cache size and it
@@ -1179,13 +1200,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                             + tree);
             return null; // dead code
         }
-        if (shouldCache && fromTreeCache.containsKey(tree)) {
-            return fromTreeCache.get(tree).deepCopy();
+        if (shouldCache && fromMemberTreeCache.containsKey(tree)) {
+            return fromMemberTreeCache.get(tree).deepCopy();
         }
         AnnotatedTypeMirror result = TypeFromTree.fromMember(this, tree);
         annotateInheritedFromClass(result);
         if (shouldCache) {
-            fromTreeCache.put(tree, result.deepCopy());
+            fromMemberTreeCache.put(tree, result.deepCopy());
         }
         return result;
     }
@@ -1207,8 +1228,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @see TypeFromExpressionVisitor
      */
     private AnnotatedTypeMirror fromExpression(ExpressionTree tree) {
-        if (shouldCache && fromTreeCache.containsKey(tree)) {
-            return fromTreeCache.get(tree).deepCopy();
+        if (shouldCache && fromExpressionTreeCache.containsKey(tree)) {
+            return fromExpressionTreeCache.get(tree).deepCopy();
         }
 
         AnnotatedTypeMirror result = TypeFromTree.fromExpression(this, tree);
@@ -1216,7 +1237,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         annotateInheritedFromClass(result);
 
         if (shouldCache) {
-            fromTreeCache.put(tree, result.deepCopy());
+            fromExpressionTreeCache.put(tree, result.deepCopy());
         }
         return result;
     }
@@ -1236,15 +1257,15 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @return the (partially) annotated type of the type in the AST
      */
     /*package private*/ final AnnotatedTypeMirror fromTypeTree(Tree tree) {
-        if (shouldCache && fromTreeCache.containsKey(tree)) {
-            return fromTreeCache.get(tree).deepCopy();
+        if (shouldCache && fromTypeTreeCache.containsKey(tree)) {
+            return fromTypeTreeCache.get(tree).deepCopy();
         }
 
         AnnotatedTypeMirror result = TypeFromTree.fromTypeTree(this, tree);
 
         annotateInheritedFromClass(result);
         if (shouldCache) {
-            fromTreeCache.put(tree, result.deepCopy());
+            fromTypeTreeCache.put(tree, result.deepCopy());
         }
         return result;
     }
@@ -2779,12 +2800,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 : "AnnotatedTypeFactory.getPath: root needs to be set when used on trees; factory: "
                         + this.getClass();
 
-        if (node == null) return null;
+        if (node == null) {
+            return null;
+        }
 
         if (treePathCache.isCached(node)) {
             return treePathCache.getPath(root, node);
         }
-        ;
 
         TreePath currentPath = visitorState.getPath();
         if (currentPath == null) {
@@ -2859,9 +2881,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     static final boolean validAnnotatedType(AnnotatedTypeMirror type) {
         if (type == null) {
             return false;
-        }
-        if (type.getUnderlyingType() == null) {
-            return true; // e.g., for receiver types
         }
         return validType(type.getUnderlyingType());
     }
@@ -3529,7 +3548,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     private AnnotatedDeclaredType getFunctionalInterfaceType(Tree tree) {
 
-        Tree parentTree = TreePath.getPath(this.root, tree).getParentPath().getLeaf();
+        Tree parentTree = getPath(tree).getParentPath().getLeaf();
         switch (parentTree.getKind()) {
             case PARENTHESIZED:
                 return getFunctionalInterfaceType(parentTree);
@@ -3604,7 +3623,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             case RETURN:
                 Tree enclosing =
                         TreeUtils.enclosingOfKind(
-                                TreePath.getPath(this.root, parentTree),
+                                getPath(parentTree),
                                 new HashSet<>(
                                         Arrays.asList(
                                                 Tree.Kind.METHOD, Tree.Kind.LAMBDA_EXPRESSION)));

--- a/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -307,22 +307,19 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Mapping from an expression tree to its annotated type; before implicits are applied, just
-     * what the programmer wrote. Might alias the same object as fromMemberTreeCache and
-     * fromTypeTreeCache.
+     * what the programmer wrote.
      */
     protected final Map<Tree, AnnotatedTypeMirror> fromExpressionTreeCache;
 
     /**
      * Mapping from a member tree to its annotated type; before implicits are applied, just what the
-     * programmer wrote. Might alias the same object as fromExpressionTreeCache and
-     * fromTypeTreeCache
+     * programmer wrote.
      */
     protected final Map<Tree, AnnotatedTypeMirror> fromMemberTreeCache;
 
     /**
      * Mapping from a type tree to its annotated type; before implicits are applied, just what the
-     * programmer wrote. Might alias the same object as fromExpressionTreeCache and
-     * fromMemberTreeCache.
+     * programmer wrote.
      */
     protected final Map<Tree, AnnotatedTypeMirror> fromTypeTreeCache;
 

--- a/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -40,7 +40,7 @@ import org.checkerframework.javacutil.TypesUtils;
  *
  * @see org.checkerframework.framework.type.TypeFromTree
  */
-class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
+class TypeFromTypeTreeVisitor extends TypeFromExpressionVisitor {
 
     private final Map<Tree, AnnotatedTypeMirror> visitedBounds = new HashMap<>();
 

--- a/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -40,7 +40,7 @@ import org.checkerframework.javacutil.TypesUtils;
  *
  * @see org.checkerframework.framework.type.TypeFromTree
  */
-class TypeFromTypeTreeVisitor extends TypeFromExpressionVisitor {
+class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
 
     private final Map<Tree, AnnotatedTypeMirror> visitedBounds = new HashMap<>();
 

--- a/framework/tests/all-systems/Issue1809.java
+++ b/framework/tests/all-systems/Issue1809.java
@@ -1,0 +1,36 @@
+// Test case for Issue 1809:
+// https://github.com/typetools/checker-framework/issues/1809
+
+// Note that -AatfCacheSize=5 is required to exercise the problem.
+// This test is to ensure the basic code compiles.
+// For a reproduction of the issue, see checker/jtreg/nullness/Issue1809.java
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@SuppressWarnings("unchecked")
+abstract class Issue1809 {
+
+    abstract <T> Stream<T> concat(Stream<? extends T>... streams);
+
+    abstract Optional<A> f();
+
+    private static class A {}
+
+    interface B {
+        List<C> g();
+    }
+
+    interface C {
+        List<S> h();
+    }
+
+    interface S {}
+
+    private Stream<A> xrefsFor(B b) {
+        return concat(b.g().stream().flatMap(a -> a.h().stream().map(c -> f())))
+                .filter(Optional::isPresent)
+                .map(Optional::get);
+    }
+}


### PR DESCRIPTION
1. Correctly type the "qualifier expression" of a member reference, where "qualifier expression" is the type or expression before `::`.
2. Use separate caches for types for Expressions, Members, and Type Trees.  (Using a single cache masked the bug.)