### PR TITLE
Use ArrayRange and ArrayLen in LessThan Checker.

### DIFF
--- a/checker/tests/index/Kelloggm225.java
+++ b/checker/tests/index/Kelloggm225.java
@@ -1,0 +1,13 @@
+import org.checkerframework.checker.index.qual.*;
+import org.checkerframework.common.value.qual.*;
+
+class Kelloggm225 {
+    void method(int @MinLen(1) [] bar) {
+        foo(bar, 0, bar.length);
+    }
+
+    void foo(
+            int @MinLen(1) [] bar,
+            @IndexFor("#1") @LessThan("#3") int start,
+            @IndexOrHigh("#1") int end) {}
+}

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -764,11 +764,9 @@ public abstract class GenericAnnotatedTypeFactory<
      * @param tree current tree
      * @param clazz the Class of the annotation
      * @return the annotation on expression or null if one does not exist
-     * @throws FlowExpressionParseException thrown if the expression cannot be parsed
      */
     public AnnotationMirror getAnnotationFromReceiver(
-            FlowExpressions.Receiver receiver, Tree tree, Class<? extends Annotation> clazz)
-            throws FlowExpressionParseException {
+            FlowExpressions.Receiver receiver, Tree tree, Class<? extends Annotation> clazz) {
 
         AnnotationMirror annotationMirror = null;
         if (CFAbstractStore.canInsertReceiver(receiver)) {


### PR DESCRIPTION
Fixes https://github.com/kelloggm/checker-framework/issues/225.

The test case was failing because `bar.length` isn't in the Value Checker's store until after `0`.  So the Value Checker doesn't have a value for `bar.length`.  But is does have an ArrayRange for `bar`, so I changed the code to use that. 