### PR TITLE
Correct dependent type annotations for NewClassTrees

### DIFF
--- a/checker/tests/nullness/Issue415.java
+++ b/checker/tests/nullness/Issue415.java
@@ -13,7 +13,7 @@ public final class Issue415 {
     Map<String, Integer> mymap = new HashMap<>();
     // :: error: (expression.unparsable.type.invalid)
     public static void usesField(Set<@KeyFor("this.mymap") String> keySet) {
-        // :: error: (expression.unparsable.type.invalid) :: error: (argument.type.incompatible)
+        // :: error: (expression.unparsable.type.invalid)
         new ArrayList<@KeyFor("this.mymap") String>(keySet);
     }
 

--- a/checker/tests/nullness/KeyForDiamond.java
+++ b/checker/tests/nullness/KeyForDiamond.java
@@ -1,0 +1,17 @@
+import java.util.*;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+
+public class KeyForDiamond {
+    private final Map<Integer, Double> map = new HashMap<>();
+
+    public void method() {
+        Map<@KeyFor("map") Integer, Double> paths1; // does not compile
+        Map<@KeyFor("map") Integer, Double> paths = new HashMap<>(); // does not compile
+        Set<@KeyFor("map") Integer> set = new HashSet<>(); // compiles
+        List<@KeyFor("map") Integer> list = new ArrayList<>(); // does not compile
+    }
+
+    public static void main(String[] args) {
+        KeyForDiamond t = new KeyForDiamond();
+    }
+}

--- a/checker/tests/nullness/KeyForDiamond.java
+++ b/checker/tests/nullness/KeyForDiamond.java
@@ -5,10 +5,9 @@ public class KeyForDiamond {
     private final Map<Integer, Double> map = new HashMap<>();
 
     public void method() {
-        Map<@KeyFor("map") Integer, Double> paths1; // does not compile
-        Map<@KeyFor("map") Integer, Double> paths = new HashMap<>(); // does not compile
-        Set<@KeyFor("map") Integer> set = new HashSet<>(); // compiles
-        List<@KeyFor("map") Integer> list = new ArrayList<>(); // does not compile
+        Map<@KeyFor("map") Integer, Double> paths = new HashMap<>();
+        Set<@KeyFor("map") Integer> set = new HashSet<>();
+        List<@KeyFor("map") Integer> list = new ArrayList<>();
     }
 
     public static void main(String[] args) {

--- a/checker/tests/nullness/KeyForValidation.java
+++ b/checker/tests/nullness/KeyForValidation.java
@@ -111,7 +111,7 @@ public class KeyForValidation {
 
     // :: error: (expression.unparsable.type.invalid)
     public static void test2(Set<@KeyFor("this.instanceField") String> keySet) {
-        // :: error: (expression.unparsable.type.invalid) :: error: (argument.type.incompatible)
+        // :: error: (expression.unparsable.type.invalid)
         new ArrayList<@KeyFor("this.instanceField") String>(keySet);
         // :: error: (expression.unparsable.type.invalid)
         new ArrayList<@KeyFor("this.instanceField") String>();

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -228,8 +228,13 @@ public class DependentTypesHelper {
         }
 
         TreePath path = factory.getPath(tree);
+        Tree enclosingClass = TreeUtils.enclosingClass(path);
+        if (enclosingClass == null) {
+            return;
+        }
+        TypeMirror enclosingType = TreeUtils.typeOf(enclosingClass);
         FlowExpressions.Receiver r =
-                FlowExpressions.internalReprOfImplicitReceiver(TreeUtils.elementFromUse(tree));
+                FlowExpressions.internalReprOfPseudoReceiver(path, enclosingType);
         FlowExpressionContext context =
                 new FlowExpressionContext(
                         r,


### PR DESCRIPTION
See `checker/tests/nullness/KeyForDiamond.java` for examples that were failing.