### PR TITLE
Move some methods of SignednessUtil to new class

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtil.java
@@ -10,7 +10,9 @@ import org.checkerframework.checker.signedness.qual.Unsigned;
 /**
  * Provides static utility methods for unsigned values. Some re-implement functionality in JDK 8,
  * making it available in earlier versions of Java. Others provide new functionality. {@link
- * SignednessUtilExtra} has more methods that reference
+ * SignednessUtilExtra} has more methods that reference packages that Android does not provide.
+ *
+ * @checker_framework.manual #signedness-utilities Utility routines for manipulating unsigned values
  */
 public final class SignednessUtil {
 

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtil.java
@@ -1,7 +1,5 @@
 package org.checkerframework.checker.signedness;
 
-import java.awt.Dimension;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
@@ -11,24 +9,13 @@ import org.checkerframework.checker.signedness.qual.Unsigned;
 
 /**
  * Provides static utility methods for unsigned values. Some re-implement functionality in JDK 8,
- * making it available in earlier versions of Java. Others provide new functionality.
+ * making it available in earlier versions of Java. Others provide new functionality. {@link
+ * SignednessUtilExtra} has more methods that reference
  */
 public final class SignednessUtil {
 
     private SignednessUtil() {
         throw new Error("Do not instantiate");
-    }
-
-    /** Gets the unsigned width of a {@code Dimension}. */
-    @SuppressWarnings("signedness")
-    public static @Unsigned int dimensionUnsignedWidth(Dimension dim) {
-        return dim.width;
-    }
-
-    /** Gets the unsigned height of a {@code Dimension}. */
-    @SuppressWarnings("signedness")
-    public static @Unsigned int dimensionUnsignedHeight(Dimension dim) {
-        return dim.height;
     }
 
     /**
@@ -219,42 +206,6 @@ public final class SignednessUtil {
     @SuppressWarnings("signedness")
     public static ByteBuffer putUnsignedLong(ByteBuffer b, int i, @Unsigned long ulong) {
         return b.putLong(i, ulong);
-    }
-
-    /**
-     * Sets rgb of BufferedImage b given unsigned ints. This method is a wrapper around {@link
-     * java.awt.image.BufferedImage#setRGB(int, int, int, int, int[], int, int) setRGB(int, int,
-     * int, int, int[], int, int)}, but assumes that the input should be interpreted as unsigned.
-     */
-    @SuppressWarnings("signedness")
-    public static void setUnsignedRGB(
-            BufferedImage b,
-            int startX,
-            int startY,
-            int w,
-            int h,
-            @Unsigned int[] rgbArray,
-            int offset,
-            int scansize) {
-        b.setRGB(startX, startY, w, h, rgbArray, offset, scansize);
-    }
-
-    /**
-     * Gets rgb of BufferedImage b as unsigned ints. This method is a wrapper around {@link
-     * java.awt.image.BufferedImage#getRGB(int, int, int, int, int[], int, int) getRGB(int, int,
-     * int, int, int[], int, int)}, but assumes that the output should be interpreted as unsigned.
-     */
-    @SuppressWarnings("signedness")
-    public static @Unsigned int[] getUnsignedRGB(
-            BufferedImage b,
-            int startX,
-            int startY,
-            int w,
-            int h,
-            @Unsigned int[] rgbArray,
-            int offset,
-            int scansize) {
-        return b.getRGB(startX, startY, w, h, rgbArray, offset, scansize);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtilExtra.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtilExtra.java
@@ -1,0 +1,63 @@
+package org.checkerframework.checker.signedness;
+
+import java.awt.Dimension;
+import java.awt.image.BufferedImage;
+import org.checkerframework.checker.signedness.qual.Unsigned;
+
+/**
+ * Provides more static utility methods for unsigned values. These methods use Java packages not
+ * included in Android. {@link SignednessUtil} has more methods.
+ */
+public class SignednessUtilExtra {
+    private SignednessUtilExtra() {
+        throw new Error("Do not instantiate");
+    }
+
+    /** Gets the unsigned width of a {@code Dimension}. */
+    @SuppressWarnings("signedness")
+    public static @Unsigned int dimensionUnsignedWidth(Dimension dim) {
+        return dim.width;
+    }
+
+    /** Gets the unsigned height of a {@code Dimension}. */
+    @SuppressWarnings("signedness")
+    public static @Unsigned int dimensionUnsignedHeight(Dimension dim) {
+        return dim.height;
+    }
+
+    /**
+     * Sets rgb of BufferedImage b given unsigned ints. This method is a wrapper around {@link
+     * java.awt.image.BufferedImage#setRGB(int, int, int, int, int[], int, int) setRGB(int, int,
+     * int, int, int[], int, int)}, but assumes that the input should be interpreted as unsigned.
+     */
+    @SuppressWarnings("signedness")
+    public static void setUnsignedRGB(
+            BufferedImage b,
+            int startX,
+            int startY,
+            int w,
+            int h,
+            @Unsigned int[] rgbArray,
+            int offset,
+            int scansize) {
+        b.setRGB(startX, startY, w, h, rgbArray, offset, scansize);
+    }
+
+    /**
+     * Gets rgb of BufferedImage b as unsigned ints. This method is a wrapper around {@link
+     * java.awt.image.BufferedImage#getRGB(int, int, int, int, int[], int, int) getRGB(int, int,
+     * int, int, int[], int, int)}, but assumes that the output should be interpreted as unsigned.
+     */
+    @SuppressWarnings("signedness")
+    public static @Unsigned int[] getUnsignedRGB(
+            BufferedImage b,
+            int startX,
+            int startY,
+            int w,
+            int h,
+            @Unsigned int[] rgbArray,
+            int offset,
+            int scansize) {
+        return b.getRGB(startX, startY, w, h, rgbArray, offset, scansize);
+    }
+}

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtilExtra.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessUtilExtra.java
@@ -7,6 +7,8 @@ import org.checkerframework.checker.signedness.qual.Unsigned;
 /**
  * Provides more static utility methods for unsigned values. These methods use Java packages not
  * included in Android. {@link SignednessUtil} has more methods.
+ *
+ * @checker_framework.manual #signedness-utilities Utility routines for manipulating unsigned values
  */
 public class SignednessUtilExtra {
     private SignednessUtilExtra() {

--- a/docs/manual/signedness-checker.tex
+++ b/docs/manual/signedness-checker.tex
@@ -156,4 +156,4 @@ you need to write.
 
 Class \refclass{checker/signedness}{SignednessUtilExtra} contains more utility
 methods that reference packages not included in Android.  This class is not
-included in checker-qual.jar, so you may want to copy the methods to your code.
+included in \code{checker-qual.jar}, so you may want to copy the methods to your code.

--- a/docs/manual/signedness-checker.tex
+++ b/docs/manual/signedness-checker.tex
@@ -153,3 +153,7 @@ versions of Java.  Others provide new functionality.  All of them are
 properly annotated with \refqualclass{checker/signedness/qual}{Unsigned}
 where appropriate, so using them may reduce the number of annotations that
 you need to write.
+
+Class \refclass{checker/signedness}{SignednessUtilExtra} contains more utility
+methods that reference packages not included in Android.  This class is not
+included in checker-qual.jar, so you may want to copy the methods to your code.


### PR DESCRIPTION
Android doesn't include java.awt packages, so including references to those packages cause the Android lint tool to fail.  The only references to those packages are in SignednessUtil, so this pull request moves them to a new class that isn't included in checker-qual.jar.

Fixes #1978.