### PR TITLE
Rename two methods

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -185,7 +185,7 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
     public void annotate(
             AnnotatedExecutableType functionalInterface, AnnotatedExecutableType memberReference) {
         for (AnnotationMirror type : functionalInterface.getReturnType().getAnnotations()) {
-            if (QualifierPolymorphism.isPolymorphicQualified(type)) {
+            if (QualifierPolymorphism.hasPolymorphicQualifier(type)) {
                 // functional interface has a polymorphic qualifier, so they should not be resolved
                 // on memberReference.
                 return;

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/QualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/QualifierPolymorphism.java
@@ -41,8 +41,17 @@ public interface QualifierPolymorphism {
         return null;
     }
 
-    /** @return true if {@code qual} has the {@link PolymorphicQualifier} meta-annotation. */
+    /**
+     * @return true if {@code qual} has the {@link PolymorphicQualifier} meta-annotation
+     * @deprecated use {@link #hasPolymorphicQualifier}
+     */
+    @Deprecated // use hasPolymorphicQualifier()
     static boolean isPolymorphicQualified(AnnotationMirror qual) {
+        return getPolymorphicQualifier(qual) != null;
+    }
+
+    /** @return true if {@code qual} has the {@link PolymorphicQualifier} meta-annotation. */
+    static boolean hasPolymorphicQualifier(AnnotationMirror qual) {
         return getPolymorphicQualifier(qual) != null;
     }
 
@@ -60,8 +69,37 @@ public interface QualifierPolymorphism {
      * @return the class specified by the {@link PolymorphicQualifier} meta-annotation on {@code
      *     qual}, if {@code qual} is a polymorphic qualifier; otherwise, null.
      * @see org.checkerframework.framework.qual.PolymorphicQualifier#value()
+     * @deprecated use {@link getPolymorphicQualifierElement}
      */
+    @Deprecated // use getPolymorphicQualifierElement()
     static Name getPolymorphicQualifierTop(AnnotationMirror qual) {
+        AnnotationMirror poly = getPolymorphicQualifier(qual);
+
+        // System.out.println("poly: " + poly + " pq: " +
+        //     PolymorphicQualifier.class.getCanonicalName());
+        if (poly == null) {
+            return null;
+        }
+        Name ret = AnnotationUtils.getElementValueClassName(poly, "value", true);
+        return ret;
+    }
+
+    /**
+     * If {@code qual} is a polymorphic qualifier, return the class specified by the {@link
+     * PolymorphicQualifier} meta-annotation on the polymorphic qualifier is returned. Otherwise,
+     * return null.
+     *
+     * <p>This value identifies the qualifier hierarchy to which this polymorphic qualifier belongs.
+     * By convention, it is the top qualifier of the hierarchy. Use of {@code
+     * PolymorphicQualifier.class} is discouraged, because it can lead to ambiguity if used for
+     * multiple type systems.
+     *
+     * @param qual an annotation
+     * @return the class specified by the {@link PolymorphicQualifier} meta-annotation on {@code
+     *     qual}, if {@code qual} is a polymorphic qualifier; otherwise, null.
+     * @see org.checkerframework.framework.qual.PolymorphicQualifier#value()
+     */
+    static Name getPolymorphicQualifierElement(AnnotationMirror qual) {
         AnnotationMirror poly = getPolymorphicQualifier(qual);
 
         // System.out.println("poly: " + poly + " pq: " +

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -1218,7 +1218,7 @@ public class AnnotatedTypes {
         // Collect all polymorphic qualifiers; we should substitute them.
         Set<AnnotationMirror> polys = AnnotationUtils.createAnnotationSet();
         for (AnnotationMirror anno : returnType.getAnnotations()) {
-            if (QualifierPolymorphism.isPolymorphicQualified(anno)) {
+            if (QualifierPolymorphism.hasPolymorphicQualifier(anno)) {
                 polys.add(anno);
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -91,7 +91,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
                 return;
             }
 
-            Name pqtopclass = QualifierPolymorphism.getPolymorphicQualifierTop(qual);
+            Name pqtopclass = QualifierPolymorphism.getPolymorphicQualifierElement(qual);
             if (pqtopclass != null) {
                 AnnotationMirror pqtop =
                         AnnotationBuilder.fromName(atypeFactory.getElementUtils(), pqtopclass);


### PR DESCRIPTION
isPolymorphicQualified => hasPolymorphicQualifier
Previously, the code had isPolymorphicQualified and getPolymorphicQualifier.
I feel that parallelism between hasPolymorphicQualifier and getPolymorphicQualifier is nicer.

 getPolymorphicQualifierTop => getPolymorphicQualifierElement
The new name better reflects the actual semantics.
We could instead require that the argument to @PolymorphicQualifier must be exactly
top, and in that case this renaming would not be necessary.