### PR TITLE
QualifierDefault: Do not permit passing arbitrary tops and bottoms as standard defaults.

### DIFF
--- a/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -603,9 +603,7 @@ public abstract class GenericAnnotatedTypeFactory<
      */
     protected void addCheckedStandardDefaults(QualifierDefaults defs) {
         if (this.everUseFlow) {
-            Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
-            Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
-            defs.addClimbStandardDefaults(tops, bottoms);
+            defs.addClimbStandardDefaults();
         }
     }
 
@@ -655,9 +653,7 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param defs {@link QualifierDefaults} object to which defaults are added
      */
     protected void addUncheckedStandardDefaults(QualifierDefaults defs) {
-        Set<? extends AnnotationMirror> tops = this.qualHierarchy.getTopAnnotations();
-        Set<? extends AnnotationMirror> bottoms = this.qualHierarchy.getBottomAnnotations();
-        defs.addUncheckedStandardDefaults(tops, bottoms);
+        defs.addUncheckedStandardDefaults();
     }
 
     /**

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -202,12 +202,7 @@ public class QualifierDefaults {
         return false;
     }
 
-    /**
-     * Add standard unchecked defaults that do not conflict with previously added defaults.
-     *
-     * @param tops AnnotationMirrors that are top
-     * @param bottoms AnnotationMirrors that are bottom
-     */
+    /** Add standard unchecked defaults that do not conflict with previously added defaults. */
     public void addUncheckedStandardDefaults() {
         for (TypeUseLocation loc : standardUncheckedDefaultsTop) {
             // Only add standard defaults in locations where a default has not be specified
@@ -229,12 +224,7 @@ public class QualifierDefaults {
         }
     }
 
-    /**
-     * Add standard CLIMB defaults that do not conflict with previously added defaults.
-     *
-     * @param tops AnnotationMirrors that are top
-     * @param bottoms AnnotationMirrors that are bottom
-     */
+    /** Add standard CLIMB defaults that do not conflict with previously added defaults. */
     public void addClimbStandardDefaults() {
         QualifierHierarchy qualHierarchy = this.atypeFactory.getQualifierHierarchy();
         Set<? extends AnnotationMirror> tops = qualHierarchy.getTopAnnotations();

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -208,12 +208,10 @@ public class QualifierDefaults {
      * @param tops AnnotationMirrors that are top
      * @param bottoms AnnotationMirrors that are bottom
      */
-    public void addUncheckedStandardDefaults(
-            Iterable<? extends AnnotationMirror> tops,
-            Iterable<? extends AnnotationMirror> bottoms) {
+    public void addUncheckedStandardDefaults() {
         for (TypeUseLocation loc : standardUncheckedDefaultsTop) {
             // Only add standard defaults in locations where a default has not be specified
-            for (AnnotationMirror top : tops) {
+            for (AnnotationMirror top : atypeFactory.getQualifierHierarchy().getTopAnnotations()) {
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, top, loc)) {
                     addUncheckedCodeDefault(top, loc);
                 }
@@ -221,7 +219,8 @@ public class QualifierDefaults {
         }
 
         for (TypeUseLocation loc : standardUncheckedDefaultsBottom) {
-            for (AnnotationMirror bottom : bottoms) {
+            for (AnnotationMirror bottom :
+                    atypeFactory.getQualifierHierarchy().getBottomAnnotations()) {
                 // Only add standard defaults in locations where a default has not be specified
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, bottom, loc)) {
                     addUncheckedCodeDefault(bottom, loc);
@@ -236,9 +235,11 @@ public class QualifierDefaults {
      * @param tops AnnotationMirrors that are top
      * @param bottoms AnnotationMirrors that are bottom
      */
-    public void addClimbStandardDefaults(
-            Iterable<? extends AnnotationMirror> tops,
-            Iterable<? extends AnnotationMirror> bottoms) {
+    public void addClimbStandardDefaults() {
+        QualifierHierarchy qualHierarchy = this.atypeFactory.getQualifierHierarchy();
+        Set<? extends AnnotationMirror> tops = qualHierarchy.getTopAnnotations();
+        Set<? extends AnnotationMirror> bottoms = qualHierarchy.getBottomAnnotations();
+
         for (TypeUseLocation loc : standardClimbDefaultsTop) {
             for (AnnotationMirror top : tops) {
                 if (!conflictsWithExistingDefaults(checkedCodeDefaults, top, loc)) {

--- a/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -204,9 +204,13 @@ public class QualifierDefaults {
 
     /** Add standard unchecked defaults that do not conflict with previously added defaults. */
     public void addUncheckedStandardDefaults() {
+        QualifierHierarchy qualHierarchy = this.atypeFactory.getQualifierHierarchy();
+        Set<? extends AnnotationMirror> tops = qualHierarchy.getTopAnnotations();
+        Set<? extends AnnotationMirror> bottoms = qualHierarchy.getBottomAnnotations();
+
         for (TypeUseLocation loc : standardUncheckedDefaultsTop) {
             // Only add standard defaults in locations where a default has not be specified
-            for (AnnotationMirror top : atypeFactory.getQualifierHierarchy().getTopAnnotations()) {
+            for (AnnotationMirror top : tops) {
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, top, loc)) {
                     addUncheckedCodeDefault(top, loc);
                 }
@@ -214,8 +218,7 @@ public class QualifierDefaults {
         }
 
         for (TypeUseLocation loc : standardUncheckedDefaultsBottom) {
-            for (AnnotationMirror bottom :
-                    atypeFactory.getQualifierHierarchy().getBottomAnnotations()) {
+            for (AnnotationMirror bottom : bottoms) {
                 // Only add standard defaults in locations where a default has not be specified
                 if (!conflictsWithExistingDefaults(uncheckedCodeDefaults, bottom, loc)) {
                     addUncheckedCodeDefault(bottom, loc);


### PR DESCRIPTION
Originally, `QualifierDefault#addClimbStandardDefaults()` and `QualifierDefault#addUncheckedStandardDefaults()` ask callers to pass `tops` and `bottoms` as the default top qualifiers and default bottom qualifiers. This actually permits clients
to pass arbitrary `tops` and `bottoms` as the standard defaults, which can lead to inconsistencies.

Since `QualifierDefault` itself keeps a reference to `aTypeFactory`, a better and more consistent way of initializing `ClimbStandardDefaults` and `UncheckedStandardDefault` is to directly use the `tops` and `bottoms` from the `qualifierHierarchy` within the `aTypeFactory` that this `QualifierDefault` has been initialized with.

This PR makes this change.

Original PR review in opprop: https://github.com/opprop/checker-framework/pull/66
