### PR TITLE
Add task to print jdk8.jar manifest.

### DIFF
--- a/.travis-build-without-test.sh
+++ b/.travis-build-without-test.sh
@@ -70,7 +70,7 @@ fi
 
 if [[ "${BUILDJDK}" == "downloadjdk" ]]; then
   echo "running \"./gradlew assemble\" for checker-framework"
-  ./gradlew assemble --console=plain --warning-mode=all -s --no-daemon
+  ./gradlew assemble printJdkJarManifest --console=plain --warning-mode=all -s --no-daemon
 fi
 
 echo Exiting `pwd`/.travis-build-without-test.sh

--- a/.travis-build-without-test.sh
+++ b/.travis-build-without-test.sh
@@ -65,7 +65,7 @@ echo "... done: (cd ../stubparser/ && ./.travis-build-without-test.sh)"
 # Two options: rebuild the JDK or download a prebuilt JDK.
 if [[ "${BUILDJDK}" == "buildjdk" ]]; then
   echo "running \"./gradlew assemble -PuseLocalJdk\" for checker-framework"
-  ./gradlew assemble -PuseLocalJdk --console=plain --warning-mode=all -s --no-daemon
+  ./gradlew assemble printJdkJarManifest -PuseLocalJdk --console=plain --warning-mode=all -s --no-daemon
 fi
 
 if [[ "${BUILDJDK}" == "downloadjdk" ]]; then

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -70,7 +70,7 @@ fi
 
 if [[ "${GROUP}" == "jdk.jar" || "${GROUP}" == "all" ]]; then
   ## Run the tests for the type systems that use the annotated JDK
-  ./gradlew IndexTest LockTest NullnessFbcTest OptionalTest -PuseLocalJdk --console=plain --warning-mode=all --no-daemon
+  ./gradlew IndexTest LockTest NullnessFbcTest OptionalTest printJdkJarManifest -PuseLocalJdk --console=plain --warning-mode=all --no-daemon
 fi
 
 if [[ "${GROUP}" == "misc" || "${GROUP}" == "all" ]]; then

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -1,3 +1,5 @@
+import java.util.zip.ZipFile
+
 ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
@@ -134,6 +136,21 @@ task updateJdk() {
             }
         }
     }
+}
+''
+task printJdkJarManifest(type: Copy) {
+    description 'Outputs the manifest file for checker/dist/jdk8.jar'
+    outputs.upToDateWhen { false }
+
+      from (zipTree('dist/jdk8.jar')) {
+          include"META-INF/MANIFEST.MF"
+        }
+    into 'tmp'
+    doLast{
+        println(new File(projectDir,'tmp/META-INF/MANIFEST.MF').text)
+        delete 'tmp/META-INF/MANIFEST.MF'
+    }
+
 }
 
 task copyJarsToDist(dependsOn: shadowJar, group: 'Build') {

--- a/checker/jdk/Makefile
+++ b/checker/jdk/Makefile
@@ -32,7 +32,8 @@ jdk.jar-unconditionally: clean classes
 # the original JDK.
 jdk.jar-insertion:
 	echo Checker-Framework-Version: `git rev-parse --short HEAD` > manifest.txt
-	echo Checker-Framework-Commit-Author: `git show -s --pretty=%aN\ \<%ae\>\ %d HEAD` > manifest.txt
+	echo Checker-Framework-Commit-Author: `git show -s --pretty=%aN\ \<%ae\> HEAD` >> manifest.txt
+	echo Checker-Framework-Commit-Refs: `git show -s --pretty=%d HEAD` >> manifest.txt
 	echo Creation-Date: `date` >> manifest.txt
 	cd annotated; jar cfm ../jdk.jar ../manifest.txt .
 	rm manifest.txt

--- a/checker/jdk/Makefile
+++ b/checker/jdk/Makefile
@@ -32,7 +32,7 @@ jdk.jar-unconditionally: clean classes
 # the original JDK.
 jdk.jar-insertion:
 	echo Checker-Framework-Version: `git rev-parse --short HEAD` > manifest.txt
-	echo Checker-Framework-Commit-Author: `git show -s --pretty=%an HEAD` > manifest.txt
+	echo Checker-Framework-Commit-Author: `git show -s --pretty=%aN\ \<%ae\>\ %d HEAD` > manifest.txt
 	echo Creation-Date: `date` >> manifest.txt
 	cd annotated; jar cfm ../jdk.jar ../manifest.txt .
 	rm manifest.txt

--- a/checker/jdk/Makefile
+++ b/checker/jdk/Makefile
@@ -32,6 +32,7 @@ jdk.jar-unconditionally: clean classes
 # the original JDK.
 jdk.jar-insertion:
 	echo Checker-Framework-Version: `git rev-parse --short HEAD` > manifest.txt
+	echo Checker-Framework-Commit-Author: `git show -s --pretty=%an HEAD` > manifest.txt
 	echo Creation-Date: `date` >> manifest.txt
 	cd annotated; jar cfm ../jdk.jar ../manifest.txt .
 	rm manifest.txt


### PR DESCRIPTION
Call this task in Travis when use a prebuilt jdk.  Also adds more information to the manifest:

```
Checker-Framework-Version: 242f33a
Checker-Framework-Commit-Author: Noone <noone@cares.com>
Creation-Date: Fri Jul 5 21:07:03 UTC 2019
Created-By: 1.8.0_131 (Oracle Corporation)
Checker-Framework-Commit-Refs: (HEAD)
```