### PR TITLE
Reflection Resolution:

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
@@ -366,6 +366,9 @@ public class DefaultReflectionResolver implements ReflectionResolver {
 
             // Resolve the Symbol(s) for the current method
             for (Symbol symbol : getMethodSymbolsfor(className, methodName, paramLength, env)) {
+                if (!processingEnv.getTypeUtils().isSubtype(receiver.type, symbol.owner.type)) {
+                    continue;
+                }
                 if ((symbol.flags() & Flags.PUBLIC) > 0) {
                     debugReflection("Resolved public method: " + symbol.owner + "." + symbol);
                 } else {

--- a/framework/tests/reflection/MethodTest.java
+++ b/framework/tests/reflection/MethodTest.java
@@ -8,6 +8,7 @@ public class MethodTest {
 
     @Sibling1 int sibling1;
     @Sibling2 int sibling2;
+    @ReflectBottom SuperClass superClass;
 
     public void real_class() {
         try {
@@ -21,35 +22,35 @@ public class MethodTest {
         }
     }
 
-    public void pass1(@ReflectBottom MethodTest this) {
+    public void pass1() {
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod("getA", new Class[] {});
-            @Sibling1 Object a = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling1 Object a = m.invoke(superClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass1b(@ReflectBottom MethodTest this) {
+    public void pass1b() {
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod("getA", (Class[]) null);
-            @Sibling1 Object a = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling1 Object a = m.invoke(superClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass2(@ReflectBottom MethodTest this) {
+    public void pass2() {
         String str = "get" + "A";
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod(str, new Class[] {});
-            @Sibling1 Object a = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling1 Object a = m.invoke(superClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass3(@ReflectBottom MethodTest this) {
+    public void pass3() {
         String str = "get";
         str += "A";
         try {
@@ -59,25 +60,25 @@ public class MethodTest {
             // and remove the expected error
 
             // :: error: (assignment.type.incompatible)
-            @Sibling1 Object a = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling1 Object a = m.invoke(superClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass4(@ReflectBottom MethodTest this) {
+    public void pass4() {
         String str = "setA";
         @Sibling1 int val1 = sibling1;
         @Sibling1 Integer val2 = val1;
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod(str, new Class[] {Integer.class});
-            m.invoke(this, val1);
-            m.invoke(this, val2);
+            m.invoke(superClass, val1);
+            m.invoke(superClass, val2);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass4b(@ReflectBottom MethodTest this) {
+    public void pass4b() {
         String str = "setA";
         @Sibling1 int val1 = sibling1;
         @Sibling1 Integer val2 = val1;
@@ -85,17 +86,19 @@ public class MethodTest {
             //
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod(str, int.class);
-            m.invoke(this, val1);
-            m.invoke(this, val2);
+            m.invoke(superClass, val1);
+            m.invoke(superClass, val2);
         } catch (Exception ignore) {
         }
     }
+
+    @ReflectBottom SubClass subClass;
     // Test resolution of methods declared in super class
-    public void pass5(@ReflectBottom MethodTest this) {
+    public void pass5() {
         try {
             Class<?> c = Class.forName("MethodTest$SubClass");
             Method m = c.getMethod("getB", new Class[0]);
-            @Sibling2 Object o = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling2 Object o = m.invoke(subClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
@@ -120,17 +123,17 @@ public class MethodTest {
         }
     }
 
-    public void pass8(@ReflectBottom MethodTest this) {
+    public void pass8() {
         String str = "setA";
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
             Method m = c.getMethod(str, new Class[] {Integer.class});
-            m.invoke(this, sibling1);
+            m.invoke(superClass, sibling1);
         } catch (Exception ignore) {
         }
     }
 
-    public void pass9(@ReflectBottom MethodTest this) {
+    public void pass9() {
         String str = "getA";
         if (true) {
             str = "getB";
@@ -138,7 +141,7 @@ public class MethodTest {
         try {
             Class<?> c = Class.forName("MethodTest$SubClass");
             Method m = c.getMethod(str, new Class[0]);
-            @Top Object o = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Top Object o = m.invoke(subClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
@@ -226,17 +229,17 @@ public class MethodTest {
     }
 
     // Test unresolvable methods
-    public void fail2(@ReflectBottom MethodTest this, String str) {
+    public void fail2(String str) {
         try {
             Class<?> c = Class.forName(str);
             Method m = c.getMethod("getA", new Class[] {Integer.class});
             // :: error: (assignment.type.incompatible)
-            @Sibling1 Object o = m.invoke(this, (@ReflectBottom Object[]) null);
+            @Sibling1 Object o = m.invoke(subClass, (@ReflectBottom Object[]) null);
         } catch (Exception ignore) {
         }
     }
 
-    public void fail3(@ReflectBottom MethodTest this) {
+    public void fail3() {
         String str = "setB";
         try {
             Class<?> c = Class.forName("MethodTest$SuperClass");
@@ -247,7 +250,7 @@ public class MethodTest {
         }
     }
 
-    public void fail4(@ReflectBottom MethodTest this) {
+    public void fail4() {
         String str = "setA";
         try {
             Class<?> c = Class.forName("MethodTest$SubClass");
@@ -258,7 +261,7 @@ public class MethodTest {
         }
     }
 
-    public void fail5(@ReflectBottom MethodTest this) {
+    public void fail5() {
         String str = "setAB";
         try {
             Class<?> c = Class.forName("MethodTest$SubClass");
@@ -269,7 +272,7 @@ public class MethodTest {
         }
     }
 
-    public void fail6(@ReflectBottom MethodTest this) {
+    public void fail6() {
         String str = "setA";
         if (true) {
             str = "setB";
@@ -304,7 +307,7 @@ public class MethodTest {
         }
     }
 
-    public void bug(@ReflectBottom MethodTest this) {
+    public void bug() {
         String str = "setA";
         @Sibling1 int val1 = sibling1;
         @Sibling1 Object[] args = new Object[] {val1};
@@ -322,7 +325,7 @@ public class MethodTest {
         }
     }
 
-    public void bug2(@ReflectBottom MethodTest this) {
+    public void bug2() {
         String str = "setAB";
         @Sibling1 int val1 = sibling1;
         @Sibling2 int val2 = sibling2;


### PR DESCRIPTION
Verify that the first argument to an invoke call is a subtype of the possible class.

The fix for https://github.com/typetools/checker-framework/issues/2107 uncovered this bug.  The test cases with `this` were crashing that fix.  This fixes the crash.  With the crash fixed, the test case with `this` correctly issued errors.  But, since the point of those tests were to check the reflection resolution was improving the precision of the checker, I had to change them to something that would pass.