### PR TITLE
Minor Documentation update for Option 3 of Section 31.6

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -446,7 +446,7 @@ use the last one.
    run checker.jar via \<java> (not \<javac>) as in:
 
 \begin{Verbatim}
-  java -jar "$CHECKERFRAMEWORK/checker/dist/checker.jar" ...
+  java -jar "$CHECKERFRAMEWORK/checker/dist/checker.jar" -processor nullness MyFile.java
 \end{Verbatim}
 
     You can simplify the above command by introducing an alias.  Then,


### PR DESCRIPTION
Complete command example will be more meaning & easy from user point of view while running any checker. As, `processor` as argument is specified for` javac `but for `java` it is not mentioned that clearly.

```
java [ options ] -jar file.jar [ arguments ]
arguments
The arguments passed to the main function.
```

reference links :
https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html
https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html  