### PR TITLE
Issue #2183. Obtain constructor annotations even if using diamond operator to infer type arguments.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2204,36 +2204,45 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @return AnnotatedDeclaredType
      */
     public AnnotatedDeclaredType fromNewClass(NewClassTree newClassTree) {
-        if (TreeUtils.isDiamondTree(newClassTree)) {
-            AnnotatedDeclaredType type =
-                    (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
-            if (((com.sun.tools.javac.code.Type) type.actualType)
-                    .tsym
-                    .getTypeParameters()
-                    .nonEmpty()) {
-                Pair<Tree, AnnotatedTypeMirror> ctx = this.visitorState.getAssignmentContext();
-                if (ctx != null) {
-                    AnnotatedTypeMirror ctxtype = ctx.second;
-                    fromNewClassContextHelper(type, ctxtype);
-                }
-            }
-            return type;
-        } else if (newClassTree.getClassBody() != null) {
-            AnnotatedDeclaredType type =
-                    (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
+        AnnotatedDeclaredType type;
+        if (newClassTree.getClassBody() != null) {
+            type = (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
             // If newClassTree creates an anonymous class, then annotations in this location:
             //   new @HERE Class() {}
             // are on not on the identifier newClassTree, but rather on the modifier newClassTree.
             List<? extends AnnotationTree> annos =
                     newClassTree.getClassBody().getModifiers().getAnnotations();
             type.addAnnotations(TreeUtils.annotationsFromTypeAnnotationTrees(annos));
-            return type;
         } else {
             // If newClassTree does not create anonymous class,
             // newClassTree.getIdentifier includes the explicit annotations in this location:
             //   new @HERE Class()
-            return (AnnotatedDeclaredType) fromTypeTree(newClassTree.getIdentifier());
+            type = (AnnotatedDeclaredType) fromTypeTree(newClassTree.getIdentifier());
         }
+
+        if (TreeUtils.isDiamondTree(newClassTree)) {
+            // When the diamond operator is used, fromTypeTree() above does not appropriately
+            // populate the type arguments on the type. To do this, we need to create the type
+            // mirror again, using toAnnotatedType(). However, this does not populate any
+            // annotations -- so we need to take these from the fromTreeType() mirror.
+            AnnotatedDeclaredType typeWithInferences =
+                    (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
+            typeWithInferences.addAnnotations(type.getAnnotations());
+
+            if (((com.sun.tools.javac.code.Type) typeWithInferences.actualType)
+                    .tsym
+                    .getTypeParameters()
+                    .nonEmpty()) {
+                Pair<Tree, AnnotatedTypeMirror> ctx = this.visitorState.getAssignmentContext();
+                if (ctx != null) {
+                    AnnotatedTypeMirror ctxtype = ctx.second;
+                    fromNewClassContextHelper(typeWithInferences, ctxtype);
+                }
+            }
+
+            return typeWithInferences;
+        }
+        return type;
     }
 
     // This method extracts the ugly hacky parts.

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2224,7 +2224,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             // When the diamond operator is used, fromTypeTree() above does not appropriately
             // populate the type arguments on the type. To do this, we need to create the type
             // mirror again, using toAnnotatedType(). However, this does not populate any
-            // annotations -- so we need to take these from the fromTreeType() mirror.
+            // annotations -- so we need to take these from the fromTypeTree() mirror.
             AnnotatedDeclaredType typeWithInferences =
                     (AnnotatedDeclaredType) toAnnotatedType(TreeUtils.typeOf(newClassTree), false);
             typeWithInferences.addAnnotations(type.getAnnotations());

--- a/framework/tests/framework/AnnotatedGenerics.java
+++ b/framework/tests/framework/AnnotatedGenerics.java
@@ -17,6 +17,98 @@ class AnnotatedGenerics {
         @Odd String n2 = n.get();
     }
 
+    // Tests the type of the constructed class is correctly inferred for generics.
+    public void testConstructors() {
+        // Variant without annotated type parameters
+        @Odd MyClass<@Odd String> innerClass1 = new @Odd MyClass<@Odd String>();
+        @Odd NormalClass<@Odd String> normal1 = new @Odd NormalClass<@Odd String>();
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<@Odd String> innerClass2 = new MyClass<@Odd String>();
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<@Odd String> normal2 = new NormalClass<@Odd String>();
+
+        // Variant with annotated type parameters
+        @Odd MyClass<String> innerClass3 = new @Odd MyClass<String>();
+        @Odd NormalClass<String> normal3 = new @Odd NormalClass<String>();
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<String> innerClass4 = new MyClass<String>();
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<String> normal4 = new NormalClass<String>();
+    }
+
+    // Tests the type of the constructed class is correctly inferred when the
+    // diamond operator is used.
+    public void testConstructorsWithTypeParameterInferrence() {
+        @Odd MyClass<@Odd String> innerClass1 = new @Odd MyClass<>();
+        @Odd NormalClass<@Odd String> normal1 = new @Odd NormalClass<>();
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<@Odd String> innerClass2 = new MyClass<>();
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<@Odd String> normal2 = new NormalClass<>();
+
+        @Odd MyClass<String> innerClass3 = new @Odd MyClass<>();
+        @Odd NormalClass<String> normal3 = new @Odd NormalClass<>();
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<String> innerClass4 = new MyClass<>();
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<String> normal4 = new NormalClass<>();
+    }
+
+    // Tests the type of the constructor is appropriately inferred for anonymous classes
+    // N.B. This does not / cannot assert that the RHS is infact a subtype of the LHS.
+    public void testAnonymousConstructors() {
+        @Odd MyClass<@Odd String> innerClass1 = new @Odd MyClass<@Odd String>() {};
+        @Odd NormalClass<@Odd String> normal1 = new @Odd NormalClass<@Odd String>() {};
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<@Odd String> innerClass2 = new MyClass<@Odd String>() {};
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<@Odd String> normal2 = new NormalClass<@Odd String>() {};
+
+        @Odd MyClass<String> innerClass3 = new @Odd MyClass<String>() {};
+        @Odd NormalClass<String> normal3 = new @Odd NormalClass<String>() {};
+
+        // Should error because the RHS isn't annotated as '@Odd'
+        // :: error: (assignment.type.incompatible)
+        @Odd MyClass<String> innerClass4 = new MyClass<String>() {};
+        // :: error: (assignment.type.incompatible)
+        @Odd NormalClass<String> normal4 = new NormalClass<String>() {};
+    }
+
+    // The following test cases are not included because the Java compiler currently does
+    // not seem to support the diamond operator in conjunction with anonymous classes.
+    //
+    //    public void testAnonymousConstructorsWithTypeParameterInferrence() {
+    //    	@Odd MyClass<@Odd String> innerClass1 = new @Odd MyClass<>() {};
+    //    	@Odd NormalClass<@Odd String> normal1 = new @Odd NormalClass<>() {};
+    //
+    //    	// Should error because the RHS isn't annotated as '@Odd'
+    //    	@Odd MyClass<@Odd String> innerClass2 = new MyClass<>() {};
+    //    	@Odd NormalClass<@Odd String> normal2 = new NormalClass<>() {};
+    //
+    //    	@Odd MyClass<String> innerClass3 = new @Odd MyClass<>() {};
+    //    	@Odd NormalClass<String> normal3 = new @Odd NormalClass<>() {};
+    //
+    //    	// Should error because the RHS isn't annotated as '@Odd'
+    //    	@Odd MyClass<String> innerClass4 = new MyClass<>() {};
+    //    	@Odd NormalClass<String> normal4 = new NormalClass<>() {};
+    //    }
+
+    static class NormalClass<T> {
+        @Odd T get() {
+            return null;
+        }
+    }
+
     class MyClass<T> implements java.util.Iterator<@Odd T> {
         public boolean hasNext() {
             return true;


### PR DESCRIPTION
Here is the pull request to fix Issue #2183. 

Note: I have run the JUnit tests in the framework project in eclipse, but have had trouble running ./gradlew allTests on my environment.