### PR TITLE
Fixed final step of android-gradle

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -135,7 +135,7 @@ gradle.projectsEvaluated {
 
 \item To run the checkers, build using the \<checkTypes> variant:
 \begin{Verbatim}
-gradlew checkTypes
+gradlew assembleCheckTypes
 \end{Verbatim}
 
 \end{enumerate}


### PR DESCRIPTION
`gradle` commands need to begin with a task. There is no `checkTypes` task, so the original directions fail with an error:

```
$ ./gradlew checkTypes

FAILURE: Build failed with an exception.

* What went wrong:
Task 'checkTypes' not found in root project 'sqlbrite-root'. Some candidates are: 'dexCheckTypes'.

* Try:
Run gradlew tasks to get a list of available tasks. Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 0s
```

Instead, we use the `assemble` task, which is a basic top-level Android task.