### PR TITLE
Put javadoc.astub in the top level of checker.jar

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -11,7 +11,7 @@ sourceSets {
     main {
         resources {
             // Stub files, message.properties, etc.
-            srcDirs = ['src/main/java']
+            srcDirs += ['src/main/java']
             exclude '**/*.java'
         }
     }

--- a/checker/resources
+++ b/checker/resources
@@ -1,0 +1,1 @@
+src/main/resources

--- a/checker/src/main/resources/javadoc.astub
+++ b/checker/src/main/resources/javadoc.astub
@@ -1,7 +1,7 @@
 // This file, javadoc.astub, models the JavaDoc classes in the JDK's
 // com.sun.javadoc package, which are not exposed by ct.sym and therefore
 // cannot be part of an annotated JDK.
-// It is annotated for the Index and Nullness checkers.
+// It is annotated for the Value and Nullness checkers.
 
 import org.checkerframework.common.value.qual.MinLen;
 

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -583,7 +583,7 @@ classpath; you don't have to do anything special for it.
 For the Javadoc classes in the JDK's \<com.sun.javadoc> package,
 % are not exposed by ct.sym and therefore cannot be part of an
 % annotated JDK
-use the stub file \<checker/resources/javadoc.astub>.
+use the stub file \<checker/src/main/resources/javadoc.astub> by using -Astubs=checker.jar/javadoc.astub.
 \end{itemize}
 
 

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -583,7 +583,8 @@ classpath; you don't have to do anything special for it.
 For the Javadoc classes in the JDK's \<com.sun.javadoc> package,
 % are not exposed by ct.sym and therefore cannot be part of an
 % annotated JDK
-use the stub file \<checker/src/main/resources/javadoc.astub> by using -Astubs=checker.jar/javadoc.astub.
+use the stub file \<checker/resources/javadoc.astub> by using \<-Astubs=checker.jar/javadoc.astub>.
+% Note: that this syntax only works for checker.jar.
 \end{itemize}
 
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -3100,6 +3100,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
             List<StubResource> stubs = StubUtil.allStubFiles(stubPathFull);
             if (stubs.isEmpty()) {
+                // If the stub file has a prefix of "checker.jar/" then look for the file in the top
+                // level directory of the jar that contains the checker.
+                stubPath = stubPath.replace("checker.jar/", "/");
                 InputStream in = checker.getClass().getResourceAsStream(stubPath);
                 if (in == null) {
                     // Didn't find the stubfile.


### PR DESCRIPTION
Also, allow it to be specified via `-Astubs=checker.jar/javadoc.astub`.

Fixes #2499.