### PR TITLE
Compare for same type after wildcard modifications.

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -520,10 +520,6 @@ public final class TypesUtils {
         JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
         com.sun.tools.javac.code.Types types =
                 com.sun.tools.javac.code.Types.instance(javacEnv.getContext());
-        if (types.isSameType(t1, t2)) {
-            // Special case if the two types are equal.
-            return t1;
-        }
         // Handle the 'null' type manually (not done by types.lub).
         if (t1.getKind() == TypeKind.NULL) {
             return t2;
@@ -550,6 +546,10 @@ public final class TypesUtils {
                 return elements.getTypeElement("java.lang.Object").asType();
             }
             t2 = bound;
+        }
+        if (types.isSameType(t1, t2)) {
+            // Special case if the two types are equal.
+            return t1;
         }
         // Special case for primitives.
         if (isPrimitive(t1) || isPrimitive(t2)) {


### PR DESCRIPTION
This should work with Java 8. With Java 9 the behavior of `types.isSameType` handles wildcards more strictly. The new order should work for both.