### PR TITLE
Add CFG edges into finally blocks

### DIFF
--- a/checker/tests/nullness/Issue1797.java
+++ b/checker/tests/nullness/Issue1797.java
@@ -1,0 +1,179 @@
+// Test case for Issue 1797:
+// https://github.com/typetools/checker-framework/issues/1797
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Issue1797 {
+    void fooReturn(@Nullable Object o) {
+        try {
+            return;
+        } finally {
+            if (o != null) {
+                o.toString();
+            }
+        }
+    }
+
+    void fooReturnNested(@Nullable Object o) {
+        while (this.hashCode() < 10) {
+            while (this.hashCode() < 5) {
+                try {
+                    return;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                    // TODO: should go to exit, not either loop!
+                }
+            }
+        }
+    }
+
+    void fooBreak(@Nullable Object o) {
+        while (this.hashCode() < 5) {
+            try {
+                break;
+            } finally {
+                if (o != null) {
+                    o.toString();
+                }
+            }
+        }
+    }
+
+    void fooBreakLabel(@Nullable Object o) {
+        outer:
+        while (this.hashCode() < 10) {
+            while (this.hashCode() < 5) {
+                try {
+                    break outer;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                    // TODO: this should continue after outer
+                }
+            }
+        }
+    }
+
+    void fooBreakLabel2(@Nullable Object o) {
+        outer:
+        while (this.hashCode() < 10) {
+            try {
+                inner:
+                while (this.hashCode() < 5) {
+                    if (this.hashCode() < 2) {
+                        break outer;
+                        // TODO: should go to finally
+                    } else {
+                        break inner;
+                        // TODO: should not go to finally
+                    }
+                }
+            } finally {
+                if (o != null) {
+                    o.toString();
+                }
+                // TODO: this should continue either at outer or after outer
+            }
+        }
+    }
+
+    void fooBreakNoLabel(@Nullable Object o) {
+        outer:
+        while (this.hashCode() < 10) {
+            inner:
+            while (this.hashCode() < 5) {
+                try {
+                    break;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                    // TODO: this should continue at outer
+                }
+            }
+        }
+    }
+
+    void fooContinue(@Nullable Object o) {
+        while (this.hashCode() < 5) {
+            try {
+                continue;
+            } finally {
+                if (o != null) {
+                    o.toString();
+                }
+            }
+        }
+    }
+
+    void fooContinueLabel(@Nullable Object o) {
+        outer:
+        while (this.hashCode() < 10) {
+            while (this.hashCode() < 5) {
+                try {
+                    continue outer;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                }
+            }
+        }
+    }
+
+    void fooSwitch(@Nullable Object o) {
+        switch (this.hashCode()) {
+            case 1:
+                try {
+                    break;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                }
+            default:
+        }
+    }
+
+    // A few tests to make sure also return with expression works.
+
+    int barReturn(@Nullable Object o) {
+        try {
+            return 5;
+        } finally {
+            if (o != null) {
+                o.toString();
+            }
+        }
+    }
+
+    int barReturnInFinally(@Nullable Object o) {
+        try {
+            return 5;
+        } finally {
+            if (o != null) {
+                o.toString();
+            }
+            return 10;
+        }
+    }
+
+    int barReturnNested(@Nullable Object o) {
+        while (this.hashCode() < 10) {
+            while (this.hashCode() < 5) {
+                try {
+                    return 5;
+                } finally {
+                    if (o != null) {
+                        o.toString();
+                    }
+                    // TODO: should go to return 5, not either loop!
+                }
+            }
+        }
+        return 10;
+    }
+}

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -802,10 +802,10 @@ public class CFGBuilder {
      * when control flows outside of the try block.
      */
     @SuppressWarnings("serial")
-    protected static class FakeLabelsMap extends HashMap<Name, Label> implements Map<Name, Label> {
+    protected static class TryFinallyScopeMap extends HashMap<Name, Label> {
         private final Label finallyLabel;
 
-        protected FakeLabelsMap(Label finallyLabel) {
+        protected TryFinallyScopeMap(Label finallyLabel) {
             this.finallyLabel = finallyLabel;
         }
 
@@ -4342,9 +4342,9 @@ public class CFGBuilder {
                 tryStack.pushFrame(new TryFinallyFrame(finallyLabel));
                 returnTargetL = finallyLabel;
                 breakTargetL = finallyLabel;
-                breakLabels = new FakeLabelsMap(finallyLabel);
+                breakLabels = new TryFinallyScopeMap(finallyLabel);
                 continueTargetL = finallyLabel;
-                continueLabels = new FakeLabelsMap(finallyLabel);
+                continueLabels = new TryFinallyScopeMap(finallyLabel);
             }
 
             Label doneLabel = new Label();

--- a/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -630,6 +630,23 @@ public class CFGBuilder {
             this.catchLabels = catchLabels;
         }
 
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            if (this.catchLabels.isEmpty()) {
+                sb.append("TryCatchFrame: no catch labels.\n");
+            } else {
+                sb.append("TryCatchFrame: ");
+            }
+            for (Pair<TypeMirror, Label> ptml : this.catchLabels) {
+                sb.append(ptml.first.toString());
+                sb.append(" -> ");
+                sb.append(ptml.second.toString());
+                sb.append('\n');
+            }
+            return sb.toString();
+        }
+
         /**
          * Given a type of thrown exception, add the set of possible control flow successor {@link
          * Label}s to the argument set. Return true if the exception is known to be caught by one of
@@ -713,6 +730,13 @@ public class CFGBuilder {
         }
 
         @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("TryFinallyFrame: finallyLabel: " + finallyLabel + '\n');
+            return sb.toString();
+        }
+
+        @Override
         public boolean possibleLabels(TypeMirror thrown, Set<Label> labels) {
             labels.add(finallyLabel);
             return true;
@@ -756,6 +780,47 @@ public class CFGBuilder {
             }
             labels.add(exitLabel);
             return labels;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("TryStack: exitLabel: " + this.exitLabel + '\n');
+            if (this.frames.isEmpty()) {
+                sb.append("No TryFrames.\n");
+            }
+            for (TryFrame tf : this.frames) {
+                sb.append(tf.toString());
+            }
+            return sb.toString();
+        }
+    }
+
+    /**
+     * A map that keeps track of new labels added within a try block. For names that are outside of
+     * the try block, the finally label is returned. This ensures that a finally block is executed
+     * when control flows outside of the try block.
+     */
+    @SuppressWarnings("serial")
+    protected static class FakeLabelsMap extends HashMap<Name, Label> implements Map<Name, Label> {
+        private final Label finallyLabel;
+
+        protected FakeLabelsMap(Label finallyLabel) {
+            this.finallyLabel = finallyLabel;
+        }
+
+        @Override
+        public Label get(Object key) {
+            if (super.containsKey(key)) {
+                return super.get(key);
+            } else {
+                return finallyLabel;
+            }
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return true;
         }
     }
 
@@ -1451,6 +1516,12 @@ public class CFGBuilder {
         protected AnnotationProvider annotationProvider;
 
         /**
+         * Current {@link Label} to which a return statement should jump, or null if there is no
+         * valid destination.
+         */
+        protected /*@Nullable*/ Label returnTargetL;
+
+        /**
          * Current {@link Label} to which a break statement with no label should jump, or null if
          * there is no valid destination.
          */
@@ -1545,6 +1616,7 @@ public class CFGBuilder {
             nodeList = new ArrayList<>();
             bindings = new HashMap<>();
             leaders = new HashSet<>();
+            returnTargetL = regularExitLabel;
             breakLabels = new HashMap<>();
             continueLabels = new HashMap<>();
             returnNodes = new ArrayList<>();
@@ -4147,8 +4219,12 @@ public class CFGBuilder {
                 returnNodes.add(result);
                 extendWithNode(result);
             }
-            extendWithExtendedNode(new UnconditionalJump(regularExitLabel));
-            // TODO: return statements should also flow to an enclosing finally block
+
+            extendWithExtendedNode(new UnconditionalJump(this.returnTargetL));
+
+            // TODO: return statements flow to an enclosing finally, but we need a way to get
+            // the finally to flow back to the original return.
+
             return result;
         }
 
@@ -4250,6 +4326,13 @@ public class CFGBuilder {
                 catchLabels.add(Pair.of(type, new Label()));
             }
 
+            // Store return/break/continue labels, just in case we need them for a finally block.
+            Label oldReturnTargetL = returnTargetL;
+            Label oldBreakTargetL = breakTargetL;
+            Map<Name, Label> oldBreakLabels = breakLabels;
+            Label oldContinueTargetL = continueTargetL;
+            Map<Name, Label> oldContinueLabels = continueLabels;
+
             Label finallyLabel = null;
             // Label exceptionalFinallyLabel = null; // #293
             if (finallyBlock != null) {
@@ -4257,6 +4340,11 @@ public class CFGBuilder {
                 // exceptionalFinallyLabel = new Label(); // #293
                 // tryStack.pushFrame(new TryFinallyFrame(exceptionalFinallyLabel));
                 tryStack.pushFrame(new TryFinallyFrame(finallyLabel));
+                returnTargetL = finallyLabel;
+                breakTargetL = finallyLabel;
+                breakLabels = new FakeLabelsMap(finallyLabel);
+                continueTargetL = finallyLabel;
+                continueLabels = new FakeLabelsMap(finallyLabel);
             }
 
             Label doneLabel = new Label();
@@ -4277,6 +4365,13 @@ public class CFGBuilder {
                         new UnconditionalJump(firstNonNull(finallyLabel, doneLabel)));
             }
 
+            // Reset values before analyzing the finally block!
+            returnTargetL = oldReturnTargetL;
+            breakTargetL = oldBreakTargetL;
+            breakLabels = oldBreakLabels;
+            continueTargetL = oldContinueTargetL;
+            continueLabels = oldContinueLabels;
+
             if (finallyLabel != null) {
                 tryStack.popFrame();
 
@@ -4285,6 +4380,7 @@ public class CFGBuilder {
                 // and scan copied 'finallyBlock' for 'finallyLabel' (a successful path). If there
                 // is no successful path, it will be removed in later phase.
                 // addLabelForNextNode(exceptionalFinallyLabel);
+
                 addLabelForNextNode(finallyLabel);
                 scan(finallyBlock, p);
 
@@ -4316,6 +4412,9 @@ public class CFGBuilder {
             }
 
             addLabelForNextNode(doneLabel);
+
+            // TODO: if there was control flow, e.g. a return, in the try block,
+            // we need to add an edge to that same location again.
 
             return null;
         }


### PR DESCRIPTION
As described in #1797 return statements didn't have CFG edges to their enclosing finally blocks.
This actually was a bigger problem, as it also applied to break and continue statements.
This PR makes sure that there are CFG edges *into* finally blocks from all control flow statements.
Some CFG edges *out of* finally blocks still seem incorrect. This will be addressed after #293 in separate PRs. (This has no effect on type checking, but is important for other uses of dataflow.)

Fixes #1797