### PR TITLE
 Don't issue Lower Bound Checker Warnings on List and other classes.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundChecker.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.lowerbound;
 
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import org.checkerframework.checker.index.inequality.LessThanChecker;
 import org.checkerframework.checker.index.searchindex.SearchIndexChecker;
@@ -15,6 +16,25 @@ import org.checkerframework.framework.source.SuppressWarningsKeys;
  */
 @SuppressWarningsKeys({"index", "lowerbound"})
 public class LowerBoundChecker extends BaseTypeChecker {
+    private HashSet<String> collectionBaseTypeNames;
+
+    public LowerBoundChecker() {
+        // These classes are bases for both mutable and immutable sequence collections, which contain methods that change the length.
+        // Lower bound checker warnings are skipped at uses of them.
+        Class<?>[] collectionBaseClasses = {java.util.List.class, java.util.AbstractList.class};
+        collectionBaseTypeNames = new HashSet<>(collectionBaseClasses.length);
+        for (Class<?> collectionBaseClass : collectionBaseClasses) {
+            collectionBaseTypeNames.add(collectionBaseClass.getName());
+        }
+    }
+
+    @Override
+    public boolean shouldSkipUses(String typeName) {
+        if (collectionBaseTypeNames.contains(typeName)) {
+            return true;
+        }
+        return super.shouldSkipUses(typeName);
+    }
 
     @Override
     protected LinkedHashSet<Class<? extends BaseTypeChecker>> getImmediateSubcheckerClasses() {

--- a/checker/tests/index/ListLowerBound.java
+++ b/checker/tests/index/ListLowerBound.java
@@ -1,3 +1,4 @@
+// @skip-test until we bring list support back
 import java.util.List;
 import java.util.ListIterator;
 import org.checkerframework.checker.index.qual.GTENegativeOne;


### PR DESCRIPTION
This is a follow up to #1716.