### PR TITLE
Added NonNegative default annotation to `char`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -10,6 +10,7 @@ import com.sun.source.tree.VariableTree;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
 import org.checkerframework.checker.index.IndexRefinementInfo;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
@@ -39,6 +40,7 @@ import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.TreeUtils;
 
 /**
  * Implements dataflow refinement rules based on tests: &lt;, &gt;, ==, and their derivatives.
@@ -155,6 +157,7 @@ import org.checkerframework.javacutil.AnnotationUtils;
  *   <li>30. anything right-shifted by a non-negative is non-negative
  *   <li>31. anything bitwise-anded by a non-negative is non-negative
  *   <li>32. If a and b are non-negative and {@code a <= b} and {@code a != b}, then b is pos.
+ *   <li>33. A char is always non-negative
  * </ul>
  */
 public class LowerBoundTransfer extends IndexAbstractTransfer {
@@ -699,6 +702,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         return UNKNOWN;
     }
 
+    /** Adds a default NonNegative annotation to every character. Implements case 33. */
     @Override
     protected void addInformationFromPreconditions(
             CFStore info,
@@ -711,7 +715,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         List<? extends VariableTree> paramTrees = methodTree.getParameters();
 
         for (VariableTree variableTree : paramTrees) {
-            if (variableTree.getType().toString().equalsIgnoreCase("char")) {
+            if (TreeUtils.typeOf(variableTree).getKind().equals(TypeKind.CHAR)) {
 
                 Receiver rec = null;
                 try {

--- a/checker/tests/index/CharToIntCast.java
+++ b/checker/tests/index/CharToIntCast.java
@@ -1,7 +1,5 @@
 // Test case for issue #2540: https://github.com/typetools/checker-framework/issues/2540
 
-// @skip-test until the issue is fixed
-
 import org.checkerframework.common.value.qual.IntRange;
 
 public class CharToIntCast {

--- a/checker/tests/index/IndexByChar.java
+++ b/checker/tests/index/IndexByChar.java
@@ -1,0 +1,7 @@
+public class IndexByChar {
+    public int m(char c) {
+        int[] i = new int[128];
+        if (c < 128) return i[c]; // line 5
+        else return -1;
+    }
+}

--- a/checker/tests/index/NonnegativeChar.java
+++ b/checker/tests/index/NonnegativeChar.java
@@ -1,0 +1,37 @@
+import java.util.ArrayList;
+import org.checkerframework.checker.index.qual.LowerBoundBottom;
+import org.checkerframework.checker.index.qual.PolyLowerBound;
+
+public class NonnegativeChar {
+    void foreach(char[] array) {
+        for (char value : array) ; // line 7
+    }
+
+    char constant() {
+        return Character.MAX_VALUE; // line 11
+    }
+
+    char conversion(int i) {
+        return (char) i; // line 15
+    }
+
+    public void takeList(ArrayList<Character> z) {}
+
+    public void passList() {
+        takeList(new ArrayList<Character>()); // line 20
+    }
+
+    static class CustomList extends ArrayList<Character> {}
+
+    public void passCustomList() {
+        takeList(new CustomList()); // line 25
+    }
+
+    public @LowerBoundBottom char bottomLB(@LowerBoundBottom char c) {
+        return c; // line 29
+    }
+
+    public @PolyLowerBound char polyLB(@PolyLowerBound char c) {
+        return c; // line 32
+    }
+}

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -76,7 +76,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         if (valueType.getKind().equals(TypeKind.CHAR)
                 && valueType.hasAnnotation(getTypeFactory().UNKNOWNVAL)) {
             valueType.addAnnotation(
-                    getTypeFactory().createIntRangeAnnotation(new Range(0, Character.MAX_VALUE)));
+                    getTypeFactory().createIntRangeAnnotation(Range.CHAR_EVERYTHING));
         }
 
         super.commonAssignmentCheck(varType, valueType, valueTree, errorKey);

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -72,6 +72,13 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
             @CompilerMessageKey String errorKey) {
 
         replaceSpecialIntRangeAnnotations(varType);
+
+        if (valueType.getKind().equals(TypeKind.CHAR)
+                && valueType.hasAnnotation(getTypeFactory().UNKNOWNVAL)) {
+            valueType.addAnnotation(
+                    getTypeFactory().createIntRangeAnnotation(new Range(0, Character.MAX_VALUE)));
+        }
+
         super.commonAssignmentCheck(varType, valueType, valueTree, errorKey);
     }
 


### PR DESCRIPTION
Every `char` method parameter is now `@NonNegative` by default.
In an assignment, this is further improved to `@IntRange(from = 0, to = Character.MAX_VALUE)` if necessary.

Related: #1675, kelloggm#192.

Fixes #2540

Two test cases were written by @panacekcz.

@kelloggm 