### PR TITLE
When expanding varargs, copy parameters rather than using the same object. Fixes #2171

### DIFF
--- a/checker/tests/nullness/Issue2171.java
+++ b/checker/tests/nullness/Issue2171.java
@@ -1,3 +1,4 @@
+import java.util.List;
 import org.checkerframework.checker.nullness.qual.*;
 
 public class Issue2171 {
@@ -14,5 +15,20 @@ public class Issue2171 {
         varArgsMethod(pn, nble);
         varArgsMethod(pn, nn);
         varArgsMethod(pn, pn);
+    }
+
+    static void genVarArgsMethod(List<? extends @PolyNull Object>... args) {}
+
+    static void genCallToVarArgsObject(
+            List<@PolyNull Object> pn, List<@NonNull Object> nn, List<@Nullable Object> nble) {
+        genVarArgsMethod(nble, nble);
+        genVarArgsMethod(nble, nn);
+        genVarArgsMethod(nble, pn);
+        genVarArgsMethod(nn, nble);
+        genVarArgsMethod(nn, nn);
+        genVarArgsMethod(nn, pn);
+        genVarArgsMethod(pn, nble);
+        genVarArgsMethod(pn, nn);
+        genVarArgsMethod(pn, pn);
     }
 }

--- a/checker/tests/nullness/Issue2171.java
+++ b/checker/tests/nullness/Issue2171.java
@@ -17,8 +17,10 @@ public class Issue2171 {
         varArgsMethod(pn, pn);
     }
 
+    @SuppressWarnings("unchecked")
     static void genVarArgsMethod(List<? extends @PolyNull Object>... args) {}
 
+    @SuppressWarnings("unchecked")
     static void genCallToVarArgsObject(
             List<@PolyNull Object> pn, List<@NonNull Object> nn, List<@Nullable Object> nble) {
         genVarArgsMethod(nble, nble);

--- a/checker/tests/nullness/Issue2171.java
+++ b/checker/tests/nullness/Issue2171.java
@@ -1,0 +1,18 @@
+import org.checkerframework.checker.nullness.qual.*;
+
+public class Issue2171 {
+    static void varArgsMethod(@PolyNull Object... args) {}
+
+    static void callToVarArgsObject(
+            @PolyNull Object pn, @NonNull Object nn, @Nullable Object nble) {
+        varArgsMethod(nble, nble);
+        varArgsMethod(nble, nn);
+        varArgsMethod(nble, pn);
+        varArgsMethod(nn, nble);
+        varArgsMethod(nn, nn);
+        varArgsMethod(nn, pn);
+        varArgsMethod(pn, nble);
+        varArgsMethod(pn, nn);
+        varArgsMethod(pn, pn);
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -629,7 +629,7 @@ public class AnnotatedTypes {
 
         parameters = new ArrayList<>(parameters.subList(0, parameters.size() - 1));
         for (int i = args.size() - parameters.size(); i > 0; --i) {
-            parameters.add(varargs.getComponentType());
+            parameters.add(varargs.getComponentType().shallowCopy());
         }
 
         return parameters;

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -629,7 +629,7 @@ public class AnnotatedTypes {
 
         parameters = new ArrayList<>(parameters.subList(0, parameters.size() - 1));
         for (int i = args.size() - parameters.size(); i > 0; --i) {
-            parameters.add(varargs.getComponentType().shallowCopy());
+            parameters.add(varargs.getComponentType().deepCopy());
         }
 
         return parameters;


### PR DESCRIPTION
Fixes #2171