### PR TITLE
Explicit annotations on type parameter upper bounds.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4013,13 +4013,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /**
      * Annotates uses of type variables with annotation written explicitly on the type parameter
      * declaration and/or its upper bound.
-     *
-     * <p>For all uses, except those in a method declaration or from an element, the type of the
-     * type variable is computed using {@link TypeFromTree#fromTypeTree(AnnotatedTypeFactory,
-     * Tree)}. {@link TypeFromTypeTreeVisitor#forTypeVariable(AnnotatedTypeMirror,
-     * AnnotatedTypeFactory)} is called for all uses of type variables and that method looks up the
-     * annotations on type parameters and type parameter upper bounds from the tree. Types in method
-     * signatures aren't created using TypeFromTree#fromTypeTree, so it needs special handling.
      */
     class TypeVarAnnotator extends AnnotatedTypeScanner<Void, Void> {
         @Override
@@ -4030,7 +4023,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             if (type.getAnnotations().isEmpty()
                     && type.getUpperBound().getAnnotations().isEmpty()
                     && tpelt.getEnclosingElement().getKind() != ElementKind.TYPE_PARAMETER) {
-                ElementAnnotationApplier.apply(type, tpelt, AnnotatedTypeFactory.this);
+                ElementAnnotationApplier.applyInternal(type, tpelt, AnnotatedTypeFactory.this);
             }
             return super.visitTypeVariable(type, p);
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1188,7 +1188,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 && (typesFromStubFiles == null || !typesFromStubFiles.containsKey(elt))) {
             type = toAnnotatedType(elt.asType(), ElementUtils.isTypeDeclaration(elt));
             ElementAnnotationApplier.apply(type, elt, this);
-            typeVarAnnotator.visit(type);
 
             if (elt instanceof ExecutableElement || elt instanceof VariableElement) {
                 annotateInheritedFromClass(type);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -47,7 +47,6 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.IntersectionType;
@@ -398,12 +397,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     protected final ExecutableElement objectGetClass;
 
     /**
-     * Adds explicit annotations on type parameter declarations an their upper bounds to uses of
-     * type variables.
-     */
-    protected final TypeVarAnnotator typeVarAnnotator;
-
-    /**
      * Constructs a factory from the given {@link ProcessingEnvironment} instance and syntax tree
      * root. (These parameters are required so that the factory may conduct the appropriate
      * annotation-gathering analyses on certain tree types.)
@@ -469,7 +462,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         ignoreUninferredTypeArguments = !checker.hasOption("conservativeUninferredTypeArguments");
 
         objectGetClass = TreeUtils.getMethod("java.lang.Object", "getClass", 0, processingEnv);
-        this.typeVarAnnotator = new TypeVarAnnotator();
     }
 
     /**
@@ -4006,25 +3998,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                 constantExpression = constantExpression.substring(1);
             }
             return "-" + constantExpression;
-        }
-    }
-
-    /**
-     * Annotates uses of type variables with annotation written explicitly on the type parameter
-     * declaration and/or its upper bound.
-     */
-    class TypeVarAnnotator extends AnnotatedTypeScanner<Void, Void> {
-        @Override
-        public Void visitTypeVariable(AnnotatedTypeVariable type, Void p) {
-            TypeParameterElement tpelt =
-                    (TypeParameterElement) type.getUnderlyingType().asElement();
-
-            if (type.getAnnotations().isEmpty()
-                    && type.getUpperBound().getAnnotations().isEmpty()
-                    && tpelt.getEnclosingElement().getKind() != ElementKind.TYPE_PARAMETER) {
-                ElementAnnotationApplier.applyInternal(type, tpelt, AnnotatedTypeFactory.this);
-            }
-            return super.visitTypeVariable(type, p);
         }
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -173,7 +173,7 @@ public class ElementAnnotationApplier {
      * Annotates uses of type variables with annotation written explicitly on the type parameter
      * declaration and/or its upper bound.
      */
-    static class TypeVarAnnotator extends AnnotatedTypeScanner<Void, AnnotatedTypeFactory> {
+    private static class TypeVarAnnotator extends AnnotatedTypeScanner<Void, AnnotatedTypeFactory> {
         @Override
         public Void visitTypeVariable(AnnotatedTypeVariable type, AnnotatedTypeFactory factory) {
             TypeParameterElement tpelt =

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -7,10 +7,13 @@ import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.code.Symbol;
 import java.util.List;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.element.ClassTypeParamApplier;
 import org.checkerframework.framework.util.element.MethodApplier;
 import org.checkerframework.framework.util.element.MethodTypeParamApplier;
@@ -71,7 +74,7 @@ public class ElementAnnotationApplier {
             final AnnotatedTypeFactory typeFactory) {
         applyInternal(type, element, typeFactory);
         // Also copy annotations from type parameters to their uses.
-        typeFactory.typeVarAnnotator.visit(type);
+        new TypeVarAnnotator().visit(type, typeFactory);
     }
 
     /** Same as apply except that annatation aren't copied from type parameter declarations. */
@@ -164,5 +167,24 @@ public class ElementAnnotationApplier {
     private static boolean isCaptureConvertedTypeVar(final Element element) {
         final Element enclosure = element.getEnclosingElement();
         return (((Symbol) enclosure).kind == com.sun.tools.javac.code.Kinds.NIL);
+    }
+
+    /**
+     * Annotates uses of type variables with annotation written explicitly on the type parameter
+     * declaration and/or its upper bound.
+     */
+    static class TypeVarAnnotator extends AnnotatedTypeScanner<Void, AnnotatedTypeFactory> {
+        @Override
+        public Void visitTypeVariable(AnnotatedTypeVariable type, AnnotatedTypeFactory factory) {
+            TypeParameterElement tpelt =
+                    (TypeParameterElement) type.getUnderlyingType().asElement();
+
+            if (type.getAnnotations().isEmpty()
+                    && type.getUpperBound().getAnnotations().isEmpty()
+                    && tpelt.getEnclosingElement().getKind() != ElementKind.TYPE_PARAMETER) {
+                ElementAnnotationApplier.applyInternal(type, tpelt, factory);
+            }
+            return super.visitTypeVariable(type, factory);
+        }
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -69,6 +69,17 @@ public class ElementAnnotationApplier {
             final AnnotatedTypeMirror type,
             final Element element,
             final AnnotatedTypeFactory typeFactory) {
+        applyInternal(type, element, typeFactory);
+        // Also copy annotations from type parameters to their uses.
+        typeFactory.typeVarAnnotator.visit(type);
+    }
+
+    /** Same as apply except that annatation aren't copied from type parameter declarations. */
+    /*package-private*/ static void applyInternal(
+            final AnnotatedTypeMirror type,
+            final Element element,
+            final AnnotatedTypeFactory typeFactory) {
+
         if (element == null) {
             throw new BugInCF("ElementAnnotationUtil.apply: element cannot be null");
 

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -78,7 +78,7 @@ public class ElementAnnotationApplier {
     }
 
     /** Same as apply except that annatation aren't copied from type parameter declarations. */
-    /*package-private*/ static void applyInternal(
+    private static void applyInternal(
             final AnnotatedTypeMirror type,
             final Element element,
             final AnnotatedTypeFactory typeFactory) {

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -9,11 +9,8 @@ import com.sun.source.tree.VariableTree;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeParameterElement;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
-import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
-import org.checkerframework.framework.type.visitor.AnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
@@ -24,12 +21,6 @@ import org.checkerframework.javacutil.TreeUtils;
  * @see org.checkerframework.framework.type.TypeFromTree
  */
 class TypeFromMemberVisitor extends TypeFromTreeVisitor {
-
-    /**
-     * Adds explicit annotations on type parameter declarations an their upper bounds to uses of
-     * type variables.
-     */
-    private final TypeVarAnnotator typeVarAnnotator = new TypeVarAnnotator();
 
     @Override
     public AnnotatedTypeMirror visitVariable(VariableTree node, AnnotatedTypeFactory f) {
@@ -81,35 +72,9 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         result.setElement(elt);
 
         ElementAnnotationApplier.apply(result, elt, f);
-        typeVarAnnotator.visit(result, f);
+        f.typeVarAnnotator.visit(result);
 
         return result;
-    }
-
-    /**
-     * Annotates uses of type variables with annotation written explicitly on the type parameter
-     * declaration and/or its upper bound.
-     *
-     * <p>For all uses, except those in a method declaration, the type of the type variable is
-     * computed using {@link TypeFromTree#fromTypeTree(AnnotatedTypeFactory, Tree)}. {@link
-     * TypeFromTypeTreeVisitor#forTypeVariable(AnnotatedTypeMirror, AnnotatedTypeFactory)} is called
-     * for all uses of type variables and that method looks up the annotations on type parameters
-     * and type parameter upper bounds from the tree. Types in method signatures aren't created
-     * using TypeFromTree#fromTypeTree, so it needs special handling.
-     */
-    static class TypeVarAnnotator extends AnnotatedTypeScanner<Void, AnnotatedTypeFactory> {
-        @Override
-        public Void visitTypeVariable(AnnotatedTypeVariable type, AnnotatedTypeFactory p) {
-            TypeParameterElement tpelt =
-                    (TypeParameterElement) type.getUnderlyingType().asElement();
-
-            if (type.getAnnotations().isEmpty()
-                    && type.getUpperBound().getAnnotations().isEmpty()
-                    && tpelt.getEnclosingElement().getKind() != ElementKind.TYPE_PARAMETER) {
-                ElementAnnotationApplier.apply(type, tpelt, p);
-            }
-            return super.visitTypeVariable(type, p);
-        }
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -72,8 +72,6 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         result.setElement(elt);
 
         ElementAnnotationApplier.apply(result, elt, f);
-        f.typeVarAnnotator.visit(result);
-
         return result;
     }
 


### PR DESCRIPTION
The changes in #2472 caused daikon-type-check to fail. 
Here's the error:
```
daikon/diff/Node.java:22: error: [assignment.type.incompatible] incompatible types in assignment.
    this.userObject = userObject;
                      ^
  found   : @NonNull @NonRaw Pair<CONTENT[ extends @NonNull @NonRaw Object super @NonNull @NonRaw Void], CONTENT[ extends @NonNull @NonRaw Object super @NonNull @NonRaw Void]>
  required: @NonNull @NonRaw Pair<CONTENT[ extends @NonRaw @Nullable Object super @NonNull @NonRaw Void], CONTENT[ extends @NonRaw @Nullable Object super @NonNull @NonRaw Void]>
```
Here is the relevant snippet of the Node.java file:
```
public abstract class Node<CONTENT extends @Nullable Object, CHILD> {

  private List<CHILD> children = new ArrayList<CHILD>();
  // Nonsensical for RootNode
  private Pair<CONTENT, CONTENT> userObject;

  public Node(Pair<CONTENT, CONTENT> userObject) {
    this.userObject = userObject;
  }
```
The error only seems to happen when the tree for the element isn't available, so I'm not sure how to create a test case for this.   However, I have verified locally that this pull request fixes the bug.