### PR TITLE
Only check the primary annotations when checking constructor invocation annotation

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2677,7 +2677,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // Issue a warning if the type at constructor invocation is a subtype of the constructor
         // declaration type.
         // This is equivalent to down-casting.
-        if (!atypeFactory.getTypeHierarchy().isSubtype(returnType, invocation)) {
+        // Only check the primary annotations, the type arguments are checked elsewhere.
+        if (!atypeFactory
+                .getQualifierHierarchy()
+                .isSubtype(returnType.getAnnotations(), invocation.getAnnotations())) {
             checker.report(
                     Result.warning(
                             "cast.unsafe.constructor.invocation",


### PR DESCRIPTION
When checking `new @B Banana()` assuming `Banana` is defined as
```
class Banana{
  @A Banana() {...}
}
```
Only issue a warning if `@B <: @A`, rather than considering the whole type. 

The crashed reported in Issue #2302 was caused by checking the whole type, so this pull request reverts the changes added to fix the crash.  (Note diamond type inference will be improved as a part of Java 8 type inference.)