### PR TITLE
AsSuper and QualifierPolymorphism fixes

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -805,7 +805,17 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
                     visit(type.getExtendsBound(), superType.getExtendsBound(), p);
             superType.setExtendsBound(upperBound);
         } else {
+            // The upper bound of a wildcard can be a super type of upper bound of the type
+            // parameter for which it is an argument.
+            // See org.checkerframework.framework.type.AnnotatedTypeFactory.widenToUpperBound for an
+            // example.  In these cases, the upper bound of type might be a super type of the
+            // upper bound of superType.
+
+            // The underlying type of the annotated type mirror returned by asSuper must be the
+            // same as the passed type, so just copy the primary annotations.
             copyPrimaryAnnos(type.getExtendsBound(), superType.getExtendsBound());
+
+            // Add defaults in case any locations are missing annotations.
             annotatedTypeFactory.addDefaultAnnotations(superType.getExtendsBound());
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -342,11 +342,6 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             }
         }
 
-        if (type.getUnderlyingType().asElement().getKind().isInterface()) {
-            // An interface might actually implement the supertype.
-            return superType;
-        }
-
         return errorTypeNotErasedSubtypeOfSuperType(type, superType, p);
     }
 
@@ -803,9 +798,16 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
             isUninferredTypeAgrument = true;
             superType.setUninferredTypeArgument();
         }
-        AnnotatedTypeMirror upperBound =
-                visit(type.getExtendsBound(), superType.getExtendsBound(), p);
-        superType.setExtendsBound(upperBound);
+        if (types.isSubtype(
+                type.getExtendsBound().getUnderlyingType(),
+                superType.getExtendsBound().getUnderlyingType())) {
+            AnnotatedTypeMirror upperBound =
+                    visit(type.getExtendsBound(), superType.getExtendsBound(), p);
+            superType.setExtendsBound(upperBound);
+        } else {
+            copyPrimaryAnnos(type.getExtendsBound(), superType.getExtendsBound());
+            annotatedTypeFactory.addDefaultAnnotations(superType.getExtendsBound());
+        }
 
         AnnotatedTypeMirror lowerBound;
         if (type.getSuperBound().getKind() == TypeKind.NULL

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -30,6 +30,7 @@ import org.checkerframework.framework.util.AnnotationMirrorMap;
 import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypesUtils;
 
 /**
  * Implements framework support for qualifier polymorphism.
@@ -469,7 +470,12 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
             Iterator<AnnotatedTypeMirror> type2Args = type2.getTypeArguments().iterator();
             for (AnnotatedTypeMirror type1Arg : type1.getTypeArguments()) {
                 AnnotatedTypeMirror type2Arg = type2Args.next();
-                result = reduce(result, visit(type1Arg, type2Arg));
+                if (TypesUtils.isErasedSubtype(
+                        type1Arg.getUnderlyingType(),
+                        type2Arg.getUnderlyingType(),
+                        atypeFactory.getContext().getTypeUtils())) {
+                    result = reduce(result, visit(type1Arg, type2Arg));
+                }
             }
 
             return result;

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -475,7 +475,7 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
                         type2Arg.getUnderlyingType(),
                         atypeFactory.getContext().getTypeUtils())) {
                     result = reduce(result, visit(type1Arg, type2Arg));
-                }
+                } // else an unchecked warning was issued by Java, ignore this part of the type.
             }
 
             return result;

--- a/framework/tests/all-systems/Issue2370.java
+++ b/framework/tests/all-systems/Issue2370.java
@@ -1,0 +1,33 @@
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@SuppressWarnings("")
+public class Issue2370 {
+    private Stream<Action2370> getAction2370s(final State2370 state) {
+        return Stream.of(
+                        toStream(state.getOnExit()).flatMap(t -> t.getAction2370s().stream()),
+                        toStream(state.getOnSignal()).flatMap(t -> t.getAction2370s().stream()),
+                        toStream(state.getOnEnter()).flatMap(t -> t.getAction2370s().stream()))
+                .flatMap(actionStream -> actionStream);
+    }
+
+    private <T> Stream<T> toStream(final Collection<T> obj) {
+        return Optional.ofNullable(obj)
+                .map(Stream::of)
+                .orElseGet(Stream::empty)
+                .flatMap(Collection::stream);
+    }
+}
+
+interface Action2370 {
+    public Collection<Action2370> getAction2370s();
+}
+
+interface State2370 {
+    public Collection<Action2370> getOnExit();
+
+    public Collection<Action2370> getOnSignal();
+
+    public Collection<Action2370> getOnEnter();
+}

--- a/framework/tests/all-systems/Issue2371.java
+++ b/framework/tests/all-systems/Issue2371.java
@@ -1,3 +1,4 @@
+@SuppressWarnings("")
 public class Issue2371<T extends Issue2371<T>> {
     void method(Issue2371<? extends Object> i) {
         other(i);

--- a/framework/tests/all-systems/Issue2371.java
+++ b/framework/tests/all-systems/Issue2371.java
@@ -1,5 +1,4 @@
-// @skip-test
-public class Issue2371<T extends IssueNew<T>> {
+public class Issue2371<T extends Issue2371<T>> {
     void method(Issue2371<? extends Object> i) {
         other(i);
     }


### PR DESCRIPTION
Undo some of the fixes committed in https://github.com/typetools/checker-framework/pull/2193.
This pull request correctly fixes #2196 and #2190.
This pull request also fixes #2370 and fixes #2371 which has the same root cause as #2190 and #2196.