### PR TITLE
Refine IntRange annotations in conditional expressions inside for loops

### DIFF
--- a/checker/tests/index/IndexConditionalReport.java
+++ b/checker/tests/index/IndexConditionalReport.java
@@ -1,0 +1,13 @@
+// test case for https://github.com/typetools/checker-framework/issues/2345
+
+class IndexConditionalReport {
+
+    public int getI(int len) {
+        for (int i = 0; i < len; i++) {
+            if (false) {
+                return i == 0 ? -1 : i; // unexpected error issued here
+            }
+        }
+        return -1;
+    }
+}

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -2223,15 +2223,19 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
-        if (tree instanceof ConditionalExpressionTree) {
+        AnnotatedTypeMirror atm = super.getAnnotatedType(tree);
+
+        if (atm.isAnnotatedInHierarchy(UNKNOWNVAL) && tree instanceof ConditionalExpressionTree) {
             AnnotatedTypeMirror atmTrue =
                     getAnnotatedType(((ConditionalExpressionTree) tree).getTrueExpression());
             AnnotatedTypeMirror atmFalse =
                     getAnnotatedType(((ConditionalExpressionTree) tree).getFalseExpression());
             TypeMirror alub = TreeUtils.typeOf(tree);
-            return AnnotatedTypes.leastUpperBound(this, atmTrue, atmFalse, alub);
+            atm.replaceAnnotation(
+                    AnnotatedTypes.leastUpperBound(this, atmTrue, atmFalse, alub)
+                            .getEffectiveAnnotationInHierarchy(UNKNOWNVAL));
         }
 
-        return super.getAnnotatedType(tree);
+        return atm;
     }
 }

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1457,7 +1457,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 ConditionalExpressionTree node, AnnotatedTypeMirror annotatedTypeMirror) {
             // Work around for https://github.com/typetools/checker-framework/issues/602.
             annotatedTypeMirror.replaceAnnotation(UNKNOWNVAL);
-            return super.visitConditionalExpression(node, annotatedTypeMirror);
+            return null;
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value;
 
+import com.sun.source.tree.ConditionalExpressionTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.MemberSelectTree;
@@ -66,6 +67,7 @@ import org.checkerframework.framework.type.treeannotator.PropagationTreeAnnotato
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.framework.type.typeannotator.ListTypeAnnotator;
 import org.checkerframework.framework.type.typeannotator.TypeAnnotator;
+import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.FieldInvariants;
 import org.checkerframework.framework.util.FlowExpressionParseUtil.FlowExpressionParseException;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
@@ -2217,5 +2219,19 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         return getMinLenValue(lengthAnno);
+    }
+
+    @Override
+    public AnnotatedTypeMirror getAnnotatedType(Tree tree) {
+        if (tree instanceof ConditionalExpressionTree) {
+            AnnotatedTypeMirror atmTrue =
+                    getAnnotatedType(((ConditionalExpressionTree) tree).getTrueExpression());
+            AnnotatedTypeMirror atmFalse =
+                    getAnnotatedType(((ConditionalExpressionTree) tree).getFalseExpression());
+            TypeMirror alub = TreeUtils.typeOf(tree);
+            return AnnotatedTypes.leastUpperBound(this, atmTrue, atmFalse, alub);
+        }
+
+        return super.getAnnotatedType(tree);
     }
 }

--- a/framework/tests/value/Repo.java
+++ b/framework/tests/value/Repo.java
@@ -9,8 +9,6 @@ class Repo {
         for (int i = 0; i < 20; i++) {
             // :: error: (assignment.type.incompatible)
             @IntVal(0) int x = i;
-            // TODO: this is a dataflow bug. (March, 6, 2015)
-            // :: error: (conditional.type.incompatible)
             int j = flag ? i : 3;
         }
     }


### PR DESCRIPTION
In a for loop, `@IntRange` annotations can be unpredictable (#1669). In the test case, `i` had `@IntRange(from = Integer.MIN_VALUE, to = Integer.MAX_VALUE)` annotation, which was wrong to begin with (`i` is greater than 0) and redundant, because it is an `int`.

The actual problem was that the type of the conditional expression was `IntVal(-1)`, which is again wrong. It is supposed to be the LUB of true and false expressions, in this case simply `int`. Here is the bug in CF:

1. The LUB of `@IntVal(-1) int` and `int` is `int` (correct).
2. The LUB of `@IntVal(-1) int` and `@IntRange(from = Integer.MIN_VALUE, to = Integer.MAX_VALUE) int` is `@IntVal(-1) int` (wrong).

In the for loop from the test case, the second case is applied and therefore the bug.

This PR fixes this by changing the ValueChecker annotation of the conditional expression if it is annotated. The updated annotation matches the initial annotation given to the conditional expression in `visitConditionalExpression(ConditionalExpressionTree, AnnotatedTypeFactory)` from `TypeFromExpressionVisitor.java`.

Fixes #2345 

@kelloggm 