### PR TITLE
Remove unnecessary download of jsr308-langtools

### DIFF
--- a/.travis-build-without-test.sh
+++ b/.travis-build-without-test.sh
@@ -62,13 +62,6 @@ echo "... done: (cd ../stubparser/ && ./.travis-build-without-test.sh)"
 
 ## Compile
 
-# Download jsr308-langtools replacement for javac.jar that fixes some bugs
-if [ ! -d ../jsr308-langtools ] ; then
-  (cd .. && wget -q https://checkerframework.org/jsr308/jsr308-langtools-2.4.0.zip)
-  (cd .. && unzip -q jsr308-langtools-2.4.0.zip)
-  (cd .. && mv jsr308-langtools-2.4.0 jsr308-langtools)
-fi
-
 # Two options: rebuild the JDK or download a prebuilt JDK.
 if [[ "${BUILDJDK}" == "buildjdk" ]]; then
   echo "running \"./gradlew assemble -PuseLocalJdk\" for checker-framework"

--- a/build.gradle
+++ b/build.gradle
@@ -490,12 +490,8 @@ subprojects {
                                 "-keywords:!ignore",
                                 '-samevm',
                                 // Required for checker/jtreg/nullness/PersistUtil.java and other tests
-                                // Must use langtools javap.jar rather than tools.jar because the
-                                // tools.jar in the docker vm doesn't have the required classes.
                                 "-vmoptions:-Xbootclasspath/p:${configurations.javacJar.asPath}:" +
-                                        "${parentDir}/jsr308-langtools/dist/lib/javap.jar:" +
                                         "${tasks.shadowJar.archivePath}:${sourceSets.test.output.asPath}",
-
                                 "-javacoptions:-Xbootclasspath/p:${configurations.javacJar.asPath}",
                         ]
                         if (project.name.is('checker')) {


### PR DESCRIPTION
This was added in #2124 but doesn't seem necessary.
Is there any reason to keep this around?