### PR TITLE
Use erased type to compare type frames in Initialization Checker.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -611,7 +611,7 @@ public abstract class InitializationAnnotatedTypeFactory<
         AnnotationMirror initializationAnno = type.getEffectiveAnnotationInHierarchy(UNCLASSIFIED);
         TypeMirror typeFrame = getTypeFrameFromAnnotation(initializationAnno);
         Types types = processingEnv.getTypeUtils();
-        return types.isSubtype(typeFrame, frame);
+        return types.isSubtype(typeFrame, types.erasure(frame));
     }
 
     /**

--- a/checker/tests/nullness/Issue2052.java
+++ b/checker/tests/nullness/Issue2052.java
@@ -1,0 +1,18 @@
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
+
+public class Issue2052 {
+    public static class ParentW<S> {
+        protected final String field;
+
+        public ParentW() {
+            // Initializing "field" at the declaration, did not trigger the bug.
+            field = "";
+        }
+    }
+
+    public static class ChildW extends ParentW<String> {
+        public String getField(@UnknownInitialization(ParentW.class) ChildW this) {
+            return this.field;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2052.