### PR TITLE
Fix an issue with #2003

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
@@ -206,6 +206,8 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                             ValueAnnotatedTypeFactory.getArrayLength(arrayLen);
                     return Collections.min(possibleValues);
                 }
+                // Even arrays that we know nothing about must have at least zero length.
+                return 0;
             }
         }
 

--- a/checker/tests/index/LessThanCustomCollection.java
+++ b/checker/tests/index/LessThanCustomCollection.java
@@ -22,8 +22,6 @@ public class LessThanCustomCollection {
     ) int end;
 
     private LessThanCustomCollection(int[] array) {
-        // 0 should be @LessThan(array.length + 1)
-        // :: error: (argument.type.incompatible)
         this(array, 0, array.length);
     }
 

--- a/checker/tests/index/LessThanZeroArrayLength.java
+++ b/checker/tests/index/LessThanZeroArrayLength.java
@@ -1,0 +1,9 @@
+import org.checkerframework.checker.index.qual.LessThan;
+
+class LessThanZeroArrayLength {
+    void test(int[] a) {
+        foo(0, a.length);
+    }
+
+    void foo(@LessThan("#2 + 1") int x, int y) {}
+}


### PR DESCRIPTION
#2003 added use of the Value Checker to the Less Than Checker, so that constants are considered less than array lengths with appropriate MinLen annotations. This PR fixes an oversight in that PR, which assumed that arrays with no MinLen annotation have length `Long.MIN_VALUE`. This changes that default to `0` for array lengths, which removes some warnings in Guava. I also removed an expected warning in the test suite that should have been a suppressed warning - that warning was a false positive (it's identical to the case I'm trying to fix).

I'd normally wait for Suzanne for this, but since it's an easy fix and removes 3 false positives in Guava I figured I'd do it now. Whoever gets to it first can review it and remove the other.