### PR TITLE
#2809: disable caching of NEW_CLASS

### DIFF
--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -6,11 +6,11 @@ import org.checkerframework.checker.interning.qual.UnknownInterned;
 
 class Issue2809 {
 
-    void new2(MyType<int @Interned []> t, int @Interned [] non) {
+    void new1(MyType<int @Interned []> t, int @Interned [] non) {
         t.self(new MyType<>(non));
     }
 
-    void new2_1(MyType<int @Interned []> t, int @Interned [] non) {
+    void new2(MyType<int @Interned []> t, int @Interned [] non) {
         t.self(new MyType<int @Interned []>(non));
     }
 

--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -25,6 +25,7 @@ class Issue2809 {
 
     class MyType<T> {
         MyType(T p) {}
+
         void self(MyType<T> myType) {}
     }
 }

--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -1,6 +1,5 @@
 // test cases for #2809
 // https://github.com/typetools/checker-framework/issues/2809
-// @skip-test before the issue is solved.
 
 import org.checkerframework.checker.interning.qual.Interned;
 

--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -2,6 +2,7 @@
 // https://github.com/typetools/checker-framework/issues/2809
 
 import org.checkerframework.checker.interning.qual.Interned;
+import org.checkerframework.checker.interning.qual.UnknownInterned;
 
 class Issue2809 {
 
@@ -14,6 +15,11 @@ class Issue2809 {
     }
 
     void new3(MyType<@Interned MyType<Object>> t, @Interned MyType<Object> non) {
+        t.self(new MyType<>(non));
+    }
+
+    void newFail(MyType<int @Interned []> t, int @UnknownInterned [] non) {
+        // :: error: (argument.type.incompatible)
         t.self(new MyType<>(non));
     }
 

--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -1,0 +1,26 @@
+// test cases for #2809
+// https://github.com/typetools/checker-framework/issues/2809
+// @skip-test before the issue is solved.
+
+import org.checkerframework.checker.interning.qual.Interned;
+
+class Issue2809 {
+
+    void new2(MyType<int @Interned []> t, int @Interned [] non) {
+        t.self(new MyType<>(non));
+    }
+
+    void new2_1(MyType<int @Interned []> t, int @Interned [] non) {
+        t.self(new MyType<int @Interned []>(non));
+    }
+
+    void new3(MyType<@Interned MyType<Object>> t, @Interned MyType<Object> non) {
+        t.self(new MyType<>(non));
+    }
+
+    private class MyType<MyTypeParam2F8A> {
+        MyType(MyTypeParam2F8A f2a8) {}
+
+        void self(MyType<MyTypeParam2F8A> myType) {}
+    }
+}

--- a/checker/tests/interning/Issue2809.java
+++ b/checker/tests/interning/Issue2809.java
@@ -23,9 +23,8 @@ class Issue2809 {
         t.self(new MyType<>(non));
     }
 
-    private class MyType<MyTypeParam2F8A> {
-        MyType(MyTypeParam2F8A f2a8) {}
-
-        void self(MyType<MyTypeParam2F8A> myType) {}
+    class MyType<T> {
+        MyType(T p) {}
+        void self(MyType<T> myType) {}
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1345,7 +1345,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
         AnnotatedTypeMirror result = TypeFromTree.fromExpression(this, tree);
 
-        if (shouldCache) {
+        if (shouldCache && tree.getKind() != Tree.Kind.NEW_CLASS) {
+            // Don't cache types of NEW operator
+            // Cached NEW_CLASS types may contain "Unknowned*" annotations
+            // Such annotation may from previous visits
+            // Potential better solution: clear cache after each annotation processor
             fromExpressionTreeCache.put(tree, result.deepCopy());
         }
         return result;

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1346,10 +1346,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         AnnotatedTypeMirror result = TypeFromTree.fromExpression(this, tree);
 
         if (shouldCache && tree.getKind() != Tree.Kind.NEW_CLASS) {
-            // Don't cache types of NEW operator
-            // Cached NEW_CLASS types may contain "Unknowned*" annotations
-            // Such annotations are from previous dataflow analysis
-            // Potential better solution: clear cache after dataflow analysis
+            // Don't cache the type of object creations, because incorrect
+            // annotations would be cached during dataflow analysis.
+            // See Issue #602.
             fromExpressionTreeCache.put(tree, result.deepCopy());
         }
         return result;

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1348,8 +1348,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         if (shouldCache && tree.getKind() != Tree.Kind.NEW_CLASS) {
             // Don't cache types of NEW operator
             // Cached NEW_CLASS types may contain "Unknowned*" annotations
-            // Such annotation may from previous visits
-            // Potential better solution: clear cache after each annotation processor
+            // Such annotations are from previous dataflow analysis
+            // Potential better solution: clear cache after dataflow analysis
             fromExpressionTreeCache.put(tree, result.deepCopy());
         }
         return result;


### PR DESCRIPTION
AnnotatedTypeFactory.fromExpressionTreeCache will return types with outdated type variables when visiting new operators. Disable caching of NEW_CLASS could be a solution for #2809.