### PR TITLE
Signature checker extended

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
@@ -10,10 +10,7 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
-import org.checkerframework.checker.signature.qual.BinaryName;
-import org.checkerframework.checker.signature.qual.InternalForm;
-import org.checkerframework.checker.signature.qual.SignatureBottom;
-import org.checkerframework.checker.signature.qual.SignatureUnknown;
+import org.checkerframework.checker.signature.qual.*;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -31,6 +28,10 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     protected final AnnotationMirror SIGNATURE_UNKNOWN;
     protected final AnnotationMirror BINARY_NAME;
     protected final AnnotationMirror INTERNAL_FORM;
+    protected final AnnotationMirror FULLY_QUALIFIED_NAME;
+    protected final AnnotationMirror CLASS_GET_NAME;
+    protected final AnnotationMirror BINARY_NAME_FOR_NON_ARRAY;
+    protected final AnnotationMirror INTERNAL_FORM_FOR_NON_ARRAY;
 
     /** The {@link String#replace(char, char)} method. */
     private final ExecutableElement replaceCharChar;
@@ -43,6 +44,10 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         SIGNATURE_UNKNOWN = AnnotationBuilder.fromClass(elements, SignatureUnknown.class);
         BINARY_NAME = AnnotationBuilder.fromClass(elements, BinaryName.class);
         INTERNAL_FORM = AnnotationBuilder.fromClass(elements, InternalForm.class);
+        FULLY_QUALIFIED_NAME = AnnotationBuilder.fromClass(elements, FullyQualifiedName.class);
+        CLASS_GET_NAME = AnnotationBuilder.fromClass(elements, ClassGetName.class);
+        BINARY_NAME_FOR_NON_ARRAY = AnnotationBuilder.fromClass(elements, BinaryNameForNonArray.class);
+        INTERNAL_FORM_FOR_NON_ARRAY = AnnotationBuilder.fromClass(elements, InternalFormForNonArray.class);
 
         replaceCharChar =
                 TreeUtils.getMethod(
@@ -105,24 +110,15 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public Void visitMethodInvocation(MethodInvocationTree tree, AnnotatedTypeMirror type) {
+            char c1 = ' ';
+            char c2 = ' ';
             if (TreeUtils.isMethodInvocation(tree, replaceCharChar, processingEnv)) {
                 ExpressionTree arg0 = tree.getArguments().get(0);
                 ExpressionTree arg1 = tree.getArguments().get(1);
                 if (arg0.getKind() == Tree.Kind.CHAR_LITERAL
                         && arg1.getKind() == Tree.Kind.CHAR_LITERAL) {
-                    char const0 = (char) ((LiteralTree) arg0).getValue();
-                    char const1 = (char) ((LiteralTree) arg1).getValue();
-                    ExpressionTree receiver = TreeUtils.getReceiverTree(tree);
-                    final AnnotatedTypeMirror receiverType = getAnnotatedType(receiver);
-                    if (const0 == '.'
-                            && const1 == '/'
-                            && receiverType.getAnnotation(BinaryName.class) != null) {
-                        type.replaceAnnotation(INTERNAL_FORM);
-                    } else if (const0 == '/'
-                            && const1 == '.'
-                            && receiverType.getAnnotation(InternalForm.class) != null) {
-                        type.replaceAnnotation(BINARY_NAME);
-                    }
+                    c1 = (char) ((LiteralTree) arg0).getValue();
+                    c2 = (char) ((LiteralTree) arg1).getValue();
                 }
             } else if (TreeUtils.isMethodInvocation(
                     tree, replaceCharSequenceCharSequence, processingEnv)) {
@@ -132,20 +128,50 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         && arg1.getKind() == Tree.Kind.STRING_LITERAL) {
                     String const0 = (String) ((LiteralTree) arg0).getValue();
                     String const1 = (String) ((LiteralTree) arg1).getValue();
-                    ExpressionTree receiver = TreeUtils.getReceiverTree(tree);
-                    final AnnotatedTypeMirror receiverType = getAnnotatedType(receiver);
-                    if (const0.equals(".")
-                            && const1.equals("/")
-                            && receiverType.getAnnotation(BinaryName.class) != null) {
-                        type.replaceAnnotation(INTERNAL_FORM);
-                    } else if (const0.equals("/")
-                            && const1.equals(".")
-                            && receiverType.getAnnotation(InternalForm.class) != null) {
-                        type.replaceAnnotation(BINARY_NAME);
+                    if (const0.length() == 1 && const1.length() == 1) {
+                        c1 = const0.charAt(0);
+                        c2 = const1.charAt(0);
                     }
                 }
+            } else {
+                return super.visitMethodInvocation(tree, type);
             }
+            ExpressionTree receiver = TreeUtils.getReceiverTree(tree);
+            final AnnotatedTypeMirror receiverType = getAnnotatedType(receiver);
+            if (receiverType.getAnnotation(BinaryName.class) != null){
+                handleReplaceOnBinaryName(c1, c2, type);
+            } else if (receiverType.getAnnotation(InternalForm.class) != null){
+                handleReplaceOnInternalForm(c1, c2, type);
+            } else if (receiverType.getAnnotation(InternalFormForNonArray.class) != null){
+                handleReplaceOnInternalFormForNonArray(c1, c2, type);
+            } else if (receiverType.getAnnotation(BinaryNameForNonArray.class) != null){
+                handleReplaceOnBinaryNameForNonArray(c1, c2, type);
+            } 
             return super.visitMethodInvocation(tree, type);
+        }
+
+        private void handleReplaceOnBinaryName(char c1, char c2, AnnotatedTypeMirror type) {
+            if (c1 == '.' && c2 == '/') {
+                type.replaceAnnotation(INTERNAL_FORM);
+            }
+        }
+
+        private void handleReplaceOnBinaryNameForNonArray(char c1, char c2, AnnotatedTypeMirror type) {
+            if (c1 == '.' && c2 == '/') {
+                type.replaceAnnotation(INTERNAL_FORM_FOR_NON_ARRAY);
+            }
+        }
+
+        private void handleReplaceOnInternalFormForNonArray(char c1, char c2, AnnotatedTypeMirror type) {
+            if (c1 == '/' && c2 == '.') {
+                type.replaceAnnotation(BINARY_NAME_FOR_NON_ARRAY);
+            }
+        }
+
+        private void handleReplaceOnInternalForm(char c1, char c2, AnnotatedTypeMirror type) {
+            if (c1 == '/' && c2 == '.') {
+                type.replaceAnnotation(BINARY_NAME);
+            }
         }
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
@@ -46,8 +46,10 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         INTERNAL_FORM = AnnotationBuilder.fromClass(elements, InternalForm.class);
         FULLY_QUALIFIED_NAME = AnnotationBuilder.fromClass(elements, FullyQualifiedName.class);
         CLASS_GET_NAME = AnnotationBuilder.fromClass(elements, ClassGetName.class);
-        BINARY_NAME_FOR_NON_ARRAY = AnnotationBuilder.fromClass(elements, BinaryNameForNonArray.class);
-        INTERNAL_FORM_FOR_NON_ARRAY = AnnotationBuilder.fromClass(elements, InternalFormForNonArray.class);
+        BINARY_NAME_FOR_NON_ARRAY =
+                AnnotationBuilder.fromClass(elements, BinaryNameForNonArray.class);
+        INTERNAL_FORM_FOR_NON_ARRAY =
+                AnnotationBuilder.fromClass(elements, InternalFormForNonArray.class);
 
         replaceCharChar =
                 TreeUtils.getMethod(
@@ -138,15 +140,15 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
             ExpressionTree receiver = TreeUtils.getReceiverTree(tree);
             final AnnotatedTypeMirror receiverType = getAnnotatedType(receiver);
-            if (receiverType.getAnnotation(BinaryName.class) != null){
+            if (receiverType.getAnnotation(BinaryName.class) != null) {
                 handleReplaceOnBinaryName(c1, c2, type);
-            } else if (receiverType.getAnnotation(InternalForm.class) != null){
+            } else if (receiverType.getAnnotation(InternalForm.class) != null) {
                 handleReplaceOnInternalForm(c1, c2, type);
-            } else if (receiverType.getAnnotation(InternalFormForNonArray.class) != null){
+            } else if (receiverType.getAnnotation(InternalFormForNonArray.class) != null) {
                 handleReplaceOnInternalFormForNonArray(c1, c2, type);
-            } else if (receiverType.getAnnotation(BinaryNameForNonArray.class) != null){
+            } else if (receiverType.getAnnotation(BinaryNameForNonArray.class) != null) {
                 handleReplaceOnBinaryNameForNonArray(c1, c2, type);
-            } 
+            }
             return super.visitMethodInvocation(tree, type);
         }
 
@@ -156,13 +158,15 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
         }
 
-        private void handleReplaceOnBinaryNameForNonArray(char c1, char c2, AnnotatedTypeMirror type) {
+        private void handleReplaceOnBinaryNameForNonArray(
+                char c1, char c2, AnnotatedTypeMirror type) {
             if (c1 == '.' && c2 == '/') {
                 type.replaceAnnotation(INTERNAL_FORM_FOR_NON_ARRAY);
             }
         }
 
-        private void handleReplaceOnInternalFormForNonArray(char c1, char c2, AnnotatedTypeMirror type) {
+        private void handleReplaceOnInternalFormForNonArray(
+                char c1, char c2, AnnotatedTypeMirror type) {
             if (c1 == '/' && c2 == '.') {
                 type.replaceAnnotation(BINARY_NAME_FOR_NON_ARRAY);
             }

--- a/checker/tests/signature/Conversion.java
+++ b/checker/tests/signature/Conversion.java
@@ -11,6 +11,14 @@ public class Conversion {
             return iform.replace('/', '.');
         }
 
+        @BinaryName String internalFormForNonArrayToBinaryName(@InternalFormForNonArray String iformna) {
+            return iformna.replace('/', '.');
+        }
+
+        @ClassGetName String internalFormForNonArrayToClassGetName(@InternalFormForNonArray String iformna) {
+            return iformna.replace('/', '.');
+        }
+
         @InternalForm String binaryNameToInternalFormWRONG1(@BinaryName String bn) {
             // :: error: (return.type.incompatible)
             return bn.replace('/', '.');


### PR DESCRIPTION
Added rules for conversion between BinaryNameForNonArray and InternalFormForNonArray, and tests for them. 

As a side note, git pre-commit hook in this repo run the google java format script by calling the python interpreter like this:

    python checker/bin-devel/.run-google-java-format/check-google-java-format.py 

The script being called is a python2 script. This above command will fail on systems which have python3 as the default(arch linux). The script is executable and it should specify the required python version with a hashbang. (https://github.com/plume-lib/run-google-java-format/pull/6). So it would be better to execute the script directly in pre-commit hook like this:

    ./checker/bin-devel/.run-google-java-format/check-google-java-format.py 

 