### PR TITLE
Remove @Documented from @CFComment

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/qual/CFComment.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/CFComment.java
@@ -1,6 +1,5 @@
 package org.checkerframework.framework.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -25,7 +24,6 @@ import java.lang.annotation.RetentionPolicy;
  * to which the comment applies (e.g., local variable rather than method, and method rather than
  * class).
  */
-@Documented
 @Retention(RetentionPolicy.SOURCE)
 public @interface CFComment {
     /**


### PR DESCRIPTION
Otherwise @CFComment is part of the public API and has to be exported.
And, @CFComment doesn't need to be in public API documentation.