### PR TITLE
IndexChecker treats single-argument `@IntVal` as constant value

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
@@ -64,6 +65,24 @@ public class IndexUtil {
      */
     public static Long getExactValue(Tree tree, ValueAnnotatedTypeFactory factory) {
         AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+        Range possibleValues = getPossibleValues(valueType, factory);
+        if (possibleValues != null && possibleValues.from == possibleValues.to) {
+            return possibleValues.from;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the exact value of an annotated element according to the Constant Value Checker, or
+     * null if the exact value is not known.
+     *
+     * @param element the element to get the exact value from
+     * @param factory ValueAnnotatedTypeFactory used for annotation accessing
+     * @return the exact value of the element if it is constant, or null otherwise
+     */
+    public static Long getExactValue(Element element, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(element);
         Range possibleValues = getPossibleValues(valueType, factory);
         if (possibleValues != null && possibleValues.from == possibleValues.to) {
             return possibleValues.from;

--- a/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
@@ -142,4 +142,18 @@ public class IndexUtil {
         }
         return min.intValue();
     }
+
+    /**
+     * @param am AnnotationMirror to return the int value from
+     * @return the single int argument of @IntVal annotation, or null if @am is not an @IntVal
+     *     annotation or it has more than one arguments
+     */
+    public static Integer getIntegerFromIntValWithOneArgument(AnnotationMirror am) {
+        if (am != null
+                && AnnotationUtils.areSameByClass(am, IntVal.class)
+                && ValueAnnotatedTypeFactory.getIntValues(am).size() == 1) {
+            return ValueAnnotatedTypeFactory.getIntValues(am).get(0).intValue();
+        }
+        return null;
+    }
 }

--- a/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
@@ -142,18 +142,4 @@ public class IndexUtil {
         }
         return min.intValue();
     }
-
-    /**
-     * @param am AnnotationMirror to return the int value from
-     * @return the single int argument of @IntVal annotation, or null if @am is not an @IntVal
-     *     annotation or it has more than one arguments
-     */
-    public static Integer getIntegerFromIntValWithOneArgument(AnnotationMirror am) {
-        if (am != null
-                && AnnotationUtils.areSameByClass(am, IntVal.class)
-                && ValueAnnotatedTypeFactory.getIntValues(am).size() == 1) {
-            return ValueAnnotatedTypeFactory.getIntValues(am).get(0).intValue();
-        }
-        return null;
-    }
 }

--- a/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
@@ -44,7 +44,7 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
         }
         try {
             // Standardize individual terms of the expression.
-            equation.standardizeAndViewpointAdaptExpressions(context, localScope, useLocalScope);
+            equation.standardizeAndViewpointAdaptExpressions(context, localScope, useLocalScope, factory);
         } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
             return new DependentTypesError(expression, e).toString();
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
@@ -44,7 +44,8 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
         }
         try {
             // Standardize individual terms of the expression.
-            equation.standardizeAndViewpointAdaptExpressions(context, localScope, useLocalScope, factory);
+            equation.standardizeAndViewpointAdaptExpressions(
+                    context, localScope, useLocalScope, factory);
         } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
             return new DependentTypesError(expression, e).toString();
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -354,10 +354,7 @@ public class OffsetEquation {
             FlowExpressionContext context, TreePath scope, boolean useLocalScope)
             throws FlowExpressionParseException {
 
-        standardizeAndViewpointAdaptExpressions(
-                addedTerms, false, context, scope, useLocalScope, null);
-        standardizeAndViewpointAdaptExpressions(
-                subtractedTerms, true, context, scope, useLocalScope, null);
+        standardizeAndViewpointAdaptExpressions(context, scope, useLocalScope, null);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
@@ -24,9 +25,6 @@ import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressio
 import org.checkerframework.framework.util.dependenttypes.DependentTypesError;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.TreeUtils;
-
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.AnnotationValue;
 
 /**
  * An offset equation is 2 sets of Java expression strings, one set of added terms and one set of
@@ -274,10 +272,15 @@ public class OffsetEquation {
                 }
             }
         } else if (termReceiver instanceof FlowExpressions.LocalVariable) {
-            AnnotationMirror am = ((BaseAnnotatedTypeFactory) factory).getTypeFactoryOfSubchecker(ValueChecker.class).getAnnotatedType(((FlowExpressions.LocalVariable) termReceiver).getElement()).getAnnotation(IntVal.class);
+            AnnotationMirror am =
+                    ((BaseAnnotatedTypeFactory) factory)
+                            .getTypeFactoryOfSubchecker(ValueChecker.class)
+                            .getAnnotatedType(
+                                    ((FlowExpressions.LocalVariable) termReceiver).getElement())
+                            .getAnnotation(IntVal.class);
             if (am != null && am.getElementValues().values().size() == 1) {
-                List<AnnotationValue> list = new ArrayList<>(am.getElementValues().values());
-                return Integer.parseInt(((List) list.get(0).getValue()).get(0).toString().substring(0, ((List) list.get(0).getValue()).get(0).toString().length() - 1));
+                List<Long> list = ValueAnnotatedTypeFactory.getIntValues(am);
+                return list.get(0).intValue();
             }
         }
 
@@ -326,10 +329,14 @@ public class OffsetEquation {
      *     thrown. If this happens, no string terms are changed.
      */
     public void standardizeAndViewpointAdaptExpressions(
-            FlowExpressionContext context, TreePath scope, boolean useLocalScope, AnnotatedTypeFactory factory)
+            FlowExpressionContext context,
+            TreePath scope,
+            boolean useLocalScope,
+            AnnotatedTypeFactory factory)
             throws FlowExpressionParseException {
 
-        standardizeAndViewpointAdaptExpressions(addedTerms, false, context, scope, useLocalScope, factory);
+        standardizeAndViewpointAdaptExpressions(
+                addedTerms, false, context, scope, useLocalScope, factory);
         standardizeAndViewpointAdaptExpressions(
                 subtractedTerms, true, context, scope, useLocalScope, factory);
     }

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import org.checkerframework.checker.index.IndexUtil;
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
+import org.checkerframework.common.value.ValueChecker;
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
@@ -272,7 +274,7 @@ public class OffsetEquation {
                 }
             }
         } else if (termReceiver instanceof FlowExpressions.LocalVariable) {
-            AnnotationMirror am = ((UpperBoundAnnotatedTypeFactory) factory).getValueAnnotatedTypeFactory().getAnnotatedType(((FlowExpressions.LocalVariable) termReceiver).getElement()).getAnnotation(IntVal.class);
+            AnnotationMirror am = ((BaseAnnotatedTypeFactory) factory).getTypeFactoryOfSubchecker(ValueChecker.class).getAnnotatedType(((FlowExpressions.LocalVariable) termReceiver).getElement()).getAnnotation(IntVal.class);
             if (am != null && am.getElementValues().values().size() == 1) {
                 List<AnnotationValue> list = new ArrayList<>(am.getElementValues().values());
                 return Integer.parseInt(((List) list.get(0).getValue()).get(0).toString().substring(0, ((List) list.get(0).getValue()).get(0).toString().length() - 1));

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -11,7 +11,6 @@ import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
-import org.checkerframework.common.value.util.Range;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Unknown;
@@ -19,7 +18,6 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.NumericalAdditionNode;
 import org.checkerframework.dataflow.cfg.node.NumericalSubtractionNode;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
-import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionContext;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionParseException;
@@ -277,7 +275,8 @@ public class OffsetEquation {
         } else if (factory != null && termReceiver instanceof FlowExpressions.LocalVariable) {
             Element element = ((FlowExpressions.LocalVariable) termReceiver).getElement();
             Long exactValue =
-                    getExactValue(element, factory.getTypeFactoryOfSubchecker(ValueChecker.class));
+                    IndexUtil.getExactValue(
+                            element, factory.getTypeFactoryOfSubchecker(ValueChecker.class));
 
             if (exactValue != null) {
                 return exactValue.intValue();
@@ -285,23 +284,6 @@ public class OffsetEquation {
         }
 
         return null;
-    }
-
-    /**
-     * Returns the exact value of an annotated element.
-     *
-     * @param element the element to get the exact value from
-     * @param factory ValueAnnotatedTypeFactory used for annotation accessing
-     * @return the exact value of the element if it is constant, or null otherwise
-     */
-    public static Long getExactValue(Element element, ValueAnnotatedTypeFactory factory) {
-        AnnotatedTypeMirror valueType = factory.getAnnotatedType(element);
-        Range possibleValues = IndexUtil.getPossibleValues(valueType, factory);
-        if (possibleValues != null && possibleValues.from == possibleValues.to) {
-            return possibleValues.from;
-        } else {
-            return null;
-        }
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -271,16 +271,15 @@ public class OffsetEquation {
                     }
                 }
             }
-        } else if (termReceiver instanceof FlowExpressions.LocalVariable) {
+        } else if (factory != null && termReceiver instanceof FlowExpressions.LocalVariable) {
             AnnotationMirror am =
                     ((BaseAnnotatedTypeFactory) factory)
                             .getTypeFactoryOfSubchecker(ValueChecker.class)
                             .getAnnotatedType(
                                     ((FlowExpressions.LocalVariable) termReceiver).getElement())
                             .getAnnotation(IntVal.class);
-            if (am != null && am.getElementValues().values().size() == 1) {
-                List<Long> list = ValueAnnotatedTypeFactory.getIntValues(am);
-                return list.get(0).intValue();
+            if (am != null && ValueAnnotatedTypeFactory.getIntValues(am).size() == 1) {
+                return ValueAnnotatedTypeFactory.getIntValues(am).get(0).intValue();
             }
         }
 
@@ -325,6 +324,7 @@ public class OffsetEquation {
      * @param context FlowExpressionContext
      * @param scope local scope
      * @param useLocalScope whether or not local scope is used
+     * @param factory AnnotatedTypeFactory
      * @throws FlowExpressionParseException if any term isn't able to be parsed this exception is
      *     thrown. If this happens, no string terms are changed.
      */
@@ -339,6 +339,25 @@ public class OffsetEquation {
                 addedTerms, false, context, scope, useLocalScope, factory);
         standardizeAndViewpointAdaptExpressions(
                 subtractedTerms, true, context, scope, useLocalScope, factory);
+    }
+
+    /**
+     * Standardizes and viewpoint-adapts the string terms based us the supplied context.
+     *
+     * @param context FlowExpressionContext
+     * @param scope local scope
+     * @param useLocalScope whether or not local scope is used
+     * @throws FlowExpressionParseException if any term isn't able to be parsed this exception is
+     *     thrown. If this happens, no string terms are changed.
+     */
+    public void standardizeAndViewpointAdaptExpressions(
+            FlowExpressionContext context, TreePath scope, boolean useLocalScope)
+            throws FlowExpressionParseException {
+
+        standardizeAndViewpointAdaptExpressions(
+                addedTerms, false, context, scope, useLocalScope, null);
+        standardizeAndViewpointAdaptExpressions(
+                subtractedTerms, true, context, scope, useLocalScope, null);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -6,13 +6,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
-import org.checkerframework.common.value.qual.IntVal;
+import org.checkerframework.common.value.util.Range;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Unknown;
@@ -20,6 +19,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.NumericalAdditionNode;
 import org.checkerframework.dataflow.cfg.node.NumericalSubtractionNode;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionContext;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionParseException;
@@ -276,14 +276,32 @@ public class OffsetEquation {
             }
         } else if (factory != null && termReceiver instanceof FlowExpressions.LocalVariable) {
             Element element = ((FlowExpressions.LocalVariable) termReceiver).getElement();
-            AnnotationMirror am =
-                    factory.getTypeFactoryOfSubchecker(ValueChecker.class)
-                            .getAnnotatedType(element)
-                            .getAnnotation(IntVal.class);
-            return IndexUtil.getIntegerFromIntValWithOneArgument(am);
+            Long exactValue =
+                    getExactValue(element, factory.getTypeFactoryOfSubchecker(ValueChecker.class));
+
+            if (exactValue != null) {
+                return exactValue.intValue();
+            }
         }
 
         return null;
+    }
+
+    /**
+     * Returns the exact value of an annotated element.
+     *
+     * @param element the element to get the exact value from
+     * @param factory ValueAnnotatedTypeFactory used for annotation accessing
+     * @return the exact value of the element if it is constant, or null otherwise
+     */
+    public static Long getExactValue(Element element, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(element);
+        Range possibleValues = IndexUtil.getPossibleValues(valueType, factory);
+        if (possibleValues != null && possibleValues.from == possibleValues.to) {
+            return possibleValues.from;
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/checker/tests/index/IndexIntValVsConstant.java
+++ b/checker/tests/index/IndexIntValVsConstant.java
@@ -1,0 +1,29 @@
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.LTLengthOf;
+import org.checkerframework.checker.index.qual.LessThan;
+import org.checkerframework.checker.index.qual.NonNegative;
+import org.checkerframework.checker.interning.qual.Interned;
+import org.checkerframework.common.value.qual.ArrayLen;
+import org.checkerframework.common.value.qual.IntVal;
+
+public class IndexIntValVsConstant {
+
+    void m() {
+
+        int @ArrayLen(7) [] a1 = new int[] {1, 2, 3, 4, 5, 6, 7};
+
+        @IntVal(2) int i = 2;
+        @IntVal(4) int j = 4;
+
+        int[] s0 = internSubsequence(a1, 2, 4);
+        int[] s1 = internSubsequence(a1, i, j);
+    }
+
+    int @Interned [] internSubsequence(
+            int @Interned [] seq,
+            @IndexFor("#1") @LessThan("#3") int start,
+            @NonNegative @LTLengthOf(value = "#1", offset = "#2 - 1") int end) {
+        // dummy implementation
+        return new int[0];
+    }
+}


### PR DESCRIPTION
Fixes #2484.

When an offset is calculated, IndexChecker now treats variables annotated with single-argument `@IntVal` as constant, just like literal values. 

@kelloggm 