### PR TITLE
Update code formatting commands in manual to use gradlew [ci skip]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,7 +288,7 @@ subprojects {
         ignoreExitValue = true
         doLast {
             if (execResult.exitValue != 0) {
-                throw new RuntimeException('Found improper formatting, try running:  gradle reformat"')
+                throw new RuntimeException('Found improper formatting, try running:  ./gradlew reformat"')
             }
         }
     }

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -1076,11 +1076,6 @@ the pre-commit hook fails
 because of improper formatting, run \<./gradlew reformat>, stage the
 changes, and try the commit operation again.
 
-If the pre-commit hook or \<./gradlew reformat> fails with an
-"Argument list too long" error, then create a \code{local.properties} file
-in the top-level directory that sets the property \code{maxparallel} to 4000.  If the error is still issued, reduce the number and
-try again.
-
 
 \section{Contributing fixes (creating a pull request)\label{pull-request}}
 

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -1069,14 +1069,14 @@ Code in this project follows the
 \ahref{https://google.github.io/styleguide/javaguide.html}{Google Java Style
 Guide} except 4 spaces are used for indentation.  If you commit changes to the
 Git repository, then a pre-commit hook verifies that the changes follow the
-style by running \<ant check-format> in the top-level directory.
+style by running \<./gradlew checkFormat> in the top-level directory.
 
 If
 the pre-commit hook fails
-because of improper formatting, run \<ant reformat>, stage the
+because of improper formatting, run \<./gradlew reformat>, stage the
 changes, and try the commit operation again.
 
-If the pre-commit hook or \<ant reformat> fails with an
+If the pre-commit hook or \<./gradlew reformat> fails with an
 "Argument list too long" error, then create a \code{local.properties} file
 in the top-level directory that sets the property \code{maxparallel} to 4000.  If the error is still issued, reduce the number and
 try again.


### PR DESCRIPTION
- use `./gradlew` instead of `ant` in the manual
- for consistency, recommend using `./gradlew` in build.gradle

I don't know whether the paragraph about `maxparallel` is still relevant. In case it is not, I have removed it. If it is, you can update and add it back, or tell me what should be there.