### PR TITLE
Make the checker-source.jar and checker-javadoc.jar contain all framework classes

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -150,6 +150,23 @@ task printPlumeUtilJarPath {
     doFirst { println project.configurations.compile.find { it.name.startsWith("plume-util") } }
 }
 
+task allSourcesJar(type: Jar) {
+    description 'Creates a sources jar that includes sources for all Checker Framework classes in checker.jar'
+    destinationDir = file("${projectDir}/dist")
+    archiveName = "checker-source.jar"
+    from (sourceSets.main.java, project(':framework').sourceSets.main.allJava,
+            project(':dataflow').sourceSets.main.allJava, project(':javacutil').sourceSets.main.allJava)
+}
+
+task allJavadocJar(type: Jar) {
+    description 'Creates javadoc jar include Javadoc for all of the framework'
+    dependsOn rootProject.tasks.allJavadoc
+    destinationDir = file("${projectDir}/dist")
+    archiveName = "checker-javadoc.jar"
+    from rootProject.tasks.allJavadoc.destinationDir
+}
+
+
 shadowJar {
     description 'Creates the "fat" checker.jar in dist/.'
     destinationDir = file("${projectDir}/dist")
@@ -158,6 +175,8 @@ shadowJar {
     // doFirst { println sourceSets.main.runtimeClasspath.asPath }
 }
 artifacts {
+    archives allJavadocJar
+    archives allSourcesJar
     archives shadowJar
 }
 

--- a/docs/developer/release/release_vars.py
+++ b/docs/developer/release/release_vars.py
@@ -138,8 +138,8 @@ CF_VERSION = execute("./gradlew version -q", True, True, TMP_DIR + "/checker-fra
 
 CHECKER_BINARY = os.path.join(CHECKER_BIN_DIR, 'checker.jar')
 CHECKER_LIBS_DIR = os.path.join(CHECKER_FRAMEWORK, "checker", "build", "libs")
-CHECKER_SOURCE = os.path.join(CHECKER_LIBS_DIR, 'checker-'+CF_VERSION+'-source.jar')
-CHECKER_JAVADOC = os.path.join(CHECKER_LIBS_DIR, 'checker-'+CF_VERSION+'-javadoc.jar')
+CHECKER_SOURCE = os.path.join(CHECKER_BIN_DIR, 'checker-source.jar')
+CHECKER_JAVADOC = os.path.join(CHECKER_LIBS_DIR, 'checker-javadoc.jar')
 
 CHECKER_QUAL = os.path.join(CHECKER_BIN_DIR, 'checker-qual.jar')
 CHECKER_QUAL_DIST_DIR = os.path.join(CHECKER_FRAMEWORK, "checker-qual", "build", "libs")


### PR DESCRIPTION
Fixes #2462. 