### PR TITLE
Document Index Checker type rules by cases

### DIFF
--- a/checker/src/org/checkerframework/checker/index/inequality/LessThanTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/inequality/LessThanTransfer.java
@@ -11,12 +11,23 @@ import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 
+/**
+ * Implements 2 refinement rules:
+ *
+ * <ul>
+ *   <li>1. if left &gt; right, right has type <code>@LessThan("left")</code>
+ *   <li>2. if left &ge; right, right has type <code>@LessThan("left + 1")</code>
+ * </ul>
+ *
+ * These are implemented generally, so they also apply to e.g. &lt; and &le; comparisons.
+ */
 public class LessThanTransfer extends IndexAbstractTransfer {
 
     public LessThanTransfer(CFAnalysis analysis) {
         super(analysis);
     }
 
+    /** Case 1. */
     @Override
     protected void refineGT(
             Node left,
@@ -43,6 +54,7 @@ public class LessThanTransfer extends IndexAbstractTransfer {
         }
     }
 
+    /** Case 2. */
     @Override
     protected void refineGTE(
             Node left,

--- a/checker/src/org/checkerframework/checker/index/inequality/LessThanTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/inequality/LessThanTransfer.java
@@ -15,8 +15,8 @@ import org.checkerframework.framework.flow.CFValue;
  * Implements 2 refinement rules:
  *
  * <ul>
- *   <li>1. if left &gt; right, right has type <code>@LessThan("left")</code>
- *   <li>2. if left &ge; right, right has type <code>@LessThan("left + 1")</code>
+ *   <li>1. if left &gt; right, right has type {@code @LessThan("left")}
+ *   <li>2. if left &ge; right, right has type {@code @LessThan("left + 1")}
  * </ul>
  *
  * These are implemented generally, so they also apply to e.g. &lt; and &le; comparisons.

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -75,12 +75,12 @@ import org.checkerframework.javacutil.TreeUtils;
  *       refine that expression's type to non-negative.
  *   <li>3. If the value checker type for any expression is &ge; -1 and cases 1 and 2 did not apply,
  *       then refine that expression's type to GTEN1.
- *   <li>4. A unary prefix decrement shifts the type "down" in the hierarchy (i.e. <code>--i</code>
- *       when <code>i</code> is non-negative implies that <code>i</code> will be GTEN1 afterwards).
- *       Should this be 3 rules?
- *   <li>5. A unary prefix increment shifts the type "up" in the hierarchy (i.e. <code>++i</code>
- *       when <code>i</code> is non-negative implies that <code>i</code> will be positive
- *       afterwards). Should this be 3 rules?
+ *   <li>4. A unary prefix decrement shifts the type "down" in the hierarchy (i.e. {@code --i} when
+ *       {@code i} is non-negative implies that {@code i} will be GTEN1 afterwards). Should this be
+ *       3 rules?
+ *   <li>5. A unary prefix increment shifts the type "up" in the hierarchy (i.e. {@code ++i} when
+ *       {@code i} is non-negative implies that {@code i} will be positive afterwards). Should this
+ *       be 3 rules?
  *   <li>6. Unary negation on a NegativeIndexFor from the SearchIndex type system results in a
  *       non-negative.
  *   <li>7. The result of a call to Math.max is the GLB of its arguments.

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -118,8 +118,8 @@ import org.checkerframework.javacutil.AnnotationUtils;
  *   <li>5. The rule described above for ==
  *   <li>6. The rule described above for !=
  *   <li>7. A special refinement for != when the value being compared to is a compile-time constant
- *       with a value exactly equal to -1 or 0 (i.e. <code>x != -1</code> and x is GTEN1 implies x
- *       is non-negative). Maybe two rules?
+ *       with a value exactly equal to -1 or 0 (i.e. {@code x != -1} and x is GTEN1 implies x is
+ *       non-negative). Maybe two rules?
  *   <li>8. When a compile-time constant -2 is added to a positive, the result is GTEN1
  *   <li>9. When a compile-time constant 2 is added to a GTEN1, the result is positive
  *   <li>10. When a positive is added to a positive, the result is positive

--- a/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -107,6 +107,48 @@ import org.checkerframework.javacutil.AnnotationUtils;
  *                                   y_refined = GLB(x_orig, y_orig)
  *
  * </pre>
+ *
+ * Dividing these rules up by cases, this class implements:
+ *
+ * <ul>
+ *   <li>1. The rule described above for &gt;
+ *   <li>2. The rule described above for &ge;
+ *   <li>3. The rule described above for &lt;
+ *   <li>4. The rule described above for &le;
+ *   <li>5. The rule described above for ==
+ *   <li>6. The rule described above for !=
+ *   <li>7. A special refinement for != when the value being compared to is a compile-time constant
+ *       with a value exactly equal to -1 or 0 (i.e. <code>x != -1</code> and x is GTEN1 implies x
+ *       is non-negative). Maybe two rules?
+ *   <li>8. When a compile-time constant -2 is added to a positive, the result is GTEN1
+ *   <li>9. When a compile-time constant 2 is added to a GTEN1, the result is positive
+ *   <li>10. When a positive is added to a positive, the result is positive
+ *   <li>11. When a non-negative is added to any other type, the result is that other type
+ *   <li>12. When a GTEN1 is added to a positive, the result is non-negative
+ *   <li>13. When the left side of a subtraction expression is &gt; the right side according to the
+ *       LessThanChecker, the result of the subtraction expression is positive
+ *   <li>14. When the left side of a subtraction expression is &ge; the right side according to the
+ *       LessThanChecker, the result of the subtraction expression is non-negative
+ *   <li>15. special handling for when the left side is the length of an array or String that's
+ *       stored as a field, and the right side is a compile time constant. Do we need this?
+ *   <li>16. Multiplying any value by a compile time constant of 1 preserves its type
+ *   <li>17. Multiplying two positives produces a positive
+ *   <li>18. Multiplying a positive and a non-negative produces a non-negative
+ *   <li>19. Multiplying two non-negatives produces a non-negative
+ *   <li>20. When the result of Math.random is multiplied by an array length, the result is
+ *       NonNegative.
+ *   <li>21. literal 0 divided by anything is non-negative
+ *   <li>22. anything divided by literal zero is bottom
+ *   <li>23. literal 1 divided by a positive or non-negative is non-negative
+ *   <li>24. literal 1 divided by anything else is GTEN1
+ *   <li>25. anything divided by literal 1 is itself
+ *   <li>26. a positive or non-negative divided by a positive or non-negative is non-negative
+ *   <li>27. anything modded by literal 1 or -1 is non-negative
+ *   <li>28. a positive or non-negative modded by anything is non-negative
+ *   <li>29. a GTEN1 modded by anything is GTEN1
+ *   <li>30. anything right-shifted by a non-negative is non-negative
+ *   <li>31. anything bitwise-anded by a non-negative is non-negative
+ * </ul>
  */
 public class LowerBoundTransfer extends IndexAbstractTransfer {
 
@@ -134,6 +176,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
 
     /**
      * Refines GTEN1 to NN if it is not equal to -1, and NN to Pos if it is not equal to 0.
+     * Implements case 7.
      *
      * @param mLiteral a potential literal
      * @param otherNode the node on the other side of the ==/!=
@@ -169,7 +212,9 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         }
     }
 
-    /** Implements the transfer rules for both equal nodes and not-equals nodes. */
+    /**
+     * Implements the transfer rules for both equal nodes and not-equals nodes (i.e. cases 5 and 6).
+     */
     @Override
     protected TransferResult<CFValue, CFStore> strengthenAnnotationOfEqualTo(
             TransferResult<CFValue, CFStore> result,
@@ -203,6 +248,9 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
      * greater one) to one closer to bottom than the type of right. Can't call the promote function
      * from the ATF directly because a new expression isn't introduced here - the modifications have
      * to be made to an existing one.
+     *
+     * <p>This implements parts of cases 1, 2, 3, and 4 using the decomposition strategy described
+     * in the Javadoc of this class.
      */
     @Override
     protected void refineGT(
@@ -237,6 +285,9 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
      * Refines left to exactly the level of right, since in the worst case they're equal. Modifies
      * an existing type in the store, but has to be careful not to overwrite a more precise existing
      * type.
+     *
+     * <p>This implements parts of cases 1, 2, 3, and 4 using the decomposition strategy described
+     * in this class's Javadoc.
      */
     @Override
     protected void refineGTE(
@@ -284,7 +335,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * Helper method for getAnnotationForPlus. Handles addition of constants.
+     * Helper method for getAnnotationForPlus. Handles addition of constants (cases 8 and 9).
      *
      * @param val the integer value of the constant
      * @param nonLiteralType the type of the side of the expression that isn't a constant
@@ -310,18 +361,18 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * getAnnotationForPlus handles the following cases:
+     * getAnnotationForPlus handles the following cases (cases 10-12 above):
      *
      * <pre>
-     *      lit -2 + pos &rarr; gte-1
+     *      8. lit -2 + pos &rarr; gte-1
      *      lit -1 + * &rarr; call demote
      *      lit 0 + * &rarr; *
      *      lit 1 + * &rarr; call promote
-     *      lit &ge; 2 + {gte-1, nn, or pos} &rarr; pos
+     *      9. lit &ge; 2 + {gte-1, nn, or pos} &rarr; pos
      *      let all other lits, including sets, fall through:
-     *      pos + pos &rarr; pos
-     *      nn + * &rarr; *
-     *      pos + gte-1 &rarr; nn
+     *      10. pos + pos &rarr; pos
+     *      11. nn + * &rarr; *
+     *      12. pos + gte-1 &rarr; nn
      *      * + * &rarr; lbu
      *  </pre>
      */
@@ -380,6 +431,12 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
      * <pre>
      *      * - lit &rarr; call plus(*, -1 * the value of the lit)
      *      * - * &rarr; lbu
+     *      13. if the LessThan type checker can establish that the left side of the expression is &gt; the right side,
+     *      returns POS.
+     *      14. if the LessThan type checker can establish that the left side of the expression is &ge; the right side,
+     *      returns NN.
+     *      15. special handling for when the left side is the length of an array or String that's stored as a field,
+     *      and the right side is a compile time constant. Do we need this?
      *  </pre>
      */
     private AnnotationMirror getAnnotationForMinus(
@@ -463,12 +520,14 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
      *
      * <pre>
      *        * * lit 0 &rarr; nn (=0)
-     *        * * lit 1 &rarr; *
-     *        pos * pos &rarr; pos
-     *        pos * nn &rarr; nn
-     *        nn * nn &rarr; nn
+     *        16. * * lit 1 &rarr; *
+     *        17. pos * pos &rarr; pos
+     *        18. pos * nn &rarr; nn
+     *        19. nn * nn &rarr; nn
      *        * * * &rarr; lbu
      *  </pre>
+     *
+     * Also handles a special case involving Math.random (case 20).
      */
     private AnnotationMirror getAnnotationForMultiply(
             NumericalMultiplicationNode node, TransferInput<CFValue, CFStore> p) {
@@ -550,10 +609,10 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * getAnnotationForDivide handles these cases:
+     * getAnnotationForDivide handles these cases (21-26):
      *
      * <pre>
-     * lit 0 / * &rarr; nn (=0)
+     *      lit 0 / * &rarr; nn (=0)
      *      * / lit 0 &rarr; pos
      *      lit 1 / {pos, nn} &rarr; nn
      *      lit 1 / * &rarr; gten1
@@ -612,8 +671,14 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * getAnnotationForRemainder handles these cases: * % 1/-1 &rarr; nn pos/nn % * &rarr; nn gten1
-     * % * &rarr; gten1 * % * &rarr; lbu
+     * getAnnotationForRemainder handles these cases:
+     *
+     * <pre>
+     *      27. * % 1/-1 &rarr; nn
+     *      28. pos/nn % * &rarr; nn
+     *      29. gten1 % * &rarr; gten1
+     *      * % * &rarr; lbu
+     * </pre>
      */
     public AnnotationMirror getAnnotationForRemainder(
             IntegerRemainderNode node, TransferInput<CFValue, CFStore> p) {
@@ -644,7 +709,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         return UNKNOWN;
     }
 
-    /** Handles shifts. * &gt;&gt; NonNegative &rarr; NonNegative */
+    /** Handles shifts (case 30). * &gt;&gt; NonNegative &rarr; NonNegative */
     private AnnotationMirror getAnnotationForRightShift(
             BinaryOperationNode node, TransferInput<CFValue, CFStore> p) {
         AnnotationMirror leftAnno = getLowerBoundAnnotation(node.getLeftOperand(), p);
@@ -659,8 +724,8 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * Handles masking. Particularly, handles the following cases: * &amp; NonNegative &rarr;
-     * NonNegative
+     * Handles masking (case 31). Particularly, handles the following cases: * &amp; NonNegative
+     * &rarr; NonNegative
      */
     private AnnotationMirror getAnnotationForAnd(
             BitwiseAndNode node, TransferInput<CFValue, CFStore> p) {

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -49,17 +49,16 @@ import org.checkerframework.javacutil.AnnotationUtils;
  * <p>This annotated type factory refines types in X cases:
  *
  * <ul>
- *   <li>1. <code>@PolyAll</code> and <code>@PolyLength</code> are refined to <code>@PolySameLen
- *       </code>.
- *   <li>2. If a variable is declared with a user-written <code>@SameLen</code> annotation, then the
- *       type of the new variable is the union of the user-written arrays in the annotation and the
+ *   <li>1. {@code @PolyAll} and {@code @PolyLength} are refined to {@code @PolySameLen }.
+ *   <li>2. If a variable is declared with a user-written {@code @SameLen} annotation, then the type
+ *       of the new variable is the union of the user-written arrays in the annotation and the
  *       arrays listed in the SameLen types of each of those arrays.
  *   <li>3. The greatest lower bound of two SameLen annotations is the union of the two sets of
  *       arrays.
  *   <li>4. The least upper bound of two SameLen annotations is the intersection of the two sets of
  *       arrays.
- *   <li>5. The type of an expression of the form <code>new T[a.length]</code> is the union of the
- *       SameLen type of <code>a</code> and the arrays listed in <code>a</code>'s SameLen type.
+ *   <li>5. The type of an expression of the form {@code new T[a.length]} is the union of the
+ *       SameLen type of {@code a} and the arrays listed in {@code a}'s SameLen type.
  * </ul>
  */
 public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -45,6 +45,22 @@ import org.checkerframework.javacutil.AnnotationUtils;
  * The SameLen Checker is used to determine whether there are multiple fixed-length sequences (such
  * as arrays or strings) in a program that share the same length. It is part of the Index Checker,
  * and is used as a subchecker by the Index Checker's components.
+ *
+ * <p>This annotated type factory refines types in X cases:
+ *
+ * <ul>
+ *   <li>1. <code>@PolyAll</code> and <code>@PolyLength</code> are refined to <code>@PolySameLen
+ *       </code>.
+ *   <li>2. If a variable is declared with a user-written <code>@SameLen</code> annotation, then the
+ *       type of the new variable is the union of the user-written arrays in the annotation and the
+ *       arrays listed in the SameLen types of each of those arrays.
+ *   <li>3. The greatest lower bound of two SameLen annotations is the union of the two sets of
+ *       arrays.
+ *   <li>4. The least upper bound of two SameLen annotations is the intersection of the two sets of
+ *       arrays.
+ *   <li>5. The type of an expression of the form <code>new T[a.length]</code> is the union of the
+ *       SameLen type of <code>a</code> and the arrays listed in <code>a</code>'s SameLen type.
+ * </ul>
  */
 public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
@@ -54,6 +70,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     private final IndexMethodIdentifier imf;
 
+    /** Handles case 1. */
     public SameLenAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
         UNKNOWN = AnnotationBuilder.fromClass(elements, SameLenUnknown.class);
@@ -88,6 +105,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return new SameLenQualifierHierarchy(factory);
     }
 
+    /** Handles case 2. */
     @Override
     public AnnotatedTypeMirror getAnnotatedTypeLhs(Tree tree) {
         AnnotatedTypeMirror atm = super.getAnnotatedTypeLhs(tree);
@@ -208,6 +226,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return UNKNOWN;
         }
 
+        /** Case 3. */
         @Override
         public AnnotationMirror greatestLowerBound(AnnotationMirror a1, AnnotationMirror a2) {
             if (AnnotationUtils.hasElementValue(a1, "value")
@@ -233,6 +252,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
         }
 
+        /** Case 4. */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
             if (AnnotationUtils.hasElementValue(a1, "value")
@@ -302,6 +322,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             super(factory);
         }
 
+        /** Case 5. */
         @Override
         public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
             if (node.getDimensions().size() == 1) {

--- a/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -28,9 +28,9 @@ import org.checkerframework.javacutil.AnnotationUtils;
  * The transfer function for the SameLen checker. Contains three cases:
  *
  * <ol>
- *   <li>"b = new T[a.length]" implies that b is the same length as a.
- *   <li>after "if (a.length == b.length)", a and b have the same length.
- *   <li>after "if (a == b)", a and b have the same length, if they are arrays or strings.
+ *   <li>1. "b = new T[a.length]" implies that b is the same length as a.
+ *   <li>2. after "if (a.length == b.length)", a and b have the same length.
+ *   <li>3. after "if (a == b)", a and b have the same length, if they are arrays or strings.
  * </ol>
  */
 public class SameLenTransfer extends CFTransfer {
@@ -64,6 +64,7 @@ public class SameLenTransfer extends CFTransfer {
         return null;
     }
 
+    /** Handles case 1 */
     @Override
     public TransferResult<CFValue, CFStore> visitAssignment(
             AssignmentNode node, TransferInput<CFValue, CFStore> in) {
@@ -168,8 +169,8 @@ public class SameLenTransfer extends CFTransfer {
                 && ((FieldAccessNode) node).getReceiver().getType().getKind() == TypeKind.ARRAY);
     }
     /**
-     * Handles refinement of equality comparisons. After "a.length == b.length" evaluates to true, a
-     * and b have SameLen of each other in the store.
+     * Handles refinement of equality comparisons (cases 2 and 3). After "a.length == b.length"
+     * evaluates to true, a and b have SameLen of each other in the store.
      */
     private void refineEq(Node left, Node right, CFStore store) {
         List<Receiver> receivers = new ArrayList<>();

--- a/checker/src/org/checkerframework/checker/index/searchindex/SearchIndexTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/searchindex/SearchIndexTransfer.java
@@ -16,6 +16,8 @@ import org.checkerframework.framework.flow.CFValue;
 /**
  * The transfer function for the SearchIndexFor checker. Allows {@link SearchIndexFor} to be refined
  * to {@link NegativeIndexFor}.
+ *
+ * <p>Contains 1 refinement rule: SearchIndexFor &rarr; NegativeIndexFor when compared against zero.
  */
 public class SearchIndexTransfer extends IndexAbstractTransfer {
 

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -45,12 +45,12 @@ import org.checkerframework.framework.type.QualifierHierarchy;
  *
  * <ul>
  *   <li>1. Refine the type of expressions used as an array dimension to be less than length of the
- *       array to which the new array is assigned. For example, in <code>
- *       int[] array = new int[expr];</code>, the type of expr is <code>@LTEqLength("array")</code>.
- *   <li>2. If <code>other * node</code> has type <code>typeOfMultiplication</code>, then if {@code
- *       other} is positive, then {@code node} is {@code typeOfMultiplication}.
- *   <li>3. If <code>other * node</code> has type <code>typeOfMultiplication</code>, if {@code
- *       other} is greater than 1, then {@code node} is {@code typeOfMultiplication} plus 1.
+ *       array to which the new array is assigned. For example, in {@code int[] array = new
+ *       int[expr];}, the type of expr is {@code @LTEqLength("array")}.
+ *   <li>2. If {@code other * node} has type {@code typeOfMultiplication}, then if {@code other} is
+ *       positive, then {@code node} is {@code typeOfMultiplication}.
+ *   <li>3. If {@code other * node} has type {@code typeOfMultiplication}, if {@code other} is
+ *       greater than 1, then {@code node} is {@code typeOfMultiplication} plus 1.
  *   <li>4. Given a subtraction node, {@code node}, that is known to have type {@code
  *       typeOfSubtraction}. An offset can be applied to the left node (i.e. the left node has the
  *       same type, but with an offset based on the right node).
@@ -74,27 +74,27 @@ import org.checkerframework.framework.type.QualifierHierarchy;
  *       sequence length (minus the offset), then refine the other node's type to less than the
  *       sequence length (minus the offset).
  *   <li>13. If some Node a is known to be less than the length of some array, x, then, the type of
- *       a + b, is <code>@LTLengthOf(value="x", offset="-b")</code>. If b is known to be less than
- *       the length of some other array, y, then the type of a + b is <code>
- *       @LTLengthOf(value={"x", "y"}, offset={"-b", "-a"})</code>.
+ *       a + b, is {@code @LTLengthOf(value="x", offset="-b")}. If b is known to be less than the
+ *       length of some other array, y, then the type of a + b is {@code @LTLengthOf(value={"x",
+ *       "y"}, offset={"-b", "-a"})}.
  *   <li>14. If a is known to be less than the length of x when some offset, o, is added to a (the
- *       type of a is <code>@LTLengthOf(value="x", offset="o"))</code>, then the type of a + b is
- *       <code>@LTLengthOf(value="x",offset="o - b")</code>. (Note, if "o - b" can be computed, then
- *       it is and the result is used in the annotation.)
- *   <li>15. If expression i has type <code>@LTLengthOf(value = "f2", offset = "f1.length")</code>
- *       int and expression j is less than or equal to the length of f1, then the type of i + j is
- *       <code>@LTLengthOf("f2")</code>.
+ *       type of a is {@code @LTLengthOf(value="x", offset="o"))}, then the type of a + b is
+ *       {@code @LTLengthOf(value="x",offset="o - b")}. (Note, if "o - b" can be computed, then it
+ *       is and the result is used in the annotation.)
+ *   <li>15. If expression i has type {@code @LTLengthOf(value = "f2", offset = "f1.length")} int
+ *       and expression j is less than or equal to the length of f1, then the type of i + j is
+ *       {@code @LTLengthOf("f2")}.
  *   <li>16. If some Node a is known to be less than the length of some sequence x, then the type of
- *       a - b is <code>@LTLengthOf(value="x", offset="b")</code>.
+ *       a - b is {@code @LTLengthOf(value="x", offset="b")}.
  *   <li>17. If some Node a is known to be less than the length of some sequence x, and if b is
  *       non-negative or positive, then a - b should keep the types of a.
- *   <li>18. The type of a sequence length access (i.e. array.length) is <code>
- *       @LTLength(value={"array"...}, offset="-1")</code> where "array"... is the set of all
+ *   <li>18. The type of a sequence length access (i.e. array.length) is
+ *       {@code @LTLength(value={"array"...}, offset="-1")} where "array"... is the set of all
  *       sequences that are the same length (via the SameLen checker) as "array"
- *   <li>19. If n is an array length field access, then the type of a.length is the glb of <code>
- *       @LTEqLengthOf("a")</code> and the value of a.length in the store.
+ *   <li>19. If n is an array length field access, then the type of a.length is the glb of
+ *       {@code @LTEqLengthOf("a")} and the value of a.length in the store.
  *   <li>20. If n is a String.length() method invocation, then the type of s.length() is the glb of
- *       <code>@LTEqLengthOf("s")</code> and the value of s.length() in the store.
+ *       {@code @LTEqLengthOf("s")} and the value of s.length() in the store.
  * </ul>
  */
 public class UpperBoundTransfer extends IndexAbstractTransfer {

--- a/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -39,6 +39,64 @@ import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
 
+/**
+ * Contains the transfer functions for the upper bound type system, a part of the Index Checker.
+ * This class implements the following refinement rules:
+ *
+ * <ul>
+ *   <li>1. Refine the type of expressions used as an array dimension to be less than length of the
+ *       array to which the new array is assigned. For example, in <code>
+ *       int[] array = new int[expr];</code>, the type of expr is <code>@LTEqLength("array")</code>.
+ *   <li>2. If <code>other * node</code> has type <code>typeOfMultiplication</code>, then if {@code
+ *       other} is positive, then {@code node} is {@code typeOfMultiplication}.
+ *   <li>3. If <code>other * node</code> has type <code>typeOfMultiplication</code>, if {@code
+ *       other} is greater than 1, then {@code node} is {@code typeOfMultiplication} plus 1.
+ *   <li>4. Given a subtraction node, {@code node}, that is known to have type {@code
+ *       typeOfSubtraction}. An offset can be applied to the left node (i.e. the left node has the
+ *       same type, but with an offset based on the right node).
+ *   <li>5. In an addition expression, refine the two operands based on the type of the whole
+ *       expression with appropriate offsets.
+ *   <li>6. If an addition expression has a type that is less than length of an array, and one of
+ *       the operands is non-negative, then the other is less than or equal to the length of the
+ *       array.
+ *   <li>7. If an addition expression has a type that is less than length of an array, and one of
+ *       the operands is positive, then the other is also less than the length of the array.
+ *   <li>8. if x &lt; y, and y has a type that is related to the length of an array, then x has the
+ *       same type, with an offset that is one less.
+ *   <li>9. if x &le; y, and y has a type that is related to the length of an array, then x has the
+ *       same type.
+ *   <li>10. refine the subtrahend in a subtraction which is greater than or equal to a certain
+ *       offset. The type of the subtrahend is refined to the type of the minuend with the offset
+ *       added.
+ *   <li>11. if two variables are equal, they have the same type
+ *   <li>12. If one node in a != expression is an sequence length field or method access (optionally
+ *       with a constant offset subtracted) and the other node is less than or equal to that
+ *       sequence length (minus the offset), then refine the other node's type to less than the
+ *       sequence length (minus the offset).
+ *   <li>13. If some Node a is known to be less than the length of some array, x, then, the type of
+ *       a + b, is <code>@LTLengthOf(value="x", offset="-b")</code>. If b is known to be less than
+ *       the length of some other array, y, then the type of a + b is <code>
+ *       @LTLengthOf(value={"x", "y"}, offset={"-b", "-a"})</code>.
+ *   <li>14. If a is known to be less than the length of x when some offset, o, is added to a (the
+ *       type of a is <code>@LTLengthOf(value="x", offset="o"))</code>, then the type of a + b is
+ *       <code>@LTLengthOf(value="x",offset="o - b")</code>. (Note, if "o - b" can be computed, then
+ *       it is and the result is used in the annotation.)
+ *   <li>15. If expression i has type <code>@LTLengthOf(value = "f2", offset = "f1.length")</code>
+ *       int and expression j is less than or equal to the length of f1, then the type of i + j is
+ *       <code>@LTLengthOf("f2")</code>.
+ *   <li>16. If some Node a is known to be less than the length of some sequence x, then the type of
+ *       a - b is <code>@LTLengthOf(value="x", offset="b")</code>.
+ *   <li>17. If some Node a is known to be less than the length of some sequence x, and if b is
+ *       non-negative or positive, then a - b should keep the types of a.
+ *   <li>18. The type of a sequence length access (i.e. array.length) is <code>
+ *       @LTLength(value={"array"...}, offset="-1")</code> where "array"... is the set of all
+ *       sequences that are the same length (via the SameLen checker) as "array"
+ *   <li>19. If n is an array length field access, then the type of a.length is the glb of <code>
+ *       @LTEqLengthOf("a")</code> and the value of a.length in the store.
+ *   <li>20. If n is a String.length() method invocation, then the type of s.length() is the glb of
+ *       <code>@LTEqLengthOf("s")</code> and the value of s.length() in the store.
+ * </ul>
+ */
 public class UpperBoundTransfer extends IndexAbstractTransfer {
 
     private UpperBoundAnnotatedTypeFactory atypeFactory;
@@ -48,9 +106,11 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         atypeFactory = (UpperBoundAnnotatedTypeFactory) analysis.getTypeFactory();
     }
 
-    // Refine the type of expressions used as an array dimension to be
-    // less than length of the array to which the new array is assigned.
-    // For example, in "int[] array = new int[expr];", the type of expr is @LTEqLength("array").
+    /**
+     * Case 1: Refine the type of expressions used as an array dimension to be less than length of
+     * the array to which the new array is assigned. For example, in "int[] array = new int[expr];",
+     * the type of expr is @LTEqLength("array").
+     */
     @Override
     public TransferResult<CFValue, CFStore> visitAssignment(
             AssignmentNode node, TransferInput<CFValue, CFStore> in) {
@@ -127,7 +187,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      *
      * <p>This implies that if {@code other} is positive, then {@code node} is {@code
      * typeOfMultiplication}. If {@code other} is greater than 1, then {@code node} is {@code
-     * typeOfMultiplication} plus 1.
+     * typeOfMultiplication} plus 1. These are cases 2 and 3, respectively.
      */
     private void propagateToMultiplicationOperand(
             LessThanLengthOf typeOfMultiplication,
@@ -156,7 +216,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * right node is subtracted from the left node. Note that unlike {@link
      * #propagateToAdditionOperand(LessThanLengthOf, Node, Node, TransferInput, CFStore)} and {@link
      * #propagateToMultiplicationOperand(LessThanLengthOf, Node, Node, TransferInput, CFStore)},
-     * this method takes the NumericalSubtractionNode instead of the two operand nodes.
+     * this method takes the NumericalSubtractionNode instead of the two operand nodes. This
+     * implements case 4.
      *
      * @param typeOfSubtraction type of node
      * @param node subtraction node that has typeOfSubtraction
@@ -180,7 +241,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * Refines the type of {@code operand} to {@code typeOfAddition} plus {@code other}. If {@code
      * other} is non-negative, then {@code operand} also less than the length of the arrays in
      * {@code typeOfAddition}. If {@code other} is positive, then {@code operand} also less than the
-     * length of the arrays in {@code typeOfAddition} plus 1.
+     * length of the arrays in {@code typeOfAddition} plus 1. These are cases 5, 6, and 7.
      *
      * @param typeOfAddition type of {@code operand + other}
      * @param operand the Node to refine
@@ -207,6 +268,10 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         store.insertValue(operandRec, atypeFactory.convertUBQualifierToAnnotation(newQual));
     }
 
+    /**
+     * Case 8: if x &lt; y, and y has a type that is related to the length of an array, then x has
+     * the same type, with an offset that is one less.
+     */
     @Override
     protected void refineGT(
             Node larger,
@@ -233,11 +298,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * This method refines the type of the right expression to the glb the previous type of right
-     * and the type of left.
-     *
-     * <p>Also, if the left expression is an array access, then the types of sub expressions of the
-     * right are refined.
+     * Case 9: if x &le; y, and y has a type that is related to the length of an array, then x has
+     * the same type.
      */
     @Override
     protected void refineGTE(
@@ -263,7 +325,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
 
     /**
      * Refines the subtrahend in a subtraction which is greater than or equal to a certain offset.
-     * The type of the subtrahend is refined to the type of the minuend with the offset added.
+     * The type of the subtrahend is refined to the type of the minuend with the offset added. This
+     * is case 10.
      *
      * <p>This is based on the fact that if {@code (minuend - subtrahend) >= offset}, and {@code
      * minuend + o < l}, then {@code subtrahend + o + offset < l}.
@@ -300,6 +363,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         }
     }
 
+    /** Implements case 11. */
     @Override
     protected TransferResult<CFValue, CFStore> strengthenAnnotationOfEqualTo(
             TransferResult<CFValue, CFStore> res,
@@ -354,8 +418,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     /**
      * If lengthAccess node is an sequence length field or method access (optionally with a constant
      * offset subtracted) and the other node is less than or equal to that sequence length (minus
-     * the offset), then refine the other nodes type to less than the sequence length (minus the
-     * offset).
+     * the offset), then refine the other node's type to less than the sequence length (minus the
+     * offset). This is case 12.
      */
     private void refineNeqSequenceLength(
             Node lengthAccess, Node otherNode, AnnotationMirror otherNodeAnno, CFStore store) {
@@ -426,6 +490,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * <p>In addition, If expression i has type @LTLengthOf(value = "f2", offset = "f1.length") int
      * and expression j is less than or equal to the length of f1, then the type of i + j is
      * .@LTLengthOf("f2").
+     *
+     * <p>These three cases correspond to cases 13-15.
      */
     @Override
     public TransferResult<CFValue, CFStore> visitNumericalAddition(
@@ -495,7 +561,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
      * If some Node a is known to be less than the length of some sequence x, then the type of a - b
      * is @LTLengthOf(value="x", offset="b"). If b is known to be less than the length of some other
      * sequence, this doesn't add any information about the type of a - b. But, if b is non-negative
-     * or positive, then a - b should keep the types of a.
+     * or positive, then a - b should keep the types of a. This corresponds to cases 16 and 17.
      */
     @Override
     public TransferResult<CFValue, CFStore> visitNumericalSubtraction(
@@ -514,7 +580,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * Computes a type of a sequence length access.
+     * Computes a type of a sequence length access. This is case 18.
      *
      * @param n sequence length access node
      */
@@ -550,7 +616,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
 
     /**
      * If n is an array length field access, then the type of a.length is the glb
-     * of @LTEqLengthOf("a") and the value of a.length in the store.
+     * of @LTEqLengthOf("a") and the value of a.length in the store. This is case 19.
      */
     @Override
     public TransferResult<CFValue, CFStore> visitFieldAccess(
@@ -568,8 +634,8 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     }
 
     /**
-     * If n is an String.length() method invocation, then the type of s.length() is the glb
-     * of @LTEqLengthOf("s") and the value of s.length() in the store.
+     * If n is a String.length() method invocation, then the type of s.length() is the glb
+     * of @LTEqLengthOf("s") and the value of s.length() in the store. This is case 20.
      */
     @Override
     public TransferResult<CFValue, CFStore> visitMethodInvocation(


### PR DESCRIPTION
Modifies and expands the documentation on each Index Checker subchecker to split out the refinement rules by cases, and provide a summary at the top of each class that implements some refinement rules.