### PR TITLE
Correct location of Javadoc when building the manual

### DIFF
--- a/docs/manual/Makefile
+++ b/docs/manual/Makefile
@@ -71,7 +71,7 @@ manual.html: manual.pdf CFLogo.png favicon-checkerframework.png ../api
 	sed -i -e "s%<style type=\"text/css\">%<style type=\"text/css\">\nimg { max-width: 100\%; max-height: 100\%; }%" manual.html
 
 ../api:
-	cd .. && ln -fs ../checker/api api
+	cd ../.. && ./gradlew allJavadoc
 
 CFLogo.png: ../logo/Logo/CFLogo.png
 	cp -p $< $@


### PR DESCRIPTION
The Gradle task `allJavadoc` builds the Javadoc in docs/api, so run that tasks if docs/api doesn't exist.