### PR TITLE
Change argument types of warnAboutTypeAnnotationsTooEarly

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -773,8 +773,7 @@ public class AnnotationClassLoader {
 
     /**
      * Checks to see whether a particular annotation class has the {@link Target} meta-annotation,
-     * and has the required {@link ElementType} values as checked by {@link
-     * AnnotatedTypes#hasTypeQualifierElementTypes(ElementType[], Class)}.
+     * and has the required {@link ElementType} values.
      *
      * <p>A subclass may override this method to load annotations that are not intended to be
      * annotated in source code. E.g.: {@code SubtypingChecker} overrides this method to load {@code

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -837,9 +837,9 @@ public class AnnotatedTypes {
      *     something besides {@link ElementType#TYPE_PARAMETER}
      */
     public static boolean hasTypeQualifierElementTypes(ElementType[] elements, Class<?> cls) {
-        // True if it contains TYPE_USE
+        // True if the array contains TYPE_USE
         boolean hasTypeUse = false;
-        // Non-null if it has an element other than TYPE_USE or TYPE_PARAMETER
+        // Non-null if the array contains an element other than TYPE_USE or TYPE_PARAMETER
         ElementType otherElementType = null;
 
         for (ElementType element : elements) {

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -828,25 +828,24 @@ public class AnnotatedTypes {
     }
 
     /**
-     * Sees if the passed in array of {@link ElementType} values have the correct set of values
-     * which defines a type qualifier.
+     * Returns true if the given array contains {@link ElementType#TYPE_USE}, false otherwise.
      *
      * @param elements an array of {@link ElementType} values
      * @param cls the annotation class being tested; used for diagnostic messages only
+     * @return true iff the give array contains {@link ElementType#TYPE_USE}
      * @throws RuntimeException if the array contains both {@link ElementType#TYPE_USE} and
      *     something besides {@link ElementType#TYPE_PARAMETER}
      */
     public static boolean hasTypeQualifierElementTypes(ElementType[] elements, Class<?> cls) {
+        // True if it contains TYPE_USE
         boolean hasTypeUse = false;
+        // Non-null if it has an element other than TYPE_USE or TYPE_PARAMETER
         ElementType otherElementType = null;
 
         for (ElementType element : elements) {
             if (element.equals(ElementType.TYPE_USE)) {
-                // valid annotations have to have TYPE_USE
                 hasTypeUse = true;
             } else if (!element.equals(ElementType.TYPE_PARAMETER)) {
-                // if there's an ElementType with a enumerated value of something other than
-                // TYPE_USE or TYPE_PARAMETER then it isn't a valid annotation
                 otherElementType = element;
             }
             if (hasTypeUse && otherElementType != null) {


### PR DESCRIPTION
Also some documentation improvements.

This incorporates the working parts of https://github.com/typetools/checker-framework/pull/2376, which we can close (and delete its branch) to keep the repository clean.