### PR TITLE
Compile-time char constants are treated as literals

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1049,7 +1049,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror newQual;
                 Class<?> clazz = ValueCheckerUtils.getClassFromType(type.getUnderlyingType());
                 String stringVal = null;
-                if (clazz.equals(char[].class) || clazz.equals(byte[].class)) {
+                if (clazz.equals(char[].class)) {
                     stringVal = getCharArrayStringVal(initializers);
                 }
 

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1181,21 +1181,13 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             boolean allLiterals = true;
             StringBuilder stringVal = new StringBuilder();
             for (ExpressionTree e : initializers) {
-                if (e.getKind() == Tree.Kind.INT_LITERAL) {
-                    char charVal = (char) ((Integer) ((LiteralTree) e).getValue()).intValue();
+                Range range = getRange(getAnnotatedType(e).getAnnotationInHierarchy(UNKNOWNVAL));
+                if (range != null && range.from == range.to) {
+                    char charVal = (char) range.from;
                     stringVal.append(charVal);
-                } else if (e.getKind() == Tree.Kind.CHAR_LITERAL) {
-                    char charVal = (((Character) ((LiteralTree) e).getValue()));
-                    stringVal.append(charVal);
-                } else if (e.getKind() == Tree.Kind.IDENTIFIER) {
-                    Range range =
-                            getRange(getAnnotatedType(e).getAnnotationInHierarchy(UNKNOWNVAL));
-                    if (range != null && range.from == range.to) {
-                        char charVal = (char) range.from;
-                        stringVal.append(charVal);
-                    }
                 } else {
                     allLiterals = false;
+                    break;
                 }
             }
             if (allLiterals) {

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -1049,7 +1049,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror newQual;
                 Class<?> clazz = ValueCheckerUtils.getClassFromType(type.getUnderlyingType());
                 String stringVal = null;
-                if (clazz.equals(char[].class)) {
+                if (clazz.equals(char[].class) || clazz.equals(byte[].class)) {
                     stringVal = getCharArrayStringVal(initializers);
                 }
 
@@ -1187,6 +1187,13 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 } else if (e.getKind() == Tree.Kind.CHAR_LITERAL) {
                     char charVal = (((Character) ((LiteralTree) e).getValue()));
                     stringVal.append(charVal);
+                } else if (e.getKind() == Tree.Kind.IDENTIFIER) {
+                    Range range =
+                            getRange(getAnnotatedType(e).getAnnotationInHierarchy(UNKNOWNVAL));
+                    if (range != null && range.from == range.to) {
+                        char charVal = (char) range.from;
+                        stringVal.append(charVal);
+                    }
                 } else {
                     allLiterals = false;
                 }

--- a/framework/tests/value/ByteArrayWithNonLiteralConstants.java
+++ b/framework/tests/value/ByteArrayWithNonLiteralConstants.java
@@ -5,7 +5,7 @@ public class ByteArrayWithNonLiteralConstants {
 
     public static void main(String[] args) {
         char @StringVal("hello") [] greeting1 = {'h', 'e', 'l', 'l', 'o'};
-        @IntVal('e') byte e = 'e';
+        @IntVal('e') char e = 'e';
         char @StringVal("hello") [] greeting2 = {'h', e, 'l', 'l', 'o'};
     }
 }

--- a/framework/tests/value/ByteArrayWithNonLiteralConstants.java
+++ b/framework/tests/value/ByteArrayWithNonLiteralConstants.java
@@ -4,8 +4,8 @@ import org.checkerframework.common.value.qual.StringVal;
 public class ByteArrayWithNonLiteralConstants {
 
     public static void main(String[] args) {
-        byte @StringVal("hello") [] greeting1 = {'h', 'e', 'l', 'l', 'o'};
+        char @StringVal("hello") [] greeting1 = {'h', 'e', 'l', 'l', 'o'};
         @IntVal('e') byte e = 'e';
-        byte @StringVal("hello") [] greeting2 = {'h', e, 'l', 'l', 'o'};
+        char @StringVal("hello") [] greeting2 = {'h', e, 'l', 'l', 'o'};
     }
 }

--- a/framework/tests/value/ByteArrayWithNonLiteralConstants.java
+++ b/framework/tests/value/ByteArrayWithNonLiteralConstants.java
@@ -1,0 +1,11 @@
+import org.checkerframework.common.value.qual.IntVal;
+import org.checkerframework.common.value.qual.StringVal;
+
+public class ByteArrayWithNonLiteralConstants {
+
+    public static void main(String[] args) {
+        byte @StringVal("hello") [] greeting1 = {'h', 'e', 'l', 'l', 'o'};
+        @IntVal('e') byte e = 'e';
+        byte @StringVal("hello") [] greeting2 = {'h', e, 'l', 'l', 'o'};
+    }
+}

--- a/framework/tests/value/CharArrayWithNonLiteralConstants.java
+++ b/framework/tests/value/CharArrayWithNonLiteralConstants.java
@@ -1,7 +1,7 @@
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.common.value.qual.StringVal;
 
-public class ByteArrayWithNonLiteralConstants {
+public class CharArrayWithNonLiteralConstants {
 
     public static void main(String[] args) {
         char @StringVal("hello") [] greeting1 = {'h', 'e', 'l', 'l', 'o'};


### PR DESCRIPTION
When initializing a `char[]`, check if the elements of the array are annotated with single-value `@IntVal`
Fixes #1152

I modified the test case from `byte[]` to `char[]` because of different character encodings.