### PR TITLE
Fixes failing jtreg test

### DIFF
--- a/checker/jtreg/multipleexecutions/Main.java
+++ b/checker/jtreg/multipleexecutions/Main.java
@@ -47,7 +47,12 @@ public class Main {
                                 "../../dist/checker.jar",
                                 "-proc:only",
                                 "-AprintErrorStack",
-                                "-AprintAllQualifiers"),
+                                "-AprintAllQualifiers",
+                                "-source",
+                                "8",
+                                "-target",
+                                "8",
+                                "-Xlint:-options"),
                         null,
                         fileManager.getJavaFileObjects(testfile));
         task.setProcessors(Arrays.asList(new RegexChecker()));


### PR DESCRIPTION
The test 'multipleexecutions/Main.java' failed when running './gradlew jtreg' on the https://github.com/eisop/checker-framework
This fork of typetools uses Java 9 javac.
This pull request solves this issue. 