### PR TITLE
 Issue warning for invalid annotation locations.

### DIFF
--- a/checker/jtreg/nullness/issue2173/View.java
+++ b/checker/jtreg/nullness/issue2173/View.java
@@ -3,7 +3,8 @@
  * @summary Test case for issue #2173: https://github.com/typetools/checker-framework/issues/2173
  * See README in this directory.
  *
- * @compile -processor org.checkerframework.checker.nullness.NullnessChecker View.java
+ * @compile/ref=View.out -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker View.java -Anomsgtext
+ * @compile -processor org.checkerframework.checker.nullness.NullnessChecker View.java -AignoreInvalidAnnotationLocations -Werror
  */
 
 public class View {

--- a/checker/jtreg/nullness/issue2173/View.out
+++ b/checker/jtreg/nullness/issue2173/View.out
@@ -1,0 +1,5 @@
+- compiler.warn.proc.messager: (invalid.annotation.location)
+- compiler.warn.proc.messager: (invalid.annotation.location)
+- compiler.warn.proc.messager: (invalid.annotation.location)
+- compiler.warn.proc.messager: (invalid.annotation.location)
+4 warnings

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -103,4 +103,4 @@ field.invariant.not.wellformed=the field invariant annotation does not have equa
 field.invariant.not.found.superclass=the field invariant annotation is missing fields that are listed in the superclass field invariant.\nfields not found: %s
 field.invariant.not.subtype.superclass=the qualifier for field %s is not a subtype of the qualifier in the superclass field invariant\nfound: %s\nsuperclass type: %s
 
-invalid.annotation.location=found annotation in unexpected location in bytecode on element: %s
+invalid.annotation.location=found annotation in unexpected location in bytecode on element: %s -AignoreInvalidAnnotationLocations to suppress these warnings

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -102,3 +102,5 @@ field.invariant.not.subtype=the qualifier for field %s is not a subtype of the d
 field.invariant.not.wellformed=the field invariant annotation does not have equal numbers of fields and qualifiers.
 field.invariant.not.found.superclass=the field invariant annotation is missing fields that are listed in the superclass field invariant.\nfields not found: %s
 field.invariant.not.subtype.superclass=the qualifier for field %s is not a subtype of the qualifier in the superclass field invariant\nfound: %s\nsuperclass type: %s
+
+invalid.annotation.location=found annotation in unexpected location in bytecode on element: %s

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -207,6 +207,11 @@ import org.checkerframework.javacutil.UserError;
     // java.lang.String)
     "requirePrefixInWarningSuppressions",
 
+    // Ignore annotations in bytecode that have invalid annotation locations.
+    // See https://github.com/typetools/checker-framework/issues/2173
+    // org.checkerframework.framework.type.ElementAnnotationApplier.apply
+    "ignoreInvalidAnnotationLocations",
+
     ///
     /// Partially-annotated libraries
     ///

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementAnnotationApplier.java
@@ -88,10 +88,12 @@ public class ElementAnnotationApplier {
             // location, such as a type argument, that doesn't exist. Since Java 8 bytecode
             // might be on the classpath, catch this exception and ignore the type.
             // TODO: Issue an error if this annotation is from Java 9+ bytecode.
-            typeFactory.checker.report(
-                    Result.warning(
-                            "invalid.annotation.location", ElementUtils.getVerboseName(report)),
-                    element);
+            if (!typeFactory.checker.hasOption("ignoreInvalidAnnotationLocations")) {
+                typeFactory.checker.report(
+                        Result.warning(
+                                "invalid.annotation.location", ElementUtils.getVerboseName(report)),
+                        element);
+            }
         }
         // Also copy annotations from type parameters to their uses.
         new TypeVarAnnotator().visit(type, typeFactory);

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ClassTypeParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ClassTypeParamApplier.java
@@ -17,6 +17,7 @@ import org.checkerframework.javacutil.BugInCF;
  */
 public class ClassTypeParamApplier extends TypeParamElementAnnotationApplier {
 
+    /** Apply annotations from {@code element} to {@code type}. */
     public static void apply(
             AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory)
             throws UnexpectedAnnotationLocationException {

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ClassTypeParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ClassTypeParamApplier.java
@@ -8,6 +8,7 @@ import javax.lang.model.element.ElementKind;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -17,7 +18,8 @@ import org.checkerframework.javacutil.BugInCF;
 public class ClassTypeParamApplier extends TypeParamElementAnnotationApplier {
 
     public static void apply(
-            AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory) {
+            AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new ClassTypeParamApplier(type, element, typeFactory).extractAndApply();
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -285,22 +285,13 @@ public class ElementAnnotationUtil {
      * @param annos all of the element annotations, TypeCompounds, for type
      */
     static void annotateViaTypeAnnoPosition(
-            final AnnotatedTypeMirror type, final Collection<TypeCompound> annos) {
+            final AnnotatedTypeMirror type, final Collection<TypeCompound> annos)
+            throws UnexpectedAnnotationLocationException {
         final Map<AnnotatedWildcardType, WildcardBoundAnnos> wildcardToAnnos =
                 new IdentityHashMap<>();
         for (final TypeCompound anno : annos) {
             AnnotatedTypeMirror target;
-            try {
-                target = getTypeAtLocation(type, anno.position.location);
-            } catch (UnexpectedAnnotationLocationException ex) {
-                // There's a bug in Java 8 compiler that creates bad bytecode such that an
-                // annotation on a lambda parameter is applied to a method parameter. (This bug has
-                // been fixed in Java 9.) If this happens, then the location could refer to a
-                // location, such as a type argument, that doesn't exist. Since Java 8 bytecode
-                // might be on the classpath, catch this exception and ignore the type.
-                // TODO: Issue an error if this annotation is from Java 9+ bytecode.
-                continue;
-            }
+            target = getTypeAtLocation(type, anno.position.location);
             if (target.getKind() == TypeKind.WILDCARD) {
                 addWildcardToBoundMap((AnnotatedWildcardType) target, anno, wildcardToAnnos);
             } else {
@@ -581,7 +572,7 @@ public class ElementAnnotationUtil {
 
     /** Exception indicating an invalid location for an annotation was found. */
     @SuppressWarnings("serial")
-    static class UnexpectedAnnotationLocationException extends Exception {
+    public static class UnexpectedAnnotationLocationException extends Exception {
 
         /**
          * Creates an UnexpectedAnnotationLocationException.

--- a/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
@@ -26,6 +26,7 @@ import org.checkerframework.javacutil.PluginUtil;
  */
 public class MethodApplier extends TargetedElementAnnotationApplier {
 
+    /** Apply annotations from {@code element} to {@code type}. */
     public static void apply(
             AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory)
             throws UnexpectedAnnotationLocationException {

--- a/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
@@ -15,6 +15,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.PluginUtil;
@@ -26,7 +27,8 @@ import org.checkerframework.javacutil.PluginUtil;
 public class MethodApplier extends TargetedElementAnnotationApplier {
 
     public static void apply(
-            AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory) {
+            AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new MethodApplier(type, element, typeFactory).extractAndApply();
     }
 
@@ -97,7 +99,7 @@ public class MethodApplier extends TargetedElementAnnotationApplier {
      * annotations.
      */
     @Override
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         methodType.setElement(methodSymbol); // Preserves previous behavior
 
         // Add declaration annotations to the return type if
@@ -126,7 +128,8 @@ public class MethodApplier extends TargetedElementAnnotationApplier {
 
     // NOTE that these are the only locations not handled elsewhere, otherwise we call apply
     @Override
-    protected void handleTargeted(final List<Attribute.TypeCompound> targeted) {
+    protected void handleTargeted(final List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException {
         final List<TypeCompound> unmatched = new ArrayList<>();
         final Map<TargetType, List<TypeCompound>> targetTypeToAnno =
                 ElementAnnotationUtil.partitionByTargetType(
@@ -156,7 +159,8 @@ public class MethodApplier extends TargetedElementAnnotationApplier {
     }
 
     /** For each thrown type, collect all the annotations for that type and apply them. */
-    private void applyThrowsAnnotations(final List<Attribute.TypeCompound> annos) {
+    private void applyThrowsAnnotations(final List<Attribute.TypeCompound> annos)
+            throws UnexpectedAnnotationLocationException {
         final List<AnnotatedTypeMirror> thrown = methodType.getThrownTypes();
         if (thrown.isEmpty()) {
             return;
@@ -196,7 +200,7 @@ public class MethodApplier extends TargetedElementAnnotationApplier {
      * If the return type is a use of a type variable first apply the bound annotations from the
      * type variables declaration.
      */
-    private void applyTypeVarUseOnReturnType() {
+    private void applyTypeVarUseOnReturnType() throws UnexpectedAnnotationLocationException {
         new TypeVarUseApplier(methodType.getReturnType(), methodSymbol, typeFactory)
                 .extractAndApply();
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/element/MethodTypeParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/MethodTypeParamApplier.java
@@ -14,6 +14,7 @@ import org.checkerframework.javacutil.BugInCF;
 /** Applies the annotations present for a method type parameter onto an AnnotatedTypeVariable. */
 public class MethodTypeParamApplier extends TypeParamElementAnnotationApplier {
 
+    /** Apply annotations from {@code element} to {@code type}. */
     public static void apply(
             AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory)
             throws UnexpectedAnnotationLocationException {

--- a/framework/src/main/java/org/checkerframework/framework/util/element/MethodTypeParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/MethodTypeParamApplier.java
@@ -8,13 +8,15 @@ import javax.lang.model.element.ElementKind;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 
 /** Applies the annotations present for a method type parameter onto an AnnotatedTypeVariable. */
 public class MethodTypeParamApplier extends TypeParamElementAnnotationApplier {
 
     public static void apply(
-            AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory) {
+            AnnotatedTypeVariable type, Element element, AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new MethodTypeParamApplier(type, element, typeFactory).extractAndApply();
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ParamApplier.java
@@ -23,6 +23,7 @@ import org.checkerframework.javacutil.Pair;
 /** Adds annotations to one formal parameter of a method or lambda within a method. */
 public class ParamApplier extends IndexedElementAnnotationApplier {
 
+    /** Apply annotations from {@code element} to {@code type}. */
     public static void apply(
             AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory)
             throws UnexpectedAnnotationLocationException {

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ParamApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ParamApplier.java
@@ -16,6 +16,7 @@ import javax.lang.model.element.VariableElement;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.ElementAnnotationApplier;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.Pair;
 
@@ -23,7 +24,8 @@ import org.checkerframework.javacutil.Pair;
 public class ParamApplier extends IndexedElementAnnotationApplier {
 
     public static void apply(
-            AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory) {
+            AnnotatedTypeMirror type, Element element, AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new ParamApplier(type, element, typeFactory).extractAndApply();
     }
 
@@ -178,7 +180,8 @@ public class ParamApplier extends IndexedElementAnnotationApplier {
      *     == getIndex
      */
     @Override
-    protected void handleTargeted(final List<Attribute.TypeCompound> targeted) {
+    protected void handleTargeted(final List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException {
 
         final List<TypeCompound> formalParams = new ArrayList<>();
         Map<TargetType, List<TypeCompound>> targetToAnnos =
@@ -226,7 +229,7 @@ public class ParamApplier extends IndexedElementAnnotationApplier {
     }
 
     @Override
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         ElementAnnotationUtil.addAnnotationsFromElement(type, element.getAnnotationMirrors());
         super.extractAndApply();
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/element/SuperTypeApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/SuperTypeApplier.java
@@ -1,11 +1,13 @@
 package org.checkerframework.framework.util.element;
 
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import java.util.List;
 import javax.lang.model.element.TypeElement;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 
 /**
  * When discovering supertypes of an AnnotatedTypeMirror we want to annotate each supertype with the
@@ -21,8 +23,8 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
      * @param subtypeElement element that may have annotations to apply to supertypes
      */
     public static void annotateSupers(
-            List<AnnotatedTypeMirror.AnnotatedDeclaredType> supertypes,
-            TypeElement subtypeElement) {
+            List<AnnotatedTypeMirror.AnnotatedDeclaredType> supertypes, TypeElement subtypeElement)
+            throws UnexpectedAnnotationLocationException {
         for (int i = 0; i < supertypes.size(); i++) {
             final AnnotatedTypeMirror supertype = supertypes.get(i);
             // Offset i by -1 since typeIndex should start from -1.
@@ -104,7 +106,8 @@ public class SuperTypeApplier extends IndexedElementAnnotationApplier {
     }
 
     @Override
-    protected void handleTargeted(List<Attribute.TypeCompound> targeted) {
+    protected void handleTargeted(List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException {
         ElementAnnotationUtil.annotateViaTypeAnnoPosition(type, targeted);
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TargetedElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TargetedElementAnnotationApplier.java
@@ -1,6 +1,7 @@
 package org.checkerframework.framework.util.element;
 
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.TargetType;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -9,6 +10,7 @@ import java.util.Map;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.PluginUtil;
 
@@ -92,7 +94,8 @@ abstract class TargetedElementAnnotationApplier {
      * @param targeted the list of annotations that were returned by getRawTypeAttributes and had a
      *     TargetType contained by annotatedTargets
      */
-    protected abstract void handleTargeted(List<Attribute.TypeCompound> targeted);
+    protected abstract void handleTargeted(List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException;
 
     /**
      * The default implementation of this method does nothing.
@@ -191,7 +194,7 @@ abstract class TargetedElementAnnotationApplier {
      *
      * <p>This method will throw a runtime exception if isAccepted returns false.
      */
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         if (!isAccepted()) {
             throw new BugInCF(
                     "LocalVariableExtractor.extractAndApply: "

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeDeclarationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeDeclarationApplier.java
@@ -1,6 +1,7 @@
 package org.checkerframework.framework.util.element;
 
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import java.util.List;
@@ -8,6 +9,7 @@ import javax.lang.model.element.Element;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.TypesUtils;
 
 /** Apply annotations to a declared type based on its declaration. */
@@ -16,7 +18,8 @@ public class TypeDeclarationApplier extends TargetedElementAnnotationApplier {
     public static void apply(
             final AnnotatedTypeMirror type,
             final Element element,
-            final AnnotatedTypeFactory typeFactory) {
+            final AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new TypeDeclarationApplier(type, element, typeFactory).extractAndApply();
     }
 
@@ -83,7 +86,8 @@ public class TypeDeclarationApplier extends TargetedElementAnnotationApplier {
      * @param extendsAndImplementsAnnos annotations with a TargetType of CLASS_EXTENDS
      */
     @Override
-    protected void handleTargeted(List<Attribute.TypeCompound> extendsAndImplementsAnnos) {
+    protected void handleTargeted(List<TypeCompound> extendsAndImplementsAnnos)
+            throws UnexpectedAnnotationLocationException {
         if (TypesUtils.isAnonymous(typeSymbol.type)) {
             // If this is an anonymous class, then the annotations after "new" but before the
             // class name are stored as super class annotations. Treat them as annotations on the
@@ -99,7 +103,7 @@ public class TypeDeclarationApplier extends TargetedElementAnnotationApplier {
 
     /** Adds extends/implements and class annotations to type. Annotates type parameters. */
     @Override
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         // ensures that we check that there only valid target types on this class, there are no
         // "targeted" locations
         super.extractAndApply();

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeParamElementAnnotationApplier.java
@@ -14,6 +14,7 @@ import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -72,7 +73,8 @@ abstract class TypeParamElementAnnotationApplier extends IndexedElementAnnotatio
      *     type parameter is placed on that bound.
      */
     @Override
-    protected void handleTargeted(final List<TypeCompound> targeted) {
+    protected void handleTargeted(final List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException {
         final int paramIndex = getElementIndex();
         final List<TypeCompound> upperBoundAnnos = new ArrayList<>();
         final List<TypeCompound> lowerBoundAnnos = new ArrayList<>();
@@ -170,7 +172,8 @@ abstract class TypeParamElementAnnotationApplier extends IndexedElementAnnotatio
         annoList.add(anno);
     }
 
-    private void applyComponentAnnotation(final TypeCompound anno) {
+    private void applyComponentAnnotation(final TypeCompound anno)
+            throws UnexpectedAnnotationLocationException {
         final AnnotatedTypeMirror upperBoundType = typeParam.getUpperBound();
 
         Map<AnnotatedTypeMirror, List<TypeCompound>> typeToAnnotations = new HashMap<>();

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TypeVarUseApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TypeVarUseApplier.java
@@ -28,7 +28,8 @@ public class TypeVarUseApplier {
     public static void apply(
             final AnnotatedTypeMirror type,
             final Element element,
-            final AnnotatedTypeFactory typeFactory) {
+            final AnnotatedTypeFactory typeFactory)
+            throws UnexpectedAnnotationLocationException {
         new TypeVarUseApplier(type, element, typeFactory).extractAndApply();
     }
 
@@ -110,7 +111,7 @@ public class TypeVarUseApplier {
      * Applies the bound annotations from the declaration of the type parameter and then applies the
      * explicit annotations written on the type variable.
      */
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         ElementAnnotationUtil.addAnnotationsFromElement(
                 typeVariable, useElem.getAnnotationMirrors());
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/VariableApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/VariableApplier.java
@@ -1,6 +1,7 @@
 package org.checkerframework.framework.util.element;
 
 import com.sun.tools.javac.code.Attribute;
+import com.sun.tools.javac.code.Attribute.TypeCompound;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.TargetType;
 import java.util.List;
@@ -8,6 +9,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 
 /**
@@ -15,7 +17,8 @@ import org.checkerframework.javacutil.BugInCF;
  */
 public class VariableApplier extends TargetedElementAnnotationApplier {
 
-    public static void apply(final AnnotatedTypeMirror type, final Element element) {
+    public static void apply(final AnnotatedTypeMirror type, final Element element)
+            throws UnexpectedAnnotationLocationException {
         new VariableApplier(type, element).extractAndApply();
     }
 
@@ -85,12 +88,13 @@ public class VariableApplier extends TargetedElementAnnotationApplier {
     }
 
     @Override
-    protected void handleTargeted(final List<Attribute.TypeCompound> targeted) {
+    protected void handleTargeted(final List<TypeCompound> targeted)
+            throws UnexpectedAnnotationLocationException {
         ElementAnnotationUtil.annotateViaTypeAnnoPosition(type, targeted);
     }
 
     @Override
-    public void extractAndApply() {
+    public void extractAndApply() throws UnexpectedAnnotationLocationException {
         // Add declaration annotations to the local variable type
         ElementAnnotationUtil.addAnnotationsFromElement(type, varSymbol.getAnnotationMirrors());
         super.extractAndApply();

--- a/framework/src/main/java/org/checkerframework/framework/util/element/VariableApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/VariableApplier.java
@@ -17,6 +17,7 @@ import org.checkerframework.javacutil.BugInCF;
  */
 public class VariableApplier extends TargetedElementAnnotationApplier {
 
+    /** Apply annotations from {@code element} to {@code type}. */
     public static void apply(final AnnotatedTypeMirror type, final Element element)
             throws UnexpectedAnnotationLocationException {
         new VariableApplier(type, element).extractAndApply();


### PR DESCRIPTION
Also, adds a command line option `-AignoreInvalidAnnotationLocations` to suppress the warnings.

(Follow up to #2672 )