### PR TITLE
Read `--patch-module` arguments from 'Patch_Modules_argsFile' file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Please see the Checker Framework manual1
+Please see the Checker Framework manual
 ([HTML](https://checkerframework.org/manual/),
 [PDF](https://checkerframework.org/manual/checker-framework-manual.pdf)).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Please see the Checker Framework manual
+Please see the Checker Framework manual1
 ([HTML](https://checkerframework.org/manual/),
 [PDF](https://checkerframework.org/manual/checker-framework-manual.pdf)).
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -4013,10 +4013,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
 
             String jdkJarName = PluginUtil.getJdkJarName();
+            String howToFix;
+            if (PluginUtil.getJreVersion() < 9) {
+                howToFix = "-Xbootclasspath/p:.../checker/dist/ . ";
+            } else {
+                // {@code --patch-module} has replaced {@code -Xbootclasspath} in Java 9+.
+                howToFix =
+                        "--patch-module <jdkModule>=<.../checker/dist/annotatedJDK/jdk{VERSION}/annotatedModule.jar>";
+            }
             checker.message(
                     Kind.WARNING,
                     "You do not seem to be using the distributed annotated JDK. "
-                            + "To fix the problem, supply javac an argument like:  -Xbootclasspath/p:.../checker/dist/ . "
+                            + "To fix the problem, supply javac an argument like:  "
+                            + howToFix
                             + "Currently using: "
                             + jdkJarName);
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -165,10 +165,7 @@ public class CheckerMain {
         if (PluginUtil.getJreVersion() < 9) {
             assertFilesExist(Arrays.asList(javacJar, jdkJar, checkerJar, checkerQualJar));
         } else {
-            assertFilesExist(Arrays.asList(javacJar, checkerJar, checkerQualJar));
-            // TODO: once the jdk11 jars exist, check for them by uncommenting the line below.
-            // assertFilesExist(Arrays.asList(javacJar, jdkModulesPath, checkerJar,
-            // checkerQualJar));
+            assertFilesExist(Arrays.asList(javacJar, jdkModulesPath, checkerJar, checkerQualJar));
         }
     }
 
@@ -765,7 +762,7 @@ public class CheckerMain {
                 missingAbsoluteFilenames.add(missingFile.getAbsolutePath());
             }
             throw new RuntimeException(
-                    "The following files and/or directory could not be located: "
+                    "The following files and/or directories could not be located: "
                             + String.join(", ", missingAbsoluteFilenames));
         }
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/PluginUtil.java
@@ -34,11 +34,31 @@ public class PluginUtil {
     public static final String JAVAC_PATH_OPT = "-javacJar";
 
     /**
-     * Option name for specifying an alternative jdk.jar location. The accompanying value MUST be
-     * the path to the jar file (NOT the path to its encompassing directory)
+     * Option name for specifying an alternative location for the annotated JDK.
+     *
+     * <p>In case of Java 8, an alternative jdk.jar location. The accompanying value MUST be the
+     * path to the jar file (NOT the path to its encompassing directory).
+     *
+     * <p>In case of Java 9+, a directory containing annotated JDK modules. The supplied directory
+     * MUST contain a {@code Patch_Modules_argfile} file containing {@code --patch-module
+     * <jdkModule>=<annotatedModule>} directives, one per line.
      */
-    public static final String JDK_PATH_OPT = "-jdkJar";
+    public static final String JDK_PATH_OPT;
 
+    static {
+        if (PluginUtil.getJreVersion() == 8) {
+            JDK_PATH_OPT = "-jdkJar";
+        } else {
+            JDK_PATH_OPT = "-jdkModulesPath";
+        }
+    }
+
+    /**
+     * Convert a list of file names into a list of files.
+     *
+     * @param fileNames list of file names
+     * @return a list of files created from {@code fileNames}
+     */
     public static List<File> toFiles(final List<String> fileNames) {
         final List<File> files = new ArrayList<>(fileNames.size());
         for (final String fn : fileNames) {


### PR DESCRIPTION
This Enables CheckerMain to read all `--patch-module` arguments in `${CHECKERFRAMEWORK}/checker/dist/annotatedJDK/jdk${JDK_VERSION}/Patch_Modules_argfile`

Merge after successfully integrating AnnotatedJDK-11

This PR was initially made at eisop/checker-framework#36