### PR TITLE
Make guieffect qualifiers CLASS retention (not RUNTIME).

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/AlwaysSafe.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/AlwaysSafe.java
@@ -20,6 +20,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @DefaultQualifierInHierarchy
 @ImplicitFor(literals = LiteralKind.NULL)
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface AlwaysSafe {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUI.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUI.java
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  */
 @PolymorphicQualifier(UI.class)
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolyUI {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUIEffect.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUIEffect.java
@@ -13,6 +13,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD})
 public @interface PolyUIEffect {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUIType.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUIType.java
@@ -13,6 +13,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})
 public @interface PolyUIType {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/SafeEffect.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/SafeEffect.java
@@ -12,6 +12,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD})
 public @interface SafeEffect {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/SafeType.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/SafeType.java
@@ -14,6 +14,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})
 public @interface SafeType {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UI.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UI.java
@@ -14,6 +14,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf({})
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UI {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIEffect.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIEffect.java
@@ -12,6 +12,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
 public @interface UIEffect {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIPackage.java
@@ -12,6 +12,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.PACKAGE})
 public @interface UIPackage {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIType.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UIType.java
@@ -12,6 +12,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
 @Documented
-@Retention(RetentionPolicy.RUNTIME)
+@Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})
 public @interface UIType {}


### PR DESCRIPTION
This is one of the small internal patches mentioned in #2113 and is **not** needed for us to open source the RxThreadEffectChecker, so it is not high priority to us. The idea is to avoid these annotations being preserved into the APKs of analyzed Android apps, since we never check them after building. It probably doesn't make much of a difference for plain Java apps, but at least in the way our build system works, `CLASS` annotations and not retained after dexing. Chances are other type annotations could be switched as well, but these are the only ones we use.