### PR TITLE
For a member select that refers to a class use the type of the whole tree

### DIFF
--- a/checker/tests/lock/FullyQualified.java
+++ b/checker/tests/lock/FullyQualified.java
@@ -1,0 +1,15 @@
+package com.example.mypackage;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.checkerframework.checker.lock.qual.GuardedBy;
+
+public class FullyQualified {
+    public static final @GuardedBy("<self>") List<Object> all_classes = new ArrayList<>();
+
+    void test() {
+        synchronized (com.example.mypackage.FullyQualified.all_classes) {
+            com.example.mypackage.FullyQualified.all_classes.add(new Object());
+        }
+    }
+}

--- a/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -304,7 +304,7 @@ public class FlowExpressions {
                 }
                 break;
             case MEMBER_SELECT:
-                receiver = internalRepOfMemberSelect(provider, (MemberSelectTree) receiverTree);
+                receiver = internalReprOfMemberSelect(provider, (MemberSelectTree) receiverTree);
                 break;
             case IDENTIFIER:
                 IdentifierTree identifierTree = (IdentifierTree) receiverTree;
@@ -392,7 +392,7 @@ public class FlowExpressions {
         }
     }
 
-    private static Receiver internalRepOfMemberSelect(
+    private static Receiver internalReprOfMemberSelect(
             AnnotationProvider provider, MemberSelectTree memberSelectTree) {
         TypeMirror expressionType = TreeUtils.typeOf(memberSelectTree.getExpression());
         if (TreeUtils.isClassLiteral(memberSelectTree)) {
@@ -407,7 +407,8 @@ public class FlowExpressions {
             case ENUM:
             case INTERFACE: // o instanceof MyClass.InnerInterface
             case ANNOTATION_TYPE:
-                return new ClassName(expressionType);
+                TypeMirror selectType = TreeUtils.typeOf(memberSelectTree);
+                return new ClassName(selectType);
             case ENUM_CONSTANT:
             case FIELD:
                 Receiver r = internalReprOf(provider, memberSelectTree.getExpression());


### PR DESCRIPTION
Previously, for a fully-qualified class name like p.q.C it used p.q as ClassName, which doesn't make sense. But maybe I misunderstood and this needs documentation.