### PR TITLE
In Java 11, member references and lambda could be intersection types.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -135,17 +135,13 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     @Override
     public AnnotatedTypeMirror visitMemberReference(
             MemberReferenceTree node, AnnotatedTypeFactory f) {
-        AnnotatedDeclaredType type =
-                (AnnotatedDeclaredType) f.toAnnotatedType(TreeUtils.typeOf(node), false);
-        return type;
+        return f.toAnnotatedType(TreeUtils.typeOf(node), false);
     }
 
     @Override
     public AnnotatedTypeMirror visitLambdaExpression(
             LambdaExpressionTree node, AnnotatedTypeFactory f) {
-        AnnotatedDeclaredType type =
-                (AnnotatedDeclaredType) f.toAnnotatedType(TreeUtils.typeOf(node), false);
-        return type;
+        return f.toAnnotatedType(TreeUtils.typeOf(node), false);
     }
 
     @Override


### PR DESCRIPTION
checker-framework/framework/tests/all-systems/java8/lambda/Issue573.java crashes
using Java 11 without this change.