### PR TITLE
removed double inverted commas from @MinLen error message

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/messages.properties
@@ -1,6 +1,6 @@
 ### Error messages for the Upper Bound Checker
 array.access.unsafe.high=Potentially unsafe array access: the index could be larger than the array's bound\nfound   : %s\nrequired: @IndexFor("%s") or @LTLengthOf("%s") -- an integer less than %s's length
-array.access.unsafe.high.constant=Potentially unsafe array access: the constant index %s could be larger than the array's bound\nfound   : %s\nrequired: @MinLen("%s") -- an array guaranteed to have at least %s elements
+array.access.unsafe.high.constant=Potentially unsafe array access: the constant index %s could be larger than the array's bound\nfound   : %s\nrequired: @MinLen(%s) -- an array guaranteed to have at least %s elements
 array.access.unsafe.high.range=Potentially unsafe array access: the index could be larger than the array's bound\nindex type found: %s\narray type found: %s\nrequired        : index of type @IndexFor("%s") or @LTLengthOf("%s"), or array of type @MinLen(%s)
 different.length.sequences.offsets=If offsets are provided, the annotation must contain the same number of sequences and offsets, but this annotation has %s sequence(s) and %s offset(s).
 to.not.ltel=While attempting to validate a subsequence type, the Upper Bound Checker could not prove that %s is less than or equal to the length of %s.\nfound   : %s\nrequired: @IndexOrHigh("%s") or @LTEqLengthOf("%s") -- an integer less than or equal to %s's length


### PR DESCRIPTION
Consider the following code:

```
class tryit{
public void check_it(int[] x){
x[0] = 0;
}  
}
```

Run it by typing in the terminal:
javac -processor index tryit.java

Output:
tryit.java:3: error: [array.access.unsafe.high.constant] Potentially unsafe array access: the constant index 0 could be larger than the array's bound
x[0] = 0;
 ^
  found   : @UnknownVal int @UnknownVal []
  required: @MinLen("1") -- an array guaranteed to have at least 1 elements
1 error

However, while annotating, we can't use @MinLen("1") because String cannot be converted to int, hence, we use @MinLen(1).
Hence, I removed the double inverted commas (" ") from the error message.