### PR TITLE
TreePathCacher: cache null when path not found

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/TreePathCacher.java
@@ -66,6 +66,8 @@ public class TreePathCacher extends TreeScanner<TreePath, Tree> {
         } catch (Result result) {
             return result.path;
         }
+        // If a path wasn't found, cache null so the whole compilation unit isn't searched again.
+        foundPaths.put(target, null);
         return null;
     }
 


### PR DESCRIPTION
When getPath is called with an artificial tree created by dataflow, null is returned.  Cache this so that the whole compilation unit isn't searched again.  (This fixes the daikon type check failure.)   