### PR TITLE
Remove unreachable code

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -706,9 +706,7 @@ public class FlowExpressionParseUtil {
                 depth++;
             } else if (ch == close) {
                 depth--;
-                if (depth < 0) {
-                    break;
-                } else if (depth == 0) {
+                if (depth == 0) {
                     return i - 1;
                 }
             }


### PR DESCRIPTION
Here depth can never be negative, since it starts positive, and
if it ever reaches 0, we return immediately.