### PR TITLE
buildJdk task does not build on functionality of gradle's Jar type

### DIFF
--- a/jdk8/build.gradle
+++ b/jdk8/build.gradle
@@ -29,7 +29,7 @@ task downloadJdk() {
     }
 }
 
-task buildJdk(type: Jar, group: 'Build') {
+task buildJdk(group: 'Build') {
     description 'Builds jdk8.jar'
     dependsOn(':checker:copyJarsToDist')
 


### PR DESCRIPTION
The buildJdk task is an exec task.  Declaring it as a Jar task breaks gradle's dependency processing and prevents the task from running when it should.