### PR TITLE
StubParser warning changes (AstubWarnIfNotFoundIgnoresClasses and Wildcards)

### DIFF
--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -675,6 +675,12 @@ overrides the \<-AstubWarnIfNotFound> command-line option, and no warning
 will be issued.
 
 Use command-line option
+\<-AstubWarnIfNotFoundIgnoresClasses in conjuntion with the previous option
+to report only missing methods/fields, but ignore missing classes, even if
+other classes from the same package are present.
+Useful if a package spans more than one jar.
+
+Use command-line option
 \<-AstubWarnIfOverwritesBytecode> to warn whenever some element of a
 stub file overwrites annotations contained in bytecode.
 

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -211,6 +211,11 @@ import org.checkerframework.javacutil.TreeUtils;
     // that were not found on the class path
     // org.checkerframework.framework.stub.StubParser.warnIfNotFound
     "stubWarnIfNotFound",
+    // Whether to ignore missing classes even when warnIfNotFound is set to true and
+    // other classes from the same package are present (useful if a package spans more than one
+    // jar).
+    // org.checkerframework.framework.stub.StubParser.warnIfNotFoundIgnoresClasses
+    "stubWarnIfNotFoundIgnoresClasses",
     // Whether to print warnings about stub files that overwrite annotations
     // from bytecode.
     "stubWarnIfOverwritesBytecode",

--- a/framework/src/main/java/org/checkerframework/framework/stub/StubParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/StubParser.java
@@ -97,6 +97,14 @@ public class StubParser {
      */
     private final boolean warnIfNotFound;
 
+    /**
+     * Whether to ignore missing classes even when warnIfNotFound is set to true. This allows the
+     * stubs to contain classes not in the classpath (even if another class in the classpath has the
+     * same package), but still warn if members of the class (methods, fields) are missing. This
+     * option does nothing unless warnIfNotFound is also set.
+     */
+    private final boolean warnIfNotFoundIgnoresClasses;
+
     /** Whether to print warnings about stub files that overwrite annotations from bytecode. */
     private final boolean warnIfStubOverwritesBytecode;
 
@@ -180,6 +188,7 @@ public class StubParser {
 
         Map<String, String> options = processingEnv.getOptions();
         this.warnIfNotFound = options.containsKey("stubWarnIfNotFound");
+        this.warnIfNotFoundIgnoresClasses = options.containsKey("stubWarnIfNotFoundIgnoresClasses");
         this.warnIfStubOverwritesBytecode = options.containsKey("stubWarnIfOverwritesBytecode");
         this.debugStubParser = options.containsKey("stubDebug");
 
@@ -455,7 +464,8 @@ public class StubParser {
         if (typeElt == null) {
             if (debugStubParser
                     || (!hasNoStubParserWarning(typeDecl.getAnnotations())
-                            && !hasNoStubParserWarning(packageAnnos))) {
+                                    && !hasNoStubParserWarning(packageAnnos))
+                            && !warnIfNotFoundIgnoresClasses) {
                 stubWarnNotFound("Type not found: " + fqTypeName);
             }
             return;
@@ -884,6 +894,23 @@ public class StubParser {
                 break;
             case WILDCARD:
                 AnnotatedWildcardType wildcardType = (AnnotatedWildcardType) atype;
+                // Ensure that the stub also has a wildcard type, report an error otherwise
+                if (!typeDef.isWildcardType()) {
+                    // We throw an error here, as otherwise we are just getting a generic cast error
+                    // on the very next line.
+                    throw new Error(
+                            "StubParser: Wildcard type <"
+                                    + atype.toString()
+                                    + "> doesn't match type in stubs file: <"
+                                    + typeDef.toString()
+                                    + ">"
+                                    + LINE_SEPARATOR
+                                    + "In file "
+                                    + filename
+                                    + LINE_SEPARATOR
+                                    + "While parsing "
+                                    + parseState.toString());
+                }
                 WildcardType wildcardDef = (WildcardType) typeDef;
                 if (wildcardDef.getExtendedType().isPresent()) {
                     annotate(
@@ -1777,7 +1804,7 @@ public class StubParser {
     }
 
     /**
-     * Issues a warning, onlyif it has not been previously issued.
+     * Issues a warning, only if it has not been previously issued.
      *
      * @param warning a format string
      * @param args the arguments for {@code warning}


### PR DESCRIPTION
* Add `-AstubWarnIfNotFoundIgnoresClasses`, which allows us to use `-AstubWarnIfNotFound` in a way that ignores missing classes due to packages that are distributed across more than one JAR
* Report a better error, with type and file info, when the code has a wildcard type but the stub has something else, rather than giving a generic cast error. There is probably more generic code-type to stub-type missmatch checking that could be done here, but this is the case that has bitten us before.