### PR TITLE
Don't call getDeclAnnotationNoAliases in ContractsUtils

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/ContractsUtils.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/ContractsUtils.java
@@ -338,7 +338,7 @@ public class ContractsUtils {
         for (ExecutableElement meth :
                 ElementFilter.methodsIn(contractAnnoElement.getEnclosedElements())) {
             AnnotationMirror argumentAnnotation =
-                    factory.getDeclAnnotationNoAliases(meth, QualifierArgument.class);
+                    factory.getDeclAnnotation(meth, QualifierArgument.class);
             if (argumentAnnotation != null) {
                 String sourceName = meth.getSimpleName().toString();
                 String targetName =


### PR DESCRIPTION
No tests fail.  Is this an acceptable change to make?