### PR TITLE
Rename areSameIgnoringValues to areSameByName

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
@@ -89,15 +89,15 @@ public class FenumAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, FENUM)
-                    && AnnotationUtils.areSameIgnoringValues(subAnno, FENUM)) {
+            if (AnnotationUtils.areSameByName(superAnno, FENUM)
+                    && AnnotationUtils.areSameByName(subAnno, FENUM)) {
                 return AnnotationUtils.areSame(superAnno, subAnno);
             }
             // Ignore annotation values to ensure that annotation is in supertype map.
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, FENUM)) {
+            if (AnnotationUtils.areSameByName(superAnno, FENUM)) {
                 superAnno = FENUM;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, FENUM)) {
+            if (AnnotationUtils.areSameByName(subAnno, FENUM)) {
                 subAnno = FENUM;
             }
             return super.isSubtype(subAnno, superAnno);

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
@@ -107,8 +107,8 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, FORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(superAnno, FORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, FORMAT)
+                    && AnnotationUtils.areSameByName(superAnno, FORMAT)) {
                 ConversionCategory[] rhsArgTypes = treeUtil.formatAnnotationToCategories(subAnno);
                 ConversionCategory[] lhsArgTypes = treeUtil.formatAnnotationToCategories(superAnno);
 
@@ -123,16 +123,16 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
                 return true;
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, FORMAT)) {
+            if (AnnotationUtils.areSameByName(superAnno, FORMAT)) {
                 superAnno = FORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, FORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, FORMAT)) {
                 subAnno = FORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, INVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(superAnno, INVALIDFORMAT)) {
                 superAnno = INVALIDFORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, INVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, INVALIDFORMAT)) {
                 subAnno = INVALIDFORMAT;
             }
 
@@ -141,14 +141,14 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror anno1, AnnotationMirror anno2) {
-            if (AnnotationUtils.areSameIgnoringValues(anno1, FORMATBOTTOM)) {
+            if (AnnotationUtils.areSameByName(anno1, FORMATBOTTOM)) {
                 return anno2;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno2, FORMATBOTTOM)) {
+            if (AnnotationUtils.areSameByName(anno2, FORMATBOTTOM)) {
                 return anno1;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, FORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, FORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, FORMAT)
+                    && AnnotationUtils.areSameByName(anno2, FORMAT)) {
                 ConversionCategory[] shorterArgTypesList =
                         treeUtil.formatAnnotationToCategories(anno1);
                 ConversionCategory[] longerArgTypesList =
@@ -176,8 +176,8 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
                 return treeUtil.categoriesToFormatAnnotation(resultArgTypes);
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, INVALIDFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, INVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, INVALIDFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, INVALIDFORMAT)) {
                 assert !anno1.getElementValues().isEmpty();
                 assert !anno2.getElementValues().isEmpty();
 
@@ -198,14 +198,14 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror greatestLowerBound(AnnotationMirror anno1, AnnotationMirror anno2) {
-            if (AnnotationUtils.areSameIgnoringValues(anno1, UNKNOWNFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, UNKNOWNFORMAT)) {
                 return anno2;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno2, UNKNOWNFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno2, UNKNOWNFORMAT)) {
                 return anno1;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, FORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, FORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, FORMAT)
+                    && AnnotationUtils.areSameByName(anno2, FORMAT)) {
                 ConversionCategory[] anno1ArgTypes = treeUtil.formatAnnotationToCategories(anno1);
                 ConversionCategory[] anno2ArgTypes = treeUtil.formatAnnotationToCategories(anno2);
 
@@ -224,8 +224,8 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
                 return treeUtil.categoriesToFormatAnnotation(anno3ArgTypes);
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, INVALIDFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, INVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, INVALIDFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, INVALIDFORMAT)) {
                 assert !anno1.getElementValues().isEmpty();
                 assert !anno2.getElementValues().isEmpty();
 

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
@@ -181,8 +181,8 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
         // than required, but a warning is issued."
         // The format.missing.arguments warning is issued here for assignments.
         // For method calls, it is issued in visitMethodInvocation.
-        if (AnnotationUtils.areSameIgnoringValues(rhs, atypeFactory.FORMAT)
-                && AnnotationUtils.areSameIgnoringValues(lhs, atypeFactory.FORMAT)) {
+        if (AnnotationUtils.areSameByName(rhs, atypeFactory.FORMAT)
+                && AnnotationUtils.areSameByName(lhs, atypeFactory.FORMAT)) {
             ConversionCategory[] rhsArgTypes =
                     atypeFactory.treeUtil.formatAnnotationToCategories(rhs);
             ConversionCategory[] lhsArgTypes =

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
@@ -223,8 +223,8 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, I18NFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(superAnno, I18NFORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, I18NFORMAT)
+                    && AnnotationUtils.areSameByName(superAnno, I18NFORMAT)) {
 
                 I18nConversionCategory[] rhsArgTypes =
                         treeUtil.formatAnnotationToCategories(subAnno);
@@ -243,30 +243,30 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                 return true;
             }
 
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, I18NINVALIDFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(subAnno, I18NINVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(superAnno, I18NINVALIDFORMAT)
+                    && AnnotationUtils.areSameByName(subAnno, I18NINVALIDFORMAT)) {
                 return AnnotationUtils.getElementValue(subAnno, "value", String.class, true)
                         .equals(
                                 AnnotationUtils.getElementValue(
                                         superAnno, "value", String.class, true));
             }
 
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, I18NFORMAT)) {
+            if (AnnotationUtils.areSameByName(superAnno, I18NFORMAT)) {
                 superAnno = I18NFORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, I18NFORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, I18NFORMAT)) {
                 subAnno = I18NFORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, I18NINVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(superAnno, I18NINVALIDFORMAT)) {
                 superAnno = I18NINVALIDFORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, I18NINVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(subAnno, I18NINVALIDFORMAT)) {
                 subAnno = I18NINVALIDFORMAT;
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, I18NFORMATFOR)) {
+            if (AnnotationUtils.areSameByName(superAnno, I18NFORMATFOR)) {
                 superAnno = I18NFORMATFOR;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, I18NFORMATFOR)) {
+            if (AnnotationUtils.areSameByName(subAnno, I18NFORMATFOR)) {
                 subAnno = I18NFORMATFOR;
             }
 
@@ -275,14 +275,14 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
 
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror anno1, AnnotationMirror anno2) {
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NFORMATBOTTOM)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NFORMATBOTTOM)) {
                 return anno2;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno2, I18NFORMATBOTTOM)) {
+            if (AnnotationUtils.areSameByName(anno2, I18NFORMATBOTTOM)) {
                 return anno1;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, I18NFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, I18NFORMAT)) {
                 I18nConversionCategory[] shorterArgTypesList =
                         treeUtil.formatAnnotationToCategories(anno1);
                 I18nConversionCategory[] longerArgTypesList =
@@ -310,8 +310,8 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                 }
                 return treeUtil.categoriesToFormatAnnotation(resultArgTypes);
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NINVALIDFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, I18NINVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NINVALIDFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, I18NINVALIDFORMAT)) {
                 assert !anno1.getElementValues().isEmpty();
                 assert !anno2.getElementValues().isEmpty();
 
@@ -328,7 +328,7 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
             }
 
             // All @I18nFormatFor annotations are unrelated by subtyping.
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NFORMATFOR)
+            if (AnnotationUtils.areSameByName(anno1, I18NFORMATFOR)
                     && AnnotationUtils.areSame(anno1, anno2)) {
                 return anno1;
             }
@@ -338,14 +338,14 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
 
         @Override
         public AnnotationMirror greatestLowerBound(AnnotationMirror anno1, AnnotationMirror anno2) {
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NUNKNOWNFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NUNKNOWNFORMAT)) {
                 return anno2;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno2, I18NUNKNOWNFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno2, I18NUNKNOWNFORMAT)) {
                 return anno1;
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, I18NFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, I18NFORMAT)) {
                 I18nConversionCategory[] anno1ArgTypes =
                         treeUtil.formatAnnotationToCategories(anno1);
                 I18nConversionCategory[] anno2ArgTypes =
@@ -367,8 +367,8 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                 }
                 return treeUtil.categoriesToFormatAnnotation(anno3ArgTypes);
             }
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NINVALIDFORMAT)
-                    && AnnotationUtils.areSameIgnoringValues(anno2, I18NINVALIDFORMAT)) {
+            if (AnnotationUtils.areSameByName(anno1, I18NINVALIDFORMAT)
+                    && AnnotationUtils.areSameByName(anno2, I18NINVALIDFORMAT)) {
                 assert !anno1.getElementValues().isEmpty();
                 assert !anno2.getElementValues().isEmpty();
 
@@ -384,7 +384,7 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                                 + ")");
             }
             // All @I18nFormatFor annotations are unrelated by subtyping.
-            if (AnnotationUtils.areSameIgnoringValues(anno1, I18NFORMATFOR)
+            if (AnnotationUtils.areSameByName(anno1, I18NFORMATFOR)
                     && AnnotationUtils.areSame(anno1, anno2)) {
                 return anno1;
             }

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -129,8 +129,8 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
         // i18nformat.missing.arguments and i18nformat.excess.arguments are issued here for
         // assignments.
         // For method calls, they are issued in checkInvocationFormatFor.
-        if (AnnotationUtils.areSameIgnoringValues(rhs, atypeFactory.I18NFORMAT)
-                && AnnotationUtils.areSameIgnoringValues(lhs, atypeFactory.I18NFORMAT)) {
+        if (AnnotationUtils.areSameByName(rhs, atypeFactory.I18NFORMAT)
+                && AnnotationUtils.areSameByName(lhs, atypeFactory.I18NFORMAT)) {
             I18nConversionCategory[] rhsArgTypes =
                     atypeFactory.treeUtil.formatAnnotationToCategories(rhs);
             I18nConversionCategory[] lhsArgTypes =

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -638,8 +638,7 @@ public abstract class InitializationAnnotatedTypeFactory<
         }
         // not necessary if there is an explicit UnknownInitialization
         // annotation on the field
-        if (AnnotationUtils.containsSameByName(
-                fieldAnnotations.getAnnotations(), UNCLASSIFIED)) {
+        if (AnnotationUtils.containsSameByName(fieldAnnotations.getAnnotations(), UNCLASSIFIED)) {
             return;
         }
         if (isUnclassified(receiverType) || isFree(receiverType)) {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -140,10 +140,10 @@ public abstract class InitializationAnnotatedTypeFactory<
      */
     protected boolean isInitializationAnnotation(AnnotationMirror anno) {
         assert anno != null;
-        return AnnotationUtils.areSameIgnoringValues(anno, UNCLASSIFIED)
-                || AnnotationUtils.areSameIgnoringValues(anno, FREE)
-                || AnnotationUtils.areSameIgnoringValues(anno, COMMITTED)
-                || AnnotationUtils.areSameIgnoringValues(anno, FBCBOTTOM);
+        return AnnotationUtils.areSameByName(anno, UNCLASSIFIED)
+                || AnnotationUtils.areSameByName(anno, FREE)
+                || AnnotationUtils.areSameByName(anno, COMMITTED)
+                || AnnotationUtils.areSameByName(anno, FBCBOTTOM);
     }
 
     /*

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -638,7 +638,7 @@ public abstract class InitializationAnnotatedTypeFactory<
         }
         // not necessary if there is an explicit UnknownInitialization
         // annotation on the field
-        if (AnnotationUtils.containsSameIgnoringValues(
+        if (AnnotationUtils.containsSameByName(
                 fieldAnnotations.getAnnotations(), UNCLASSIFIED)) {
             return;
         }

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -110,7 +110,7 @@ public class InitializationVisitor<
             // UnknownInitialization annotation
             Set<AnnotationMirror> fieldAnnotations =
                     atypeFactory.getAnnotatedType(TreeUtils.elementFromUse(lhs)).getAnnotations();
-            if (!AnnotationUtils.containsSameIgnoringValues(
+            if (!AnnotationUtils.containsSameByName(
                     fieldAnnotations, atypeFactory.UNCLASSIFIED)) {
                 if (!ElementUtils.isStatic(el)
                         && !(atypeFactory.isCommitted(yType)

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -110,8 +110,7 @@ public class InitializationVisitor<
             // UnknownInitialization annotation
             Set<AnnotationMirror> fieldAnnotations =
                     atypeFactory.getAnnotatedType(TreeUtils.elementFromUse(lhs)).getAnnotations();
-            if (!AnnotationUtils.containsSameByName(
-                    fieldAnnotations, atypeFactory.UNCLASSIFIED)) {
+            if (!AnnotationUtils.containsSameByName(fieldAnnotations, atypeFactory.UNCLASSIFIED)) {
                 if (!ElementUtils.isStatic(el)
                         && !(atypeFactory.isCommitted(yType)
                                 || atypeFactory.isFree(xType)

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -274,11 +274,11 @@ public class LockAnnotatedTypeFactory
         }
 
         boolean isGuardedBy(AnnotationMirror am) {
-            return AnnotationUtils.areSameIgnoringValues(am, GUARDEDBY);
+            return AnnotationUtils.areSameByName(am, GUARDEDBY);
         }
 
         boolean isGuardSatisfied(AnnotationMirror am) {
-            return AnnotationUtils.areSameIgnoringValues(am, GUARDSATISFIED);
+            return AnnotationUtils.areSameByName(am, GUARDSATISFIED);
         }
 
         @Override

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -200,18 +200,18 @@ public class KeyForAnnotatedTypeFactory
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, KEYFOR)
-                    && AnnotationUtils.areSameIgnoringValues(subAnno, KEYFOR)) {
+            if (AnnotationUtils.areSameByName(superAnno, KEYFOR)
+                    && AnnotationUtils.areSameByName(subAnno, KEYFOR)) {
                 List<String> lhsValues = extractValues(superAnno);
                 List<String> rhsValues = extractValues(subAnno);
 
                 return rhsValues.containsAll(lhsValues);
             }
             // Ignore annotation values to ensure that annotation is in supertype map.
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, KEYFOR)) {
+            if (AnnotationUtils.areSameByName(superAnno, KEYFOR)) {
                 superAnno = KEYFOR;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, KEYFOR)) {
+            if (AnnotationUtils.areSameByName(subAnno, KEYFOR)) {
                 subAnno = KEYFOR;
             }
             return super.isSubtype(subAnno, superAnno);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -114,12 +114,12 @@ public class NullnessVisitor
         for (AnnotationMirror anno : useType.getAnnotations()) {
             if (QualifierPolymorphism.isPolyAll(anno)) {
                 // ok.
-            } else if (containsSameIgnoringValues(initQuals, anno)) {
+            } else if (containsSameByName(initQuals, anno)) {
                 if (foundInit) {
                     return false;
                 }
                 foundInit = true;
-            } else if (containsSameIgnoringValues(nonNullQuals, anno)) {
+            } else if (containsSameByName(nonNullQuals, anno)) {
                 if (foundNonNull) {
                     return false;
                 }
@@ -160,7 +160,7 @@ public class NullnessVisitor
         return super.isValidUse(type, tree);
     }
 
-    private boolean containsSameIgnoringValues(
+    private boolean containsSameByName(
             Set<Class<? extends Annotation>> quals, AnnotationMirror anno) {
         for (Class<? extends Annotation> q : quals) {
             if (AnnotationUtils.areSameByClass(anno, q)) {
@@ -543,7 +543,7 @@ public class NullnessVisitor
             for (AnnotationMirror a : atypeFactory.getAnnotatedType(t).getAnnotations()) {
                 // is this an annotation of the nullness checker?
                 boolean nullnessCheckerAnno =
-                        containsSameIgnoringValues(atypeFactory.getNullnessAnnotations(), a);
+                        containsSameByName(atypeFactory.getNullnessAnnotations(), a);
                 if (nullnessCheckerAnno && !AnnotationUtils.areSame(NONNULL, a)) {
                     // The type is not non-null => warning
                     checker.report(

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -171,24 +171,24 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, REGEX)
-                    && AnnotationUtils.areSameIgnoringValues(superAnno, REGEX)) {
+            if (AnnotationUtils.areSameByName(subAnno, REGEX)
+                    && AnnotationUtils.areSameByName(superAnno, REGEX)) {
                 int rhsValue = getRegexValue(subAnno);
                 int lhsValue = getRegexValue(superAnno);
                 return lhsValue <= rhsValue;
             }
             // TODO: subtyping between PartialRegex?
             // Ignore annotation values to ensure that annotation is in supertype map.
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, REGEX)) {
+            if (AnnotationUtils.areSameByName(superAnno, REGEX)) {
                 superAnno = REGEX;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, REGEX)) {
+            if (AnnotationUtils.areSameByName(subAnno, REGEX)) {
                 subAnno = REGEX;
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, PARTIALREGEX)) {
+            if (AnnotationUtils.areSameByName(superAnno, PARTIALREGEX)) {
                 superAnno = PARTIALREGEX;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, PARTIALREGEX)) {
+            if (AnnotationUtils.areSameByName(subAnno, PARTIALREGEX)) {
                 subAnno = PARTIALREGEX;
             }
             return super.isSubtype(subAnno, superAnno);

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -518,7 +518,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, subAnno)) {
+            if (AnnotationUtils.areSameByName(superAnno, subAnno)) {
                 return AnnotationUtils.areSame(superAnno, subAnno);
             }
             superAnno = removePrefix(superAnno);
@@ -549,7 +549,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // if the two units have the same base SI unit
             // TODO: it is possible to rewrite these two lines to use UnitsRelationsTools, will it
             // have worse performance?
-            if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+            if (AnnotationUtils.areSameByName(a1, a2)) {
                 // and if they have the same Prefix, it means it is the same unit
                 if (AnnotationUtils.areSame(a1, a2)) {
                     // return the unit

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsRelationsTools.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsRelationsTools.java
@@ -311,7 +311,6 @@ public class UnitsRelationsTools {
             return false;
         }
 
-        return AnnotationUtils.containsSameByName(
-                annoType.getAnnotations(), unitsAnnotation);
+        return AnnotationUtils.containsSameByName(annoType.getAnnotations(), unitsAnnotation);
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsRelationsTools.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsRelationsTools.java
@@ -311,7 +311,7 @@ public class UnitsRelationsTools {
             return false;
         }
 
-        return AnnotationUtils.containsSameIgnoringValues(
+        return AnnotationUtils.containsSameByName(
                 annoType.getAnnotations(), unitsAnnotation);
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
@@ -110,7 +110,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameIgnoringValues(
+            if (!AnnotationUtils.areSameByName(
                     getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {
@@ -136,7 +136,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror greatestLowerBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameIgnoringValues(
+            if (!AnnotationUtils.areSameByName(
                     getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {

--- a/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
@@ -110,8 +110,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameByName(
-                    getTopAnnotation(a1), getTopAnnotation(a2))) {
+            if (!AnnotationUtils.areSameByName(getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {
                 return a2;
@@ -136,8 +135,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public AnnotationMirror greatestLowerBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameByName(
-                    getTopAnnotation(a1), getTopAnnotation(a2))) {
+            if (!AnnotationUtils.areSameByName(getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {
                 return a1;

--- a/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
@@ -157,8 +157,7 @@ public class MethodValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameByName(
-                    getTopAnnotation(a1), getTopAnnotation(a2))) {
+            if (!AnnotationUtils.areSameByName(getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {
                 return a2;

--- a/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
@@ -157,14 +157,14 @@ public class MethodValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameIgnoringValues(
+            if (!AnnotationUtils.areSameByName(
                     getTopAnnotation(a1), getTopAnnotation(a2))) {
                 return null;
             } else if (isSubtype(a1, a2)) {
                 return a2;
             } else if (isSubtype(a2, a1)) {
                 return a1;
-            } else if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+            } else if (AnnotationUtils.areSameByName(a1, a2)) {
                 List<MethodSignature> a1Sigs = getListOfMethodSignatures(a1);
                 List<MethodSignature> a2Sigs = getListOfMethodSignatures(a2);
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -676,7 +676,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameIgnoringValues(
+            if (!AnnotationUtils.areSameByName(
                     getTopAnnotation(a1), getTopAnnotation(a2))) {
                 // The annotations are in different hierarchies
                 return null;
@@ -691,7 +691,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 return a1;
             }
 
-            if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+            if (AnnotationUtils.areSameByName(a1, a2)) {
                 // If both are the same type, determine the type and merge
                 if (AnnotationUtils.areSameByClass(a1, IntRange.class)) {
                     // special handling for IntRange
@@ -858,7 +858,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 return AnnotationUtils.areSameByClass(superAnno, PolyValue.class);
             } else if (AnnotationUtils.areSameByClass(superAnno, PolyValue.class)) {
                 return AnnotationUtils.areSameByClass(subAnno, PolyValue.class);
-            } else if (AnnotationUtils.areSameIgnoringValues(superAnno, subAnno)) {
+            } else if (AnnotationUtils.areSameByName(superAnno, subAnno)) {
                 // Same type, so might be subtype
                 if (AnnotationUtils.areSameByClass(subAnno, IntRange.class)
                         || AnnotationUtils.areSameByClass(subAnno, ArrayLenRange.class)) {
@@ -1088,7 +1088,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotationMirror dimType =
                     getAnnotatedType(dimensions.get(0)).getAnnotationInHierarchy(UNKNOWNVAL);
 
-            if (AnnotationUtils.areSameIgnoringValues(dimType, BOTTOMVAL)) {
+            if (AnnotationUtils.areSameByName(dimType, BOTTOMVAL)) {
                 type.replaceAnnotation(BOTTOMVAL);
             } else {
                 RangeOrListOfValues rolv = null;

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -676,8 +676,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if (!AnnotationUtils.areSameByName(
-                    getTopAnnotation(a1), getTopAnnotation(a2))) {
+            if (!AnnotationUtils.areSameByName(getTopAnnotation(a1), getTopAnnotation(a2))) {
                 // The annotations are in different hierarchies
                 return null;
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3278,7 +3278,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
              * For now, do nothing and just take the first, most concrete, annotation.
             AnnotationMirror prev = null;
             for (AnnotationMirror an : results) {
-                if (AnnotationUtils.areSameIgnoringValues(an, annotation)) {
+                if (AnnotationUtils.areSameByName(an, annotation)) {
                     prev = an;
                     break;
                 }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1164,7 +1164,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     annos = AnnotationUtils.createAnnotationSet();
                     declAnnosFromStubFiles.put(ElementUtils.getVerboseName(elt), annos);
                 }
-                if (!AnnotationUtils.containsSameIgnoringValues(annos, fromStubFile)) {
+                if (!AnnotationUtils.containsSameByName(annos, fromStubFile)) {
                     annos.add(fromByteCode);
                 }
             }
@@ -2471,7 +2471,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         if (a == null) {
             return false;
         }
-        return AnnotationUtils.containsSameIgnoringValues(
+        return AnnotationUtils.containsSameByName(
                 this.getQualifierHierarchy().getTypeQualifiers(), a);
     }
 
@@ -3258,7 +3258,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     }
                     if (AnnotationUtils.containsSameByClass(
                                     annotationsOnAnnotation, InheritedAnnotation.class)
-                            || AnnotationUtils.containsSameIgnoringValues(
+                            || AnnotationUtils.containsSameByName(
                                     inheritedAnnotations, annotation)) {
                         addOrMerge(results, annotation);
                     }
@@ -3268,7 +3268,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     private void addOrMerge(Set<AnnotationMirror> results, AnnotationMirror annotation) {
-        if (AnnotationUtils.containsSameIgnoringValues(results, annotation)) {
+        if (AnnotationUtils.containsSameByName(results, annotation)) {
             /*
              * TODO: feature request: figure out a way to merge multiple annotations
              * of the same kind. For some annotations this might mean merging some

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -366,7 +366,7 @@ public abstract class AnnotatedTypeMirror {
                 atypeFactory.getQualifierHierarchy().getTypeQualifiers();
         for (AnnotationMirror explicitAnno : typeAnnotations) {
             for (AnnotationMirror validAnno : validAnnotations) {
-                if (AnnotationUtils.areSameIgnoringValues(explicitAnno, validAnno)) {
+                if (AnnotationUtils.areSameByName(explicitAnno, validAnno)) {
                     explicitAnnotations.add(explicitAnno);
                 }
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -511,8 +511,7 @@ public abstract class AnnotatedTypeMirror {
      * @see #getExplicitAnnotations()
      */
     public boolean hasExplicitAnnotation(Class<? extends Annotation> a) {
-        return AnnotationUtils.containsSameByName(
-                getExplicitAnnotations(), getAnnotation(a));
+        return AnnotationUtils.containsSameByName(getExplicitAnnotations(), getAnnotation(a));
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -470,7 +470,7 @@ public abstract class AnnotatedTypeMirror {
      * @see #hasAnnotation(AnnotationMirror)
      */
     public boolean hasAnnotationRelaxed(AnnotationMirror a) {
-        return AnnotationUtils.containsSameIgnoringValues(annotations, a);
+        return AnnotationUtils.containsSameByName(annotations, a);
     }
 
     /**
@@ -480,7 +480,7 @@ public abstract class AnnotatedTypeMirror {
      * @see #hasAnnotationRelaxed(AnnotationMirror)
      */
     public boolean hasEffectiveAnnotationRelaxed(AnnotationMirror a) {
-        return AnnotationUtils.containsSameIgnoringValues(getEffectiveAnnotations(), a);
+        return AnnotationUtils.containsSameByName(getEffectiveAnnotations(), a);
     }
 
     /**
@@ -494,7 +494,7 @@ public abstract class AnnotatedTypeMirror {
      * @see #getExplicitAnnotations()
      */
     public boolean hasExplicitAnnotationRelaxed(AnnotationMirror a) {
-        return AnnotationUtils.containsSameIgnoringValues(getExplicitAnnotations(), a);
+        return AnnotationUtils.containsSameByName(getExplicitAnnotations(), a);
     }
 
     /**
@@ -511,7 +511,7 @@ public abstract class AnnotatedTypeMirror {
      * @see #getExplicitAnnotations()
      */
     public boolean hasExplicitAnnotation(Class<? extends Annotation> a) {
-        return AnnotationUtils.containsSameIgnoringValues(
+        return AnnotationUtils.containsSameByName(
                 getExplicitAnnotations(), getAnnotation(a));
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -392,13 +392,13 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
 
     @Override
     public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-        if (!AnnotationUtils.areSameIgnoringValues(getTopAnnotation(a1), getTopAnnotation(a2))) {
+        if (!AnnotationUtils.areSameByName(getTopAnnotation(a1), getTopAnnotation(a2))) {
             return null;
         } else if (isSubtype(a1, a2)) {
             return a2;
         } else if (isSubtype(a2, a1)) {
             return a1;
-        } else if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+        } else if (AnnotationUtils.areSameByName(a1, a2)) {
             return getTopAnnotation(a1);
         }
         if (lubs == null) {
@@ -422,7 +422,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
 
     @Override
     public AnnotationMirror greatestLowerBound(AnnotationMirror a1, AnnotationMirror a2) {
-        if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+        if (AnnotationUtils.areSameByName(a1, a2)) {
             return AnnotationUtils.areSame(a1, a2) ? a1 : getBottomAnnotation(a1);
         }
         if (glbs == null) {
@@ -471,7 +471,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
             return true;
             }
         }*/
-        if (AnnotationUtils.areSameIgnoringValues(subAnno, superAnno)) {
+        if (AnnotationUtils.areSameByName(subAnno, superAnno)) {
             return AnnotationUtils.areSame(subAnno, superAnno);
         }
         Set<AnnotationMirror> supermap1 = this.supertypesMap.get(subAnno);
@@ -650,7 +650,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
                 outer:
                 for (AnnotationMirror btm : bottoms) {
                     for (AnnotationMirror btmsuper : fullMap.get(btm)) {
-                        if (AnnotationUtils.areSameIgnoringValues(btmsuper, polyTop)) {
+                        if (AnnotationUtils.areSameByName(btmsuper, polyTop)) {
                             found = true;
                             bottom = btm;
                             break outer;
@@ -676,7 +676,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
         Map<AnnotationPair, AnnotationMirror> newlubs = new HashMap<>();
         for (AnnotationMirror a1 : typeQualifiers) {
             for (AnnotationMirror a2 : typeQualifiers) {
-                if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+                if (AnnotationUtils.areSameByName(a1, a2)) {
                     continue;
                 }
                 if (!AnnotationUtils.areSame(getTopAnnotation(a1), getTopAnnotation(a2))) {
@@ -799,7 +799,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
         Map<AnnotationPair, AnnotationMirror> newglbs = new HashMap<>();
         for (AnnotationMirror a1 : typeQualifiers) {
             for (AnnotationMirror a2 : typeQualifiers) {
-                if (AnnotationUtils.areSameIgnoringValues(a1, a2)) {
+                if (AnnotationUtils.areSameByName(a1, a2)) {
                     continue;
                 }
                 if (!AnnotationUtils.areSame(getTopAnnotation(a1), getTopAnnotation(a2))) {
@@ -968,12 +968,12 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
                 return false;
             }
             AnnotationPair other = (AnnotationPair) o;
-            if (AnnotationUtils.areSameIgnoringValues(a1, other.a1)
-                    && AnnotationUtils.areSameIgnoringValues(a2, other.a2)) {
+            if (AnnotationUtils.areSameByName(a1, other.a1)
+                    && AnnotationUtils.areSameByName(a2, other.a2)) {
                 return true;
             }
-            if (AnnotationUtils.areSameIgnoringValues(a2, other.a1)
-                    && AnnotationUtils.areSameIgnoringValues(a1, other.a2)) {
+            if (AnnotationUtils.areSameByName(a2, other.a1)
+                    && AnnotationUtils.areSameByName(a1, other.a2)) {
                 return true;
             }
             return false;

--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -627,7 +627,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
                     polyTop = declTop;
                 } else {
                     for (AnnotationMirror ds : declSupers) {
-                        if (AnnotationUtils.containsSameIgnoringValues(tops, ds)) {
+                        if (AnnotationUtils.containsSameByName(tops, ds)) {
                             polyTop = ds;
                         }
                     }

--- a/framework/src/test/java/testlib/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/util/FlowTestAnnotatedTypeFactory.java
@@ -73,14 +73,14 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, VALUE)
-                    && AnnotationUtils.areSameIgnoringValues(subAnno, VALUE)) {
+            if (AnnotationUtils.areSameByName(superAnno, VALUE)
+                    && AnnotationUtils.areSameByName(subAnno, VALUE)) {
                 return AnnotationUtils.areSame(superAnno, subAnno);
             }
-            if (AnnotationUtils.areSameIgnoringValues(superAnno, VALUE)) {
+            if (AnnotationUtils.areSameByName(superAnno, VALUE)) {
                 superAnno = VALUE;
             }
-            if (AnnotationUtils.areSameIgnoringValues(subAnno, VALUE)) {
+            if (AnnotationUtils.areSameByName(subAnno, VALUE)) {
                 subAnno = VALUE;
             }
             return super.isSubtype(subAnno, superAnno);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -75,12 +75,11 @@ public class AnnotationUtils {
     }
 
     /**
-     * Checks if both annotations are the same.
+     * Returns true iff both annotations are of the same type and have the same annotation values.
      *
-     * <p>Returns true iff both annotations are of the same type and have the same annotation
-     * values. This behavior differs from {@code AnnotationMirror.equals(Object)}. The equals method
+     * <p>This behavior differs from {@code AnnotationMirror.equals(Object)}. The equals method
      * returns true iff both annotations are the same and annotate the same annotation target (e.g.
-     * field, variable, etc).
+     * field, variable, etc) -- that is, if its arguments are the same annotation instance.
      *
      * @return true iff a1 and a2 are the same annotation
      */
@@ -106,7 +105,7 @@ public class AnnotationUtils {
 
     /**
      * @see #areSame(AnnotationMirror, AnnotationMirror)
-     * @return true iff a1 and a2 have the same annotation type
+     * @return true iff a1 and a2 have the same annotation name
      */
     public static boolean areSameByName(
             @Nullable AnnotationMirror a1, @Nullable AnnotationMirror a2) {
@@ -266,9 +265,9 @@ public class AnnotationUtils {
      *
      * @return true iff c contains anno, according to areSameByName
      */
-    public static boolean containsSameIgnoringValues(
+    public static boolean containsSameByName(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
-        return getSameIgnoringValues(c, anno) != null;
+        return getSameByName(c, anno) != null;
     }
 
     /**
@@ -278,7 +277,7 @@ public class AnnotationUtils {
      * @return AnnotationMirror with the same class as {@code anno} iff c contains anno, according
      *     to areSameByName; otherwise, {@code null}
      */
-    public static AnnotationMirror getSameIgnoringValues(
+    public static AnnotationMirror getSameByName(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
         for (AnnotationMirror an : c) {
             if (AnnotationUtils.areSameByName(an, anno)) {

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -89,7 +89,7 @@ public class AnnotationUtils {
             return true;
         }
 
-        if (!areSameIgnoringValues(a1, a2)) {
+        if (!areSameByName(a1, a2)) {
             return false;
         }
 
@@ -108,7 +108,7 @@ public class AnnotationUtils {
      * @see #areSame(AnnotationMirror, AnnotationMirror)
      * @return true iff a1 and a2 have the same annotation type
      */
-    public static boolean areSameIgnoringValues(
+    public static boolean areSameByName(
             @Nullable AnnotationMirror a1, @Nullable AnnotationMirror a2) {
         if (a1 == a2) {
             return true;
@@ -262,9 +262,9 @@ public class AnnotationUtils {
 
     /**
      * Checks that the collection contains the annotation ignoring values. Using Collection.contains
-     * does not always work, because it does not use areSameIgnoringValues for comparison.
+     * does not always work, because it does not use areSameByName for comparison.
      *
-     * @return true iff c contains anno, according to areSameIgnoringValues
+     * @return true iff c contains anno, according to areSameByName
      */
     public static boolean containsSameIgnoringValues(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
@@ -276,12 +276,12 @@ public class AnnotationUtils {
      * ignoring values.
      *
      * @return AnnotationMirror with the same class as {@code anno} iff c contains anno, according
-     *     to areSameIgnoringValues; otherwise, {@code null}
+     *     to areSameByName; otherwise, {@code null}
      */
     public static AnnotationMirror getSameIgnoringValues(
             Collection<? extends AnnotationMirror> c, AnnotationMirror anno) {
         for (AnnotationMirror an : c) {
-            if (AnnotationUtils.areSameIgnoringValues(an, anno)) {
+            if (AnnotationUtils.areSameByName(an, anno)) {
                 return an;
             }
         }


### PR DESCRIPTION
This is clearer, shorter, and consistent with existing areSameByName methods.