### PR TITLE
Fix position of -q option in git pull command

### DIFF
--- a/.travis-build-without-test.sh
+++ b/.travis-build-without-test.sh
@@ -32,7 +32,7 @@ echo SLUGOWNER=$SLUGOWNER
 
 ## Build annotation-tools (Annotation File Utilities)
 if [ -d ../annotation-tools ] ; then
-    git -C ../annotation-tools -q pull || true
+    git -C ../annotation-tools pull -q || true
 else
     [ -d /tmp/plume-scripts ] || (cd /tmp && git clone --depth 1 -q https://github.com/plume-lib/plume-scripts.git)
     REPO=`/tmp/plume-scripts/git-find-fork ${SLUGOWNER} typetools annotation-tools`


### PR DESCRIPTION
When running `./gradlew cloneAndBuildDependencies`, git fails to pull recent changes from annotation-tools, due to unkown `-q` option.
This was discovered because due to recent changes, up-to-date version of annotation-tools is required, but running `cloneAndBuildDependencies` does not help.