### PR TITLE
Permit LessThan Checker assignments when they are tautologies

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanVisitor.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.index.inequality;
 
 import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,6 +66,8 @@ public class LessThanVisitor extends BaseTypeVisitor<LessThanAnnotatedTypeFactor
             @CompilerMessageKey String errorKey) {
         // If value is less than all expressions in the annotation in varType,
         // using the Value Checker, then skip the common assignment check.
+        // Also skip the check if the only expression is "a + 1" and the valueTree
+        // is "a".
         List<String> expressions =
                 LessThanAnnotatedTypeFactory.getLessThanExpressions(
                         varType.getEffectiveAnnotationInHierarchy(atypeFactory.UNKNOWN));
@@ -75,6 +78,19 @@ public class LessThanVisitor extends BaseTypeVisitor<LessThanAnnotatedTypeFactor
                     isLessThan = false;
                 }
             }
+            if (!isLessThan && expressions.size() == 1) {
+                String expression = expressions.get(0);
+                if (expression.endsWith(" + 1")) {
+                    String value = expression.substring(0, expression.length() - 4);
+                    if (valueTree.getKind() == Tree.Kind.IDENTIFIER) {
+                        String id = ((IdentifierTree) valueTree).getName().toString();
+                        if (id.equals(value)) {
+                            isLessThan = true;
+                        }
+                    }
+                }
+            }
+
             if (isLessThan) {
                 // Print the messages because super isn't called.
                 commonAssignmentCheckStartDiagnostic(varType, valueType, valueTree);

--- a/checker/tests/index/Issue2629.java
+++ b/checker/tests/index/Issue2629.java
@@ -1,0 +1,10 @@
+// Test case for Issue 2629
+// https://github.com/typetools/checker-framework/issues/2629
+
+import org.checkerframework.checker.index.qual.LessThan;
+
+class Issue2629 {
+    @LessThan("#1 + 1") int test(int a) {
+        return a;
+    }
+}


### PR DESCRIPTION
Fixes #2629 

Implementation is adding an exception to the common assignment check for assignments where the expected type is `@LessThan("${id} + 1")` for some identifier `${id}`, and the right hand side of the assignment is exactly the identifier tree containing id.