### PR TITLE
Removed @NonNegative annotation to the argument of write(int)

### DIFF
--- a/checker/jdk/index/src/java/io/Writer.java
+++ b/checker/jdk/index/src/java/io/Writer.java
@@ -105,7 +105,7 @@ public abstract class Writer implements Appendable, Closeable, Flushable {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public void write() throws IOException {
+    public void write(int c) throws IOException {
         synchronized (lock) {
             if (writeBuffer == null){
                 writeBuffer = new char[writeBufferSize];

--- a/checker/jdk/index/src/java/io/Writer.java
+++ b/checker/jdk/index/src/java/io/Writer.java
@@ -105,7 +105,7 @@ public abstract class Writer implements Appendable, Closeable, Flushable {
      * @throws  IOException
      *          If an I/O error occurs
      */
-    public void write(@NonNegative int c) throws IOException {
+    public void write() throws IOException {
         synchronized (lock) {
             if (writeBuffer == null){
                 writeBuffer = new char[writeBufferSize];

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/messages.properties
@@ -1,6 +1,6 @@
 ### Error messages for the Upper Bound Checker
 array.access.unsafe.high=Potentially unsafe array access: the index could be larger than the array's bound\nfound   : %s\nrequired: @IndexFor("%s") or @LTLengthOf("%s") -- an integer less than %s's length
-array.access.unsafe.high.constant=Potentially unsafe array access: the constant index %s could be larger than the array's bound\nfound   : %s\nrequired: @MinLen("%s") -- an array guaranteed to have at least %s elements
+array.access.unsafe.high.constant=Potentially unsafe array access: the constant index %s could be larger than the array's bound\nfound   : %s\nrequired: @MinLen(%s) -- an array guaranteed to have at least %s elements
 array.access.unsafe.high.range=Potentially unsafe array access: the index could be larger than the array's bound\nindex type found: %s\narray type found: %s\nrequired        : index of type @IndexFor("%s") or @LTLengthOf("%s"), or array of type @MinLen(%s)
 different.length.sequences.offsets=If offsets are provided, the annotation must contain the same number of sequences and offsets, but this annotation has %s sequence(s) and %s offset(s).
 to.not.ltel=While attempting to validate a subsequence type, the Upper Bound Checker could not prove that %s is less than or equal to the length of %s.\nfound   : %s\nrequired: @IndexOrHigh("%s") or @LTEqLengthOf("%s") -- an integer less than or equal to %s's length


### PR DESCRIPTION
The argument of write(int) need not be `@NonNegative`.
Consider the following code:

import java.io.*;
class tryit{
public static void main(String[] args) throws IOException {
	Writer a = new PrintWriter(System.out);
	a.write(-1);
}
}

Compiling it by 'javac tryit.java' and executing it by 'java tryit'.
It gives no error and is run safely.