### PR TITLE
BaseTypeVisitor: scan ParameterizedTypeTrees

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.nullness;
 
 import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayAccessTree;
 import com.sun.source.tree.AssertTree;
 import com.sun.source.tree.BinaryTree;
@@ -590,5 +591,10 @@ public class NullnessVisitor
         // BasetypeVisitor forces annotations on exception parameters to be top,
         // but because exceptions can never be null, the Nullness Checker
         // does not require this check.
+    }
+
+    @Override
+    public Void visitAnnotation(AnnotationTree node, Void p) {
+        return null;
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -595,6 +595,7 @@ public class NullnessVisitor
 
     @Override
     public Void visitAnnotation(AnnotationTree node, Void p) {
+        // All annotation arguments are non-null and initialized, so no need to check them.
         return null;
     }
 }

--- a/checker/tests/lock/GuardSatisfiedTest.java
+++ b/checker/tests/lock/GuardSatisfiedTest.java
@@ -238,12 +238,12 @@ public class GuardSatisfiedTest {
                 @GuardSatisfied MyParameterizedClass1<T>[] array) {}
     };
 
-    // :: error: (guardsatisfied.location.disallowed)
     void testGuardSatisfiedOnWildCardExtendsBound(
+            // :: error: (guardsatisfied.location.disallowed)
             MyParameterizedClass1<? extends @GuardSatisfied Object> l) {}
 
-    // :: error: (guardsatisfied.location.disallowed)
     void testGuardSatisfiedOnWildCardSuperBound(
+            // :: error: (guardsatisfied.location.disallowed)
             MyParameterizedClass1<? super @GuardSatisfied Object> l) {}
 
     @GuardSatisfied(1) Object testGuardSatisfiedOnParameters(

--- a/checker/tests/lock/GuardSatisfiedTest.java
+++ b/checker/tests/lock/GuardSatisfiedTest.java
@@ -238,11 +238,11 @@ public class GuardSatisfiedTest {
                 @GuardSatisfied MyParameterizedClass1<T>[] array) {}
     };
 
-    // TODO: Enable :: error: (guardsatisfied.location.disallowed)
+    // :: error: (guardsatisfied.location.disallowed)
     void testGuardSatisfiedOnWildCardExtendsBound(
             MyParameterizedClass1<? extends @GuardSatisfied Object> l) {}
 
-    // TODO: Enable :: error: (guardsatisfied.location.disallowed)
+    // :: error: (guardsatisfied.location.disallowed)
     void testGuardSatisfiedOnWildCardSuperBound(
             MyParameterizedClass1<? super @GuardSatisfied Object> l) {}
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1829,7 +1829,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     @Override
     public final Void visitParameterizedType(ParameterizedTypeTree node, Void p) {
-        return null; // super.visitParameterizedType(node, p);
+        return super.visitParameterizedType(node, p);
     }
 
     protected void checkTypecastRedundancy(TypeCastTree node, Void p) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -21,7 +21,6 @@ import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.ModifiersTree;
 import com.sun.source.tree.NewArrayTree;
 import com.sun.source.tree.NewClassTree;
-import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.ReturnTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
@@ -1820,16 +1819,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
 
         return super.visitNewArray(node, p);
-    }
-
-    /**
-     * Do not override this method! Previously, this method contained some logic, but the main
-     * modifier of types was missing. It has been merged with the TypeValidator below. This method
-     * doesn't need to do anything, as the type is already validated.
-     */
-    @Override
-    public final Void visitParameterizedType(ParameterizedTypeTree node, Void p) {
-        return super.visitParameterizedType(node, p);
     }
 
     protected void checkTypecastRedundancy(TypeCastTree node, Void p) {


### PR DESCRIPTION
BaseTypeVisitor should scan ParameterizedTypeTree so that all trees are scanned by the visitor.  This way, subclasses can implement their own logic, such as validating explicit annotations.