### PR TITLE
Avoid using dataflow nodes in checkers

### DIFF
--- a/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterTreeUtil.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterTreeUtil.java
@@ -200,15 +200,13 @@ public class I18nFormatterTreeUtil {
 
     /** Returns an I18nFormatCall instance, only if FormatFor is called. Otherwise, returns null. */
     public I18nFormatCall createFormatForCall(
-            MethodInvocationTree tree,
-            MethodInvocationNode node,
-            I18nFormatterAnnotatedTypeFactory atypeFactory) {
+            MethodInvocationTree tree, I18nFormatterAnnotatedTypeFactory atypeFactory) {
         ExecutableElement method = TreeUtils.elementFromUse(tree);
         AnnotatedExecutableType methodAnno = atypeFactory.getAnnotatedType(method);
         for (AnnotatedTypeMirror paramType : methodAnno.getParameterTypes()) {
             // find @FormatFor
             if (paramType.getAnnotation(I18nFormatFor.class) != null) {
-                return atypeFactory.treeUtil.new I18nFormatCall(tree, node, atypeFactory);
+                return atypeFactory.treeUtil.new I18nFormatCall(tree, atypeFactory);
             }
         }
         return null;
@@ -229,17 +227,14 @@ public class I18nFormatterTreeUtil {
 
         private AnnotatedTypeMirror formatAnno;
 
-        public I18nFormatCall(
-                MethodInvocationTree tree,
-                MethodInvocationNode node,
-                AnnotatedTypeFactory atypeFactory) {
+        public I18nFormatCall(MethodInvocationTree tree, AnnotatedTypeFactory atypeFactory) {
             this.tree = tree;
             this.atypeFactory = atypeFactory;
             List<? extends ExpressionTree> theargs = (tree).getArguments();
             this.args = null;
             ExecutableElement method = TreeUtils.elementFromUse(tree);
             AnnotatedExecutableType methodAnno = atypeFactory.getAnnotatedType(method);
-            initialCheck(theargs, method, node, methodAnno);
+            initialCheck(theargs, method, tree, methodAnno);
         }
 
         @Override
@@ -254,7 +249,7 @@ public class I18nFormatterTreeUtil {
         private void initialCheck(
                 List<? extends ExpressionTree> theargs,
                 ExecutableElement method,
-                MethodInvocationNode node,
+                MethodInvocationTree node,
                 AnnotatedExecutableType methodAnno) {
             int paramIndex = -1;
             Receiver paramArg = null;

--- a/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -13,7 +13,6 @@ import org.checkerframework.checker.i18nformatter.qual.I18nConversionCategory;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormatFor;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 
@@ -31,9 +30,8 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
 
     @Override
     public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-        MethodInvocationNode nodeNode = (MethodInvocationNode) atypeFactory.getNodeForTree(node);
         I18nFormatterTreeUtil tu = atypeFactory.treeUtil;
-        I18nFormatCall fc = tu.createFormatForCall(node, nodeNode, atypeFactory);
+        I18nFormatCall fc = tu.createFormatForCall(node, atypeFactory);
         if (fc != null) {
             checkInvocationFormatFor(fc);
             return p;

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -1204,14 +1204,12 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             return;
         }
 
-        Node node = atypeFactory.getNodeForTree(tree);
-
-        List<LockExpression> expressions = getLockExpressions(implicitThis, gbAnno, node);
+        List<LockExpression> expressions = getLockExpressions(implicitThis, gbAnno, tree);
         if (expressions.isEmpty()) {
             return;
         }
 
-        LockStore store = atypeFactory.getStoreBefore(node);
+        LockStore store = atypeFactory.getStoreBefore(tree);
         for (LockExpression expression : expressions) {
             if (expression.error != null) {
                 checker.report(
@@ -1252,7 +1250,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     }
 
     private List<LockExpression> getLockExpressions(
-            boolean implicitThis, AnnotationMirror gbAnno, Node node) {
+            boolean implicitThis, AnnotationMirror gbAnno, Tree tree) {
 
         List<String> expressions =
                 AnnotationUtils.getElementValueArray(gbAnno, "value", String.class, true);
@@ -1271,6 +1269,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         FlowExpressionContext exprContext =
                 new FlowExpressionContext(pseudoReceiver, params, atypeFactory.getContext());
 
+        Node node = atypeFactory.getNodeForTree(tree);
         Receiver self =
                 implicitThis ? pseudoReceiver : FlowExpressions.internalReprOf(atypeFactory, node);
 

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -422,7 +422,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
     @Override
     public Void visitMemberSelect(MemberSelectTree tree, Void p) {
-        if (TreeUtils.elementFromTree(tree).getKind() == ElementKind.FIELD) {
+        if (TreeUtils.isFieldAccess(tree)) {
             AnnotatedTypeMirror atmOfReceiver = atypeFactory.getAnnotatedType(tree.getExpression());
             // The atmOfReceiver for "void.class" is TypeKind.VOID, which isn't annotated so avoid
             // it.
@@ -1089,9 +1089,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
     @Override
     public Void visitIdentifier(IdentifierTree tree, Void p) {
-        if (TreeUtils.elementFromTree(tree).getKind() == ElementKind.FIELD) {
+        if (TreeUtils.isFieldAccess(tree)) {
             Tree parent = getCurrentPath().getParentPath().getLeaf();
-            if (parent.getKind() != Kind.MEMBER_SELECT) {
+            if (parent.getKind() != Kind.MEMBER_SELECT
+                    || ((MemberSelectTree) parent).getExpression() == tree) {
                 // If field isn't accessed via a member select, then it is accessed via
                 // an implicit this.
                 // All other field access are handle via visitMemberSelect

--- a/framework/src/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -21,7 +21,6 @@ import org.checkerframework.common.aliasing.qual.NonLeaked;
 import org.checkerframework.common.aliasing.qual.Unique;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
-import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
@@ -84,8 +83,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
                 // this "else" block. Once constructors are implemented
                 // correctly we could remove that code below, since the type
                 // of "this" in a @Unique constructor will be @Unique.
-                MethodInvocationNode n = (MethodInvocationNode) atypeFactory.getNodeForTree(node);
-                Tree parent = n.getTreePath().getParentPath().getLeaf();
+                Tree parent = getCurrentPath().getParentPath().getLeaf();
                 boolean parentIsStatement = parent.getKind() == Kind.EXPRESSION_STATEMENT;
                 ExecutableElement methodElement = TreeUtils.elementFromUse(node);
                 List<? extends VariableElement> params = methodElement.getParameters();
@@ -93,7 +91,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
                 assert (args.size() == params.size())
                         : "Number of arguments in"
                                 + " the method call "
-                                + n.toString()
+                                + node.toString()
                                 + " is different from the "
                                 + "number of parameters for the method declaration: "
                                 + methodElement.getSimpleName().toString();

--- a/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -69,7 +69,6 @@ import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.BooleanLiteralNode;
-import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
 import org.checkerframework.dataflow.qual.Pure;
@@ -1093,15 +1092,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         if (preconditions.isEmpty()) {
             return;
         }
-
-        Node node = atypeFactory.getNodeForTree(tree);
-
         FlowExpressionContext flowExprContext =
-                FlowExpressionContext.buildContextForMethodUse(
-                        (MethodInvocationNode) node, checker.getContext());
+                FlowExpressionContext.buildContextForMethodUse(tree, checker.getContext());
 
         if (flowExprContext == null) {
-            checker.report(Result.failure("flowexpr.parse.context.not.determined", node), tree);
+            checker.report(Result.failure("flowexpr.parse.context.not.determined", tree), tree);
             return;
         }
 
@@ -1116,7 +1111,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                         FlowExpressionParseUtil.parse(
                                 expression, flowExprContext, getCurrentPath(), false);
 
-                CFAbstractStore<?, ?> store = atypeFactory.getStoreBefore(node);
+                CFAbstractStore<?, ?> store = atypeFactory.getStoreBefore(tree);
 
                 CFAbstractValue<?> value = store.getValue(expr);
 

--- a/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -6,7 +6,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LambdaExpressionTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
@@ -1200,6 +1202,36 @@ public class FlowExpressionParseUtil {
             FlowExpressionContext flowExprContext =
                     new FlowExpressionContext(internalReceiver, internalArguments, checkerContext);
             return flowExprContext;
+        }
+
+        /**
+         * @return a {@link FlowExpressionContext} for the method {@code methodInvocation}
+         *     (represented as a {@link MethodInvocationTree} as seen at the method use (i.e., at a
+         *     method call site).
+         */
+        public static FlowExpressionContext buildContextForMethodUse(
+                MethodInvocationTree methodInvocation, BaseContext checkerContext) {
+            ExpressionTree receiverTree = TreeUtils.getReceiverTree(methodInvocation);
+            FlowExpressions.Receiver receiver;
+            if (receiverTree == null) {
+                receiver =
+                        FlowExpressions.internalRepOfImplicitReceiver(
+                                TreeUtils.elementFromUse(methodInvocation));
+            } else {
+                receiver =
+                        FlowExpressions.internalReprOf(
+                                checkerContext.getAnnotationProvider(), receiverTree);
+            }
+
+            List<? extends ExpressionTree> args = methodInvocation.getArguments();
+            List<FlowExpressions.Receiver> argReceivers = new ArrayList<>(args.size());
+            for (ExpressionTree argTree : args) {
+                argReceivers.add(
+                        FlowExpressions.internalReprOf(
+                                checkerContext.getAnnotationProvider(), argTree));
+            }
+
+            return new FlowExpressionContext(receiver, argReceivers, checkerContext);
         }
 
         /**


### PR DESCRIPTION
Change instances where nodes are used when TreeUtil methods or other means could be used instead.  (This clean up will make #1826 change less code.)