### PR TITLE
 Polymorphic constructor results

### DIFF
--- a/checker/tests/tainting/PolyConstructor.java
+++ b/checker/tests/tainting/PolyConstructor.java
@@ -1,0 +1,26 @@
+import org.checkerframework.checker.tainting.qual.PolyTainted;
+import org.checkerframework.checker.tainting.qual.Tainted;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+@SuppressWarnings({"inconsistent.constructor.type", "super.invocation.invalid"})
+public class PolyConstructor {
+
+    @PolyTainted PolyConstructor() {}
+
+    @PolyTainted PolyConstructor(@PolyTainted Object o) {}
+
+    static void uses(@Tainted Object tainted, @Untainted Object untainted) {
+        @Untainted PolyConstructor o1 = new @Untainted PolyConstructor();
+        @Tainted PolyConstructor o2 = new @Tainted PolyConstructor();
+        @PolyTainted PolyConstructor o3 = new @PolyTainted PolyConstructor();
+
+        // :: error: (assignment.type.incompatible)
+        @Untainted PolyConstructor o4 = new @Tainted PolyConstructor(untainted);
+        @Untainted PolyConstructor o5 = new PolyConstructor(untainted);
+
+        // This currently isn't supported, but could be in the future.
+        // :: error: (assignment.type.incompatible)
+        @Untainted PolyConstructor o6 = new PolyConstructor();
+        @Tainted PolyConstructor o7 = new PolyConstructor();
+    }
+}

--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -646,6 +646,9 @@ for the cast.  For either syntax, the Checker Framework will issue a
 warning that it cannot verify that the cast is correct.  The programmer may
 suppress the warning if the code is correct.
 
+One exception to this is if the annotation on the result type is polymorphic.  In this case, any
+explicit annotation between \<new> and a class name is treated as a constraint for the instantiation
+for the polymorphic qualifier.
 
 \sectionAndLabel{Type refinement (flow-sensitive type qualifier inference)}{type-refinement}
 

--- a/framework/tests/polyall/Constructors.java
+++ b/framework/tests/polyall/Constructors.java
@@ -45,14 +45,14 @@ class Constructors {
 
         // :: error: (assignment.type.incompatible)
         @H1S2 @H2S1 Constructors e1 = new Constructors(p);
-        // :: error: (assignment.type.incompatible) :: error: (constructor.invocation.invalid)
+        // :: error: (assignment.type.incompatible) :: warning: (cast.unsafe.constructor.invocation)
         @H1S2 @H2S1 Constructors e2 = new @H1S2 @H2S2 Constructors(p);
-        // :: error: (assignment.type.incompatible) :: error: (constructor.invocation.invalid)
+        // :: error: (assignment.type.incompatible) :: warning: (cast.unsafe.constructor.invocation)
         @H1S2 @H2S1 Constructors e3 = new @H1S2 Constructors(p);
 
-        // :: error: (constructor.invocation.invalid)
+        // :: warning: (cast.unsafe.constructor.invocation)
         @H1S2 @H2S2 Constructors e4 = new @H1S2 @H2S2 Constructors(p);
-        // :: error: (constructor.invocation.invalid)
+        // :: warning: (cast.unsafe.constructor.invocation)
         @H1S2 @H2S2 Constructors e5 = new @H1S2 Constructors(p);
     }
 


### PR DESCRIPTION
If a constructor result is annotated with a polymorphic qualifier, then treat explicit annotations
on new class trees as a constraint for the instantiation for the polymorphic qualifier.  For example:

```
   @PolyTainted PolyConstructor() {}

    static void uses(@Tainted Object tainted, @Untainted Object untainted) {
        @Untainted PolyConstructor o1 = new @Untainted PolyConstructor(); // legal
        @Tainted PolyConstructor o2 = new @Tainted PolyConstructor(); // legal
  }
```