### PR TITLE
Add blurb for KMS compliance checker

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,10 @@
+Version 2.5.8, December 3, 2018
+
+The manual now links to the AWS KMS compliance checker, which enforces
+that calls to AWS KMS only generate 256-bit keys.
+
+---------------------------------------------------------------------------
+
 Version 2.5.7, November 4, 2018
 
 New @EnsuresKeyFor and @EnsuresKeyForIf method annotations permit

--- a/docs/manual/external-checkers.tex
+++ b/docs/manual/external-checkers.tex
@@ -178,5 +178,12 @@ The \href{https://plv.colorado.edu/benno/ase18.pdf}{Rx Thread \& Effect Checker}
 UI Thread safety properties for stream-based Android applications and is available at
 \url{https://github.com/uber-research/RxThreadEffectChecker}.
 
+\section{AWS KMS compliance checker\label{kms-compliance-checker}}
+The \href{https://github.com/awslabs/aws-kms-compliance-checker}{AWS KMS compliance checker} extends the
+Constant Value Checker (see \chapterpageref{constant-value-checker}) to enforce that calls to
+Amazon Web Services' Key Management System only request 256-bit (or longer) data keys.
+This checker can be used to help enforce a compliance requirement (such as from SOC or PCI-DSS)
+that customer data is always encrypted with 256-bit keys.
+
 % LocalWords:  SCJ EnerJ CheckLT unsanitized JavaUI CCS IGJ OIGJ FIO08
 %%  LocalWords:  jOOQ typesafe


### PR DESCRIPTION
Adds a short blurb to section 23 (third party checkers) about the recently-released AWS KMS compliance checker (https://github.com/awslabs/aws-kms-compliance-checker), and notes it in the change log.