### PR TITLE
Clear typeArg cache in DefaultTypeHierarchy

### DIFF
--- a/checker/tests/nullness/WildcardSubtype.java
+++ b/checker/tests/nullness/WildcardSubtype.java
@@ -1,0 +1,54 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class WildcardSubtype {
+    class MyClass {}
+
+    class Visitor<T> {
+        String visit(T p) {
+            return "";
+        }
+    }
+
+    class MyClassVisitor extends Visitor<@Nullable MyClass> {}
+
+    class NonNullMyClassVisitor extends Visitor<@NonNull MyClass> {}
+
+    void test(MyClassVisitor myClassVisitor, NonNullMyClassVisitor nonNullMyClassVisitor) {
+        // :: error: (argument.type.incompatible)
+        take(new Visitor<@Nullable Object>());
+        // :: error: (argument.type.incompatible)
+        take(new Visitor<@Nullable Object>());
+
+        Visitor<?> visitor1 = myClassVisitor;
+        Visitor<?> visitor2 = nonNullMyClassVisitor;
+
+        // :: error: (assignment.type.incompatible)
+        Visitor<? extends @NonNull Object> visitor3 = myClassVisitor;
+        Visitor<? extends @NonNull Object> visitor4 = nonNullMyClassVisitor;
+
+        // :: error: (assignment.type.incompatible)
+        Visitor<? extends @NonNull Object> visitor5 = new MyClassVisitor();
+        // :: error: (assignment.type.incompatible)
+        Visitor<? extends @NonNull Object> visitor6 = new MyClassVisitor();
+        // :: error: (argument.type.incompatible)
+        take(new MyClassVisitor());
+        // :: error: (argument.type.incompatible)
+        take(new MyClassVisitor());
+    }
+
+    void take(Visitor<@NonNull ? extends @NonNull Object> v) {}
+
+    void bar() {
+        // :: error: (argument.type.incompatible)
+        take(new Visitor<@Nullable Object>());
+        // :: error: (argument.type.incompatible)
+        take(new MyClassVisitor());
+    }
+
+    void baz() {
+        // :: error: (argument.type.incompatible)
+        take(new MyClassVisitor());
+        take(new NonNullMyClassVisitor());
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -145,6 +145,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     @Override
     public boolean isSubtype(
             final AnnotatedTypeMirror subtype, final AnnotatedTypeMirror supertype) {
+        typeargVisitHistory.clear();
         for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
             if (!isSubtype(subtype, supertype, top)) {
                 return false;

--- a/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SubtypeVisitHistory.java
@@ -76,4 +76,9 @@ public class SubtypeVisitHistory {
     public String toString() {
         return "VisitHistory( " + visited + " )";
     }
+
+    /** Clears the history. */
+    public void clear() {
+        visited.clear();
+    }
 }


### PR DESCRIPTION
Otherwise, errors for identical subtyping checks are only issued once, even if the check was for a different expressions.