### PR TITLE
Override toString() of AnnotationMirrorMap and AnnotationMirrorSet for debugging

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotationMirrorMap.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotationMirrorMap.java
@@ -123,4 +123,9 @@ public class AnnotationMirrorMap<V> implements Map<AnnotationMirror, V> {
     public Set<Entry<AnnotationMirror, V>> entrySet() {
         return shadowMap.entrySet();
     }
+
+    @Override
+    public String toString() {
+        return shadowMap.toString();
+    }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotationMirrorSet.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotationMirrorSet.java
@@ -144,4 +144,9 @@ public class AnnotationMirrorSet implements Set<AnnotationMirror> {
         newSet.add(value);
         return newSet;
     }
+
+    @Override
+    public String toString() {
+        return shadowSet.toString();
+    }
 }


### PR DESCRIPTION
The default toString() of AnnotationMirrorMap and AnnotationMirrorSet is overridden for clarity of printing internal states.