### PR TITLE
Only check the primary annotations for constructor invocations.

### DIFF
--- a/checker/tests/tainting/Issue2330.java
+++ b/checker/tests/tainting/Issue2330.java
@@ -1,0 +1,15 @@
+import java.util.*;
+import org.checkerframework.checker.tainting.qual.*;
+
+public class Issue2330<T extends @Tainted Object> {
+    @SuppressWarnings("tainting")
+    public @Untainted Issue2330(@PolyTainted int i) {}
+
+    @SuppressWarnings("tainting")
+    public @Untainted Issue2330() {}
+
+    public static void f(@PolyTainted int i) {
+        new @Untainted Issue2330<@PolyTainted Integer>(i);
+        new @Untainted Issue2330<@PolyTainted Integer>();
+    }
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2642,33 +2642,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotatedDeclaredType invocation,
             AnnotatedExecutableType constructor,
             NewClassTree newClassTree) {
-        AnnotatedDeclaredType returnType = (AnnotatedDeclaredType) constructor.getReturnType();
-        // When an interface is used as the identifier in an anonymous class (e.g. new Comparable()
-        // {}) the constructor method will be Object.init() {} which has an Object return type When
-        // TypeHierarchy attempts to convert it to the supertype (e.g. Comparable) it will return
-        // null from asSuper and return false for the check.  Instead, copy the primary annotations
-        // to the declared type and then do a subtyping check.
-        if (invocation.getUnderlyingType().asElement().getKind().isInterface()
-                && TypesUtils.isObject(returnType.getUnderlyingType())) {
-            final AnnotatedDeclaredType retAsDt = invocation.deepCopy();
-            retAsDt.replaceAnnotations(returnType.getAnnotations());
-            returnType = retAsDt;
-        } else if (newClassTree.getClassBody() != null) {
-            // An anonymous class invokes the constructor of its super class, so the underlying
-            // types of invocation and returnType are not the same.  Call asSuper so they are the
-            // same and the is subtype tests below work correctly
-            invocation = AnnotatedTypes.asSuper(atypeFactory, invocation, returnType);
-        }
+        // Only check the primary annotations, the type arguments are checked elsewhere.
+        Set<AnnotationMirror> returnType = constructor.getReturnType().getAnnotations();
+        Set<AnnotationMirror> invocationAnnos = invocation.getAnnotations();
 
         // The return type of the constructor (returnType) must be comparable to the type of the
         // constructor invocation (invocation).
-        if (!(atypeFactory.getTypeHierarchy().isSubtype(invocation, returnType)
-                || atypeFactory.getTypeHierarchy().isSubtype(returnType, invocation))) {
+        if (!(atypeFactory.getQualifierHierarchy().isSubtype(invocationAnnos, returnType)
+                || atypeFactory.getQualifierHierarchy().isSubtype(returnType, invocationAnnos))) {
             checker.report(
                     Result.failure(
                             "constructor.invocation.invalid",
                             constructor.toString(),
-                            invocation,
+                            invocationAnnos,
                             returnType),
                     newClassTree);
             return false;
@@ -2677,15 +2663,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // Issue a warning if the type at constructor invocation is a subtype of the constructor
         // declaration type.
         // This is equivalent to down-casting.
-        // Only check the primary annotations, the type arguments are checked elsewhere.
-        if (!atypeFactory
-                .getQualifierHierarchy()
-                .isSubtype(returnType.getAnnotations(), invocation.getAnnotations())) {
+        if (!atypeFactory.getQualifierHierarchy().isSubtype(returnType, invocationAnnos)) {
             checker.report(
                     Result.warning(
-                            "cast.unsafe.constructor.invocation",
-                            returnType.toString(true),
-                            invocation.toString(true)),
+                            "cast.unsafe.constructor.invocation", returnType, invocationAnnos),
                     newClassTree);
         }
         return true;


### PR DESCRIPTION
the type arguments are checked elsewhere. Fixes #2330.