### PR TITLE
Improve documentation for addComputedTypeAnnotations

### DIFF
--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1218,7 +1218,7 @@ Section~\ref{creating-javac-tips} can help you get started.
 If the \<@ImplicitFor> annotation is not sufficiently expressive, then you
 can write code to set implicit annotations.  To do so, create a subclass of
 \refclass{framework/type}{AnnotatedTypeFactory} and override its
-\<addComputedTypeAnnotations> methods.
+two \<addComputedTypeAnnotations> methods.
 
 \<AnnotatedTypeFactory>, when given a program
 expression, returns the expression's type.  This should include not only
@@ -1236,7 +1236,9 @@ and
 \refmethodanchortext{framework/type}{AnnotatedTypeFactory}{addComputedTypeAnnotations}{-javax.lang.model.element.Element-org.checkerframework.framework.type.AnnotatedTypeMirror-}{addComputedTypeAnnotations(Element,AnnotatedTypeMirror)}.
 The methods operate on \refclass{framework/type}{AnnotatedTypeMirror},
 which is the Checker Framework's representation of an annotated type.
-
+The methods can make arbitrary changes to the annotations on a type, but
+try to limit their work to implicit annotations; often some existing
+simpler mechanism in the Checker Framework will serve other purposes.
 
 
 \section{Dataflow: enhancing flow-sensitive type qualifier inference\label{creating-dataflow}}

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -130,10 +130,11 @@ import org.checkerframework.javacutil.trees.DetachedVarSymbol;
  *
  * <p>Type system checker writers may need to subclass this class, to add implicit and default
  * qualifiers according to the type system semantics. Subclasses should especially override {@link
- * AnnotatedTypeFactory#addComputedTypeAnnotations(Element, AnnotatedTypeMirror)} and {@link
- * #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}. (Also, {@link
- * #addDefaultAnnotations(AnnotatedTypeMirror)} adds annotations, but that method is a work around
- * for Issue 979.)
+ * #addComputedTypeAnnotations(Element, AnnotatedTypeMirror)} and {@link
+ * #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)} to handle implicit annotations. (Also,
+ * {@link #addDefaultAnnotations(AnnotatedTypeMirror)} adds annotations, but that method is a
+ * workaround for <a href="https://github.com/typetools/checker-framework/issues/979">Issue
+ * 979</a>.)
  *
  * @checker_framework.manual #creating-a-checker How to write a checker plug-in
  */
@@ -1274,9 +1275,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     // **********************************************************************
 
     /**
-     * Adds implicit annotations to a type obtained from a {@link Tree}. By default, this method
-     * does nothing. Subclasses should use this method to implement implicit annotations specific to
-     * their type systems.
+     * Changes annotations on a type obtained from a {@link Tree}. By default, this method does
+     * nothing. GenericAnnotatedTypeFactory uses this method to implement implicit annotations,
+     * defaulting, and inference (flow-sensitive type refinement). Its subclasses usually override
+     * it only to customize implicit annotations.
+     *
+     * <p>Subclasses that override this method should also override {@link
+     * #addComputedTypeAnnotations(Element, AnnotatedTypeMirror)}.
      *
      * @param tree an AST node
      * @param type the type obtained from {@code tree}
@@ -1286,9 +1291,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * Adds implicit annotations to a type obtained from a {@link Element}. By default, this method
-     * does nothing. Subclasses should use this method to implement implicit annotations specific to
-     * their type systems.
+     * Changes annotations on a type obtained from an {@link Element}. By default, this method does
+     * nothing. GenericAnnotatedTypeFactory uses this method to implement defaulting.
+     *
+     * <p>Subclasses that override this method should also override {@link
+     * #addComputedTypeAnnotations(Tree, AnnotatedTypeMirror)}.
      *
      * @param elt an element
      * @param type the type obtained from {@code elt}
@@ -1299,7 +1306,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     /**
      * Adds default annotations to {@code type}. This method should only be used in places where the
-     * correct annotations cannot be compute because of uninferred type arguments. (See {@link
+     * correct annotations cannot be computed because of uninferred type arguments. (See {@link
      * AnnotatedWildcardType#isUninferredTypeArgument()}.)
      *
      * @param type annotated type to which default annotations are added

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
@@ -22,11 +22,9 @@ import org.checkerframework.javacutil.TypesUtils;
  * Adds annotations to a type based on the contents of a type. By default, this class honors the
  * {@link ImplicitFor} annotation and applies implicit annotations specified by {@link ImplicitFor}
  * for any type whose visitor is not overridden or does not call {@code super}; it is designed to be
- * invoked from {@link
- * org.checkerframework.framework.type.AnnotatedTypeFactory#addComputedTypeAnnotations(Element,
- * org.checkerframework.framework.type.AnnotatedTypeMirror)} and {@link
- * org.checkerframework.framework.type.AnnotatedTypeFactory#addComputedTypeAnnotations(Tree,
- * org.checkerframework.framework.type.AnnotatedTypeMirror)}.
+ * invoked from {@link AnnotatedTypeFactory#addComputedTypeAnnotations(Element,
+ * AnnotatedTypeMirror)} and {@link AnnotatedTypeFactory#addComputedTypeAnnotations(Tree,
+ * AnnotatedTypeMirror)}.
  *
  * <p>{@link ImplicitsTypeAnnotator} traverses types deeply by default, except that it skips the
  * method receiver of executable types (for interoperability with {@link


### PR DESCRIPTION
This is an attempt to improve the misleading documentation for addComputedTypeAnnotations.

Please let me know what is correct or incorrect.
Rather than commenting on the pull request, please push commits to the branch to directly improve the text.  Thanks!

One question that should be addressed in the documentation is:  When should a type factory subclass just one of the methods, and when should it subclass both?

Also, this confusing documentation for AnnotatedTypeFactory.postAsMemberOf should be improved:

>  Overriding methods should merely change the annotations on the subtypes, without changing the types.

What are "annotations on subtypes"?  Does "the types" refer to the Java type?


