### PR TITLE
Remove uses of iterator.next() on annotation collections in the Index Checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/IndexRefinementInfo.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/IndexRefinementInfo.java
@@ -66,12 +66,6 @@ public class IndexRefinementInfo {
 
     private static AnnotationMirror getAnno(
             Set<AnnotationMirror> set, QualifierHierarchy hierarchy) {
-        if (set.size() == 1) {
-            return set.iterator().next();
-        }
-        if (set.isEmpty()) {
-            return null;
-        }
         Set<? extends AnnotationMirror> tops = hierarchy.getTopAnnotations();
         if (tops.size() != 1) {
             throw new BugInCF(
@@ -79,6 +73,6 @@ public class IndexRefinementInfo {
                             + ": Found multiple tops, but expected one. \nFound: "
                             + tops.toString());
         }
-        return hierarchy.findAnnotationInSameHierarchy(set, tops.iterator().next());
+        return hierarchy.findAnnotationInHierarchy(set, tops.iterator().next());
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
@@ -124,10 +124,7 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** @return Is left less than right? */
     public boolean isLessThan(Tree left, String right) {
         AnnotatedTypeMirror leftATM = getAnnotatedType(left);
-        if (leftATM.getAnnotations().size() != 1) {
-            return false;
-        }
-        return isLessThan(leftATM.getAnnotations().iterator().next(), right);
+        return isLessThan(leftATM.getAnnotationInHierarchy(UNKNOWN), right);
     }
 
     /** @return Is left less than right? */
@@ -217,10 +214,7 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** @return Is left less than or equal to right? */
     public boolean isLessThanOrEqual(Tree left, String right) {
         AnnotatedTypeMirror leftATM = getAnnotatedType(left);
-        if (leftATM.getAnnotations().size() != 1) {
-            return false;
-        }
-        return isLessThanOrEqual(leftATM.getAnnotations().iterator().next(), right);
+        return isLessThanOrEqual(leftATM.getAnnotationInHierarchy(UNKNOWN), right);
     }
 
     /** @return Is left less than or equal to right? */
@@ -250,10 +244,7 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     public List<String> getLessThanExpressions(ExpressionTree expression) {
         AnnotatedTypeMirror annotatedTypeMirror = getAnnotatedType(expression);
-        if (annotatedTypeMirror.getAnnotations().size() != 1) {
-            return new ArrayList<>();
-        }
-        return getLessThanExpressions(annotatedTypeMirror.getAnnotations().iterator().next());
+        return getLessThanExpressions(annotatedTypeMirror.getAnnotationInHierarchy(UNKNOWN));
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanTransfer.java
@@ -122,8 +122,11 @@ public class LessThanTransfer extends IndexAbstractTransfer {
     /** Return the expressions that {@code node} are less than. */
     private List<String> getLessThanExpressions(Node node) {
         Set<AnnotationMirror> s = analysis.getValue(node).getAnnotations();
+        LessThanAnnotatedTypeFactory factory =
+                (LessThanAnnotatedTypeFactory) analysis.getTypeFactory();
         if (s != null && !s.isEmpty()) {
-            return LessThanAnnotatedTypeFactory.getLessThanExpressions(s.iterator().next());
+            return LessThanAnnotatedTypeFactory.getLessThanExpressions(
+                    factory.getQualifierHierarchy().findAnnotationInHierarchy(s, factory.UNKNOWN));
         } else {
             return Collections.emptyList();
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -211,10 +211,9 @@ public class SameLenTransfer extends CFTransfer {
             if (cfValue == null) {
                 return UNKNOWN;
             }
-            if (cfValue.getAnnotations().size() == 1) {
-                return cfValue.getAnnotations().iterator().next();
-            }
-            return UNKNOWN;
+            return aTypeFactory
+                    .getQualifierHierarchy()
+                    .findAnnotationInHierarchy(cfValue.getAnnotations(), UNKNOWN);
         }
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -784,7 +784,9 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             CFValue value = store.getValue(receiver);
             if (value != null && value.getAnnotations().size() == 1) {
                 UBQualifier newUBQ =
-                        UBQualifier.createUBQualifier(value.getAnnotations().iterator().next());
+                        UBQualifier.createUBQualifier(
+                                qualHierarchy.findAnnotationInHierarchy(
+                                        value.getAnnotations(), UNKNOWN));
                 if (ubQualifier == null) {
                     ubQualifier = newUBQ;
                 } else {


### PR DESCRIPTION
Future proofs against annotation order and removes the need to check that collections only contain one annotation.

At Mike's request.