### PR TITLE
Remove --add-exports and most --add-opens.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,19 +138,7 @@ allprojects {
                     "-Xlint:-options",
                     "-Xlint",
             ]
-            if (!isJava8) {
-                options.compilerArgs += [
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                    "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-                ]
-            }
+
             options.encoding = 'UTF-8'
             options.fork = true
             if (isJava8) {
@@ -588,15 +576,7 @@ subprojects {
         tasks.withType(Test) {
             if (!isJava8) {
                 jvmArgs += [
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                    "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                    "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
                     ]
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -125,10 +125,20 @@ allprojects {
         tasks.withType(JavaCompile) {
             dependsOn(':installGitHooks')
             sourceCompatibility = 8
-            if (isJava8) {
-                //  option --add-exports not allowed with target 1.8
-                targetCompatibility = 8
-            }
+            targetCompatibility = 8
+
+            // When sourceCompatibilty is changed to 11, then the following will be required.
+            // options.compilerArgs += [
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+            // "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            // ]
             options.failOnError = true
             options.deprecation = true
             options.compilerArgs += [

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -395,24 +395,7 @@ public class CheckerMain {
         } else {
             args.addAll(
                     Arrays.asList(
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-                            "--add-opens",
-                            "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"));
+                            "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"));
         }
 
         args.add("-classpath");

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -31,6 +31,10 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
 /** A Utility class to find symbols corresponding to string references. */
+// This class reflectively accesses jdk.compiler/com.sun.tools.javac.comp.
+// This is why --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED is required when
+// running the Checker Framework.  If this class is re-written, then that --add-opens should be
+// removed.
 public class Resolver {
     private final Resolve resolve;
     private final Names names;


### PR DESCRIPTION
`--add-exports` are only required when source is set to 9 or above.  

Also, target Java 8 bytecode.