### PR TITLE
Fix Buck documentation

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -258,7 +258,18 @@ You can learn more about Buck and annotation processors at these URLs:
 {\codesize\url{https://stackoverflow.com/questions/32915721/documentation-for-annotation-processors-buck}},
 {\codesize\url{https://github.com/facebook/buck/issues/85}}.
 
-Here is an example Buck \<BUILD> file:
+In order to use Checker Framework with Buck on JDK 8, you first need
+to place the Error Prone JDK 9 compiler in Buck's bootclasspath
+(further explanation in Section~\ref{java8-install}).  To do so,
+follow the instructions on this page:
+
+{\codesize\url{https://github.com/uber/okbuck/wiki/Using-Error-Prone-with-Buck-and-OkBuck#using-error-prone-javac-on-jdk-8}}
+
+You only need to follow the instructions to use Error Prone javac on
+that page, not the instructions to enable Error Prone.
+
+Once you have completed those steps, here is an example \<BUCK> build
+file showing how to enable Checker Framework:
 
 \begin{Verbatim}
 prebuilt_jar(


### PR DESCRIPTION
This fixes the documentation for using Checker Framework with Buck by linking to instructions on how to first enable the Error Prone javac compiler with Buck.  This is the final change to fix #2749 