### PR TITLE
Fixes #1865: change getFirstNonLambdaResultExpressionNodeForTree to require the class of node to return.

### DIFF
--- a/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -14,7 +14,6 @@ import org.checkerframework.checker.i18nformatter.qual.I18nFormatFor;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
-import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 
@@ -32,8 +31,8 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
 
     @Override
     public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
-        Node node = atypeFactory.getFirstNonImplicitNodeForTree(tree);
-        MethodInvocationNode nodeNode = (MethodInvocationNode) node;
+        MethodInvocationNode nodeNode =
+                atypeFactory.getFirstNodeOfKindForTree(tree, MethodInvocationNode.class);
         I18nFormatterTreeUtil tu = atypeFactory.treeUtil;
         I18nFormatCall fc = tu.createFormatForCall(tree, nodeNode, atypeFactory);
         if (fc != null) {

--- a/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -32,7 +32,7 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
 
     @Override
     public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
-        Node node = atypeFactory.getFirstNonLambdaResultExpressionNodeForTree(tree);
+        Node node = atypeFactory.getFirstNonImplicitNodeForTree(tree);
         MethodInvocationNode nodeNode = (MethodInvocationNode) node;
         I18nFormatterTreeUtil tu = atypeFactory.treeUtil;
         I18nFormatCall fc = tu.createFormatForCall(tree, nodeNode, atypeFactory);

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -48,7 +48,6 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
-import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.qual.Deterministic;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.framework.flow.CFAbstractValue;
@@ -1270,10 +1269,13 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
                 FlowExpressions.internalRepOfPseudoReceiver(currentPath, enclosingType);
         FlowExpressionContext exprContext =
                 new FlowExpressionContext(pseudoReceiver, params, atypeFactory.getContext());
-
-        Node node = atypeFactory.getFirstNonImplicitNodeForTree(tree);
-        Receiver self =
-                implicitThis ? pseudoReceiver : FlowExpressions.internalReprOf(atypeFactory, node);
+        Receiver self;
+        if (implicitThis) {
+            self = pseudoReceiver;
+        } else {
+            assert TreeUtils.isExpressionTree(tree);
+            self = FlowExpressions.internalReprOf(atypeFactory, (ExpressionTree) tree);
+        }
 
         List<LockExpression> lockExpressions = new ArrayList<>();
         for (String expression : expressions) {

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -1271,7 +1271,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         FlowExpressionContext exprContext =
                 new FlowExpressionContext(pseudoReceiver, params, atypeFactory.getContext());
 
-        Node node = atypeFactory.getFirstNonLambdaResultExpressionNodeForTree(tree);
+        Node node = atypeFactory.getFirstNonImplicitNodeForTree(tree);
         Receiver self =
                 implicitThis ? pseudoReceiver : FlowExpressions.internalReprOf(atypeFactory, node);
 

--- a/checker/src/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/org/checkerframework/checker/lock/LockVisitor.java
@@ -48,6 +48,7 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
+import org.checkerframework.dataflow.analysis.FlowExpressions.Unknown;
 import org.checkerframework.dataflow.qual.Deterministic;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.framework.flow.CFAbstractValue;
@@ -297,7 +298,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             AnnotationMirror guardSatisfied =
                     AnnotationUtils.getAnnotationByClass(annos, checkerGuardSatisfiedClass);
             if (guardSatisfied != null) {
-                Tree receiverTree = TreeUtils.getReceiverTree(methodInvocationTree);
+                ExpressionTree receiverTree = TreeUtils.getReceiverTree(methodInvocationTree);
                 if (receiverTree == null) {
                     checkLockOfImplicitThis(methodInvocationTree, effectiveGb);
                 } else {
@@ -1134,8 +1135,8 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     @Override
     public Void visitBinary(BinaryTree binaryTree, Void p) {
         if (TreeUtils.isStringConcatenation(binaryTree)) {
-            Tree leftTree = binaryTree.getLeftOperand();
-            Tree rightTree = binaryTree.getRightOperand();
+            ExpressionTree leftTree = binaryTree.getLeftOperand();
+            ExpressionTree rightTree = binaryTree.getRightOperand();
 
             boolean lhsIsString = TypesUtils.isString(TreeUtils.typeOf(leftTree));
             boolean rhsIsString = TypesUtils.isString(TreeUtils.typeOf(rightTree));
@@ -1177,7 +1178,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     // in contracts.precondition.not.satisfied errors being issued instead of
     // contracts.precondition.not.satisfied.field, so it would be clear that
     // the error refers to an implicit method call, not a dereference (field access).
-    private void checkPreconditionsForImplicitToStringCall(Tree tree) {
+    private void checkPreconditionsForImplicitToStringCall(ExpressionTree tree) {
         AnnotationMirror gbAnno =
                 atypeFactory
                         .getAnnotatedType(tree)
@@ -1272,9 +1273,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         Receiver self;
         if (implicitThis) {
             self = pseudoReceiver;
-        } else {
-            assert TreeUtils.isExpressionTree(tree);
+        } else if (TreeUtils.isExpressionTree(tree)) {
             self = FlowExpressions.internalReprOf(atypeFactory, (ExpressionTree) tree);
+        } else {
+            self = new Unknown(TreeUtils.typeOf(tree));
         }
 
         List<LockExpression> lockExpressions = new ArrayList<>();

--- a/dataflow/src/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -152,18 +152,20 @@ public class AnalysisResult<A extends AbstractValue<A>, S extends Store<S>> {
 
     /**
      * Returns the {@code Node}s corresponding to a particular {@code Tree}. Multiple {@code Node}s
-     * can correspond to a single {@code Tree} because of two reasons:
+     * can correspond to a single {@code Tree} because of several reasons:
      *
      * <ol>
      *   <li>In a lambda expression such as {@code () -> 5} the {@code 5} is both an {@code
-     *       IntegerLiteralNode} and a {@code LambdaResultExpressionNode}. The caller of the method
-     *       needs to decide which {@code Node} they are interested in.
+     *       IntegerLiteralNode} and a {@code LambdaResultExpressionNode}.
+     *   <li>Narrowing and widening primitive conversions can result in {@code
+     *       NarrowingConversionNode} and {@code WideningConversionNode}.
+     *   <li>Automatic String conversion can result in a {@code StringConversionNode}.
      *   <li>Trees for {@code finally} blocks are cloned to achieve a precise CFG. Any {@code Tree}
      *       within a finally block can have multiple corresponding {@code Node}s attached to them.
      * </ol>
      *
      * Callers of this method should always iterate through the returned set, possibly ignoring all
-     * {@code LambdaResultExpressionNode}.
+     * {@code Node}s they are not interested in.
      *
      * @return the set of {@link Node}s for a given {@link Tree}.
      */

--- a/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -290,7 +290,12 @@ public class FlowExpressions {
                     if (ElementUtils.isStatic(invokedMethod)) {
                         methodReceiver = new ClassName(TreeUtils.typeOf(mn.getMethodSelect()));
                     } else {
-                        methodReceiver = internalReprOf(provider, mn.getMethodSelect());
+                        ExpressionTree methodReceiverTree = TreeUtils.getReceiverTree(mn);
+                        if (methodReceiverTree != null) {
+                            methodReceiver = internalReprOf(provider, methodReceiverTree);
+                        } else {
+                            methodReceiver = internalRepOfImplicitReceiver(invokedMethod);
+                        }
                     }
                     TypeMirror type = TreeUtils.typeOf(mn);
                     receiver = new MethodCall(type, invokedMethod, methodReceiver, parameters);

--- a/framework/tests/all-systems/Issue1865.java
+++ b/framework/tests/all-systems/Issue1865.java
@@ -1,0 +1,23 @@
+// Test case for Issue 1865:
+// https://github.com/typetools/checker-framework/issues/1865
+
+abstract class Issue1865 {
+
+    // Widening conversion
+
+    abstract int f();
+
+    abstract int max(int... array);
+
+    void g() {
+        long l = max(f(), f());
+    }
+
+    // String conversion
+
+    abstract Object h(Object... args);
+
+    void i() {
+        Object o = "" + h();
+    }
+}


### PR DESCRIPTION
Also, removed use of getFirstNonImplicitNodeForTree in the LockVisitor, which required a minor fix in FlowExpressions.java.

Follow-up to #1826.