### PR TITLE
Non-static fields can't be referenced from a static inner class or enum

### DIFF
--- a/checker/tests/nullness/Issue2587.java
+++ b/checker/tests/nullness/Issue2587.java
@@ -1,0 +1,35 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.KeyFor;
+
+public abstract class Issue2587 {
+    public enum EnumType {
+        // :: error: (expression.unparsable.type.invalid) :: error: (assignment.type.incompatible)
+        @KeyFor("myMap") MY_KEY,
+        // :: error: (assignment.type.incompatible)
+        @KeyFor("enumMap") ENUM_KEY;
+        private static final Map<String, Integer> enumMap = new HashMap<>();
+
+        void method() {
+            @KeyFor("enumMap") EnumType t = ENUM_KEY;
+            int x = enumMap.get(ENUM_KEY);
+        }
+    }
+
+    public static class Inner {
+        // :: error: (expression.unparsable.type.invalid) :: error: (assignment.type.incompatible)
+        @KeyFor("myMap") String MY_KEY = "";
+
+        public static class Inner2 {
+            // :: error: (expression.unparsable.type.invalid) :: error:
+            // (assignment.type.incompatible)
+            @KeyFor("myMap") String MY_KEY2 = "";
+            // :: error: (assignment.type.incompatible)
+            @KeyFor("innerMap") String MY_KEY3 = "";
+        }
+
+        private static final Map<String, Integer> innerMap = new HashMap<>();
+    }
+
+    private final Map<String, Integer> myMap = new HashMap<>();
+}

--- a/checker/tests/nullness/Issue2587.java
+++ b/checker/tests/nullness/Issue2587.java
@@ -2,11 +2,12 @@ import java.util.HashMap;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 
+@SuppressWarnings("assignment.type.incompatible")
 public abstract class Issue2587 {
     public enum EnumType {
-        // :: error: (expression.unparsable.type.invalid) :: error: (assignment.type.incompatible)
+        // :: error: (expression.unparsable.type.invalid)
         @KeyFor("myMap") MY_KEY,
-        // :: error: (assignment.type.incompatible)
+
         @KeyFor("enumMap") ENUM_KEY;
         private static final Map<String, Integer> enumMap = new HashMap<>();
 
@@ -17,14 +18,13 @@ public abstract class Issue2587 {
     }
 
     public static class Inner {
-        // :: error: (expression.unparsable.type.invalid) :: error: (assignment.type.incompatible)
+        // :: error: (expression.unparsable.type.invalid)
         @KeyFor("myMap") String MY_KEY = "";
 
         public static class Inner2 {
-            // :: error: (expression.unparsable.type.invalid) :: error:
-            // (assignment.type.incompatible)
+            // :: error: (expression.unparsable.type.invalid)
             @KeyFor("myMap") String MY_KEY2 = "";
-            // :: error: (assignment.type.incompatible)
+
             @KeyFor("innerMap") String MY_KEY3 = "";
         }
 

--- a/checker/tests/nullness/Issue2587.java
+++ b/checker/tests/nullness/Issue2587.java
@@ -2,7 +2,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 
-@SuppressWarnings("assignment.type.incompatible")
+@SuppressWarnings("assignment.type.incompatible") // These warnings are not relevant
 public abstract class Issue2587 {
     public enum EnumType {
         // :: error: (expression.unparsable.type.invalid)

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -38,7 +38,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.*;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -62,7 +67,10 @@ import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesError;
-import org.checkerframework.javacutil.*;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.Resolver;
+import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypesUtils;
 import org.checkerframework.javacutil.trees.TreeBuilder;
 
 /**

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -313,7 +313,7 @@ public class FlowExpressionParseUtil {
                                         .getModifiers()
                                         .getFlags()
                                         .contains(Modifier.STATIC)
-                                || TreeUtils.enclosingClass(path).getKind().equals(Tree.Kind.ENUM))
+                                || TreeUtils.enclosingClass(path).getKind() == Tree.Kind.ENUM)
                         && !ElementUtils.isStatic(fieldElem)) {
                     throw new ParseRuntimeException(
                             constructParserException(

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -38,11 +38,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -66,10 +62,7 @@ import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesError;
-import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.Resolver;
-import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.TypesUtils;
+import org.checkerframework.javacutil.*;
 import org.checkerframework.javacutil.trees.TreeBuilder;
 
 /**
@@ -309,10 +302,8 @@ public class FlowExpressionParseUtil {
             if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
                 FieldAccess fieldAccess =
                         (FieldAccess) getReceiverField(s, context, originalReceiver, fieldElem);
-                String className = fieldAccess.getReceiver().getType().toString();
-                Element scopeClassElement =
-                        resolver.findClass(
-                                className.substring(className.lastIndexOf(".") + 1), path);
+                TypeElement scopeClassElement =
+                        TypesUtils.getTypeElement(fieldAccess.getReceiver().getType());
                 if (!originalReceiver
                         && !ElementUtils.isStatic(fieldElem)
                         && ElementUtils.isStatic(scopeClassElement)) {

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -307,20 +307,21 @@ public class FlowExpressionParseUtil {
             }
 
             if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
+                FieldAccess fieldAccess =
+                        (FieldAccess) getReceiverField(s, context, originalReceiver, fieldElem);
+                String className = fieldAccess.getReceiver().getType().toString();
+                Element scopeClassElement =
+                        resolver.findClass(
+                                className.substring(className.lastIndexOf(".") + 1), path);
                 if (!originalReceiver
-                        && TreeUtils.enclosingClass(path) != null
-                        && (TreeUtils.enclosingClass(path)
-                                        .getModifiers()
-                                        .getFlags()
-                                        .contains(Modifier.STATIC)
-                                || TreeUtils.enclosingClass(path).getKind() == Tree.Kind.ENUM)
-                        && !ElementUtils.isStatic(fieldElem)) {
+                        && !ElementUtils.isStatic(fieldElem)
+                        && ElementUtils.isStatic(scopeClassElement)) {
                     throw new ParseRuntimeException(
                             constructParserException(
                                     s,
                                     "a non-static field can't be referenced from a static inner class or enum"));
                 }
-                return getReceiverField(s, context, originalReceiver, fieldElem);
+                return fieldAccess;
             }
 
             // Class name

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -307,10 +307,6 @@ public class FlowExpressionParseUtil {
             }
 
             if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
-                return getReceiverField(s, context, originalReceiver, fieldElem);
-            }
-
-            if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
                 if (!originalReceiver
                         && TreeUtils.enclosingClass(path) != null
                         && (TreeUtils.enclosingClass(path)

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -310,6 +310,23 @@ public class FlowExpressionParseUtil {
                 return getReceiverField(s, context, originalReceiver, fieldElem);
             }
 
+            if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
+                if (!originalReceiver
+                        && TreeUtils.enclosingClass(path) != null
+                        && (TreeUtils.enclosingClass(path)
+                                        .getModifiers()
+                                        .getFlags()
+                                        .contains(Modifier.STATIC)
+                                || TreeUtils.enclosingClass(path).getKind().equals(Tree.Kind.ENUM))
+                        && !ElementUtils.isStatic(fieldElem)) {
+                    throw new ParseRuntimeException(
+                            constructParserException(
+                                    s,
+                                    "a non-static field can't be referenced from a static inner class or enum"));
+                }
+                return getReceiverField(s, context, originalReceiver, fieldElem);
+            }
+
             // Class name
             Element classElem = resolver.findClass(s, path);
             TypeMirror classType = ElementUtils.getType(classElem);

--- a/framework/tests/flowexpression/InnerClasses.java
+++ b/framework/tests/flowexpression/InnerClasses.java
@@ -1,0 +1,38 @@
+package flowexpression;
+
+import testlib.flowexpression.qual.FlowExp;
+
+public class InnerClasses {
+    public String outerInstanceField = "";
+    public static String outerStaticField = "";
+
+    static class InnerClass {
+        // :: error: (expression.unparsable.type.invalid)
+        @FlowExp("outerInstanceField") Object o = null;
+
+        @FlowExp("outerStaticField") Object o2 = null;
+    }
+
+    class NonStaticInnerClass {
+        @FlowExp("outerInstanceField") Object o = null;
+
+        @FlowExp("outerStaticField") Object o2 = null;
+    }
+
+    static class InnerClass2 {
+        public String outerInstanceField = "";
+
+        @FlowExp("outerInstanceField") Object o = null;
+    }
+
+    class TestUses {
+        void method(InnerClass innerClass, InnerClass2 innerClass2) {
+            // :: error: (expression.unparsable.type.invalid) :: error:
+            // (assignment.type.incompatible)
+            @FlowExp("innerClass.outerInstanceField") Object o = innerClass.o;
+            @FlowExp("InnerClasses.outerStaticField") Object o2 = innerClass.o2;
+
+            @FlowExp("innerClass2.outerInstanceField") Object o3 = innerClass2.o;
+        }
+    }
+}

--- a/framework/tests/flowexpression/InnerClasses.java
+++ b/framework/tests/flowexpression/InnerClasses.java
@@ -27,8 +27,8 @@ public class InnerClasses {
 
     class TestUses {
         void method(InnerClass innerClass, InnerClass2 innerClass2) {
-            @SuppressWarnings("assignment.type.incompatible") // Issue 152
-            // :: error: (expression.unparsable.type.invalid)
+            // :: error: (expression.unparsable.type.invalid) :: error:
+            // (assignment.type.incompatible)
             @FlowExp("innerClass.outerInstanceField") Object o = innerClass.o;
             @FlowExp("InnerClasses.outerStaticField") Object o2 = innerClass.o2;
 

--- a/framework/tests/flowexpression/InnerClasses.java
+++ b/framework/tests/flowexpression/InnerClasses.java
@@ -27,8 +27,8 @@ public class InnerClasses {
 
     class TestUses {
         void method(InnerClass innerClass, InnerClass2 innerClass2) {
-            // :: error: (expression.unparsable.type.invalid) :: error:
-            // (assignment.type.incompatible)
+            @SuppressWarnings("assignment.type.incompatible") // Issue 152
+            // :: error: (expression.unparsable.type.invalid)
             @FlowExp("innerClass.outerInstanceField") Object o = innerClass.o;
             @FlowExp("InnerClasses.outerStaticField") Object o2 = innerClass.o2;
 


### PR DESCRIPTION
Fixes #2587 

If the annotated element is inside a static class or an enum and the field that the annotation refers to is non-static, then throw an exception.

I will try to make the code cleaner.