### PR TITLE
update eclipse project classpaths and names

### DIFF
--- a/checker/.classpath
+++ b/checker/.classpath
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="build/classes/java/main" path="src/main/java"/>
-	<classpathentry kind="src" output="build/classes/java/test" path="src/test/java"/>
-	<classpathentry kind="src" output="build/classes/java/testannotations" path="src/testannotations/java"/>
+	<classpathentry kind="src" path="src/main/java" output="build/classes/java/main"/>
+	<classpathentry kind="src" path="src/test/java" output="build/classes/java/test"/>
+	<classpathentry kind="src" path="src/testannotations/java" output="build/classes/java/testannotations"/>
 	<classpathentry kind="src" path="/framework" exported="true"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="output" path="build/classes/java/default"/>
+	<classpathentry kind="output" path="build/classes/java/main"/>
 </classpath>

--- a/framework-test/.classpath
+++ b/framework-test/.classpath
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="build/classes/java/main" path="src/main/java"/>
-	<classpathentry kind="src" output="build/classes/java/taglet" path="src/taglet/java"/>
+	<classpathentry kind="src" path="src/main/java" output="build/classes/java/main"/>
+	<classpathentry kind="src" path="src/taglet/java" output="build/classes/java/taglet"/>
 	<classpathentry kind="src" path="/javacutil"/>
 	<classpathentry kind="src" path="/jsr308-langtools"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="output" path="build/default"/>
+	<classpathentry kind="output" path="build/classes/java/main"/>
 </classpath>

--- a/framework-test/.project
+++ b/framework-test/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>util</name>
+	<name>framework-test</name>
 	<comment></comment>
 	<projects/>
 	<buildSpec>

--- a/framework/.classpath
+++ b/framework/.classpath
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="build/classes/java/main" path="src/main/java"/>
-	<classpathentry kind="src" output="build/classes/java/test" path="src/test/java" excluding="tests/SubtypingStringPatternsPartialTest.java"/>
-	<classpathentry kind="src" output="build/classes/java/testannotations" path="src/testannotations/java"/>
+	<classpathentry kind="src" path="src/main/java" output="build/classes/java/main" />
+	<classpathentry kind="src" path="src/test/java" excluding="tests/SubtypingStringPatternsPartialTest.java" output="build/classes/java/test"/>
+	<classpathentry kind="src" path="src/testannotations/java" output="build/classes/java/testannotations"/>
 	<classpathentry kind="src" path="/dataflow" exported="true"/>
+	<classpathentry kind="src" path="/framework-test" exported="true"/>
 	<classpathentry kind="src" path="/scene-lib" exported="true"/>
 	<classpathentry kind="src" path="/stubparser"/>
-	<classpathentry kind="src" path="/util" exported="true"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="lib" path="/checker/dist/checker-qual.jar" sourcepath="/checker"/>
-	<classpathentry kind="output" path="build/default"/>
+	<classpathentry kind="output" path="build/classes/java/main"/>
 </classpath>


### PR DESCRIPTION
sort entries by src / con / lib / output, and by names within each kind

update output paths to correspond with gradle 4.5 outputs

update eclipse project name of `framework-test`