### PR TITLE
Make cross-module Javadoc references work

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,11 +89,13 @@ allprojects {
                 classpath += files(project(':checker').tasks.getByName('shadowJar').archivePath)
                 options.taglets 'org.checkerframework.taglet.ManualTaglet'
                 options.tagletPath(project(':util').sourceSets.taglet.output as File[])
-                options.links = ['https://docs.oracle.com/javase/8/docs/api/', 'https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/']
+                options.links = ['https://docs.oracle.com/javase/8/docs/api/', 'https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/', 'https://checkerframework.org/api/']
                 // This file is looked for by Javadoc.
                 file("${destinationDir}/resources/fonts/").mkdirs()
                 ant.touch(file: "${destinationDir}/resources/fonts/dejavu.css")
             }
+            // Turn javadoc warnings into errors.
+            options.addStringOption('Xwerror', '-quiet')
         }
 
         // Add standard javac options


### PR DESCRIPTION
A comment in `build.gradle` says:

> Add the fat checker.jar to the classpath of every Javadoc task. This allows Javadoc in any module to reference classes in any other module.

Nonetheless, cross-module Javadoc references cause warnings when I run `./gradlew` Javadoc, and many Javadoc cross-references are missing.

This pull request resolves these issues, and seems to work.

I'm not sure whether this is the right way to do it, though.
 * One issue is that the URLs are external, absolute URLs rather than relative ones.
    * It does not refer to the current Javadoc, but that of the last release.
    * It is not usable offline.
   I don't see how to resolve this without postprocessing, given that the Javadoc is generated separately and only later copied together by the `allJavadoc` task.
 * I wonder whether there will be problems when the API changes.  If a pull request changes the API, will Javadoc fail because it is getting Javadoc links from https://checkerframework.org/api/ rather than from a local source?  Or does the use of the current fat jar handle this case, and the only problem will be symbols in the Javadoc that are not linked to anywhere (as is already the case, and as this pull request fixes)?