### PR TITLE
Make a variable public because it is used by checker-framework-inference

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -342,7 +342,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     public final boolean ignoreUninferredTypeArguments;
 
     /** The Object.getClass method. */
-    protected final ExecutableElement objectGetClass;
+    public final ExecutableElement objectGetClass;
 
     /**
      * Constructs a factory from the given {@link ProcessingEnvironment} instance and syntax tree


### PR DESCRIPTION
Merge with https://github.com/typetools/checker-framework-inference/pull/97