### PR TITLE
Array creation and primitive type class literals are parsable

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1206,8 +1206,7 @@ The set of permitted expressions is a subset of all Java expressions:
 \item
   an array creation. For example: \<new int[10]>, \<new String[] {"a", "b"}>.
 
-\item literals: string, integer, char, long, float, double, null literals.
-   Class literals with class, interface, primitive or void type.
+\item literals: string, integer, char, long, float, double, null, class literals.
 
 \item a method invocation on any expression.
   This even works for overloaded methods and methods with type parameters.
@@ -1250,7 +1249,6 @@ The following Java expressions may not currently be written:
 % The Checker Framework is best at reasoning about Java expressions that
 % are variable references, but these expressions are not.
 \begin{itemize}
-\item Class literals with with array type (String[].class).
 \item String concatenation expressions.
 \item Mathematical operators (plus, minus, division, ...).
 \item Comparisons (equality, less than, etc.).

--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1203,8 +1203,11 @@ The set of permitted expressions is a subset of all Java expressions:
 \item
   an array access.  For example:  \<this.myArray[i]>, \<vals[\#1]>.
 
+\item
+  an array creation. For example: \<new int[10]>, \<new String[] {"a", "b"}>.
+
 \item literals: string, integer, char, long, float, double, null literals.
-  Class literals with class or interface type.
+   Class literals with class, interface, primitive or void type.
 
 \item a method invocation on any expression.
   This even works for overloaded methods and methods with type parameters.
@@ -1247,7 +1250,7 @@ The following Java expressions may not currently be written:
 % The Checker Framework is best at reasoning about Java expressions that
 % are variable references, but these expressions are not.
 \begin{itemize}
-\item Class literals with primitive type (int.class) or with array type (String[].class).
+\item Class literals with with array type (String[].class).
 \item String concatenation expressions.
 \item Mathematical operators (plus, minus, division, ...).
 \item Comparisons (equality, less than, etc.).

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -571,6 +571,9 @@ public class FlowExpressionParseUtil {
                 }
             } else if (type.isVoidType()) {
                 return types.getNoType(TypeKind.VOID);
+            } else if (type.isArrayType()) {
+                return types.getArrayType(
+                        convertTypeToTypeMirror(type.asArrayType().getComponentType(), context));
             }
             return null;
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -525,9 +525,11 @@ public class FlowExpressionParseUtil {
             }
             TypeMirror arrayType = convertTypeToTypeMirror(expr.getElementType(), context);
             if (arrayType == null) {
-                // TODO: issue error
+                throw new ParseRuntimeException(
+                        constructParserException(
+                                expr.getElementType().asString(), "type not parsable"));
             }
-            for (Receiver ignored : dimensions) {
+            for (int i = 0; i < dimensions.size(); i++) {
                 arrayType = TypesUtils.createArrayType(arrayType, env.getTypeUtils());
             }
             return new ArrayCreation(arrayType, dimensions, initializers);
@@ -551,25 +553,24 @@ public class FlowExpressionParseUtil {
             } else if (type.isPrimitiveType()) {
                 switch (type.asPrimitiveType().getType()) {
                     case BOOLEAN:
-                        return TypesUtils.typeFromClass(
-                                boolean.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.BOOLEAN);
                     case BYTE:
-                        return TypesUtils.typeFromClass(byte.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.BYTE);
                     case SHORT:
-                        return TypesUtils.typeFromClass(short.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.SHORT);
                     case INT:
-                        return TypesUtils.typeFromClass(int.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.INT);
                     case CHAR:
-                        return TypesUtils.typeFromClass(char.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.CHAR);
                     case FLOAT:
-                        return TypesUtils.typeFromClass(float.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.FLOAT);
                     case LONG:
-                        return TypesUtils.typeFromClass(long.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.LONG);
                     case DOUBLE:
-                        return TypesUtils.typeFromClass(double.class, types, env.getElementUtils());
+                        return types.getPrimitiveType(TypeKind.DOUBLE);
                 }
             } else if (type.isVoidType()) {
-                return TypesUtils.typeFromClass(void.class, types, env.getElementUtils());
+                return types.getNoType(TypeKind.VOID);
             }
             return null;
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -19,6 +19,7 @@ import com.github.javaparser.ast.expr.NullLiteralExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.SuperExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
+import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.GenericVisitorWithDefaults;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
@@ -31,7 +32,6 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
-import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.ClassType;
 import java.util.ArrayList;
@@ -50,6 +50,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ArrayAccess;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ArrayCreation;
@@ -495,59 +496,17 @@ public class FlowExpressionParseUtil {
          */
         @Override
         public Receiver visit(ClassExpr expr, FlowExpressionContext context) {
-            if (expr.getType().isClassOrInterfaceType()) {
-                return StaticJavaParser.parseExpression(expr.getTypeAsString())
-                        .accept(this, context);
-            } else if (expr.getType().isPrimitiveType()) {
-                switch (expr.getType().asPrimitiveType().getType()) {
-                    case BOOLEAN:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(
-                                        boolean.class, types, env.getElementUtils()));
-                    case BYTE:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(byte.class, types, env.getElementUtils()));
-                    case SHORT:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(
-                                        short.class, types, env.getElementUtils()));
-                    case INT:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(int.class, types, env.getElementUtils()));
-                    case CHAR:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(char.class, types, env.getElementUtils()));
-                    case FLOAT:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(
-                                        float.class, types, env.getElementUtils()));
-                    case LONG:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(long.class, types, env.getElementUtils()));
-                    case DOUBLE:
-                        return new ClassName(
-                                TypesUtils.typeFromClass(
-                                        double.class, types, env.getElementUtils()));
-                }
-            } else if (expr.getType().isVoidType()) {
-                return new ClassName(
-                        TypesUtils.typeFromClass(void.class, types, env.getElementUtils()));
+            TypeMirror result = convertTypeToTypeMirror(expr.getType(), context);
+            if (result == null) {
+                throw new ParseRuntimeException(
+                        constructParserException(
+                                expr.toString(), "is an unparsable class literal"));
             }
-
-            throw new ParseRuntimeException(
-                    constructParserException(expr.toString(), "is an unparsable class literal"));
+            return new ClassName(result);
         }
 
         @Override
         public Receiver visit(ArrayCreationExpr expr, FlowExpressionContext context) {
-
-            // Parse the type as a class literal
-            Receiver receiver =
-                    visit(
-                            StaticJavaParser.parseExpression(expr.getElementType() + ".class")
-                                    .asClassExpr(),
-                            context);
-
             List<Receiver> dimensions = new ArrayList<>();
             for (ArrayCreationLevel dimension : expr.getLevels()) {
                 if (dimension.getDimension().isPresent()) {
@@ -563,8 +522,55 @@ public class FlowExpressionParseUtil {
                     initializers.add(initializer.accept(this, context));
                 }
             }
+            TypeMirror arrayType = convertTypeToTypeMirror(expr.getElementType(), context);
+            if (arrayType == null) {
+                // TODO: issue error
+            }
+            for (Receiver ignored : dimensions) {
+                arrayType = TypesUtils.createArrayType(arrayType, env.getTypeUtils());
+            }
+            return new ArrayCreation(arrayType, dimensions, initializers);
+        }
 
-            return new ArrayCreation(receiver.getType(), dimensions, initializers);
+        /**
+         * Converts the JavaParser type to a TypeMirror.
+         *
+         * <p>Might return null if convert the kind of type is not handled.
+         *
+         * @param type JavaParser type
+         * @param context FlowExpressionContext
+         * @return TypeMirror corresponding to {@code type} or null if {@code type} isn't handled
+         */
+        private @Nullable TypeMirror convertTypeToTypeMirror(
+                Type type, FlowExpressionContext context) {
+            if (type.isClassOrInterfaceType()) {
+                return StaticJavaParser.parseExpression(type.asString())
+                        .accept(this, context)
+                        .getType();
+            } else if (type.isPrimitiveType()) {
+                switch (type.asPrimitiveType().getType()) {
+                    case BOOLEAN:
+                        return TypesUtils.typeFromClass(
+                                boolean.class, types, env.getElementUtils());
+                    case BYTE:
+                        return TypesUtils.typeFromClass(byte.class, types, env.getElementUtils());
+                    case SHORT:
+                        return TypesUtils.typeFromClass(short.class, types, env.getElementUtils());
+                    case INT:
+                        return TypesUtils.typeFromClass(int.class, types, env.getElementUtils());
+                    case CHAR:
+                        return TypesUtils.typeFromClass(char.class, types, env.getElementUtils());
+                    case FLOAT:
+                        return TypesUtils.typeFromClass(float.class, types, env.getElementUtils());
+                    case LONG:
+                        return TypesUtils.typeFromClass(long.class, types, env.getElementUtils());
+                    case DOUBLE:
+                        return TypesUtils.typeFromClass(double.class, types, env.getElementUtils());
+                }
+            } else if (type.isVoidType()) {
+                return TypesUtils.typeFromClass(void.class, types, env.getElementUtils());
+            }
+            return null;
         }
 
         /**
@@ -945,13 +951,13 @@ public class FlowExpressionParseUtil {
             Symbol sym = ((ClassType) type).tsym.owner;
 
             if (sym == null) {
-                return Type.noType;
+                return com.sun.tools.javac.code.Type.noType;
             }
 
             ClassSymbol cs = sym.enclClass();
 
             if (cs == null) {
-                return Type.noType;
+                return com.sun.tools.javac.code.Type.noType;
             }
 
             return cs.asType();

--- a/framework/tests/flowexpression/ArrayCreationParsing.java
+++ b/framework/tests/flowexpression/ArrayCreationParsing.java
@@ -1,0 +1,19 @@
+package flowexpression;
+
+import testlib.flowexpression.qual.FlowExp;
+
+public class ArrayCreationParsing {
+    @FlowExp("new int[2]") Object value1;
+
+    @FlowExp("new int[2][2]") Object value2;
+
+    @FlowExp("new String[2]") Object value3;
+
+    @FlowExp("new String[] {\"a\", \"b\"}") Object value4;
+
+    void method(@FlowExp("new java.lang.String[2]") Object param) {
+        value3 = param;
+        // :: error: (assignment.type.incompatible)
+        value1 = param;
+    }
+}

--- a/framework/tests/flowexpression/ArrayCreationParsing.java
+++ b/framework/tests/flowexpression/ArrayCreationParsing.java
@@ -11,6 +11,22 @@ public class ArrayCreationParsing {
 
     @FlowExp("new String[] {\"a\", \"b\"}") Object value4;
 
+    int i;
+
+    @FlowExp("new int[i]") Object value5;
+
+    @FlowExp("new int[this.i]") Object value6;
+
+    @FlowExp("new int[getI()]")
+    Object value7;
+
+    @FlowExp("new int[] {i, this.i, getI()}")
+    Object value8;
+
+    int getI() {
+        return i;
+    }
+
     void method(@FlowExp("new java.lang.String[2]") Object param) {
         value3 = param;
         // :: error: (assignment.type.incompatible)

--- a/framework/tests/flowexpression/ClassLiterals.java
+++ b/framework/tests/flowexpression/ClassLiterals.java
@@ -24,12 +24,9 @@ public class ClassLiterals {
 
     @FlowExp("int.class") String s1;
 
-    // :: error: (expression.unparsable.type.invalid)
     @FlowExp("int[].class") String s2;
 
-    // :: error: (expression.unparsable.type.invalid)
     @FlowExp("String[].class") String s3;
 
-    // :: error: (expression.unparsable.type.invalid)
     @FlowExp("java.lang.String[].class") String s4;
 }

--- a/framework/tests/flowexpression/ClassLiterals.java
+++ b/framework/tests/flowexpression/ClassLiterals.java
@@ -20,15 +20,16 @@ public class ClassLiterals {
         @FlowExp("java.lang.String.class") Object l6 = p3;
     }
 
-    // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("int.class") String s0;
+    @FlowExp("void.class") String s0;
+
+    @FlowExp("int.class") String s1;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("int[].class") String s1;
+    @FlowExp("int[].class") String s2;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("String[].class") String s2;
+    @FlowExp("String[].class") String s3;
 
     // :: error: (expression.unparsable.type.invalid)
-    @FlowExp("java.lang.String[].class") String s3;
+    @FlowExp("java.lang.String[].class") String s4;
 }


### PR DESCRIPTION
New parsable types:

1. Array creation expressions (`new int[2]`, `new String[] {"a", "b"}`, `new java.lang.String[2]`)
2. Class literals with primitive or void type (`int.class`, `double.class`, `void.class`).

I combined those 2 because I used class literals with primitive type to parse array creation expressions with primitive type.

I will add Javadoc soon.