### PR TITLE
Fixed #2409

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/DefaultAnnotationFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/DefaultAnnotationFormatter.java
@@ -86,12 +86,14 @@ public class DefaultAnnotationFormatter implements AnnotationFormatter {
                 boolean notfirst = false;
                 for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> arg :
                         args.entrySet()) {
-                    if (notfirst) {
-                        sb.append(", ");
+                    if (!"{}".equals(arg.getValue().toString())) {
+                        if (notfirst) {
+                            sb.append(", ");
+                        }
+                        notfirst = true;
+                        sb.append(arg.getKey().getSimpleName() + "=");
+                        formatAnnotationMirrorArg(arg.getValue(), sb);
                     }
-                    notfirst = true;
-                    sb.append(arg.getKey().getSimpleName() + "=");
-                    formatAnnotationMirrorArg(arg.getValue(), sb);
                 }
             }
             sb.append(")");


### PR DESCRIPTION
Small improvement to error messages. https://github.com/typetools/checker-framework/issues/2409

It no longer displays map entries with empty `AnnotationValue`. For example,

```
found : @LTEqLengthOf("a") int
required: @LTLengthOf(value="a", offset={}) int
```

becomes

```
found : @LTEqLengthOf("a") int
required: @LTLengthOf(value="a") int
```