### PR TITLE
asMemberOf:  Substitutes uninferred type arguments for type variables. (Fixes #2721)

### DIFF
--- a/checker/tests/nullness/Issue2721.java
+++ b/checker/tests/nullness/Issue2721.java
@@ -1,0 +1,13 @@
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+class Issue2721 {
+    void foo() {
+        passThrough(asList(asList(1))).get(0).get(0).intValue();
+    }
+
+    <T> List<? extends T> passThrough(List<? extends T> object) {
+        return object;
+    }
+}

--- a/checker/tests/nullness/Issue2721.java
+++ b/checker/tests/nullness/Issue2721.java
@@ -2,6 +2,7 @@ import static java.util.Arrays.asList;
 
 import java.util.List;
 
+@SuppressWarnings("") // Just check for crashed.
 class Issue2721 {
     void foo() {
         passThrough(asList(asList(1))).get(0).get(0).intValue();

--- a/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/poly/AbstractQualifierPolymorphism.java
@@ -439,6 +439,9 @@ public abstract class AbstractQualifierPolymorphism implements QualifierPolymorp
 
             if (type.getKind() == TypeKind.WILDCARD) {
                 AnnotatedWildcardType wildcardType = (AnnotatedWildcardType) type;
+                if (wildcardType.getExtendsBound().getKind() == TypeKind.WILDCARD) {
+                    wildcardType = (AnnotatedWildcardType) wildcardType.getExtendsBound();
+                }
                 if (wildcardType.isUninferredTypeArgument()) {
                     return mapQualifierToPoly(wildcardType.getExtendsBound(), polyType);
                 }


### PR DESCRIPTION
Fixes #2721. 