### PR TITLE
Check for uninitialized static fields once on the class tree.

### DIFF
--- a/checker/tests/nullness/StaticInitializer.java
+++ b/checker/tests/nullness/StaticInitializer.java
@@ -1,12 +1,12 @@
 import org.checkerframework.checker.initialization.qual.*;
 import org.checkerframework.checker.nullness.qual.*;
 
+// :: error: (initialization.fields.uninitialized)
 class StaticInitializer {
 
     public static String a;
     public static String b;
 
-    // :: error: (initialization.fields.uninitialized)
     static {
         a = "";
     }
@@ -27,6 +27,31 @@ class StaticInitializer3 {
 class StaticInitializer4 {
     public static String a = "";
     public static String b;
+
+    static {
+        b = "";
+    }
+}
+
+class StaticInitializer5 {
+    public static String a = "";
+
+    static {
+        a.toString();
+    }
+
+    public static String b = "";
+}
+
+class StaticInitializer6 {
+    public static String a = "";
+
+    public static String b;
+
+    static {
+        // TODO error expected. See #556.
+        b.toString();
+    }
 
     static {
         b = "";

--- a/checker/tests/nullness/init/Uninit12.java
+++ b/checker/tests/nullness/init/Uninit12.java
@@ -3,6 +3,7 @@
 
 import org.checkerframework.checker.nullness.qual.*;
 
+// :: error: (initialization.fields.uninitialized)
 public class Uninit12 {
 
     static Object f;
@@ -15,7 +16,6 @@ public class Uninit12 {
 
     static Object h;
 
-    // :: error: (initialization.fields.uninitialized)
     static {
         h = new Object();
     }


### PR DESCRIPTION
Checking on the last static initializer block can lead to false
positives.