### PR TITLE
Change the AnnotationMirror Comparator to allow null.

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -289,24 +289,25 @@ public class AnnotationUtils {
     }
 
     private static final Comparator<AnnotationMirror> ANNOTATION_ORDERING =
-            new Comparator<AnnotationMirror>() {
-                @Override
-                public int compare(AnnotationMirror a1, AnnotationMirror a2) {
-                    // AnnotationMirror.toString() prints the elements of an annotation in the
-                    // order in which they were written. So, use areSame to check for equality.
-                    if (AnnotationUtils.areSame(a1, a2)) {
-                        return 0;
-                    }
-
-                    String n1 = a1.toString();
-                    String n2 = a2.toString();
-
-                    // Because the AnnotationMirror.toString prints the annotation as it appears
-                    // in source code, the order in which annotations of the same class are
-                    // sorted may be confusing.  For example, it might order
-                    // @IntRange(from=1, to=MAX) before @IntRange(to=MAX,from=0).
-                    return n1.compareTo(n2);
+            (a1, a2) -> {
+                // AnnotationMirror.toString() prints the elements of an annotation in the
+                // order in which they were written. So, use areSame to check for equality.
+                if (AnnotationUtils.areSame(a1, a2)) {
+                    return 0;
+                } else if (a1 == null) {
+                    return -1;
+                } else if (a2 == null) {
+                    return 1;
                 }
+
+                String n1 = a1.toString();
+                String n2 = a2.toString();
+
+                // Because the AnnotationMirror.toString prints the annotation as it appears
+                // in source code, the order in which annotations of the same class are
+                // sorted may be confusing.  For example, it might order
+                // @IntRange(from=1, to=MAX) before @IntRange(to=MAX,from=0).
+                return n1.compareTo(n2);
             };
 
     /**


### PR DESCRIPTION
This is mainly to allow debugging of AnnotationMirror sets that erroneously contain null. 