### PR TITLE
Annotate the InvalidObjectException classes for Nullness Checker

### DIFF
--- a/checker/jdk/nullness/src/java/io/InvalidObjectException.java
+++ b/checker/jdk/nullness/src/java/io/InvalidObjectException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 1996, 2005, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Indicates that one or more deserialized objects failed validation
+ * tests.  The argument should provide the reason for the failure.
+ *
+ * @see ObjectInputValidation
+ * @since JDK1.1
+ *
+ * @author  unascribed
+ * @since   JDK1.1
+ */
+public class InvalidObjectException extends ObjectStreamException {
+
+  private static final long serialVersionUID = 3233174318281839583L;
+
+  /**
+   * Constructs an <code>InvalidObjectException</code>.
+   * @param reason Detailed message explaining the reason for the failure.
+   *
+   * @see ObjectInputValidation
+   */
+  public  InvalidObjectException(@Nullable String reason) {
+    super(reason);
+  }
+}

--- a/checker/jdk/nullness/src/java/io/ObjectStreamException.java
+++ b/checker/jdk/nullness/src/java/io/ObjectStreamException.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1996, 2005, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.io;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Superclass of all exceptions specific to Object Stream classes.
+ *
+ * @author  unascribed
+ * @since   JDK1.1
+ */
+public abstract class ObjectStreamException extends IOException {
+
+  private static final long serialVersionUID = 7260898174833392607L;
+
+  /**
+   * Create an ObjectStreamException with the specified argument.
+   *
+   * @param classname the detailed message for the exception
+   */
+  protected ObjectStreamException(@Nullable String classname) {
+    super(classname);
+  }
+
+  /**
+   * Create an ObjectStreamException.
+   */
+  protected ObjectStreamException() {
+    super();
+  }
+}


### PR DESCRIPTION
Add an annotated version of the following listed classes for Nullness Checker
 - java.io.InvalidObjectException
 - java.io.ObjectStreamException