### PR TITLE
UpperBoundChecker checks varargs methods correctly

### DIFF
--- a/checker/tests/index/IndexForVarargs.java
+++ b/checker/tests/index/IndexForVarargs.java
@@ -1,0 +1,28 @@
+import org.checkerframework.checker.index.qual.IndexFor;
+
+public class IndexForVarargs {
+    String get(@IndexFor("#2") int i, String... varargs) {
+        return varargs[i];
+    }
+
+    void method(@IndexFor("#2") int i, String[]... varargs) {}
+
+    void m() {
+        // :: error: (argument.type.incompatible)
+        get(1);
+
+        get(1, "a", "b");
+
+        // :: error: (argument.type.incompatible)
+        get(2, "abc");
+
+        String[] stringArg1 = new String[] {"a", "b"};
+        String[] stringArg2 = new String[] {"c", "d", "e"};
+        String[] stringArg3 = new String[] {"a", "b", "c"};
+
+        method(1, stringArg1, stringArg2);
+
+        // :: error: (argument.type.incompatible)
+        method(2, stringArg3);
+    }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -1193,19 +1193,19 @@ public class FlowExpressions {
             sb.append("new " + type);
             if (!dimensions.isEmpty()) {
                 boolean needComma = false;
-                sb.append(" (");
                 for (Receiver dim : dimensions) {
+                    sb.append("[");
                     if (needComma) {
                         sb.append(", ");
                     }
-                    sb.append(dim);
+                    sb.append(dim == null ? "" : dim);
                     needComma = true;
+                    sb.append("]");
                 }
-                sb.append(")");
             }
             if (!initializers.isEmpty()) {
                 boolean needComma = false;
-                sb.append(" = {");
+                sb.append(" {");
                 for (Receiver init : initializers) {
                     if (needComma) {
                         sb.append(", ");

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -2241,6 +2241,11 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             if (sequenceLiteralValue instanceof String) {
                 return ((String) sequenceLiteralValue).length();
             }
+        } else if (expressionObj instanceof FlowExpressions.ArrayCreation) {
+            FlowExpressions.ArrayCreation arrayCreation =
+                    (FlowExpressions.ArrayCreation) expressionObj;
+            // This is only expected to support array creations in varargs methods
+            return arrayCreation.getInitializers().size();
         }
 
         lengthAnno = getAnnotationFromReceiver(expressionObj, tree, ArrayLenRange.class);


### PR DESCRIPTION
In a varargs method, the varargs arguments are now placed in an `ArrayCreation` receiver as initializers, such that `UpperBoundChecker` can process them correctly.

Fixes #1635 
(More details in this comment: [link](https://github.com/typetools/checker-framework/issues/1635#issuecomment-344050065))