### PR TITLE
Add crash checking Guava to all-tests

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -52,6 +52,7 @@ if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
   (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
   echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  export CHECKERFRAMEWORK=$ROOT/checker-framework
   (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.Nul    lnessChecker)
 fi
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 # Optional argument $1 is one of:
-#   all, all-tests, jdk.jar, downstream, misc
+#   all, all-tests, jdk.jar, downstream, misc, inference
 # If it is omitted, this script does everything.
 export GROUP=$1
 if [[ "${GROUP}" == "" ]]; then
   export GROUP=all
 fi
 
-if [[ "${GROUP}" != "all" && "${GROUP}" != "all-tests" && "${GROUP}" != "jdk.jar" && "${GROUP}" != "downstream" && "${GROUP}" != "misc" ]]; then
+if [[ "${GROUP}" != "all" && "${GROUP}" != "all-tests" && "${GROUP}" != "jdk.jar" && "${GROUP}" != "downstream" && "${GROUP}" != "misc" && "${GROUP}" != "inference" ]]; then
   echo "Bad argument '${GROUP}'; should be omitted or one of: all, all-tests, jdk.jar, downstream, misc."
   exit 1
 fi
@@ -49,14 +49,6 @@ fi
 
 set -e
 if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
-  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
-  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  export CHECKERFRAMEWORK=$ROOT/checker-framework
-  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
-fi
-
-if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   ./gradlew allTests
   # Moved example-tests-nobuildjdk out of all tests because it fails in
   # the release script because the newest maven artifacts are not published yet.
@@ -70,23 +62,12 @@ if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
   ## Not done in the Travis build, but triggered as a separate Travis project:
   ##  * daikon-typecheck: (takes 2 hours)
 
-  # checker-framework-inference: 18 minutes
-  set +e
-  echo "Running: git ls-remote https://github.com/${SLUGOWNER}/checker-framework-inference.git &>-"
-  git ls-remote https://github.com/${SLUGOWNER}/checker-framework-inference.git &>-
-  if [ "$?" -ne 0 ]; then
-    CFISLUGOWNER=typetools
-  else
-    CFISLUGOWNER=${SLUGOWNER}
-  fi
-  set -e
-  echo "Running:  (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
-  (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git) || (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)
-  echo "... done: (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
-
-  export AFU=`pwd`/../annotation-tools/annotation-file-utilities
-  export PATH=$AFU/scripts:$PATH
-  (cd ../checker-framework-inference && ./gradlew dist test)
+  # guava: 7 minutes
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  export CHECKERFRAMEWORK=$ROOT/checker-framework
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
 
   # plume-lib-typecheck: 30 minutes
   set +e
@@ -152,4 +133,23 @@ if [[ "${GROUP}" == "misc" || "${GROUP}" == "all" ]]; then
   # HTML legality
   ./gradlew htmlValidate
 
+fi
+if [[ "${GROUP}" == "inference" || "${GROUP}" == "all" ]]; then
+  # checker-framework-inference: 18 minutes
+  set +e
+  echo "Running: git ls-remote https://github.com/${SLUGOWNER}/checker-framework-inference.git &>-"
+  git ls-remote https://github.com/${SLUGOWNER}/checker-framework-inference.git &>-
+  if [ "$?" -ne 0 ]; then
+    CFISLUGOWNER=typetools
+  else
+    CFISLUGOWNER=${SLUGOWNER}
+  fi
+  set -e
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
+  (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git) || (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
+
+  export AFU=`pwd`/../annotation-tools/annotation-file-utilities
+  export PATH=$AFU/scripts:$PATH
+  (cd ../checker-framework-inference && ./gradlew dist test)
 fi

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -53,7 +53,7 @@ if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
   echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
   export CHECKERFRAMEWORK=$ROOT/checker-framework
-  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.Nul    lnessChecker)
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
 fi
 
 if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -48,6 +48,12 @@ fi
 # subsequent command to build it except to test building it.
 
 set -e
+if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.Nul    lnessChecker)
+fi
 
 if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   ./gradlew allTests

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -48,6 +48,13 @@ fi
 # subsequent command to build it except to test building it.
 
 set -e
+if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  export CHECKERFRAMEWORK=$ROOT/checker-framework
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
+fi
 
 if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   ./gradlew allTests
@@ -108,12 +115,6 @@ if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
   # Travis hangs if enabled without Android installation).
   # (cd .. && git clone --depth 1 https://github.com/${SLUGOWNER}/sparta.git)
   # (cd ../sparta && ant jar all-tests)
-
-  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
-  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  export CHECKERFRAMEWORK=$ROOT/checker-framework
-  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
 
 fi
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -9,7 +9,7 @@ if [[ "${GROUP}" == "" ]]; then
 fi
 
 if [[ "${GROUP}" != "all" && "${GROUP}" != "all-tests" && "${GROUP}" != "jdk.jar" && "${GROUP}" != "downstream" && "${GROUP}" != "misc" && "${GROUP}" != "plume-lib" ]]; then
-  echo "Bad argument '${GROUP}'; should be omitted or one of: all, all-tests, jdk.jar, downstream, misc."
+  echo "Bad argument '${GROUP}'; should be omitted or one of: all, all-tests, jdk.jar, downstream, misc, plume-lib."
   exit 1
 fi
 
@@ -94,27 +94,29 @@ if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
   echo "Running:  (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
   (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git) || (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)
   echo "... done: (cd .. && git clone --depth 1 https://github.com/${CFISLUGOWNER}/checker-framework-inference.git)"
-
   export AFU=`pwd`/../annotation-tools/annotation-file-utilities
   export PATH=$AFU/scripts:$PATH
   (cd ../checker-framework-inference && ./gradlew dist test)
 
-  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
-  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  export CHECKERFRAMEWORK=$ROOT/checker-framework
-  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
-
+  # Checker Framework demos
   if [[ "${BUILDJDK}" = "downloadjdk" ]]; then
     ## If buildjdk, use "demos" below:
     ##  * checker-framework.demos (takes 15 minutes)
     ./gradlew :checker:demosTests
   fi
+
   # sparta: 1 minute, but the command is "true"!
   # TODO: requires Android installation (and at one time, it caused weird
   # Travis hangs if enabled without Android installation).
   # (cd .. && git clone --depth 1 https://github.com/${SLUGOWNER}/sparta.git)
   # (cd ../sparta && ant jar all-tests)
+
+  # Guava
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  export CHECKERFRAMEWORK=$ROOT/checker-framework
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
 
 fi
 

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -48,13 +48,6 @@ fi
 # subsequent command to build it except to test building it.
 
 set -e
-if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
-  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
-  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
-  export CHECKERFRAMEWORK=$ROOT/checker-framework
-  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
-fi
 
 if [[ "${GROUP}" == "all-tests" || "${GROUP}" == "all" ]]; then
   ./gradlew allTests
@@ -115,6 +108,12 @@ if [[ "${GROUP}" == "downstream" || "${GROUP}" == "all" ]]; then
   # Travis hangs if enabled without Android installation).
   # (cd .. && git clone --depth 1 https://github.com/${SLUGOWNER}/sparta.git)
   # (cd ../sparta && ant jar all-tests)
+
+  echo "Running:  (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  (cd .. && git clone https://github.com/typetools/guava.git) || (cd .. && git clone https://github.com/typetools/guava.git)
+  echo "... done: (cd .. && git clone --depth 1 https://github.com/typetools/guava.git)"
+  export CHECKERFRAMEWORK=$ROOT/checker-framework
+  (cd $ROOT/guava/guava && mvn compile -P checkerframework-local -Dcheckerframework.checkers=org.checkerframework.checker.nullness.NullnessChecker)
 
 fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ env:
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
+    - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=plume-lib
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=all-tests
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=jdk.jar
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=downstream
+#TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=plume-lib
     - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
 
 # The "docker run" command will pull if needed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,11 @@ env:
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
+    - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=inference
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=all-tests
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=jdk.jar
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=downstream
+#TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=inference
     - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
 
 # The "docker run" command will pull if needed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,9 @@ env:
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=all-tests
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=jdk.jar
     - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=downstream
-    - BUILDJDK=downloadjdk JDKVER=jdk8 GROUP=inference
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=all-tests
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=jdk.jar
 #TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=downstream
-#TODO    - BUILDJDK=downloadjdk JDKVER=jdk9 GROUP=inference
     - BUILDJDK=downloadjdk JDKVER=jdkany GROUP=misc
 
 # The "docker run" command will pull if needed.


### PR DESCRIPTION
Plus move plume-lib to it's own job.   Adding Guava to the "downstream" test build makes it too close to the limit.  I could move everything in the "misc" build to the "all-tests" build if we want to stick with 4 builds.