### PR TITLE
Add external Rx Thread & Effect Checker to Manual

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version ?.?.?, ??, 2018
+
+The manual links to the Rx Thread & Effect Checker.
+
 ---------------------------------------------------------------------------
 Version 2.5.6, October 3, 2018
 

--- a/docs/manual/external-checkers.tex
+++ b/docs/manual/external-checkers.tex
@@ -174,7 +174,7 @@ enforces transitive class immutability in Java.  According to its webpage:
 \end{itemize}
 
 \section{UI Thread Checker for ReactiveX\label{rx-thread-checker}}
-The \href{https://plv.colorado.edu/benno/ase18.pdf}{Rx Thread \& Effect Checker} enforces
+The \href{https://plv.colorado.edu/benno/ase18.pdf}{Rx Thread \& Effect Checker}~\cite{SteinCSC2018} enforces
 UI Thread safety properties for stream-based Android applications and is available at
 \url{https://github.com/uber-research/RxThreadEffectChecker}.
 

--- a/docs/manual/external-checkers.tex
+++ b/docs/manual/external-checkers.tex
@@ -173,6 +173,10 @@ enforces transitive class immutability in Java.  According to its webpage:
   the object.
 \end{itemize}
 
+\section{UI Thread Checker for ReactiveX\label{rx-thread-checker}}
+The \href{https://plv.colorado.edu/benno/ase18.pdf}{Rx Thread \& Effect Checker} enforces
+UI Thread safety properties for stream-based Android applications and is available at
+\url{https://github.com/uber-research/RxThreadEffectChecker}.
 
 % LocalWords:  SCJ EnerJ CheckLT unsanitized JavaUI CCS IGJ OIGJ FIO08
 %%  LocalWords:  jOOQ typesafe

--- a/docs/manual/manual.bbl
+++ b/docs/manual/manual.bbl
@@ -154,6 +154,13 @@ Jaime Quinonez, Matthew~S. Tschantz, and Michael~D. Ernst.
 \newblock In {\em ECOOP 2008 --- Object-Oriented Programming, 22nd European
   Conference}, pages 616--641, Paphos, Cyprus, July 2008.
 
+\bibitem[SCSC18]{SteinCSC2018}
+Benno Stein, Lazaro Clapp, Manu Sridharan, and Bor{-}Yuh~Evan Chang.
+\newblock Safe stream-based programming with refinement types.
+\newblock In {\em ASE 2018: Proceedings of the 33rd Annual International
+  Conference on Automated Software Engineering}, pages 565--576, Montpellier,
+  France, September 2018.
+
 \bibitem[SDE12]{SpishakDE2012}
 Eric Spishak, Werner Dietl, and Michael~D. Ernst.
 \newblock A type system for regular expressions.


### PR DESCRIPTION
Adds a reference to the [Rx Thread & Effect Checker](https://github.com/uber-research/RxThreadEffectChecker) in the manual.

Note that I didn't add a citation to the paper because the BibTeX is being pulled from an [external source](https://github.com/mernst/plume-bib).  I'm happy to add the citation and send over a BibTeX entry for the paper, just wasn't sure of the process on that.