### PR TITLE
Defer user-visible change until a subsequent release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,9 +4,6 @@ Version ??, May 1, 2019
 
 Moved text about the Purity Checker into its own chapter in the manual.
 
-Improved the diagnostic text for uninitialized static fields.  The new
-error key is initialization.static.fields.uninitialized.
-
 ---------------------------------------------------------------------------
 
 Version 2.8.0, April 3, 2019

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -64,7 +64,8 @@ public class InitializationVisitor<
     private static final @CompilerMessageKey String COMMITMENT_FIELDS_UNINITIALIZED =
             "initialization.fields.uninitialized";
     private static final @CompilerMessageKey String COMMITMENT_STATIC_FIELDS_UNINITIALIZED =
-            "initialization.static.fields.uninitialized";
+            // TODO: change to "initialization.static.fields.uninitialized";
+            "initialization.fields.uninitialized";
     private static final @CompilerMessageKey String COMMITMENT_INVALID_FIELD_TYPE =
             "initialization.invalid.field.type";
     private static final @CompilerMessageKey String COMMITMENT_INVALID_CONSTRUCTOR_RETURN_TYPE =

--- a/checker/tests/nullness/StaticInitializer.java
+++ b/checker/tests/nullness/StaticInitializer.java
@@ -1,7 +1,7 @@
 import org.checkerframework.checker.initialization.qual.*;
 import org.checkerframework.checker.nullness.qual.*;
 
-// :: error: (initialization.static.fields.uninitialized)
+// :: error: (initialization.fields.uninitialized)
 class StaticInitializer {
 
     public static String a;
@@ -14,7 +14,7 @@ class StaticInitializer {
     public StaticInitializer() {}
 }
 
-// :: error: (initialization.static.fields.uninitialized)
+// :: error: (initialization.fields.uninitialized)
 class StaticInitializer2 {
     public static String a;
     public static String b;

--- a/checker/tests/nullness/init/Uninit12.java
+++ b/checker/tests/nullness/init/Uninit12.java
@@ -3,7 +3,7 @@
 
 import org.checkerframework.checker.nullness.qual.*;
 
-// :: error: (initialization.static.fields.uninitialized)
+// :: error: (initialization.fields.uninitialized)
 public class Uninit12 {
 
     static Object f;

--- a/checker/tests/nullness/java8/lambda/Initialization.java
+++ b/checker/tests/nullness/java8/lambda/Initialization.java
@@ -12,10 +12,7 @@ interface Consumer<T> {
 }
 
 // For test purposes, f1 is never initialized
-@SuppressWarnings({
-    "initialization.fields.uninitialized",
-    "initialization.static.fields.uninitialized"
-})
+@SuppressWarnings("initialization.fields.uninitialized")
 class LambdaInit {
     String f1;
     String f2 = "";


### PR DESCRIPTION
The changelog text will be:
Improved the diagnostic text for uninitialized static fields.  The new
error key is initialization.static.fields.uninitialized.