### PR TITLE
fix eclipse project files to not depend on jsr308-langtools

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -947,18 +947,41 @@ These instructions are relevant if you use Eclipse as your IDE\@.
 \begin{enumerate}
 \item Follow the instructions earlier in Section~\ref{build-source} to
 clone and build all projects from their sources.
+\item Download the source code zip for your JDK:
+On Linux, run `sudo apt-get -qqy install openjdk-8-source`.
+On Window, re-run the JDK install wizard and in the custom setup panel, ensure
+``Source Code'' is selected for installation.
+If this step is successful, there should be a \<src.zip> file located in the
+directory pointed to by \<JAVA\_HOME>.
+\item Create symbolic links to \<tools.jar> and \<src.zip>:
+In a terminal (Linux / Mac) or command prompt with administrative
+priviliges (Windows), navigate to the
+\<\$CHECKERFRAMEWORK/../annotation-tools/annotation-file-utilities/lib>
+directory. Create symbolic links to \<\$JAVA\_HOME/lib/tools.jar> and to
+\<\$JAVA\_HOME/src.zip>. Ensure the symbolic links are named \<tools.jar> and
+\<src.zip>, respectively.
 \item Download Eclipse from
 the \href{https://www.eclipse.org/downloads/}{official Eclipse website}
 and install it.
-\item Run Eclipse.
-\item Enter the main Eclipse working screen and in the ``File'' menu,
-select ``Import'' $\rightarrow$ ``General'' $\rightarrow$ ``Existing
-Projects into Workspace''.
+\item Run Eclipse and enter the main Eclipse working screen.
+\item Checker Framework's sources depend on classes packaged in \<rt.jar> from
+the JRE. Attaching the source code to \<rt.jar> makes it easier to understand
+and work with these classes:
+In the ``Window'' menu, select ``Preferences'' $\rightarrow$ ``Java''
+$\rightarrow$ ``Installed JREs''. Select the Java 8 JRE, then Select ``Edit''.
+In the list of JRE system libraries, select \<rt.jar>. Select
+``Source Attachment'' $\rightarrow$ ``External location'' $\rightarrow$
+``External File''. Locate the directory pointed to by \<\$JAVA\_HOME>, select
+\<src.zip> and then OK to attach the source. Select ``Finish'' and
+``Apply and Close''.
+\item In the ``File'' menu, select ``Import'' $\rightarrow$ ``General''
+$\rightarrow$ ``Existing Projects into Workspace''.
 \item After the ``Import Projects'' window appears, select ``Select
 Root Directory'', and select the parent of the \code{\$CHECKERFRAMEWORK} directory.
 \item Ensure ``Search for nested projects'' is selected in the Options panel.
-\item Select all the projects in the folder except for ``personalblog-demo'',
-then select ``Finish'' to import the projects.
+\item Select all the projects in the list except for ``personalblog-demo''
+and ``jsr308-langtools'', then select ``Finish'' to import the projects.
+
 \end{enumerate}
 Eclipse should successfully build all the imported projects.
 If Eclipse reports any errors, ensure you followed the instructions

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -947,19 +947,10 @@ These instructions are relevant if you use Eclipse as your IDE\@.
 \begin{enumerate}
 \item Follow the instructions earlier in Section~\ref{build-source} to
 clone and build all projects from their sources.
-\item Download the source code zip for your JDK:
-On Linux, run `sudo apt-get -qqy install openjdk-8-source`.
-On Window, re-run the JDK install wizard and in the custom setup panel, ensure
-``Source Code'' is selected for installation.
-If this step is successful, there should be a \<src.zip> file located in the
-directory pointed to by \<JAVA\_HOME>.
-\item Create symbolic links to \<tools.jar> and \<src.zip>:
-In a terminal (Linux / Mac) or command prompt with administrative
-priviliges (Windows), navigate to the
+\item Follow the instructions in the \<README-eclipse> document found in the
 \<\$CHECKERFRAMEWORK/../annotation-tools/annotation-file-utilities/lib>
-directory. Create symbolic links to \<\$JAVA\_HOME/lib/tools.jar> and to
-\<\$JAVA\_HOME/src.zip>. Ensure the symbolic links are named \<tools.jar> and
-\<src.zip>, respectively.
+directory to download JDK 8 source code and create symbolic links to
+\<tools.jar> and \<src.zip>.
 \item Download Eclipse from
 the \href{https://www.eclipse.org/downloads/}{official Eclipse website}
 and install it.

--- a/framework-test/.classpath
+++ b/framework-test/.classpath
@@ -3,7 +3,6 @@
 	<classpathentry kind="src" output="build/classes/java/main" path="src/main/java"/>
 	<classpathentry kind="src" output="build/classes/java/taglet" path="src/taglet/java"/>
 	<classpathentry kind="src" path="/javacutil"/>
-	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="build/default"/>

--- a/framework-test/.project
+++ b/framework-test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>util</name>
+	<name>framework-test</name>
 	<comment></comment>
 	<projects/>
 	<buildSpec>

--- a/framework/.classpath
+++ b/framework/.classpath
@@ -6,7 +6,7 @@
 	<classpathentry kind="src" path="/dataflow" exported="true"/>
 	<classpathentry kind="src" path="/scene-lib" exported="true"/>
 	<classpathentry kind="src" path="/stubparser"/>
-	<classpathentry kind="src" path="/util" exported="true"/>
+	<classpathentry kind="src" path="/framework-test" exported="true"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/checker/dist/checker-qual.jar" sourcepath="/checker"/>

--- a/javacutil/.classpath
+++ b/javacutil/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
-	<classpathentry kind="src" path="/jsr308-langtools" exported="true"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
+	<classpathentry kind="lib" path="/annotation-file-utilities/lib/tools.jar" sourcepath="/annotation-file-utilities/lib/src.zip" exported="true"/>
 	<classpathentry kind="lib" path="/checker/dist/checker-qual.jar" sourcepath="/checker"/>
 	<classpathentry kind="output" path="build/classes/java/main"/>
 </classpath>


### PR DESCRIPTION
The eclipse projects now depend on `tools.jar` and `src.zip` given by the JRE, which is symlinked in `AFU/lib`. Note that these two files are also required by the `asmx`, `scene-lib`, and `AFU` projects, hence its symlink placement in `AFU/lib`.

PR https://github.com/typetools/annotation-tools/pull/180 updates the eclipse project paths for `asmx`, `scene-lib`, and `AFU`, and should be merged at the same time as this PR.

The updated manual instructions for Configure Eclipse to edit the Checker Framework requires the user to download `src.zip` and create the symlinks to the two files, so that the eclipse projects remain OS independent and easier to maintain.

Also change "util" project name to "framework-test".