### PR TITLE
Fix varargs type argument inference

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -31,6 +31,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiveType;
@@ -227,8 +228,10 @@ public class TypeArgInferenceUtil {
             // The tree wasn't found as an argument, so it has to be the receiver.
             // This can happen for inner class constructors that take an outer class argument.
             paramType = method.getReceiverType();
-        } else if (treeIndex >= method.getParameterTypes().size() && methodElt.isVarArgs()) {
-            paramType = method.getParameterTypes().get(method.getParameterTypes().size() - 1);
+        } else if (treeIndex + 1 >= method.getParameterTypes().size() && methodElt.isVarArgs()) {
+            AnnotatedTypeMirror varArgsType =
+                    method.getParameterTypes().get(method.getParameterTypes().size() - 1);
+            paramType = ((AnnotatedArrayType) varArgsType).getComponentType();
         } else {
             paramType = method.getParameterTypes().get(treeIndex);
         }

--- a/framework/tests/all-systems/TypeVarVarargs.java
+++ b/framework/tests/all-systems/TypeVarVarargs.java
@@ -1,0 +1,9 @@
+abstract class TypeVarVarargs {
+    public abstract <T> T foo();
+
+    public abstract void bar(Integer... s);
+
+    public void m() {
+        bar(foo(), foo());
+    }
+}


### PR DESCRIPTION
Currently in the varargs case, `assignedToExecutable()` returns the varargs' array type instead of its component type, which gives an incorrect assignment context for type argument inference. For instance, in the following code
```
abstract class C {
        abstract public <T> T foo();

        abstract public void bar(Integer ... s);

        public void m() {
                bar(foo(), foo());
        }
}
```
the current implementation will infer `T` as `Integer []` at both invocations of `foo()` due to this problem, and would further cause a `asSuper` crash resulted from `AbstractQualifierPolymorphism#annotate()` trying to visit the inferred type `Integer []` of `foo()` and the parameter type `Integer` expanded from `bar()`'s varargs.

This problem can be exhibited by running `./checker/bin/javac -processor org.checkerframework.checker.nullness.NullnessChecker -AshowInferenceSteps  ~/Test.java` where `Test.java` contains the above code. The output when tested using the latest checker-framework master is as follow
```
Note: DTAI: expression: foo()
    argTypes: []
    assignedTo: Integer []
Note:   after infer: {T=Integer []}
Note:   after handleNull: {T=Integer []}
Note:   results: {T=Integer []}
Note: DTAI: expression: foo()
    argTypes: []
    assignedTo: Integer []
Note:   after infer: {T=Integer []}
Note:   after handleNull: {T=Integer []}
Note:   results: {T=Integer []}
error: AsSuperVisitor: type is not an erased subtype of supertype.
  type: Integer []
  superType: Integer
  Compilation unit: /home/multipass/Test4.java
  Last visited tree at line 1 column 1:
  abstract class C {
  Exception: java.lang.Throwable; Stack trace: org.checkerframework.javacutil.BugInCF.<init>(BugInCF.java:25)
  org.checkerframework.framework.type.AsSuperVisitor.errorTypeNotErasedSubtypeOfSuperType(AsSuperVisitor.java:154)
  org.checkerframework.framework.type.AsSuperVisitor.visitArray_Declared(AsSuperVisitor.java:290)
  org.checkerframework.framework.type.AsSuperVisitor.visitArray_Declared(AsSuperVisitor.java:28)
  org.checkerframework.framework.util.AtmCombo.accept(AtmCombo.java:265)
  org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor.visit(AbstractAtmComboVisitor.java:57)
  org.checkerframework.framework.type.AsSuperVisitor.visit(AsSuperVisitor.java:85)
  org.checkerframework.framework.type.AsSuperVisitor.asSuper(AsSuperVisitor.java:67)
  org.checkerframework.framework.util.AnnotatedTypes.asSuper(AnnotatedTypes.java:112)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.visit(AbstractQualifierPolymorphism.java:407)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.visit(AbstractQualifierPolymorphism.java:370)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.access$100(AbstractQualifierPolymorphism.java:291)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism.annotate(AbstractQualifierPolymorphism.java:137)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.methodFromUse(GenericAnnotatedTypeFactory.java:1546)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:168)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:44)
  com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1477)
  com.sun.source.util.SimpleTreeVisitor.visit(SimpleTreeVisitor.java:53)
  org.checkerframework.framework.type.TypeFromTree.fromExpression(TypeFromTree.java:36)
  org.checkerframework.framework.type.AnnotatedTypeFactory.fromExpression(AnnotatedTypeFactory.java:1299)
  org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:1079)
  org.checkerframework.framework.flow.CFAbstractTransfer.getValueFromFactory(CFAbstractTransfer.java:201)
  org.checkerframework.framework.flow.CFAbstractTransfer.visitMethodInvocation(CFAbstractTransfer.java:925)
  org.checkerframework.checker.nullness.KeyForTransfer.visitMethodInvocation(KeyForTransfer.java:37)
  org.checkerframework.checker.nullness.KeyForTransfer.visitMethodInvocation(KeyForTransfer.java:20)
  org.checkerframework.dataflow.cfg.node.MethodInvocationNode.accept(MethodInvocationNode.java:76)
  org.checkerframework.dataflow.analysis.Analysis.callTransferFunction(Analysis.java:408)
  org.checkerframework.dataflow.analysis.Analysis.performAnalysisBlock(Analysis.java:234)
  org.checkerframework.dataflow.analysis.Analysis.performAnalysis(Analysis.java:187)
  org.checkerframework.framework.flow.CFAbstractAnalysis.performAnalysis(CFAbstractAnalysis.java:91)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.analyze(GenericAnnotatedTypeFactory.java:1231)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.performFlowAnalysis(GenericAnnotatedTypeFactory.java:1149)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.checkAndPerformFlowAnalysis(GenericAnnotatedTypeFactory.java:1493)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.preProcessClassTree(GenericAnnotatedTypeFactory.java:259)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:320)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:167)
  com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:720)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:50)
  org.checkerframework.framework.source.SourceVisitor.visit(SourceVisitor.java:82)
  org.checkerframework.framework.source.SourceChecker.typeProcess(SourceChecker.java:1008)
  org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:522)
  org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:515)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:182)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1342)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1296)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:901)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:860)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  com.sun.tools.javac.Main.compile(Main.java:56)
  com.sun.tools.javac.Main.main(Main.java:42)
Note: DTAI: expression: foo()
    argTypes: []
    assignedTo: @Initialized @NonNull Integer @Initialized @NonNull []
Note:   after infer: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
Note:   after handleNull: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
Note:   results: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
Note: DTAI: expression: foo()
    argTypes: []
    assignedTo: @Initialized @NonNull Integer @Initialized @NonNull []
Note:   after infer: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
Note:   after handleNull: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
Note:   results: {T=@Initialized @NonNull Integer @Initialized @NonNull []}
error: AsSuperVisitor: type is not an erased subtype of supertype.
  type: @Initialized @NonNull Integer @Initialized @NonNull []
  superType: @Initialized @NonNull Integer
  Compilation unit: /home/multipass/Test4.java
  Last visited tree at line 1 column 1:
  abstract class C {
  Exception: java.lang.Throwable; Stack trace: org.checkerframework.javacutil.BugInCF.<init>(BugInCF.java:25)
  org.checkerframework.framework.type.AsSuperVisitor.errorTypeNotErasedSubtypeOfSuperType(AsSuperVisitor.java:154)
  org.checkerframework.framework.type.AsSuperVisitor.visitArray_Declared(AsSuperVisitor.java:290)
  org.checkerframework.framework.type.AsSuperVisitor.visitArray_Declared(AsSuperVisitor.java:28)
  org.checkerframework.framework.util.AtmCombo.accept(AtmCombo.java:265)
  org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor.visit(AbstractAtmComboVisitor.java:57)
  org.checkerframework.framework.type.AsSuperVisitor.visit(AsSuperVisitor.java:85)
  org.checkerframework.framework.type.AsSuperVisitor.asSuper(AsSuperVisitor.java:67)
  org.checkerframework.framework.util.AnnotatedTypes.asSuper(AnnotatedTypes.java:112)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.visit(AbstractQualifierPolymorphism.java:407)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.visit(AbstractQualifierPolymorphism.java:370)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism$PolyCollector.access$100(AbstractQualifierPolymorphism.java:291)
  org.checkerframework.framework.type.poly.AbstractQualifierPolymorphism.annotate(AbstractQualifierPolymorphism.java:137)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.methodFromUse(GenericAnnotatedTypeFactory.java:1546)
  org.checkerframework.checker.nullness.NullnessAnnotatedTypeFactory.methodFromUse(NullnessAnnotatedTypeFactory.java:315)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:168)
  org.checkerframework.framework.type.TypeFromExpressionVisitor.visitMethodInvocation(TypeFromExpressionVisitor.java:44)
  com.sun.tools.javac.tree.JCTree$JCMethodInvocation.accept(JCTree.java:1477)
  com.sun.source.util.SimpleTreeVisitor.visit(SimpleTreeVisitor.java:53)
  org.checkerframework.framework.type.TypeFromTree.fromExpression(TypeFromTree.java:36)
  org.checkerframework.framework.type.AnnotatedTypeFactory.fromExpression(AnnotatedTypeFactory.java:1299)
  org.checkerframework.framework.type.AnnotatedTypeFactory.getAnnotatedType(AnnotatedTypeFactory.java:1079)
  org.checkerframework.framework.flow.CFAbstractTransfer.getValueFromFactory(CFAbstractTransfer.java:201)
  org.checkerframework.framework.flow.CFAbstractTransfer.visitMethodInvocation(CFAbstractTransfer.java:925)
  org.checkerframework.checker.initialization.InitializationTransfer.visitMethodInvocation(InitializationTransfer.java:195)
  org.checkerframework.checker.nullness.NullnessTransfer.visitMethodInvocation(NullnessTransfer.java:237)
  org.checkerframework.checker.nullness.NullnessTransfer.visitMethodInvocation(NullnessTransfer.java:58)
  org.checkerframework.dataflow.cfg.node.MethodInvocationNode.accept(MethodInvocationNode.java:76)
  org.checkerframework.dataflow.analysis.Analysis.callTransferFunction(Analysis.java:408)
  org.checkerframework.dataflow.analysis.Analysis.performAnalysisBlock(Analysis.java:234)
  org.checkerframework.dataflow.analysis.Analysis.performAnalysis(Analysis.java:187)
  org.checkerframework.framework.flow.CFAbstractAnalysis.performAnalysis(CFAbstractAnalysis.java:91)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.analyze(GenericAnnotatedTypeFactory.java:1231)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.performFlowAnalysis(GenericAnnotatedTypeFactory.java:1149)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.checkAndPerformFlowAnalysis(GenericAnnotatedTypeFactory.java:1493)
  org.checkerframework.framework.type.GenericAnnotatedTypeFactory.preProcessClassTree(GenericAnnotatedTypeFactory.java:259)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:320)
  org.checkerframework.common.basetype.BaseTypeVisitor.visitClass(BaseTypeVisitor.java:167)
  com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:720)
  com.sun.source.util.TreePathScanner.scan(TreePathScanner.java:50)
  org.checkerframework.framework.source.SourceVisitor.visit(SourceVisitor.java:82)
  org.checkerframework.framework.source.SourceChecker.typeProcess(SourceChecker.java:1008)
  org.checkerframework.common.basetype.BaseTypeChecker.typeProcess(BaseTypeChecker.java:522)
  org.checkerframework.javacutil.AbstractTypeProcessor$AttributionTaskListener.finished(AbstractTypeProcessor.java:182)
  com.sun.tools.javac.api.ClientCodeWrapper$WrappedTaskListener.finished(ClientCodeWrapper.java:681)
  com.sun.tools.javac.api.MultiTaskListener.finished(MultiTaskListener.java:111)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1342)
  com.sun.tools.javac.main.JavaCompiler.flow(JavaCompiler.java:1296)
  com.sun.tools.javac.main.JavaCompiler.compile2(JavaCompiler.java:901)
  com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:860)
  com.sun.tools.javac.main.Main.compile(Main.java:523)
  com.sun.tools.javac.main.Main.compile(Main.java:381)
  com.sun.tools.javac.main.Main.compile(Main.java:370)
  com.sun.tools.javac.main.Main.compile(Main.java:361)
  com.sun.tools.javac.Main.compile(Main.java:56)
  com.sun.tools.javac.Main.main(Main.java:42)
```
This change would let `assignedToExecutable()` return the component type of the varargs when such case is encountered instead of returning its actual array type, and would subsequently fix this issue.