### PR TITLE
Make get and orElseThrow consistent.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@ Renamed the Signedness Checker's @Constant annotation to @SignednessEither.
 Improved the diagnostic text for uninitialized static fields.  The new
 error key is initialization.static.fields.uninitialized.
 
-The first argument of Opt.orElseThrow is annotated as @NonNull.
+Annotated the first argument of Opt.get and Opt.orElseThrow as @NonNull.
 
 ---------------------------------------------------------------------------
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/Opt.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/Opt.java
@@ -40,12 +40,15 @@ public final class Opt {
     /**
      * If primary is non-null, returns it, otherwise throws NoSuchElementException.
      *
+     * <p>Note that primary is required to be non-null by the Nullness Checker, to ensure the
+     * exception never happens for checked code.
+     *
      * @param primary a non-null value to return
      * @return {@code primary} if it is non-null
      * @throws NoSuchElementException if primary is null
      * @see java.util.Optional#get()
      */
-    public static <T> @NonNull T get(T primary) {
+    public static <T extends @NonNull Object> T get(T primary) {
         if (primary == null) {
             throw new NoSuchElementException("No value present");
         }
@@ -128,10 +131,13 @@ public final class Opt {
      * Return primary if it is non-null. If primary is null, return an exception to be created by
      * the provided supplier.
      *
+     * <p>Note that primary is required to be non-null by the Nullness Checker, to ensure the
+     * exception never happens for checked code.
+     *
      * @see java.util.Optional#orElseThrow(Supplier)
      */
-    public static <T, X extends @NonNull Throwable> @NonNull T orElseThrow(
-            @NonNull T primary, Supplier<? extends @NonNull X> exceptionSupplier) throws X {
+    public static <T extends @NonNull Object, X extends @NonNull Throwable> T orElseThrow(
+            T primary, Supplier<? extends X> exceptionSupplier) throws X {
         if (primary != null) {
             return primary;
         } else {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/Opt.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/Opt.java
@@ -40,14 +40,12 @@ public final class Opt {
     /**
      * If primary is non-null, returns it, otherwise throws NoSuchElementException.
      *
-     * <p>Note that primary is required to be non-null by the Nullness Checker, to ensure the
-     * exception never happens for checked code.
-     *
      * @param primary a non-null value to return
      * @return {@code primary} if it is non-null
      * @throws NoSuchElementException if primary is null
      * @see java.util.Optional#get()
      */
+    // `primary` is @NanNull; otherwise, the method could throw an exception.
     public static <T extends @NonNull Object> T get(T primary) {
         if (primary == null) {
             throw new NoSuchElementException("No value present");
@@ -128,14 +126,12 @@ public final class Opt {
     }
 
     /**
-     * Return primary if it is non-null. If primary is null, return an exception to be created by
-     * the provided supplier.
-     *
-     * <p>Note that primary is required to be non-null by the Nullness Checker, to ensure the
-     * exception never happens for checked code.
+     * Return primary if it is non-null. If primary is null, throw an exception to be created by the
+     * provided supplier.
      *
      * @see java.util.Optional#orElseThrow(Supplier)
      */
+    // `primary` is @NanNull; otherwise, the method could throw an exception.
     public static <T extends @NonNull Object, X extends @NonNull Throwable> T orElseThrow(
             T primary, Supplier<? extends X> exceptionSupplier) throws X {
         if (primary != null) {

--- a/checker/tests/nullness/flow/TestOpt.java
+++ b/checker/tests/nullness/flow/TestOpt.java
@@ -66,6 +66,7 @@ class TestOpt {
     void foo7b(@Nullable Object p) {
         try {
             // :: error: (assignment.type.incompatible) :: error: (type.argument.type.incompatible)
+            // :: error: (return.type.incompatible)
             @NonNull Object o = Opt.orElseThrow(p, () -> null);
         } catch (Throwable t) {
             // p was null

--- a/checker/tests/nullness/flow/TestOpt.java
+++ b/checker/tests/nullness/flow/TestOpt.java
@@ -65,7 +65,7 @@ class TestOpt {
 
     void foo7b(@Nullable Object p) {
         try {
-            // :: error: (return.type.incompatible) :: error: (argument.type.incompatible)
+            // :: error: (assignment.type.incompatible) :: error: (type.argument.type.incompatible)
             @NonNull Object o = Opt.orElseThrow(p, () -> null);
         } catch (Throwable t) {
             // p was null


### PR DESCRIPTION
Simplify signature.
Related to 8c21ebc983f60df3f0c83550a2258fe61f165472
The change to Opt.get should also be added to the changelog.