### PR TITLE
Move Value Checker utilities to ValueCheckerUtils

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/IndexUtil.java
@@ -4,132 +4,14 @@ import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
-import java.util.Collections;
-import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
-import org.checkerframework.common.value.qual.IntRange;
-import org.checkerframework.common.value.qual.IntVal;
-import org.checkerframework.common.value.util.Range;
-import org.checkerframework.framework.type.AnnotatedTypeMirror;
-import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /** A collection of utility functions used by several Index Checker subcheckers. */
 public class IndexUtil {
-
-    /**
-     * Gets the value field of an annotation with a list of strings in its value field. Null is
-     * returned if the annotation has no value field.
-     *
-     * <p>For the Index Checker, this will get a list of array names from an Upper Bound or SameLen
-     * annotation. making this safe to call on any Upper Bound or SameLen annotation.
-     */
-    public static List<String> getValueOfAnnotationWithStringArgument(AnnotationMirror anno) {
-        if (!AnnotationUtils.hasElementValue(anno, "value")) {
-            return null;
-        }
-        return AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
-    }
-
-    /**
-     * Returns a range representing the possible integral values represented by the passed {@code
-     * AnnotatedTypeMirror}. If the passed {@code AnnotatedTypeMirror} does not contain an {@code
-     * IntRange} annotation or an {@code IntVal} annotation, returns null.
-     */
-    public static Range getPossibleValues(
-            AnnotatedTypeMirror valueType, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
-        if (valueAnnotatedTypeFactory.isIntRange(valueType.getAnnotations())) {
-            return ValueAnnotatedTypeFactory.getRange(valueType.getAnnotation(IntRange.class));
-        } else {
-            List<Long> values =
-                    ValueAnnotatedTypeFactory.getIntValues(valueType.getAnnotation(IntVal.class));
-            if (values != null) {
-                return new Range(Collections.min(values), Collections.max(values));
-            } else {
-                return null;
-            }
-        }
-    }
-
-    /**
-     * Either returns the exact value of the given tree according to the Constant Value Checker, or
-     * null if the exact value is not known. This method should only be used by clients who need
-     * exactly one value -- such as the LBC's binary operator rules -- and not by those that need to
-     * know whether a valueType belongs to a particular qualifier.
-     */
-    public static Long getExactValue(Tree tree, ValueAnnotatedTypeFactory factory) {
-        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
-        Range possibleValues = getPossibleValues(valueType, factory);
-        if (possibleValues != null && possibleValues.from == possibleValues.to) {
-            return possibleValues.from;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Returns the exact value of an annotated element according to the Constant Value Checker, or
-     * null if the exact value is not known.
-     *
-     * @param element the element to get the exact value from
-     * @param factory ValueAnnotatedTypeFactory used for annotation accessing
-     * @return the exact value of the element if it is constant, or null otherwise
-     */
-    public static Long getExactValue(Element element, ValueAnnotatedTypeFactory factory) {
-        AnnotatedTypeMirror valueType = factory.getAnnotatedType(element);
-        Range possibleValues = getPossibleValues(valueType, factory);
-        if (possibleValues != null && possibleValues.from == possibleValues.to) {
-            return possibleValues.from;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Finds the minimum value in a Value Checker type. If there is no information (such as when the
-     * list of possible values is empty or null), returns null. Otherwise, returns the smallest
-     * value in the list of possible values.
-     */
-    public static Long getMinValue(Tree tree, ValueAnnotatedTypeFactory factory) {
-        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
-        Range possibleValues = getPossibleValues(valueType, factory);
-        if (possibleValues != null) {
-            return possibleValues.from;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Finds the maximum value in a Value Checker type. If there is no information (such as when the
-     * list of possible values is empty or null), returns null. Otherwise, returns the smallest
-     * value in the list of possible values.
-     */
-    public static Long getMaxValue(Tree tree, ValueAnnotatedTypeFactory factory) {
-        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
-        Range possibleValues = getPossibleValues(valueType, factory);
-        if (possibleValues != null) {
-            return possibleValues.to;
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Queries the Value Checker to determine if there is a known minimum length for the array
-     * represented by {@code tree}. If not, returns 0.
-     */
-    public static int getMinLen(Tree tree, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
-        AnnotatedTypeMirror minLenType = valueAnnotatedTypeFactory.getAnnotatedType(tree);
-        return valueAnnotatedTypeFactory.getMinLenValue(minLenType);
-    }
-
     /** Determines whether the type is a sequence supported by this checker. */
     public static boolean isSequenceType(TypeMirror type) {
         return type.getKind() == TypeKind.ARRAY || TypesUtils.isString(type);
@@ -145,20 +27,5 @@ public class IndexUtil {
         }
 
         return null;
-    }
-
-    /**
-     * Looks up the minlen of a member select tree. The tree must be an access to a sequence length.
-     */
-    public static Integer getMinLenFromTree(Tree tree, ValueAnnotatedTypeFactory valueATF) {
-        AnnotatedTypeMirror minLenType = valueATF.getAnnotatedType(tree);
-        Long min = valueATF.getMinimumIntegralValue(minLenType);
-        if (min == null) {
-            return null;
-        }
-        if (min < 0 || min > Integer.MAX_VALUE) {
-            min = 0L;
-        }
-        return min.intValue();
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.OffsetDependentTypesHelper;
 import org.checkerframework.checker.index.qual.LessThan;
 import org.checkerframework.checker.index.qual.LessThanBottom;
@@ -22,6 +21,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.common.value.qual.ArrayLen;
 import org.checkerframework.common.value.qual.ArrayLenRange;
 import org.checkerframework.common.value.qual.IntRange;
@@ -147,7 +147,7 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** @return {@code smaller < bigger}, using information from the Value Checker */
     public boolean isLessThanByValue(Tree smaller, String bigger, TreePath path) {
-        Long smallerValue = IndexUtil.getMinValue(smaller, getValueAnnotatedTypeFactory());
+        Long smallerValue = ValueCheckerUtils.getMinValue(smaller, getValueAnnotatedTypeFactory());
         if (smallerValue == null) {
             return false;
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanTransfer.java
@@ -7,8 +7,8 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.FlowExpressions.ValueLiteral;
@@ -109,7 +109,7 @@ public class LessThanTransfer extends IndexAbstractTransfer {
         Receiver leftRec = FlowExpressions.internalReprOf(factory, n.getLeftOperand());
         if (leftRec != null && leftRec.isUnassignableByOtherCode()) {
             ValueAnnotatedTypeFactory valueFactory = factory.getValueAnnotatedTypeFactory();
-            Long right = IndexUtil.getMinValue(n.getRightOperand().getTree(), valueFactory);
+            Long right = ValueCheckerUtils.getMinValue(n.getRightOperand().getTree(), valueFactory);
             if (right != null && 0 < right) {
                 // left - right < left iff 0 < right
                 List<String> expressions = getLessThanExpressions(n.getLeftOperand());

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -1,7 +1,5 @@
 package org.checkerframework.checker.index.lowerbound;
 
-import static org.checkerframework.checker.index.IndexUtil.getPossibleValues;
-
 import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
@@ -15,7 +13,6 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import org.checkerframework.checker.index.IndexMethodIdentifier;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.inequality.LessThanAnnotatedTypeFactory;
 import org.checkerframework.checker.index.inequality.LessThanChecker;
 import org.checkerframework.checker.index.qual.GTENegativeOne;
@@ -37,6 +34,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.common.value.qual.BottomVal;
 import org.checkerframework.common.value.util.Range;
 import org.checkerframework.dataflow.cfg.node.NumericalMultiplicationNode;
@@ -203,7 +201,8 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** Returns the type in the lower bound hierarchy that a Value Checker type corresponds to. */
     private AnnotationMirror getLowerBoundAnnotationFromValueType(AnnotatedTypeMirror valueType) {
-        Range possibleValues = getPossibleValues(valueType, getValueAnnotatedTypeFactory());
+        Range possibleValues =
+                ValueCheckerUtils.getPossibleValues(valueType, getValueAnnotatedTypeFactory());
         // possibleValues is null if the Value Checker does not have any estimate.
         if (possibleValues == null) {
             // possibleValues is null if there is no IntVal annotation on the type - such as
@@ -377,7 +376,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     Integer getMinLenFromMemberSelectTree(MemberSelectTree tree) {
         if (TreeUtils.isArrayLengthAccess(tree)) {
-            return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
+            return ValueCheckerUtils.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
         }
         return null;
     }
@@ -388,7 +387,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     Integer getMinLenFromMethodInvocationTree(MethodInvocationTree tree) {
         if (imf.isLengthOfMethodInvocation(tree)) {
-            return IndexUtil.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
+            return ValueCheckerUtils.getMinLenFromTree(tree, getValueAnnotatedTypeFactory());
         }
         return null;
     }

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -1,6 +1,6 @@
 package org.checkerframework.checker.index.lowerbound;
 
-import static org.checkerframework.checker.index.IndexUtil.getExactValue;
+import static org.checkerframework.common.value.ValueCheckerUtils.getExactValue;
 
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -1,6 +1,6 @@
 package org.checkerframework.checker.index.samelen;
 
-import static org.checkerframework.checker.index.IndexUtil.getValueOfAnnotationWithStringArgument;
+import static org.checkerframework.common.value.ValueCheckerUtils.getValueOfAnnotationWithStringArgument;
 
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.NewArrayTree;
@@ -131,7 +131,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 if (r != null) {
                     String varName = r.toString();
 
-                    List<String> exprs = IndexUtil.getValueOfAnnotationWithStringArgument(anm);
+                    List<String> exprs = getValueOfAnnotationWithStringArgument(anm);
                     if (exprs.contains(varName)) {
                         exprs.remove(varName);
                     }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.qual.SameLen;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
@@ -162,7 +163,7 @@ public class SameLenTransfer extends CFTransfer {
         if (currentPath == null) {
             return;
         }
-        for (String expr : IndexUtil.getValueOfAnnotationWithStringArgument(sameLenAnno)) {
+        for (String expr : ValueCheckerUtils.getValueOfAnnotationWithStringArgument(sameLenAnno)) {
             Receiver recS;
             try {
                 recS = aTypeFactory.getReceiverFromJavaExpressionString(expr, currentPath);
@@ -287,7 +288,7 @@ public class SameLenTransfer extends CFTransfer {
                 continue;
             }
 
-            List<String> values = IndexUtil.getValueOfAnnotationWithStringArgument(anm);
+            List<String> values = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(anm);
             for (String value : values) {
                 int otherParamIndex = paramNames.indexOf(value);
                 if (otherParamIndex == -1) {

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenVisitor.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.index.qual.PolySameLen;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -47,7 +48,9 @@ public class SameLenVisitor extends BaseTypeVisitor<SameLenAnnotatedTypeFactory>
                 if (am == null) {
                     exprs = Collections.singletonList(rhsExpr);
                 } else {
-                    exprs = new TreeSet<>(IndexUtil.getValueOfAnnotationWithStringArgument(am));
+                    exprs =
+                            new TreeSet<>(
+                                    ValueCheckerUtils.getValueOfAnnotationWithStringArgument(am));
                     exprs.add(rhsExpr);
                 }
                 AnnotationMirror newSameLen = atypeFactory.createSameLen(exprs);

--- a/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexAnnotatedTypeFactory.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.qual.NegativeIndexFor;
 import org.checkerframework.checker.index.qual.SearchIndexBottom;
 import org.checkerframework.checker.index.qual.SearchIndexFor;
@@ -18,6 +17,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy;
 import org.checkerframework.javacutil.AnnotationBuilder;
@@ -99,8 +99,8 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
             // Each annotation is either NegativeIndexFor or SearchIndexFor.
             Set<String> combinedArrays =
-                    new HashSet<>(IndexUtil.getValueOfAnnotationWithStringArgument(a1));
-            combinedArrays.addAll(IndexUtil.getValueOfAnnotationWithStringArgument(a2));
+                    new HashSet<>(ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a1));
+            combinedArrays.addAll(ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a2));
 
             if (AnnotationUtils.areSameByClass(a1, NegativeIndexFor.class)
                     || AnnotationUtils.areSameByClass(a2, NegativeIndexFor.class)) {
@@ -134,8 +134,10 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // annotation that includes only their overlapping values.
 
             // Each annotation is either NegativeIndexFor or SearchIndexFor.
-            List<String> arrayIntersection = IndexUtil.getValueOfAnnotationWithStringArgument(a1);
-            arrayIntersection.retainAll(IndexUtil.getValueOfAnnotationWithStringArgument(a2));
+            List<String> arrayIntersection =
+                    ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a1);
+            arrayIntersection.retainAll(
+                    ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a2));
 
             if (arrayIntersection.isEmpty()) {
                 return UNKNOWN;
@@ -167,8 +169,10 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
 
             // Each annotation is either NegativeIndexFor or SearchIndexFor.
-            List<String> superArrays = IndexUtil.getValueOfAnnotationWithStringArgument(superAnno);
-            List<String> subArrays = IndexUtil.getValueOfAnnotationWithStringArgument(subAnno);
+            List<String> superArrays =
+                    ValueCheckerUtils.getValueOfAnnotationWithStringArgument(superAnno);
+            List<String> subArrays =
+                    ValueCheckerUtils.getValueOfAnnotationWithStringArgument(subAnno);
 
             // Subtyping requires:
             //  * subtype is NegativeIndexFor or supertype is SearchIndexFor

--- a/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexTransfer.java
@@ -3,9 +3,9 @@ package org.checkerframework.checker.index.searchindex;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.qual.NegativeIndexFor;
 import org.checkerframework.checker.index.qual.SearchIndexFor;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -56,13 +56,14 @@ public class SearchIndexTransfer extends IndexAbstractTransfer {
             Node left, Node right, CFStore store, int valueToCompareTo) {
         assert valueToCompareTo == 0 || valueToCompareTo == -1;
         Long leftValue =
-                IndexUtil.getExactValue(
+                ValueCheckerUtils.getExactValue(
                         left.getTree(), aTypeFactory.getValueAnnotatedTypeFactory());
         if (leftValue != null && leftValue == valueToCompareTo) {
             AnnotationMirror rightSI =
                     aTypeFactory.getAnnotationMirror(right.getTree(), SearchIndexFor.class);
             if (rightSI != null) {
-                List<String> arrays = IndexUtil.getValueOfAnnotationWithStringArgument(rightSI);
+                List<String> arrays =
+                        ValueCheckerUtils.getValueOfAnnotationWithStringArgument(rightSI);
                 AnnotationMirror nif = aTypeFactory.createNegativeIndexFor(arrays);
                 store.insertValue(
                         FlowExpressions.internalReprOf(analysis.getTypeFactory(), right), nif);

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/OffsetEquation.java
@@ -7,10 +7,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import javax.lang.model.element.Element;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.FlowExpressions.Unknown;
@@ -275,7 +275,7 @@ public class OffsetEquation {
         } else if (factory != null && termReceiver instanceof FlowExpressions.LocalVariable) {
             Element element = ((FlowExpressions.LocalVariable) termReceiver).getElement();
             Long exactValue =
-                    IndexUtil.getExactValue(
+                    ValueCheckerUtils.getExactValue(
                             element, factory.getTypeFactoryOfSubchecker(ValueChecker.class));
 
             if (exactValue != null) {
@@ -510,7 +510,7 @@ public class OffsetEquation {
             Node node, ValueAnnotatedTypeFactory factory, char op) {
         assert op == '+' || op == '-';
         if (node.getTree() != null && TreeUtils.isExpressionTree(node.getTree())) {
-            Long i = IndexUtil.getExactValue(node.getTree(), factory);
+            Long i = ValueCheckerUtils.getExactValue(node.getTree(), factory);
             if (i != null) {
                 if (op == '-') {
                     i = -i;

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -50,6 +50,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.common.value.qual.BottomVal;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.cfg.node.Node;
@@ -486,7 +487,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             if (AnnotationUtils.containsSameByClass(
                     searchIndexType.getAnnotations(), NegativeIndexFor.class)) {
                 AnnotationMirror nif = searchIndexType.getAnnotation(NegativeIndexFor.class);
-                List<String> arrays = IndexUtil.getValueOfAnnotationWithStringArgument(nif);
+                List<String> arrays = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(nif);
                 List<String> negativeOnes = Collections.nCopies(arrays.size(), "-1");
                 UBQualifier qual = UBQualifier.createUBQualifier(arrays, negativeOnes);
                 typeDst.addAnnotation(convertUBQualifierToAnnotation(qual));
@@ -553,7 +554,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 // For non-negative numbers, right shift is equivalent to division by a power of two
                 // The range of the shift amount is limited to 0..30 to avoid overflows and int/long
                 // differences
-                Long shiftAmount = IndexUtil.getExactValue(right, getValueAnnotatedTypeFactory());
+                Long shiftAmount =
+                        ValueCheckerUtils.getExactValue(right, getValueAnnotatedTypeFactory());
                 if (shiftAmount != null && shiftAmount >= 0 && shiftAmount < Integer.SIZE - 1) {
                     int divisor = 1 << shiftAmount;
                     // Support average by shift just like for division
@@ -640,7 +642,8 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 ExpressionTree divisorTree,
                 AnnotatedTypeMirror resultType) {
 
-            Long divisor = IndexUtil.getExactValue(divisorTree, getValueAnnotatedTypeFactory());
+            Long divisor =
+                    ValueCheckerUtils.getExactValue(divisorTree, getValueAnnotatedTypeFactory());
             if (divisor == null) {
                 resultType.addAnnotation(UNKNOWN);
                 return;

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.index.IndexAbstractTransfer;
 import org.checkerframework.checker.index.IndexRefinementInfo;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.Subsequence;
 import org.checkerframework.checker.index.inequality.LessThanAnnotatedTypeFactory;
 import org.checkerframework.checker.index.qual.LessThan;
@@ -17,6 +16,7 @@ import org.checkerframework.checker.index.qual.Positive;
 import org.checkerframework.checker.index.qual.SubstringIndexFor;
 import org.checkerframework.checker.index.upperbound.UBQualifier.LessThanLengthOf;
 import org.checkerframework.checker.index.upperbound.UBQualifier.UpperBoundUnknownQualifier;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
@@ -202,7 +202,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             CFStore store) {
         if (atypeFactory.hasLowerBoundTypeByClass(other, Positive.class)) {
             Long minValue =
-                    IndexUtil.getMinValue(
+                    ValueCheckerUtils.getMinValue(
                             other.getTree(), atypeFactory.getValueAnnotatedTypeFactory());
             if (minValue != null && minValue > 1) {
                 typeOfMultiplication = (LessThanLengthOf) typeOfMultiplication.plusOffset(1);
@@ -437,7 +437,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
             NumericalSubtractionNode subtraction = (NumericalSubtractionNode) lengthAccess;
             Node offsetNode = subtraction.getRightOperand();
             Long offsetValue =
-                    IndexUtil.getExactValue(
+                    ValueCheckerUtils.getExactValue(
                             offsetNode.getTree(), atypeFactory.getValueAnnotatedTypeFactory());
             if (offsetValue != null
                     && offsetValue > Integer.MIN_VALUE
@@ -671,7 +671,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
         List<String> sameLenSequences =
                 sameLenAnno == null
                         ? new ArrayList<>()
-                        : IndexUtil.getValueOfAnnotationWithStringArgument(sameLenAnno);
+                        : ValueCheckerUtils.getValueOfAnnotationWithStringArgument(sameLenAnno);
 
         if (!sameLenSequences.contains(sequenceRec.toString())) {
             sameLenSequences.add(sequenceRec.toString());

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -13,7 +13,6 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.index.Subsequence;
 import org.checkerframework.checker.index.qual.HasSubsequence;
 import org.checkerframework.checker.index.qual.LTLengthOf;
@@ -22,6 +21,7 @@ import org.checkerframework.checker.index.upperbound.UBQualifier.LessThanLengthO
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
 import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
 import org.checkerframework.dataflow.analysis.FlowExpressions.LocalVariable;
@@ -163,9 +163,9 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
         AnnotatedTypeMirror indexType = atypeFactory.getAnnotatedType(indexTree);
         UBQualifier qualifier = UBQualifier.createUBQualifier(indexType, atypeFactory.UNKNOWN);
         ValueAnnotatedTypeFactory valueFactory = atypeFactory.getValueAnnotatedTypeFactory();
-        Long valMax = IndexUtil.getMaxValue(indexTree, valueFactory);
+        Long valMax = ValueCheckerUtils.getMaxValue(indexTree, valueFactory);
 
-        if (IndexUtil.getExactValue(indexTree, valueFactory) != null) {
+        if (ValueCheckerUtils.getExactValue(indexTree, valueFactory) != null) {
             // Note that valMax is equal to the exact value in this case.
             checker.report(
                     Result.failure(
@@ -371,8 +371,11 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
      *  is less than the minimum possible length of arrTree, and returns true if so.
      */
     private boolean checkMinLen(ExpressionTree indexTree, ExpressionTree arrTree) {
-        int minLen = IndexUtil.getMinLen(arrTree, atypeFactory.getValueAnnotatedTypeFactory());
-        Long valMax = IndexUtil.getMaxValue(indexTree, atypeFactory.getValueAnnotatedTypeFactory());
+        int minLen =
+                ValueCheckerUtils.getMinLen(arrTree, atypeFactory.getValueAnnotatedTypeFactory());
+        Long valMax =
+                ValueCheckerUtils.getMaxValue(
+                        indexTree, atypeFactory.getValueAnnotatedTypeFactory());
         return valMax != null && valMax < minLen;
     }
 
@@ -417,7 +420,9 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
             varLtlQual = (LessThanLengthOf) newLHS;
         }
 
-        Long value = IndexUtil.getMaxValue(valueExp, atypeFactory.getValueAnnotatedTypeFactory());
+        Long value =
+                ValueCheckerUtils.getMaxValue(
+                        valueExp, atypeFactory.getValueAnnotatedTypeFactory());
 
         if (value == null && !expQual.isLessThanLengthQualifier()) {
             return false;

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import org.checkerframework.checker.index.IndexUtil;
 import org.checkerframework.checker.signedness.qual.Signed;
 import org.checkerframework.checker.signedness.qual.SignedPositive;
 import org.checkerframework.checker.signedness.qual.SignednessGlb;
@@ -17,6 +16,7 @@ import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueAnnotatedTypeFactory;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.common.value.ValueCheckerUtils;
 import org.checkerframework.common.value.qual.IntRangeFromNonNegative;
 import org.checkerframework.common.value.qual.IntRangeFromPositive;
 import org.checkerframework.common.value.util.Range;
@@ -124,7 +124,7 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                         && type.hasAnnotation(SIGNED)) {
                     type.replaceAnnotation(SIGNEDNESS_GLB);
                 } else {
-                    Range treeRange = IndexUtil.getPossibleValues(valueATM, valueFactory);
+                    Range treeRange = ValueCheckerUtils.getPossibleValues(valueATM, valueFactory);
 
                     if (treeRange != null) {
                         switch (javaType.getKind()) {

--- a/framework/src/main/java/org/checkerframework/common/value/ValueCheckerUtils.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueCheckerUtils.java
@@ -1,11 +1,13 @@
 package org.checkerframework.common.value;
 
+import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
@@ -19,6 +21,7 @@ import org.checkerframework.common.value.qual.StringVal;
 import org.checkerframework.common.value.qual.UnknownVal;
 import org.checkerframework.common.value.util.NumberUtils;
 import org.checkerframework.common.value.util.Range;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
@@ -287,5 +290,145 @@ public class ValueCheckerUtils {
             lengths.add(str.length());
         }
         return ValueCheckerUtils.removeDuplicates(lengths);
+    }
+
+    /**
+     * Gets the value field of an annotation with a list of strings in its value field. Null is
+     * returned if the annotation has no value field.
+     *
+     * <p>For the Index Checker, this will get a list of array names from an Upper Bound or SameLen
+     * annotation. making this safe to call on any Upper Bound or SameLen annotation.
+     */
+    public static List<String> getValueOfAnnotationWithStringArgument(AnnotationMirror anno) {
+        if (!AnnotationUtils.hasElementValue(anno, "value")) {
+            return null;
+        }
+        return AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
+    }
+
+    /**
+     * Returns a range representing the possible integral values represented by the passed {@code
+     * AnnotatedTypeMirror}. If the passed {@code AnnotatedTypeMirror} does not contain an {@code
+     * IntRange} annotation or an {@code IntVal} annotation, returns null.
+     */
+    public static Range getPossibleValues(
+            AnnotatedTypeMirror valueType, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
+        if (valueAnnotatedTypeFactory.isIntRange(valueType.getAnnotations())) {
+            return ValueAnnotatedTypeFactory.getRange(valueType.getAnnotation(IntRange.class));
+        } else {
+            List<Long> values =
+                    ValueAnnotatedTypeFactory.getIntValues(valueType.getAnnotation(IntVal.class));
+            if (values != null) {
+                return new Range(Collections.min(values), Collections.max(values));
+            } else {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Either returns the exact value of the given tree according to the Constant Value Checker, or
+     * null if the exact value is not known. This method should only be used by clients who need
+     * exactly one value -- such as the LBC's binary operator rules -- and not by those that need to
+     * know whether a valueType belongs to a particular qualifier.
+     */
+    public static Long getExactValue(Tree tree, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+        Range possibleValues = getPossibleValues(valueType, factory);
+        if (possibleValues != null && possibleValues.from == possibleValues.to) {
+            return possibleValues.from;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Returns the exact value of an annotated element according to the Constant Value Checker, or
+     * null if the exact value is not known.
+     *
+     * @param element the element to get the exact value from
+     * @param factory ValueAnnotatedTypeFactory used for annotation accessing
+     * @return the exact value of the element if it is constant, or null otherwise
+     */
+    public static Long getExactValue(Element element, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(element);
+        Range possibleValues = getPossibleValues(valueType, factory);
+        if (possibleValues != null && possibleValues.from == possibleValues.to) {
+            return possibleValues.from;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Either returns the exact string value of the given tree according to the Constant Value
+     * Checker, or null if the exact value is not known. This method should only be used by clients
+     * who need exactly one value and not by those that need to know whether a valueType belongs to
+     * a particular qualifier.
+     */
+    public static String getExactStringValue(Tree tree, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+        if (valueType.hasAnnotation(StringVal.class)) {
+            AnnotationMirror valueAnno = valueType.getAnnotation(StringVal.class);
+            List<String> possibleValues = getValueOfAnnotationWithStringArgument(valueAnno);
+            if (possibleValues.size() == 1) {
+                return possibleValues.get(0);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the minimum value in a Value Checker type. If there is no information (such as when the
+     * list of possible values is empty or null), returns null. Otherwise, returns the smallest
+     * value in the list of possible values.
+     */
+    public static Long getMinValue(Tree tree, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+        Range possibleValues = getPossibleValues(valueType, factory);
+        if (possibleValues != null) {
+            return possibleValues.from;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Finds the maximum value in a Value Checker type. If there is no information (such as when the
+     * list of possible values is empty or null), returns null. Otherwise, returns the smallest
+     * value in the list of possible values.
+     */
+    public static Long getMaxValue(Tree tree, ValueAnnotatedTypeFactory factory) {
+        AnnotatedTypeMirror valueType = factory.getAnnotatedType(tree);
+        Range possibleValues = getPossibleValues(valueType, factory);
+        if (possibleValues != null) {
+            return possibleValues.to;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Looks up the minlen of a member select tree. The tree must be an access to a sequence length.
+     */
+    public static Integer getMinLenFromTree(Tree tree, ValueAnnotatedTypeFactory valueATF) {
+        AnnotatedTypeMirror minLenType = valueATF.getAnnotatedType(tree);
+        Long min = valueATF.getMinimumIntegralValue(minLenType);
+        if (min == null) {
+            return null;
+        }
+        if (min < 0 || min > Integer.MAX_VALUE) {
+            min = 0L;
+        }
+        return min.intValue();
+    }
+
+    /**
+     * Queries the Value Checker to determine if there is a known minimum length for the array
+     * represented by {@code tree}. If not, returns 0.
+     */
+    public static int getMinLen(Tree tree, ValueAnnotatedTypeFactory valueAnnotatedTypeFactory) {
+        AnnotatedTypeMirror minLenType = valueAnnotatedTypeFactory.getAnnotatedType(tree);
+        return valueAnnotatedTypeFactory.getMinLenValue(minLenType);
     }
 }


### PR DESCRIPTION
`IndexUtil` contained a lot of Value Checker utilities. This PR moves them to the ValueChecker's own utility class.

I also added one new method: `getExactStringValue`, which is an analogue of `getExactValue` (which returns an integral value). That method will be useful to me in the Object Construction Checker: https://github.com/kelloggm/object-construction-checker/pull/89