### PR TITLE
Add @QualifierForLiterals meta-annotation

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
@@ -5,8 +5,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -16,21 +16,20 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #i18n-checker Internationalization Checker
  */
 @SubtypeOf(UnknownLocalized.class)
-@ImplicitFor(
-        literals = {
-            /* All integer literals */
-            LiteralKind.INT,
-            LiteralKind.LONG,
-            LiteralKind.FLOAT,
-            LiteralKind.DOUBLE,
-            LiteralKind.BOOLEAN,
+@QualifierForLiterals({
+    /* All integer literals */
+    LiteralKind.INT,
+    LiteralKind.LONG,
+    LiteralKind.FLOAT,
+    LiteralKind.DOUBLE,
+    LiteralKind.BOOLEAN,
 
-            /* null should be the bottom type */
-            LiteralKind.NULL
+    /* null should be the bottom type */
+    LiteralKind.NULL
 
-            // CHAR_LITERAL,
-            // STRING_LITERAL,
-        })
+    // CHAR_LITERAL,
+    // STRING_LITERAL,
+})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
@@ -17,18 +17,13 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf(UnknownLocalized.class)
 @QualifierForLiterals({
-    /* All integer literals */
+    // All literals except chars and strings, which may need to be localized.
+    // (null is bottom by default.)
     LiteralKind.INT,
     LiteralKind.LONG,
     LiteralKind.FLOAT,
     LiteralKind.DOUBLE,
-    LiteralKind.BOOLEAN,
-
-    /* null should be the bottom type */
-    LiteralKind.NULL
-
-    // CHAR_LITERAL,
-    // STRING_LITERAL,
+    LiteralKind.BOOLEAN
 })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/Interned.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/Interned.java
@@ -7,6 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeKind;
 
@@ -30,8 +31,8 @@ import org.checkerframework.framework.qual.TypeKind;
  * @checker_framework.manual #interning-checker Interning Checker
  */
 @SubtypeOf(UnknownInterned.class)
+@QualifierForLiterals({LiteralKind.PRIMITIVE, LiteralKind.STRING}) // everything but NULL
 @ImplicitFor(
-        literals = {LiteralKind.PRIMITIVE, LiteralKind.STRING}, // everything but NULL
         types = {
             TypeKind.BOOLEAN,
             TypeKind.BYTE,

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
@@ -11,6 +11,7 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchyInUnchecke
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
@@ -28,7 +29,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Documented
 @DefaultQualifierInHierarchy
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
-@ImplicitFor(literals = LiteralKind.NULL, typeNames = Void.class)
+@ImplicitFor(typeNames = Void.class)
+@QualifierForLiterals(LiteralKind.NULL)
 @DefaultQualifierInHierarchyInUncheckedCode
 @DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER, TypeUseLocation.LOWER_BOUND})
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -470,6 +470,7 @@ public class NullnessAnnotatedTypeFactory
 
         @Override
         public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+            // The result of newly allocated structures is always non-null.
             type.replaceAnnotation(NONNULL);
 
             // The most precise element type for `new Object[] {null}` is @FBCBottom, but

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -471,7 +471,9 @@ public class NullnessAnnotatedTypeFactory
         @Override
         public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
             // The result of newly allocated structures is always non-null.
-            type.replaceAnnotation(NONNULL);
+            if (!type.isAnnotatedInHierarchy(NONNULL)) {
+                type.replaceAnnotation(NONNULL);
+            }
 
             // The most precise element type for `new Object[] {null}` is @FBCBottom, but
             // the most useful element type is @Initialized (which is also accurate).

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -47,8 +47,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclared
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.ImplicitsTypeAnnotator;
@@ -363,14 +363,10 @@ public class NullnessAnnotatedTypeFactory
     protected TreeAnnotator createTreeAnnotator() {
         // Don't call super.createTreeAnnotator because the default tree annotators are incorrect
         // for the Nullness Checker.
-        ImplicitsTreeAnnotator implicitsTreeAnnotator = new ImplicitsTreeAnnotator(this);
-        implicitsTreeAnnotator.addTreeKind(Tree.Kind.NEW_CLASS, NONNULL);
-        implicitsTreeAnnotator.addTreeKind(Tree.Kind.NEW_ARRAY, NONNULL);
-
         return new ListTreeAnnotator(
                 // DebugListTreeAnnotator(new Tree.Kind[] {Tree.Kind.CONDITIONAL_EXPRESSION},
                 new NullnessPropagationTreeAnnotator(this),
-                implicitsTreeAnnotator,
+                new LiteralTreeAnnotator(this),
                 new NullnessTreeAnnotator(this),
                 new CommitmentTreeAnnotator(this));
     }
@@ -474,6 +470,8 @@ public class NullnessAnnotatedTypeFactory
 
         @Override
         public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+            type.replaceAnnotation(NONNULL);
+
             // The most precise element type for `new Object[] {null}` is @FBCBottom, but
             // the most useful element type is @Initialized (which is also accurate).
             AnnotatedArrayType arrayType = (AnnotatedArrayType) type;

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -10,6 +10,7 @@ import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeKind;
 import org.checkerframework.framework.qual.TypeUseLocation;
@@ -37,8 +38,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #bottom-type the bottom type
  */
 @SubtypeOf(MonotonicNonNull.class)
+@QualifierForLiterals(LiteralKind.STRING)
 @ImplicitFor(
-        literals = {LiteralKind.STRING},
         types = {
             TypeKind.PACKAGE,
             TypeKind.INT,

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
@@ -25,7 +26,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #nullness-checker Nullness Checker
  */
 @SubtypeOf({})
-@ImplicitFor(literals = LiteralKind.NULL, typeNames = Void.class)
+@QualifierForLiterals(LiteralKind.NULL)
+@ImplicitFor(typeNames = Void.class)
 @DefaultInUncheckedCodeFor({TypeUseLocation.RETURN, TypeUseLocation.UPPER_BOUND})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -10,6 +10,7 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
@@ -26,7 +27,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
-@ImplicitFor(literals = LiteralKind.NULL, typeNames = Void.class)
+@ImplicitFor(typeNames = Void.class)
+@QualifierForLiterals(LiteralKind.NULL)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -32,8 +32,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedIntersec
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.util.GraphQualifierHierarchy;
@@ -244,7 +244,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // Don't call super.createTreeAnnotator because the PropagationTreeAnnotator types binary
         // expressions as lub.
         return new ListTreeAnnotator(
-                new ImplicitsTreeAnnotator(this).addStandardImplicits(),
+                new LiteralTreeAnnotator(this).addStandardDefaults(),
                 new RegexTreeAnnotator(this),
                 new RegexPropagationTreeAnnotator(this));
     }

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -244,7 +244,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // Don't call super.createTreeAnnotator because the PropagationTreeAnnotator types binary
         // expressions as lub.
         return new ListTreeAnnotator(
-                new LiteralTreeAnnotator(this).addStandardDefaults(),
+                new LiteralTreeAnnotator(this).addStandardLiteralQualifiers(),
                 new RegexTreeAnnotator(this),
                 new RegexPropagationTreeAnnotator(this));
     }

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -31,7 +31,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(ClassGetName.class)
-@ImplicitFor(
+@QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface BinaryName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf({BinaryName.class, InternalForm.class})
-@ImplicitFor(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\$[A-Za-z_0-9]+)*$")
+@QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\$[A-Za-z_0-9]+)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface BinaryNameInUnnamedPackage {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -27,7 +27,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(SignatureUnknown.class)
-@ImplicitFor(
+@QualifierForLiterals(
         stringPatterns =
                 "(^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*|\\$[A-Za-z_0-9]+)*$)|^\\[+([BCDFIJSZ]|L[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*|\\$[A-Za-z_0-9]+)*;)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -12,6 +12,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(SignatureUnknown.class)
-@ImplicitFor(stringPatterns = "^(|[A-Za-z_][A-Za-z_0-9]*)(\\[\\])*$")
+@QualifierForLiterals(stringPatterns = "^(|[A-Za-z_][A-Za-z_0-9]*)(\\[\\])*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface ClassGetSimpleName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -16,6 +16,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf({FullyQualifiedName.class, BinaryName.class})
-@ImplicitFor(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*$")
+@QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface DotSeparatedIdentifiers {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -26,7 +26,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(SignatureUnknown.class)
-@ImplicitFor(
+@QualifierForLiterals(
         stringPatterns =
                 "^\\[*([BCDFIJSZ]|L[A-Za-z_][A-Za-z_0-9]*(/[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*;)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf({FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.class, Identifier.class})
-@ImplicitFor(stringPatterns = "^[BCDFIJSZ]$")
+@QualifierForLiterals(stringPatterns = "^[BCDFIJSZ]$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FieldDescriptorForPrimitive {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -18,6 +18,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf({ClassGetName.class, FieldDescriptor.class})
-@ImplicitFor(stringPatterns = "^([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[L[A-Za-z_][A-Za-z_0-9]*;)$")
+@QualifierForLiterals(stringPatterns = "^([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[L[A-Za-z_][A-Za-z_0-9]*;)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FieldDescriptorForPrimitiveOrArrayInUnnamedPackage {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -29,6 +29,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(SignatureUnknown.class)
-@ImplicitFor(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\[\\])*$")
+@QualifierForLiterals(
+        stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\[\\])*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FullyQualifiedName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
     BinaryNameInUnnamedPackage.class,
     IdentifierOrArray.class
 })
-@ImplicitFor(stringPatterns = "^([A-Za-z_][A-Za-z_0-9]*)$")
+@QualifierForLiterals(stringPatterns = "^([A-Za-z_][A-Za-z_0-9]*)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Identifier {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -13,6 +13,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf({FullyQualifiedName.class, ClassGetSimpleName.class})
-@ImplicitFor(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\[\\])*$")
+@QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\[\\])*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IdentifierOrArray {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
@@ -2,7 +2,7 @@ package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -22,7 +22,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #signature-checker Signature Checker
  */
 @SubtypeOf(SignatureUnknown.class)
-@ImplicitFor(
+@QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(/[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface InternalForm {}

--- a/checker/src/main/java/org/checkerframework/checker/signedness/qual/Constant.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/qual/Constant.java
@@ -8,8 +8,8 @@ import java.lang.annotation.Target;
 import org.checkerframework.checker.index.qual.NonNegative;
 import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.common.value.qual.IntRange;
-import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /**
@@ -28,5 +28,5 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({Unsigned.class, Signed.class})
-@ImplicitFor(literals = {LiteralKind.INT, LiteralKind.LONG, LiteralKind.CHAR})
+@QualifierForLiterals({LiteralKind.INT, LiteralKind.LONG, LiteralKind.CHAR})
 public @interface Constant {}

--- a/checker/src/main/java/org/checkerframework/checker/tainting/qual/Untainted.java
+++ b/checker/src/main/java/org/checkerframework/checker/tainting/qual/Untainted.java
@@ -5,8 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
@@ -16,7 +16,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #tainting-checker Tainting Checker
  */
 @SubtypeOf(Tainted.class)
-@ImplicitFor(literals = LiteralKind.STRING)
+@QualifierForLiterals(LiteralKind.STRING)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @DefaultFor(TypeUseLocation.LOWER_BOUND)

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -24,8 +24,8 @@ import org.checkerframework.framework.type.AnnotatedTypeFormatter;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotationClassLoader;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.util.GraphQualifierHierarchy;
@@ -343,7 +343,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // is incorrect.
         return new ListTreeAnnotator(
                 new UnitsPropagationTreeAnnotator(this),
-                new ImplicitsTreeAnnotator(this).addStandardImplicits(),
+                new LiteralTreeAnnotator(this).addStandardDefaults(),
                 new UnitsTreeAnnotator(this));
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -343,7 +343,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         // is incorrect.
         return new ListTreeAnnotator(
                 new UnitsPropagationTreeAnnotator(this),
-                new LiteralTreeAnnotator(this).addStandardDefaults(),
+                new LiteralTreeAnnotator(this).addStandardLiteralQualifiers(),
                 new UnitsTreeAnnotator(this));
     }
 

--- a/docs/examples/subtyping-extension/qual/Encrypted.java
+++ b/docs/examples/subtyping-extension/qual/Encrypted.java
@@ -3,14 +3,11 @@ package qual;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
-import org.checkerframework.framework.qual.ImplicitFor;
-import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 /** Denotes that the representation of an object is encrypted. */
 @SubtypeOf(PossiblyUnencrypted.class)
-@ImplicitFor(literals = {LiteralKind.NULL})
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Encrypted {}

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -709,7 +709,8 @@ Your type hierarchy must have a bottom qualifier
 --- a qualifier that is a (direct or indirect) subtype of every other
 qualifier.
 
-\<null> is the bottom type.
+\<null> is the bottom type. Because the only value with type \<Void> is
+\<null>, uses of the type \<Void> are also bottom.
 (The only exception
 is if the type system has special treatment for \<null> values, as the
 Nullness Checker does. In that case, add the meta-annotation \<@QualifierForLiterals(LiteralKind.NULL)>

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -712,7 +712,7 @@ qualifier.
 \<null> is the bottom type.
 (The only exception
 is if the type system has special treatment for \<null> values, as the
-Nullness Checker does. In that case, add the meta annotation \<@QualifierForLiterals(LiteralKind.NULL)>
+Nullness Checker does. In that case, add the meta-annotation \<@QualifierForLiterals(LiteralKind.NULL)>
 to the correct qualifier.)
 This legal code
 will not type-check unless \<null> has the bottom type:

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -709,10 +709,10 @@ Your type hierarchy must have a bottom qualifier
 --- a qualifier that is a (direct or indirect) subtype of every other
 qualifier.
 
-\<null> is the bottom type. Because the only value with type \<Void> is \<null>, uses of the type \<Void> are also bottom.
+\<null> is the bottom type.
 (The only exception
 is if the type system has special treatment for \<null> values, as the
-Nullness Checker does. In that case, add the meta-annotation \<@ImplicitFor(literals = LiteralKind.NULL, typeNames = Void.class)>
+Nullness Checker does. In that case, add the meta annotation \<@QualifierForLiterals(LiteralKind.NULL)>
 to the correct qualifier.)
 This legal code
 will not type-check unless \<null> has the bottom type:

--- a/docs/manual/subtyping-checker.tex
+++ b/docs/manual/subtyping-checker.tex
@@ -8,8 +8,8 @@ the type qualifier annotations.
 
 The Subtyping Checker can accommodate all of the type system enhancements that
 can be declaratively specified (see Chapter~\ref{creating-a-checker}).
-This includes type introduction rules meta-annotation via the
-\refqualclass{framework/qual}{QualifierForLiterals}, and other features such as
+This includes type introduction rules via the
+\refqualclass{framework/qual}{QualifierForLiterals} meta-annotation , and other features such as
 type refinement (Section~\ref{type-refinement}) and
 qualifier polymorphism (Section~\ref{qualifier-polymorphism}).
 

--- a/docs/manual/subtyping-checker.tex
+++ b/docs/manual/subtyping-checker.tex
@@ -8,7 +8,8 @@ the type qualifier annotations.
 
 The Subtyping Checker can accommodate all of the type system enhancements that
 can be declaratively specified (see Chapter~\ref{creating-a-checker}).
-This includes type introduction rules meta-annotation, and other features such as
+This includes type introduction rules meta-annotation via the
+\refqualclass{framework/qual}{QualifierForLiterals}, and other features such as
 type refinement (Section~\ref{type-refinement}) and
 qualifier polymorphism (Section~\ref{qualifier-polymorphism}).
 

--- a/docs/manual/subtyping-checker.tex
+++ b/docs/manual/subtyping-checker.tex
@@ -8,9 +8,7 @@ the type qualifier annotations.
 
 The Subtyping Checker can accommodate all of the type system enhancements that
 can be declaratively specified (see Chapter~\ref{creating-a-checker}).
-This includes type introduction rules (implicit
-annotations, e.g., literals are implicitly considered \refqualclass{checker/nullness/qual}{NonNull}) via
-the \refqualclass{framework/qual}{ImplicitFor} meta-annotation, and other features such as
+This includes type introduction rules meta-annotation, and other features such as
 type refinement (Section~\ref{type-refinement}) and
 qualifier polymorphism (Section~\ref{qualifier-polymorphism}).
 

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -463,7 +463,7 @@ Object> only if that value is of the bottom type, since the bottom type is
 the only one that is a subtype of every subtype of \<T extends @MyQualifier
 Object>.  The value \<null> satisfies this for the Java type system, and it
 must be made to satisfy it for the pluggable type system as well.  The
-typical way to address this is to call \<addStandardDefaults> on the \<LiteralTreeAnnotator>.
+typical way to address this is to call \<addStandardLiteralQualifiers> on the \<LiteralTreeAnnotator>.
 
 \item
 An error such as

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -463,7 +463,7 @@ Object> only if that value is of the bottom type, since the bottom type is
 the only one that is a subtype of every subtype of \<T extends @MyQualifier
 Object>.  The value \<null> satisfies this for the Java type system, and it
 must be made to satisfy it for the pluggable type system as well.  The
-typical way to address this is to call \<addStandardImplicits> on the \<ImplicitsTreeAnnotator>.
+typical way to address this is to call \<addStandardDefaults> on the \<LiteralTreeAnnotator>.
 
 \item
 An error such as

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
@@ -2,6 +2,8 @@ package org.checkerframework.common.subtyping.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
+import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
@@ -17,9 +19,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * introduce a top and bottom qualifier that gets stored in bytecode.
  *
  * <p>To use this qualifier, the type system designer needs to use methods like {@link
- * org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator#addTreeKind(com.sun.source.tree.Tree.Kind,
- * javax.lang.model.element.AnnotationMirror)} to add implicit annotations and needs to manually add
- * the bottom qualifier to the qualifier hierarchy.
+ * org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator#addLiteralKind(LiteralKind,
+ * AnnotationMirror)} to add implicit annotations and needs to manually add the bottom qualifier to
+ * the qualifier hierarchy.
  *
  * @see org.checkerframework.framework.type.QualifierHierarchy#getBottomAnnotations()
  */

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
@@ -2,8 +2,6 @@ package org.checkerframework.common.subtyping.qual;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import javax.lang.model.element.AnnotationMirror;
-import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
@@ -18,9 +16,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * use this qualifier during prototyping of very simple type systems. For realistic systems,
  * introduce a top and bottom qualifier that gets stored in bytecode.
  *
- * <p>To use this qualifier, the type system designer needs to use methods like {@link
- * org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator#addLiteralKind(LiteralKind,
- * AnnotationMirror)} to add implicit annotations and needs to manually add the bottom qualifier to
+ * <p>To use this qualifier, the type system designer needs to manually add the bottom qualifier to
  * the qualifier hierarchy.
  *
  * @see org.checkerframework.framework.type.QualifierHierarchy#getBottomAnnotations()

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -60,8 +60,8 @@ import org.checkerframework.framework.type.DefaultTypeHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.StructuralEqualityComparer;
 import org.checkerframework.framework.type.TypeHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.ListTypeAnnotator;
@@ -979,7 +979,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 };
         return new ListTreeAnnotator(
                 new ValueTreeAnnotator(this),
-                new ImplicitsTreeAnnotator(this).addStandardImplicits(),
+                new LiteralTreeAnnotator(this).addStandardDefaults(),
                 arrayCreation);
     }
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -979,7 +979,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 };
         return new ListTreeAnnotator(
                 new ValueTreeAnnotator(this),
-                new LiteralTreeAnnotator(this).addStandardDefaults(),
+                new LiteralTreeAnnotator(this).addStandardLiteralQualifiers(),
                 arrayCreation);
     }
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesHelper.java
@@ -375,7 +375,7 @@ public class WholeProgramInferenceScenesHelper {
         // Checks if am is an implicit annotation.
         // This case checks if it is meta-annotated with @ImplicitFor.
         // TODO: Handle cases of implicit annotations added via an
-        // org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator.
+        // org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator.
         ImplicitFor implicitFor = elt.getAnnotation(ImplicitFor.class);
         if (implicitFor != null) {
             org.checkerframework.framework.qual.TypeKind[] types = implicitFor.types();

--- a/framework/src/main/java/org/checkerframework/framework/qual/ImplicitFor.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/ImplicitFor.java
@@ -24,16 +24,6 @@ import java.lang.annotation.Target;
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface ImplicitFor {
 
-    /**
-     * @return {@link LiteralKind}s for which an annotation should be implicitly added. For example,
-     *     if {@code @MyAnno} is meta-annotated with
-     *     {@code @ImplicitFor(literals={LiteralKind.STRING})}, then a literal {@code String}
-     *     constant such as {@code "hello world"} has type {@code @MyAnno String}, but other
-     *     occurrences of {@code String} in the source code are not affected. For String literals,
-     *     also see the {@link #stringPatterns} annotation field.
-     */
-    LiteralKind[] literals() default {};
-
     /** @return {@link TypeKind}s of types for which an annotation should be implicitly added */
     TypeKind[] types() default {};
 
@@ -50,13 +40,6 @@ public @interface ImplicitFor {
      *     {@code null} literal.
      */
     Class<?>[] typeNames() default {};
-
-    /**
-     * @return regular expressions of string literals for which an annotation should be implicitly
-     *     added. If multiple patterns match, then the string literal is given the greatest lower
-     *     bound of all the matches.
-     */
-    String[] stringPatterns() default {};
 
     // TODO: do we need an option to provide implicits for locations
     // specified by a TypeUseLocation (which should then be renamed)?

--- a/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
@@ -12,10 +12,10 @@ public @interface QualifierForLiterals {
     /**
      * @return {@link LiteralKind}s for which an annotation should be implicitly added. For example,
      *     if {@code @MyAnno} is meta-annotated with
-     *     {@code @QualifierForLiterals(literals={LiteralKind.STRING})}, then a literal {@code
-     *     String} constant such as {@code "hello world"} has type {@code @MyAnno String}, but other
-     *     occurrences of {@code String} in the source code are not affected. For String literals,
-     *     also see the {@link #stringPatterns} annotation field.
+     *     {@code @QualifierForLiterals(LiteralKind.STRING)}, then a literal {@code String} constant
+     *     such as {@code "hello world"} has type {@code @MyAnno String}, but other occurrences of
+     *     {@code String} in the source code are not affected. For String literals, also see the
+     *     {@link #stringPatterns} annotation field.
      */
     LiteralKind[] value() default {};
 

--- a/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
@@ -1,0 +1,28 @@
+package org.checkerframework.framework.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** A meta-annotation that indicates what qualifier should be given to literals. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface QualifierForLiterals {
+    /**
+     * @return {@link LiteralKind}s for which an annotation should be implicitly added. For example,
+     *     if {@code @MyAnno} is meta-annotated with
+     *     {@code @QualifierForLiterals(literals={LiteralKind.STRING})}, then a literal {@code
+     *     String} constant such as {@code "hello world"} has type {@code @MyAnno String}, but other
+     *     occurrences of {@code String} in the source code are not affected. For String literals,
+     *     also see the {@link #stringPatterns} annotation field.
+     */
+    LiteralKind[] value() default {};
+
+    /**
+     * @return regular expressions of string literals for which an annotation should be implicitly
+     *     added. If multiple patterns match, then the string literal is given the greatest lower
+     *     bound of all the matches.
+     */
+    String[] stringPatterns() default {};
+}

--- a/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/QualifierForLiterals.java
@@ -5,24 +5,25 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** A meta-annotation that indicates what qualifier should be given to literals. */
+/**
+ * A meta-annotation that indicates what qualifier should be given to literals.
+ * {@code @QualifierForLiterals} is equivalent to {@code @QualfierForLiterals(LiteralKind.ALL)}
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.ANNOTATION_TYPE)
 public @interface QualifierForLiterals {
     /**
-     * @return {@link LiteralKind}s for which an annotation should be implicitly added. For example,
-     *     if {@code @MyAnno} is meta-annotated with
-     *     {@code @QualifierForLiterals(LiteralKind.STRING)}, then a literal {@code String} constant
-     *     such as {@code "hello world"} has type {@code @MyAnno String}, but other occurrences of
-     *     {@code String} in the source code are not affected. For String literals, also see the
-     *     {@link #stringPatterns} annotation field.
+     * The kinds of literals whose types have this qualifier. For example, if {@code @MyAnno} is
+     * meta-annotated with {@code @QualifierForLiterals(LiteralKind.STRING)}, then a literal {@code
+     * String} constant such as {@code "hello world"} has type {@code @MyAnno String}, but other
+     * occurrences of {@code String} in the source code are not affected. For String literals, also
+     * see the {@link #stringPatterns} annotation field.
      */
     LiteralKind[] value() default {};
 
     /**
-     * @return regular expressions of string literals for which an annotation should be implicitly
-     *     added. If multiple patterns match, then the string literal is given the greatest lower
-     *     bound of all the matches.
+     * The type of strings that match these patterns have this qualifier. If multiple patterns
+     * match, then the string literal is given the greatest lower bound of all the matches.
      */
     String[] stringPatterns() default {};
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -72,14 +72,15 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchyInUncheckedCode;
 import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.MonotonicQualifier;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.RelevantJavaTypes;
 import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.poly.DefaultQualifierPolymorphism;
 import org.checkerframework.framework.type.poly.QualifierPolymorphism;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.ImplicitsTypeAnnotator;
@@ -317,7 +318,7 @@ public abstract class GenericAnnotatedTypeFactory<
      *
      * <ol>
      *   <li>{@link PropagationTreeAnnotator}: Propagates annotations from subtrees
-     *   <li>{@link ImplicitsTreeAnnotator}: Adds annotations based on {@link ImplicitFor}
+     *   <li>{@link LiteralTreeAnnotator}: Adds annotations based on {@link QualifierForLiterals}
      *       meta-annotations
      *   <li>{@link DependentTypesTreeAnnotator}: Adapts dependent annotations based on context
      * </ol>
@@ -333,7 +334,7 @@ public abstract class GenericAnnotatedTypeFactory<
     protected TreeAnnotator createTreeAnnotator() {
         List<TreeAnnotator> treeAnnotators = new ArrayList<>();
         treeAnnotators.add(new PropagationTreeAnnotator(this));
-        treeAnnotators.add(new ImplicitsTreeAnnotator(this).addStandardImplicits());
+        treeAnnotators.add(new LiteralTreeAnnotator(this).addStandardDefaults());
         if (dependentTypesHelper != null) {
             treeAnnotators.add(dependentTypesHelper.createDependentTypesTreeAnnotator(this));
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -334,7 +334,7 @@ public abstract class GenericAnnotatedTypeFactory<
     protected TreeAnnotator createTreeAnnotator() {
         List<TreeAnnotator> treeAnnotators = new ArrayList<>();
         treeAnnotators.add(new PropagationTreeAnnotator(this));
-        treeAnnotators.add(new LiteralTreeAnnotator(this).addStandardDefaults());
+        treeAnnotators.add(new LiteralTreeAnnotator(this).addStandardLiteralQualifiers());
         if (dependentTypesHelper != null) {
             treeAnnotators.add(dependentTypesHelper.createDependentTypesTreeAnnotator(this));
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/ListTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/ListTreeAnnotator.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
  * <p>Checkers should not extend ListTreeAnnotator; they should instead pass a custom TreeAnnotator
  * to the constructor.
  *
- * @see ImplicitsTreeAnnotator
+ * @see LiteralTreeAnnotator
  * @see PropagationTreeAnnotator
  */
 public class ListTreeAnnotator extends TreeAnnotator {

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
@@ -26,15 +26,13 @@ import org.checkerframework.javacutil.BugInCF;
 /**
  * Adds annotations to a type based on the contents of a tree. This class applies annotations
  * specified by {@link org.checkerframework.framework.qual.QualifierForLiterals}; it is designed to
- * be add to a {@link ListTreeAnnotator} via {@link
+ * be added to a {@link ListTreeAnnotator} via {@link
  * GenericAnnotatedTypeFactory#createTreeAnnotator()}
  *
  * <p>{@link LiteralTreeAnnotator} does not traverse trees deeply.
  *
  * @see TreeAnnotator
  */
-//  TODO: we currently don't check that any attribute is set, that is, a qualifier could be
-// annotated as @QualifierForLiterals(), which might be misleading.
 public class LiteralTreeAnnotator extends TreeAnnotator {
 
     /* The following three fields are mappings from a particular AST kind,
@@ -102,16 +100,21 @@ public class LiteralTreeAnnotator extends TreeAnnotator {
             for (String pattern : forLiterals.stringPatterns()) {
                 addStringPattern(pattern, theQual);
             }
+
+            if (forLiterals.value().length == 0 && forLiterals.stringPatterns().length == 0) {
+                addLiteralKind(LiteralKind.ALL, theQual);
+            }
         }
     }
 
     /**
-     * Adds standard defaults. Currently sets the null literal to bottom if no other default is set
-     * for null literals. Also, see {@link ImplicitsTypeAnnotator#addStandardImplicits()}.
+     * Adds standard qualifiers for literals. Currently sets the null literal to bottom if no other
+     * default is set for null literals. Also, see {@link
+     * ImplicitsTypeAnnotator#addStandardImplicits()}.
      *
      * @return this
      */
-    public LiteralTreeAnnotator addStandardDefaults() {
+    public LiteralTreeAnnotator addStandardLiteralQualifiers() {
         // Set null to bottom if no other implicit is given.
         if (!treeKinds.containsKey(Kind.NULL_LITERAL)) {
             for (AnnotationMirror bottom : qualHierarchy.getBottomAnnotations()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
@@ -16,7 +16,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
  *
  * @see ListTreeAnnotator
  * @see PropagationTreeAnnotator
- * @see ImplicitsTreeAnnotator
+ * @see LiteralTreeAnnotator
  */
 public abstract class TreeAnnotator extends SimpleTreeVisitor<Void, AnnotatedTypeMirror> {
 

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
@@ -167,7 +167,7 @@ public class ImplicitsTypeAnnotator extends TypeAnnotator {
 
     /**
      * Adds standard implicit rules. Currently sets Void to bottom if no other implicit is set for
-     * Void. Also, see {@link LiteralTreeAnnotator#addStandardDefaults()}.
+     * Void. Also, see {@link LiteralTreeAnnotator#addStandardLiteralQualifiers()}.
      *
      * @return this
      */

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/ImplicitsTypeAnnotator.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.TypesUtils;
@@ -167,7 +167,7 @@ public class ImplicitsTypeAnnotator extends TypeAnnotator {
 
     /**
      * Adds standard implicit rules. Currently sets Void to bottom if no other implicit is set for
-     * Void. Also, see {@link ImplicitsTreeAnnotator#addStandardImplicits()}.
+     * Void. Also, see {@link LiteralTreeAnnotator#addStandardDefaults()}.
      *
      * @return this
      */

--- a/framework/src/test/java/testlib/reflection/ReflectionTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/reflection/ReflectionTestAnnotatedTypeFactory.java
@@ -3,9 +3,10 @@ package testlib.reflection;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.type.*;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.util.GraphQualifierHierarchy;
@@ -25,12 +26,12 @@ public final class ReflectionTestAnnotatedTypeFactory extends BaseAnnotatedTypeF
 
     @Override
     public TreeAnnotator createTreeAnnotator() {
-        ImplicitsTreeAnnotator implicitsTreeAnnotator = new ImplicitsTreeAnnotator(this);
+        LiteralTreeAnnotator literalTreeAnnotator = new LiteralTreeAnnotator(this);
         AnnotationMirror bottom = AnnotationBuilder.fromClass(elements, ReflectBottom.class);
-        implicitsTreeAnnotator.addTreeKind(com.sun.source.tree.Tree.Kind.INT_LITERAL, bottom);
-        implicitsTreeAnnotator.addStandardImplicits();
+        literalTreeAnnotator.addLiteralKind(LiteralKind.INT, bottom);
+        literalTreeAnnotator.addStandardDefaults();
 
-        return new ListTreeAnnotator(new PropagationTreeAnnotator(this), implicitsTreeAnnotator);
+        return new ListTreeAnnotator(new PropagationTreeAnnotator(this), literalTreeAnnotator);
     }
 
     @Override

--- a/framework/src/test/java/testlib/reflection/ReflectionTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/reflection/ReflectionTestAnnotatedTypeFactory.java
@@ -29,7 +29,7 @@ public final class ReflectionTestAnnotatedTypeFactory extends BaseAnnotatedTypeF
         LiteralTreeAnnotator literalTreeAnnotator = new LiteralTreeAnnotator(this);
         AnnotationMirror bottom = AnnotationBuilder.fromClass(elements, ReflectBottom.class);
         literalTreeAnnotator.addLiteralKind(LiteralKind.INT, bottom);
-        literalTreeAnnotator.addStandardDefaults();
+        literalTreeAnnotator.addStandardLiteralQualifiers();
 
         return new ListTreeAnnotator(new PropagationTreeAnnotator(this), literalTreeAnnotator);
     }

--- a/framework/src/test/java/testlib/util/PatternA.java
+++ b/framework/src/test/java/testlib/util/PatternA.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf({PatternAB.class, PatternAC.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[A]$")
+@QualifierForLiterals(stringPatterns = "^[A]$")
 public @interface PatternA {}

--- a/framework/src/test/java/testlib/util/PatternAB.java
+++ b/framework/src/test/java/testlib/util/PatternAB.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf(PatternUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[AB]$")
+@QualifierForLiterals(stringPatterns = "^[AB]$")
 public @interface PatternAB {}

--- a/framework/src/test/java/testlib/util/PatternAC.java
+++ b/framework/src/test/java/testlib/util/PatternAC.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf(PatternUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[AC]$")
+@QualifierForLiterals(stringPatterns = "^[AC]$")
 public @interface PatternAC {}

--- a/framework/src/test/java/testlib/util/PatternB.java
+++ b/framework/src/test/java/testlib/util/PatternB.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf({PatternAB.class, PatternBC.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[B]$")
+@QualifierForLiterals(stringPatterns = "^[B]$")
 public @interface PatternB {}

--- a/framework/src/test/java/testlib/util/PatternBC.java
+++ b/framework/src/test/java/testlib/util/PatternBC.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf(PatternUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[BC]$")
+@QualifierForLiterals(stringPatterns = "^[BC]$")
 public @interface PatternBC {}

--- a/framework/src/test/java/testlib/util/PatternC.java
+++ b/framework/src/test/java/testlib/util/PatternC.java
@@ -2,10 +2,10 @@ package testlib.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.ImplicitFor;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf({PatternBC.class, PatternAC.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@ImplicitFor(stringPatterns = "^[C]$")
+@QualifierForLiterals(stringPatterns = "^[C]$")
 public @interface PatternC {}

--- a/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
@@ -64,7 +64,7 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
     public TreeAnnotator createTreeAnnotator() {
         LiteralTreeAnnotator literalTreeAnnotator = new LiteralTreeAnnotator(this);
         literalTreeAnnotator.addLiteralKind(LiteralKind.INT, BOTTOM);
-        literalTreeAnnotator.addStandardDefaults();
+        literalTreeAnnotator.addStandardLiteralQualifiers();
 
         return new ListTreeAnnotator(new PropagationTreeAnnotator(this), literalTreeAnnotator);
     }

--- a/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
@@ -10,9 +10,10 @@ import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.reflection.qual.UnknownClass;
+import org.checkerframework.framework.qual.LiteralKind;
 import org.checkerframework.framework.type.QualifierHierarchy;
-import org.checkerframework.framework.type.treeannotator.ImplicitsTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
+import org.checkerframework.framework.type.treeannotator.LiteralTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
@@ -61,11 +62,11 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
 
     @Override
     public TreeAnnotator createTreeAnnotator() {
-        ImplicitsTreeAnnotator implicitsTreeAnnotator = new ImplicitsTreeAnnotator(this);
-        implicitsTreeAnnotator.addTreeKind(com.sun.source.tree.Tree.Kind.INT_LITERAL, BOTTOM);
-        implicitsTreeAnnotator.addStandardImplicits();
+        LiteralTreeAnnotator literalTreeAnnotator = new LiteralTreeAnnotator(this);
+        literalTreeAnnotator.addLiteralKind(LiteralKind.INT, BOTTOM);
+        literalTreeAnnotator.addStandardDefaults();
 
-        return new ListTreeAnnotator(new PropagationTreeAnnotator(this), implicitsTreeAnnotator);
+        return new ListTreeAnnotator(new PropagationTreeAnnotator(this), literalTreeAnnotator);
     }
 
     @Override

--- a/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultBottom.java
+++ b/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultBottom.java
@@ -5,13 +5,13 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
-import org.checkerframework.framework.qual.ImplicitFor;
 import org.checkerframework.framework.qual.LiteralKind;
+import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** TypeDeclDefault bottom qualifier. */
 @SubtypeOf(TypeDeclDefaultTop.class)
-@ImplicitFor(literals = LiteralKind.STRING)
+@QualifierForLiterals(LiteralKind.STRING)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy


### PR DESCRIPTION
(This is the next part of the default changes.)
1. Adds `@QualifierForLiterals` meta-annotation
2. Moves `@ImplicitFor(literals, stringpatterns)` to the `@QualifierForLiterals`
2. Renames `ImplicitsTreeAnnotator` to `LiteralTreeAnnotator`