### PR TITLE
Make SameLen annotations on parameters symmetric

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -266,6 +266,7 @@ public class SameLenTransfer extends CFTransfer {
             UnderlyingAST.CFGMethod method,
             MethodTree methodTree,
             ExecutableElement methodElement) {
+        super.addInformationFromPreconditions(info, factory, method, methodTree, methodElement);
         List<? extends VariableTree> paramTrees = methodTree.getParameters();
 
         List<String> paramNames =

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -302,9 +302,8 @@ public class SameLenTransfer extends CFTransfer {
                 Receiver otherParamRec = null;
                 try {
                     otherParamRec =
-                            aTypeFactory.getReceiverFromJavaExpressionString(
-                                    paramNames.get(otherParamIndex),
-                                    aTypeFactory.getPath(paramTrees.get(otherParamIndex)));
+                            FlowExpressionParseUtil.internalReprOfVariable(
+                                    aTypeFactory, paramTrees.get(otherParamIndex));
                 } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
                     // do nothing
                 }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -283,30 +283,33 @@ public class SameLenTransfer extends CFTransfer {
             // default the other annotation so that it is symmetric
             AnnotatedTypeMirror atm = params.get(index);
             AnnotationMirror anm = atm.getAnnotation(SameLen.class);
-            if (anm != null) {
-                List<String> values = IndexUtil.getValueOfAnnotationWithStringArgument(anm);
-                for (String value : values) {
-                    int otherParamIndex = paramNames.indexOf(value);
-                    if (otherParamIndex != -1) {
-                        // the SameLen value is in the list of params, so modify the type of
-                        // that param in the store
-                        AnnotationMirror newSameLen =
-                                aTypeFactory.createSameLen(
-                                        Collections.singletonList(paramNames.get(index)));
-                        Receiver otherParamRec = null;
-                        try {
-                            otherParamRec =
-                                    aTypeFactory.getReceiverFromJavaExpressionString(
-                                            paramNames.get(otherParamIndex),
-                                            aTypeFactory.getPath(paramTrees.get(otherParamIndex)));
-                        } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
-                            // do nothing
-                        }
+            if (anm == null) {
+                continue;
+            }
 
-                        if (otherParamRec != null) {
-                            info.insertValue(otherParamRec, newSameLen);
-                        }
-                    }
+            List<String> values = IndexUtil.getValueOfAnnotationWithStringArgument(anm);
+            for (String value : values) {
+                int otherParamIndex = paramNames.indexOf(value);
+                if (otherParamIndex == -1) {
+                    continue;
+                }
+
+                // the SameLen value is in the list of params, so modify the type of
+                // that param in the store
+                AnnotationMirror newSameLen =
+                        aTypeFactory.createSameLen(
+                                Collections.singletonList(paramNames.get(index)));
+                Receiver otherParamRec = null;
+                try {
+                    otherParamRec =
+                            aTypeFactory.getReceiverFromJavaExpressionString(
+                                    paramNames.get(otherParamIndex),
+                                    aTypeFactory.getPath(paramTrees.get(otherParamIndex)));
+                } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
+                    // do nothing
+                }
+                if (otherParamRec != null) {
+                    info.insertValue(otherParamRec, newSameLen);
                 }
             }
         }

--- a/checker/tests/index/Issue2493.java
+++ b/checker/tests/index/Issue2493.java
@@ -1,0 +1,9 @@
+// test case for issue 2493: http://tinyurl.com/cfissue/2493
+
+import org.checkerframework.checker.index.qual.*;
+
+class Issue2493 {
+    public static void test(int a[], int @SameLen("#1") [] b) {
+        for (@IndexOrHigh("b") int i = 0; i < a.length; i++) ;
+    }
+}

--- a/checker/tests/index/SameLenOnFormalParameter.java
+++ b/checker/tests/index/SameLenOnFormalParameter.java
@@ -1,30 +1,28 @@
 // Test case for issue #2434: http://tinyurl.com/cfissue/2434
 
-// @skip-test until the bug is fixed
-
 import org.checkerframework.checker.index.qual.*;
 
 class SameLenOnFormalParameter {
-    public void requiresSameLen1(String x, @SameLen("#1") String y) {}
+    public void requiresSameLen1(String x1, @SameLen("#1") String y1) {}
 
-    public void requiresSameLen2(@SameLen("#2") String x, String y) {}
+    public void requiresSameLen2(@SameLen("#2") String x2, String y2) {}
 
-    public void m1(@SameLen("#2") String a, String b) {
-        requiresSameLen1(a, b);
+    public void m1(@SameLen("#2") String a1, String b1) {
+        requiresSameLen1(a1, b1);
     }
 
-    public void m2(@SameLen("#2") String a, String b) {
-        @SameLen("a") String b2 = b;
-        requiresSameLen1(a, b2);
+    public void m2(@SameLen("#2") String a2, String b2) {
+        @SameLen("a2") String b22 = b2;
+        requiresSameLen1(a2, b22);
     }
 
-    public void m3(@SameLen("#2") String a, String b) {
-        @SameLen("b") String a2 = a;
-        @SameLen("a") String b2 = b;
-        requiresSameLen1(a, b2);
+    public void m3(@SameLen("#2") String a3, String b3) {
+        @SameLen("b3") String a2 = a3;
+        @SameLen("a3") String b32 = b3;
+        requiresSameLen1(a3, b32);
     }
 
-    public void m4(@SameLen("#2") String a, String b) {
-        requiresSameLen2(a, b);
+    public void m4(@SameLen("#2") String a4, String b4) {
+        requiresSameLen2(a4, b4);
     }
 }

--- a/checker/tests/index/SameLenOnFormalParameterSimple.java
+++ b/checker/tests/index/SameLenOnFormalParameterSimple.java
@@ -1,0 +1,11 @@
+// Test case for issue #2434: http://tinyurl.com/cfissue/2434
+
+import org.checkerframework.checker.index.qual.SameLen;
+
+class SameLenOnFormalParameterSimple {
+    public void requiresSameLen1(String x1, @SameLen("#1") String y1) {}
+
+    public void m1(@SameLen("#2") String a1, String b1) {
+        requiresSameLen1(a1, b1);
+    }
+}


### PR DESCRIPTION
This pull request adds defaulting so that `@SameLen` annotations on formal that refer to other parameters are symmetric. For example, the declaration:
```java
void foo(int @SameLen("#2")[] a, int[] b)
```
is defaulted to
```java
void foo(int @SameLen("#2")[] a, int @SameLen("#1")[] b)
```

Fixes #2434.

@Maxi17 contributed significantly to this PR, and I would appreciate any comments he has on it.