### PR TITLE
Fix clean task in checker-qual build

### DIFF
--- a/checker-qual/build.gradle
+++ b/checker-qual/build.gradle
@@ -50,5 +50,5 @@ compileJava {
 }
 
 clean {
-    delete file('generated-src/')
+    delete file('src/')
 }


### PR DESCRIPTION
On line 36, qualifiers and other java files are copied into the `src/main/java` folder, so the `clean` task should also be target the same.