### PR TITLE
Add example to EnsuresLTLengthOf Javadoc

### DIFF
--- a/checker/src/org/checkerframework/checker/index/qual/EnsuresLTLengthOf.java
+++ b/checker/src/org/checkerframework/checker/index/qual/EnsuresLTLengthOf.java
@@ -14,6 +14,37 @@ import org.checkerframework.framework.qual.QualifierArgument;
  * Indicates that the value expressions evaluate to an integer whose value is less than the lengths
  * of all the given sequences, if the method terminates successfully.
  *
+ * <p>Consider the following example, from the Index Checker's regression tests:
+ *
+ * <pre>
+ *
+ * {@code @EnsuresLTLengthOf(value = "end", targetValue = "array", offset = "#1 - 1")
+ *  public void shiftIndex(@NonNegative int x) {
+ *      int newEnd = end - x;
+ *      if (newEnd < 0) throw new RuntimeException();
+ *      end = newEnd;
+ *  }
+ * }
+ * </pre>
+ *
+ * where {@code end} is annotated as {@code @NonNegative @LTEqLengthOf("array") int end;}
+ *
+ * <p>What this method guarantees is that end has a particular type - @LTLengthOf(value="array",
+ * offset="x - 1") - after the method returns. This is useful in cases like this one:
+ *
+ * <pre>{@code
+ * public void useShiftIndex(@NonNegative int x) {
+ *    // :: error: (argument.type.incompatible)
+ *    Arrays.fill(array, end, end + x, null);
+ *    shiftIndex(x);
+ *    Arrays.fill(array, end, end + x, null);
+ * }
+ * }</pre>
+ *
+ * The first call to {@code Arrays.fill} is rejected (hence the comment about an error). But, after
+ * calling {@code shiftIndex(x)}, {@code end} has an annotation that allows the {@code end + x} to
+ * be accepted as {@code @LTLengthOf("array")}.
+ *
  * @see LTLengthOf
  * @see org.checkerframework.checker.index.IndexChecker
  * @checker_framework.manual #index-checker Index Checker


### PR DESCRIPTION
Since there was no example in this Javadoc, and I answered a question on the mailing list about it.