### PR TITLE
annotations not required in the parameters of regionMatches() in java.lang.String

### DIFF
--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -1275,8 +1275,8 @@ public final class String
      *          exactly matches the specified subregion of the string argument;
      *          {@code false} otherwise.
      */
-    public boolean regionMatches(@IndexOrHigh("this") int toffset, String other, @IndexOrHigh("#2") int ooffset,
-				 @IndexOrHigh({"this","#2"}) int len) {
+    public boolean regionMatches(int toffset, String other,int ooffset,
+				 @NonNegative int len) {
         char ta[] = value;
         int to = toffset;
         char pa[] = other.value;
@@ -1345,9 +1345,9 @@ public final class String
      *          or case insensitive depends on the {@code ignoreCase}
      *          argument.
      */
-    public boolean regionMatches(boolean ignoreCase, @IndexOrHigh("this") int toffset,
-                           String other, @IndexOrHigh("#3") int ooffset,
-				 @IndexOrHigh({"this","#3"}) int len) {
+    public boolean regionMatches(boolean ignoreCase, int toffset,
+                           String other, int ooffset,
+				 @NonNegative int len) {
         char ta[] = value;
         int to = toffset;
         char pa[] = other.value;

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -1347,7 +1347,7 @@ public final class String
      */
     public boolean regionMatches(boolean ignoreCase, int toffset,
                            String other, int ooffset,
-				            int len) {
+				        int len) {
         char ta[] = value;
         int to = toffset;
         char pa[] = other.value;

--- a/checker/jdk/index/src/java/lang/String.java
+++ b/checker/jdk/index/src/java/lang/String.java
@@ -1347,7 +1347,7 @@ public final class String
      */
     public boolean regionMatches(boolean ignoreCase, int toffset,
                            String other, int ooffset,
-				 @NonNegative int len) {
+				            int len) {
         char ta[] = value;
         int to = toffset;
         char pa[] = other.value;


### PR DESCRIPTION
The `@IndexOrHigh` annotations on the parameters `toffset`, `ooffset` and `len`  of `regionMatches()` functions is not required as it is checked in the if statements inside the function and a false value is returned if the above annotation is not satisfied by the parameters.

Consider the following code:
```
class tryit{
public static void main(String[] args) {
	String a = "abcd";
	System.out.println(a.regionMatches(-1,"abc",-2,-1));
}
}
```
Compile it by javac tryit.java
Run it by java tryit
It prints false and throws no error.