### PR TITLE
[Index Checker] Add offsets to SameLen

### DIFF
--- a/checker/jtreg/sortwarnings/OrderOfCheckers.out
+++ b/checker/jtreg/sortwarnings/OrderOfCheckers.out
@@ -5,7 +5,7 @@ OrderOfCheckers.java:12:99: compiler.err.proc.messager: [[all, index, searchinde
 found   : @SearchIndexUnknown int @SearchIndexUnknown []
 required: @SearchIndexBottom int @SearchIndexUnknown []
 OrderOfCheckers.java:12:99: compiler.err.proc.messager: [[all, index, samelen]:assignment.type.incompatible] incompatible types in assignment.
-found   : @SameLenUnknown int @SameLen("y") []
+found   : @SameLenUnknown int @SameLen(value="y", offset="0") []
 required: @SameLenUnknown int @SameLenBottom []
 OrderOfCheckers.java:12:99: compiler.err.proc.messager: [[all, index, lowerbound]:assignment.type.incompatible] incompatible types in assignment.
 found   : @LowerBoundUnknown int @LowerBoundUnknown []

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
@@ -18,4 +18,18 @@ public @interface SameLen {
     /** A list of other sequences with the same length. */
     @JavaExpression
     String[] value();
+
+    /**
+     * When an index for the value[i] is added to offset[i], then the resulting expression is an
+     * index for the array that is annotated with this SameLen annotation. The {@code offset}
+     * element must ether be empty or the same length as {@code value}. These offets work exactly
+     * like those in {@link LTLengthOf}. The default value for the offset is "0", meaning that the
+     * length of the annotated array is exactly the length the arrays listed in the value
+     * expressions.
+     *
+     * <p>The expressions in {@code offset} may be addition/subtraction of any number of Java
+     * expressions. For example, {@code @SameLen(value = "a", offset = "x + y + 2"}}.
+     */
+    @JavaExpression
+    String[] offset() default {};
 }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -166,10 +166,11 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror anm = atm.getAnnotation(SameLen.class);
                 if (anm != null) {
                     SameLenQualifier slq = SameLenQualifier.of(anm);
-                    if (slq.remove(varName)) {
+                    if (!slq.canRemove(varName)) {
                         atm.replaceAnnotation(UNKNOWN);
                     } else {
-                        atm.replaceAnnotation(slq.convertToAnnotation(processingEnv));
+                        atm.replaceAnnotation(
+                                slq.remove(varName).convertToAnnotation(processingEnv));
                     }
                 }
             }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenQualifier.java
@@ -210,35 +210,36 @@ public class SameLenQualifier {
 
     /**
      * Determines whether it is possible to remove the given sequence's mapping and still have a
-     * valid SameLenQualifier.
+     * valid SameLenQualifier. Will return false if the only sequence mapped in this qualifier is
+     * the passed sequence, and true otherwise.
      */
     public boolean canRemove(String sequence) {
-        return offsets.keySet().contains(sequence) && offsets.keySet().size() == 1;
+        return !(offsets.keySet().size() == 1 && offsets.keySet().contains(sequence));
     }
 
     /**
      * Returns a new SameLenQualifier with the mapping for the given sequence removed.
      *
+     * <p>If the given sequence is unmapped, returns this qualifier (not a copy).
+     *
      * <p>Note that you should always call canRemove(sequence) before calling this method. If
      * canRemove returns false, this method is guaranteed to throw an UnsupportedOperationException.
      */
     public SameLenQualifier remove(String sequence) {
-        if (!offsets.keySet().contains(sequence)) {
-            throw new UnsupportedOperationException(
-                    "cannot remove "
-                            + sequence
-                            + " from SameLenQualifier, because it is not mapped.");
-        } else if (!canRemove(sequence)) {
+        if (!canRemove(sequence)) {
             throw new UnsupportedOperationException(
                     "cannot remove "
                             + sequence
                             + " from SameLenQualifier, because it is the only mapped sequence");
+        } else if (!offsets.keySet().contains(sequence)) {
+            return this;
         } else {
             List<String> sequences =
                     offsets.keySet()
                             .stream()
                             .filter(seq -> !seq.equals(sequence))
                             .collect(Collectors.toList());
+
             List<String> newOffsets =
                     sequences
                             .stream()
@@ -249,8 +250,8 @@ public class SameLenQualifier {
     }
 
     /** Returns a list of all the strings mapped by this qualifier. */
-    public List<String> getAllArrays() {
-        return new ArrayList<>(offsets.keySet());
+    public Iterable<? extends String> getSequences() {
+        return offsets.keySet();
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenQualifier.java
@@ -1,0 +1,208 @@
+package org.checkerframework.checker.index.samelen;
+
+import static org.checkerframework.checker.index.IndexUtil.getValueOfAnnotationWithStringArgument;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.checker.index.qual.SameLen;
+import org.checkerframework.checker.index.upperbound.OffsetEquation;
+import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.AnnotationUtils;
+
+/** Analogue of {@link org.checkerframework.checker.index.upperbound.UBQualifier} for SameLen. */
+public class SameLenQualifier {
+    private final Map<String, OffsetEquation> offsets;
+    private final List<String> sequences;
+
+    /**
+     * Produces a SameLen qualifier with the given list of sequences and offsets. The lists must
+     * either be the same length, or the second list must be empty (in which case it is populated
+     * with all zeroes).
+     *
+     * <p>May return null if the sequence list is empty.
+     */
+    public static SameLenQualifier of(List<String> sequenceList, List<String> offsetList) {
+        if (sequenceList.size() == 0) {
+            return null;
+        }
+        if (offsetList.size() == 0) {
+            offsetList = Collections.nCopies(sequenceList.size(), "0");
+        }
+        return new SameLenQualifier(sequenceList, offsetList);
+    }
+
+    /** Produces a SameLen qualifier with the given list of sequences. */
+    public static SameLenQualifier of(List<String> sequenceList) {
+        return of(sequenceList, Collections.nCopies(sequenceList.size(), "0"));
+    }
+
+    /** Produces a SameLen qualifier with the given sequence. */
+    public static SameLenQualifier of(String sequence) {
+        return of(Collections.singletonList(sequence));
+    }
+
+    /**
+     * Produces a SameLen qualifier from the given annotation mirror. If the annotation mirror is
+     * not an instance of {@link SameLen}, this method will throw an exception.
+     */
+    public static SameLenQualifier of(AnnotationMirror annotationMirror) {
+        if (AnnotationUtils.areSameByClass(annotationMirror, SameLen.class)) {
+            List<String> offsets =
+                    AnnotationUtils.getElementValueArray(
+                            annotationMirror, "offset", String.class, true);
+            return of(getValueOfAnnotationWithStringArgument(annotationMirror), offsets);
+        } else {
+            throw new UnsupportedOperationException(
+                    "cannot convert to SameLenQualifier from non-SameLen annotation"
+                            + annotationMirror.toString());
+        }
+    }
+
+    private SameLenQualifier(List<String> sequenceList, List<String> offsetList) {
+        assert sequenceList.size() == offsetList.size();
+        assert sequenceList.size() != 0;
+        sequences = sequenceList;
+        offsets = new HashMap<>();
+        for (int i = 0; i < sequenceList.size(); i++) {
+            String sequence = sequenceList.get(i);
+            String offset = offsetList.get(i);
+            offsets.put(sequence, OffsetEquation.createOffsetFromJavaExpression(offset));
+        }
+    }
+
+    /**
+     * Returns the AnnotationMirror that represents this qualifier.
+     *
+     * <p>The returned annotation is canonicalized by sorting its arguments by sequence and then
+     * offset. This is so that {@link AnnotationUtils#areSame(AnnotationMirror, AnnotationMirror)}
+     * returns true for equivalent annotations.
+     *
+     * @param env a processing environment used to build the returned annotation
+     * @return the AnnotationMirror that represents this qualifier
+     */
+    public AnnotationMirror convertToAnnotation(ProcessingEnvironment env) {
+        Collections.sort(sequences);
+        List<String> offset =
+                sequences
+                        .stream()
+                        .map(sequence -> offsets.get(sequence).toString())
+                        .collect(Collectors.toList());
+        AnnotationBuilder builder = new AnnotationBuilder(env, SameLen.class);
+        builder.setValue("value", sequences);
+        builder.setValue("offset", offset);
+        return builder.build();
+    }
+
+    /** @return The list of sequences with an offset of zero. */
+    public List<String> sameLenArrays() {
+        return sameLenArrays("0");
+    }
+
+    /** @return The list of sequences with an offset of the given string. */
+    public List<String> sameLenArrays(String s) {
+        List<String> result =
+                sequences
+                        .stream()
+                        .filter(sequence -> offsets.get(sequence).toString().equals(s))
+                        .collect(Collectors.toList());
+        return result;
+    }
+
+    /**
+     * Returns true iff the given offset plus the value of the offset in this SameLen equation equal
+     * zero.
+     */
+    public boolean isSameLenByOffset(String sequence, OffsetEquation offset) {
+        return offset == null || !offsets.containsKey(sequence)
+                ? false
+                : offset.copyAdd('+', offsets.get(sequence)).equals(OffsetEquation.ZERO);
+    }
+
+    /** Returns true iff every sequence in the superType has the same offset in this qualifier. */
+    public boolean isSubtype(SameLenQualifier superType) {
+        for (String superArray : superType.sequences) {
+            if (!superType.offsets.get(superArray).equals(offsets.get(superArray))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * If the set of sequences in other and in this qualifier are disjoint, returns unknown.
+     *
+     * <p>Otherwise, returns a new SameLenQualifier with the intersection of the two. Unknown is
+     * also returned if the same sequence has different offsets in the two qualifiers.
+     */
+    public AnnotationMirror lub(
+            SameLenQualifier other, AnnotationMirror unknown, ProcessingEnvironment env) {
+        if (!Collections.disjoint(this.sequences, other.sequences)) {
+            List<String> intersection = new ArrayList<>();
+            intersection.addAll(sequences);
+            intersection.retainAll(other.sequences);
+            List<String> intersectionOffsets = new ArrayList<>();
+            for (String sequence : intersection) {
+                if (offsets.get(sequence).equals(other.offsets.get(sequence))) {
+                    intersectionOffsets.add(offsets.get(sequence).toString());
+                } else {
+                    return unknown;
+                }
+            }
+            return of(intersection, intersectionOffsets).convertToAnnotation(env);
+        } else {
+            return unknown;
+        }
+    }
+
+    /**
+     * If the sequences are disjoint, returns bottom. Otherwise, returns the a combined SameLen
+     * qualifier.
+     */
+    public AnnotationMirror glb(
+            SameLenQualifier other, AnnotationMirror bottom, ProcessingEnvironment env) {
+        if (!Collections.disjoint(sequences, other.sequences)) {
+            return this.combine(other).convertToAnnotation(env);
+        } else {
+            return bottom;
+        }
+    }
+
+    /**
+     * Produces a new SameLenQualifier with the union of this qualifier and the argument.
+     *
+     * <p>If the two qualifiers have different offsets for the same array, this function's behavior
+     * is undefined.
+     */
+    public SameLenQualifier combine(SameLenQualifier other) {
+        Set<String> union = new HashSet<>();
+        union.addAll(sequences);
+        union.addAll(other.sequences);
+        List<String> unionOffsets = new ArrayList<>();
+        for (String sequence : union) {
+            if (offsets.containsKey(sequence) && other.offsets.containsKey(sequence)) {
+                assert offsets.get(sequence).equals(other.offsets.get(sequence));
+            }
+            if (offsets.containsKey(sequence)) {
+                unionOffsets.add(offsets.get(sequence).toString());
+            } else if (other.offsets.containsKey(sequence)) {
+                unionOffsets.add(other.offsets.get(sequence).toString());
+            } else {
+                assert false : "could not find an offset for sequence " + sequence;
+            }
+        }
+        assert union.size() == unionOffsets.size()
+                : "union and unionOffsets have different sizes"
+                        + union.toString()
+                        + " \nand\n "
+                        + unionOffsets.toString();
+        return of(new ArrayList<>(union), unionOffsets);
+    }
+}

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -150,7 +150,7 @@ public class SameLenTransfer extends CFTransfer {
         if (currentPath == null) {
             return;
         }
-        for (String s : IndexUtil.getValueOfAnnotationWithStringArgument(combinedSameLen)) {
+        for (String s : SameLenQualifier.of(combinedSameLen).sameLenArrays()) {
             Receiver recS;
             try {
                 recS = aTypeFactory.getReceiverFromJavaExpressionString(s, currentPath);

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenVisitor.java
@@ -2,8 +2,7 @@ package org.checkerframework.checker.index.samelen;
 
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.index.IndexUtil;
@@ -37,16 +36,11 @@ public class SameLenVisitor extends BaseTypeVisitor<SameLenAnnotatedTypeFactory>
                         && varType.hasAnnotation(PolySameLen.class))) {
 
             AnnotationMirror am = valueType.getAnnotation(SameLen.class);
-            List<String> arraysInAnno =
-                    am == null
-                            ? new ArrayList<>()
-                            : IndexUtil.getValueOfAnnotationWithStringArgument(am);
-
             Receiver rec = FlowExpressions.internalReprOf(atypeFactory, (ExpressionTree) valueTree);
             if (rec != null && SameLenAnnotatedTypeFactory.shouldUseInAnnotation(rec)) {
-                List<String> names = new ArrayList<>();
-                names.add(rec.toString());
-                AnnotationMirror newSameLen = atypeFactory.getCombinedSameLen(arraysInAnno, names);
+                AnnotationMirror newSameLen =
+                        atypeFactory.createCombinedSameLen(
+                                Collections.singletonList(rec), Collections.singletonList(am));
                 valueType.replaceAnnotation(newSameLen);
             }
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.qual.LTEqLengthOf;
@@ -855,13 +854,8 @@ public abstract class UBQualifier {
                     continue;
                 }
 
-                OffsetEquation sameLenOffset = slq.get(replacementSequence);
-
                 Set<OffsetEquation> otherOffsetsMapped =
-                        otherOffsets
-                                .stream()
-                                .map(otherOffset -> sameLenOffset.copyAdd('+', otherOffset))
-                                .collect(Collectors.toSet());
+                        slq.addOffsetToAll(replacementSequence, otherOffsets);
 
                 isValid = isValid || containsSame(offsets, otherOffsetsMapped);
             }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -17,6 +17,7 @@ import org.checkerframework.checker.index.qual.PolyUpperBound;
 import org.checkerframework.checker.index.qual.SubstringIndexFor;
 import org.checkerframework.checker.index.qual.UpperBoundBottom;
 import org.checkerframework.checker.index.qual.UpperBoundUnknown;
+import org.checkerframework.checker.index.samelen.SameLenQualifier;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationBuilder;
@@ -188,11 +189,11 @@ public abstract class UBQualifier {
     /**
      * Is the value with this qualifier less than the length of any of the sequences?
      *
-     * @param sequences list of sequences
+     * @param slq a SameLen type representing the sequences
      * @return whether or not the value with this qualifier is less than the length of any of the
      *     sequences
      */
-    public boolean isLessThanLengthOfAny(List<String> sequences) {
+    public boolean isLessThanLengthOfAny(SameLenQualifier slq) {
         return false;
     }
 
@@ -249,18 +250,21 @@ public abstract class UBQualifier {
         /**
          * Is a value with this type less than the length of any of the sequences?
          *
-         * @param sequences list of sequences
+         * @param slq A SameLen qualifier representing the sequences with their associated offsets
          * @return true if a value with this type is less than the length of any of the sequences
          */
         @Override
-        public boolean isLessThanLengthOfAny(List<String> sequences) {
-            for (String sequence : sequences) {
-                if (isLessThanLengthOf(sequence)) {
-                    return true;
+        public boolean isLessThanLengthOfAny(SameLenQualifier slq) {
+            for (String sequence : map.keySet()) {
+                for (OffsetEquation offset : map.get(sequence)) {
+                    if (slq.isSameLenByOffset(sequence, offset)) {
+                        return true;
+                    }
                 }
             }
             return false;
         }
+
         /**
          * Is a value with this type less than the length of the sequence?
          *

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -843,7 +843,7 @@ public abstract class UBQualifier {
 
             boolean isValid = false;
 
-            for (String replacementSequence : slq.getAllArrays()) {
+            for (String replacementSequence : slq.getSequences()) {
 
                 Set<OffsetEquation> offsets = map.get(sequence);
                 if (offsets == null) {

--- a/checker/tests/index/GuavaPrimitives.java
+++ b/checker/tests/index/GuavaPrimitives.java
@@ -1,0 +1,128 @@
+import java.util.Collections;
+import java.util.List;
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+import org.checkerframework.checker.index.qual.IndexOrLow;
+import org.checkerframework.checker.index.qual.LTLengthOf;
+import org.checkerframework.checker.index.qual.LessThan;
+import org.checkerframework.checker.index.qual.Positive;
+import org.checkerframework.checker.index.qual.SameLen;
+import org.checkerframework.common.value.qual.MinLen;
+
+/**
+ * A simplified version of the Guava primitives classes (such as Bytes, Longs, Shorts, etc.) with
+ * all expected warnings suppressed.
+ */
+public class GuavaPrimitives {
+    final short @MinLen(1) @SameLen(value = "this", offset = "this.start") [] array;
+    final @IndexOrHigh("array") @LessThan("this.end") int start;
+    final @IndexOrHigh("array") int end;
+
+    public static @IndexOrLow("#1") int indexOf(short[] array, short target) {
+        return indexOf(array, target, 0, array.length);
+    }
+
+    private static @IndexOrLow("#1") int indexOf(
+            short[] array, short target, @IndexOrHigh("#1") int start, @IndexOrHigh("#1") int end) {
+        for (int i = start; i < end; i++) {
+            if (array[i] == target) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public static @IndexOrLow("#1") int lastIndexOf(short[] array, short target) {
+        return lastIndexOf(array, target, 0, array.length);
+    }
+
+    private static @IndexOrLow("#1") int lastIndexOf(
+            short[] array, short target, @IndexOrHigh("#1") int start, @IndexOrHigh("#1") int end) {
+        for (int i = end - 1; i >= start; i--) {
+            if (array[i] == target) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    @SuppressWarnings(
+            "lessthan:argument.type.incompatible") // https://github.com/kelloggm/checker-framework/issues/225
+    GuavaPrimitives(short @MinLen(1) [] bar) {
+        this(bar, 0, bar.length);
+    }
+
+    @SuppressWarnings(
+            "samelen:assignment.type.incompatible") // https://github.com/kelloggm/checker-framework/issues/213
+    GuavaPrimitives(
+            short @MinLen(1) [] array,
+            @IndexOrHigh("#1") @LessThan("this.end") int start,
+            @IndexOrHigh("#1") int end) {
+        this.array = array;
+        this.start = start;
+        this.end = end;
+    }
+
+    @SuppressWarnings({"upperbound:return.type.incompatible"}) // custom coll. with size end-start
+    public @Positive @LTLengthOf(
+        value = {"this", "array"},
+        offset = {"0", "start - 1"}
+    ) int size() { // INDEX: Annotation on a public method refers to private member.
+        return end - start;
+    }
+
+    public boolean isEmpty() {
+        return false;
+    }
+
+    public Short get(@IndexFor("this") int index) {
+        return array[start + index];
+    }
+
+    @SuppressWarnings({
+        "lowerbound:return.type.incompatible", // custom coll. with size end-start: indexOf returns a value that is greater than its third argument
+        "upperbound:return.type.incompatible"
+    }) // SameLen with offsets is not reflexive
+    public @IndexOrLow("this") int indexOf(Object target) {
+        // Overridden to prevent a ton of boxing
+        if (target instanceof Short) {
+            int i = GuavaPrimitives.indexOf(array, (Short) target, start, end);
+            if (i >= 0) {
+                return i - start;
+            }
+        }
+        return -1;
+    }
+
+    @SuppressWarnings({
+        "lowerbound:return.type.incompatible", // custom coll. with size end-start: indexOf returns a value that is greater than its third argument
+        "upperbound:return.type.incompatible"
+    }) // SameLen with offsets is not reflexive
+    public @IndexOrLow("this") int lastIndexOf(Object target) {
+        // Overridden to prevent a ton of boxing
+        if (target instanceof Short) {
+            int i = GuavaPrimitives.lastIndexOf(array, (Short) target, start, end);
+            if (i >= 0) {
+                return i - start;
+            }
+        }
+        return -1;
+    }
+
+    public Short set(@IndexFor("this") int index, Short element) {
+        short oldValue = array[start + index];
+        // checkNotNull for GWT (do not optimize)
+        array[start + index] = element;
+        return oldValue;
+    }
+
+    public List<Short> subList(
+            @IndexOrHigh("this") @LessThan("#2") int fromIndex, @IndexOrHigh("this") int toIndex) {
+        int size = size();
+        if (fromIndex == toIndex) {
+            return Collections.emptyList();
+        }
+        GuavaPrimitives g = new GuavaPrimitives(array, start + fromIndex, start + toIndex);
+        return null;
+    }
+}

--- a/checker/tests/index/SameLenOffsetSubtyping.java
+++ b/checker/tests/index/SameLenOffsetSubtyping.java
@@ -11,13 +11,13 @@ public class SameLenOffsetSubtyping {
                         )
                         []
                 d = b;
-        // :: error: (assignment.type.incompatible)
         int
                         @SameLen(
                             value = {"a", "b"},
                             offset = {"0", "c"}
                         )
                         []
+                // :: error: (assignment.type.incompatible)
                 e = b;
         int
                         @SameLen(
@@ -26,13 +26,13 @@ public class SameLenOffsetSubtyping {
                         )
                         []
                 f = b;
-        // :: error: (assignment.type.incompatible)
         int
                         @SameLen(
                             value = {"a"},
                             offset = {"0"}
                         )
                         []
+                // :: error: (assignment.type.incompatible)
                 g = b;
     }
 
@@ -56,22 +56,22 @@ public class SameLenOffsetSubtyping {
                         []
                 f = d;
 
-        // :: error: (assignment.type.incompatible)
         int
                         @SameLen(
                             value = {"a", "b", "d"},
                             offset = {"0", "0", "0"}
                         )
                         []
+                // :: error: (assignment.type.incompatible)
                 g = b;
 
-        // :: error: (assignment.type.incompatible)
         int
                         @SameLen(
                             value = {"a", "b", "d"},
                             offset = {"0", "0", "0"}
                         )
                         []
+                // :: error: (assignment.type.incompatible)
                 h = d;
     }
 

--- a/checker/tests/index/SameLenOffsetSubtyping.java
+++ b/checker/tests/index/SameLenOffsetSubtyping.java
@@ -1,0 +1,117 @@
+// Test case for SameLen subtyping and assignment
+
+import org.checkerframework.checker.index.qual.SameLen;
+
+public class SameLenOffsetSubtyping {
+    void foo(int[] a, int @SameLen(value = "#1", offset = "#3") [] b, int c) {
+        int
+                        @SameLen(
+                            value = {"a", "b"},
+                            offset = {"c", "0"}
+                        )
+                        []
+                d = b;
+        // :: error: (assignment.type.incompatible)
+        int
+                        @SameLen(
+                            value = {"a", "b"},
+                            offset = {"0", "c"}
+                        )
+                        []
+                e = b;
+        int
+                        @SameLen(
+                            value = {"a"},
+                            offset = {"c"}
+                        )
+                        []
+                f = b;
+        // :: error: (assignment.type.incompatible)
+        int
+                        @SameLen(
+                            value = {"a"},
+                            offset = {"0"}
+                        )
+                        []
+                g = b;
+    }
+
+    void foo2(
+            int[] a,
+            int @SameLen(value = "#1", offset = "#3") [] b,
+            int c,
+            int @SameLen(value = "#1", offset = "#3") [] d) {
+        int
+                        @SameLen(
+                            value = {"a", "b"},
+                            offset = {"c", "0"}
+                        )
+                        []
+                e = b;
+        int
+                        @SameLen(
+                            value = {"a", "d"},
+                            offset = {"c", "0"}
+                        )
+                        []
+                f = d;
+
+        // :: error: (assignment.type.incompatible)
+        int
+                        @SameLen(
+                            value = {"a", "b", "d"},
+                            offset = {"0", "0", "0"}
+                        )
+                        []
+                g = b;
+
+        // :: error: (assignment.type.incompatible)
+        int
+                        @SameLen(
+                            value = {"a", "b", "d"},
+                            offset = {"0", "0", "0"}
+                        )
+                        []
+                h = d;
+    }
+
+    void lubTest(int[] a, int @SameLen(value = "#1", offset = "#3") [] b, int c) {
+        int[] d;
+        if (c == 10) {
+            d = b;
+        } else {
+            d = a;
+        }
+
+        // :: error: (assignment.type.incompatible)
+        int @SameLen("a") [] e = d;
+
+        // :: error: (assignment.type.incompatible)
+        int @SameLen("b") [] f = d;
+
+        // :: error: (assignment.type.incompatible)
+        int @SameLen(value = "a", offset = "c") [] g = d;
+    }
+
+    void lubTest2(
+            int[] a,
+            int @SameLen(value = "#1", offset = "#3") [] b,
+            int c,
+            int @SameLen(value = "#1", offset = "#3") [] d) {
+        int[] e;
+        if (c == 10) {
+            e = b;
+        } else {
+            e = d;
+        }
+
+        // :: error: (assignment.type.incompatible)
+        int @SameLen("a") [] f = e;
+
+        int @SameLen(value = "a", offset = "c") [] h = d;
+
+        int @SameLen(value = "a", offset = "c") [] j = b;
+
+        int @SameLen(value = "a", offset = "c") [] k = e;
+    }
+}

--- a/checker/tests/index/SameLenOffsets.java
+++ b/checker/tests/index/SameLenOffsets.java
@@ -1,23 +1,43 @@
-// This class is a test case for the custom collections in Guava with a start and end variable and a backing array.
+// This class is a basic test case for SameLen with offsets. A more complete test case is in GuavaPrimitives.java.
 
 import org.checkerframework.checker.index.qual.IndexFor;
-import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.IndexOrHigh;
+import org.checkerframework.checker.index.qual.IndexOrLow;
+import org.checkerframework.checker.index.qual.LessThan;
 import org.checkerframework.checker.index.qual.SameLen;
 
 class SameLenOffsets {
 
-    @NonNegative int start;
+    @IndexOrHigh("a") @LessThan("end + 1")
+    int start;
 
-    int @SameLen(value = "this", offset = "this.start") [] a;
+    @IndexOrHigh("a") int end;
 
-    public SameLenOffsets(int[] a1, @NonNegative int start1) {
-        // the following line is the expected error
+    int
+                    @SameLen(
+                        value = {"this", "this"},
+                        offset = {"0", "this.start"}
+                    )
+                    []
+            a;
+
+    public SameLenOffsets(int[] a1) {
+        // the following line is the expected error when dealing with custom collections
         // :: error: (assignment.type.incompatible)
         a = a1;
-        start = start1;
     }
 
     public int get(@IndexFor("this") int index) {
         return a[start + index];
+    }
+
+    private static @IndexOrLow("#1") int indexOf(
+            int[] array, int target, @IndexOrHigh("#1") int start, @IndexOrHigh("#1") int end) {
+        for (int i = start; i < end; i++) {
+            if (array[i] == target) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/checker/tests/index/SameLenOffsets.java
+++ b/checker/tests/index/SameLenOffsets.java
@@ -1,0 +1,23 @@
+// This class is a test case for the custom collections in Guava with a start and end variable and a backing array.
+
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.index.qual.SameLen;
+
+class SameLenOffsets {
+
+    @NonNegative int start;
+
+    int @SameLen(value = "this", offset = "this.start") [] a;
+
+    public SameLenOffsets(int[] a1, @NonNegative int start1) {
+        // the following line is the expected error
+        // :: error: (assignment.type.incompatible)
+        a = a1;
+        start = start1;
+    }
+
+    public int get(@IndexFor("this") int index) {
+        return a[start + index];
+    }
+}

--- a/docs/manual/index-checker.tex
+++ b/docs/manual/index-checker.tex
@@ -451,7 +451,7 @@ like the following:
 When needed, you can specify which sequences have the same length using the following type qualifiers (Figure~\ref{fig-index-array-types}):
 
 \begin{description}
-\item[\refqualclasswithparams{checker/index/qual}{SameLen}{String[] names}]
+\item[\refqualclasswithparams{checker/index/qual}{SameLen}{String[] names, String[] offset}]
   An expression with this type represents a sequence that has the
   same length as the other sequences named in \<names>. In general,
   \code{@SameLen} types that have non-intersecting sets of names
@@ -471,6 +471,13 @@ When needed, you can specify which sequences have the same length using the foll
   \code{null} has this type.
 \end{description}
 
+\code{@SameLen} annotations can take an optional offset argument. If one offset is provided,
+there must be exactly as many offsets as sequence names. If no offsets are provided, then
+it is assumed that the offsets are zero. A \code{@SameLen} annotation on a sequence $s$ with
+a target sequence $t$ and an offset $x$ means that an expression $e$ is an index for $s$ if
+its type is exactly \code{LTLengthOf} with respect to $t$ with an offset $y$ such that $x + y = 0$.
+This relationship is not symetric and is never inferred; it is meant to be written on custom collections
+that are views of larger backing arrays.
 
 \section{Binary search indices\label{index-searchindex}}
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1431,7 +1431,6 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     // The field access is to the length field, as in "someArrayExpression.length"
                     AnnotatedTypeMirror receiverType = getAnnotatedType(tree.getExpression());
                     if (receiverType.getKind() == TypeKind.ARRAY) {
-
                         AnnotationMirror resultAnno =
                                 createArrayLengthResultAnnotation(receiverType);
                         if (resultAnno != null) {


### PR DESCRIPTION
This pull request adds offsets to `SameLen`, using the machinery of `OffsetEquation` in a manner similar to `UBQualifier` in the Upper Bound Checker.

Though offsets are never inferred for SameLen annotations (for now), they can be written and are taken into account when typechecking array accesses in the Upper Bound Checker. This will allow us to write annotations such as `@SameLen("this", "start")` on the arrays backing Guava data structures, allowing us to typecheck the actual implementations of various methods correctly with only a single suppressed warning per collection. This *should* reduce the number of false positives in Guava by ~40, though I haven't yet run those tests (I will on Monday).

Inference of these offsets should be possible in the future, allowing us to handle all the cases in kelloggm#158. This pull request lays the foundation for that.