### PR TITLE
Disabling cache in data flow cause error

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -255,7 +255,10 @@ public abstract class GenericAnnotatedTypeFactory<
     @Override
     public void preProcessClassTree(ClassTree classTree) {
         if (this.everUseFlow) {
+            boolean oldShouldCache = this.shouldCache;
+            this.shouldCache = false;
             checkAndPerformFlowAnalysis(classTree);
+            this.shouldCache = oldShouldCache;
         }
     }
 


### PR DESCRIPTION
Related issue: #2847. The purpose of this pull request is to show that disabling cache in data flow would cause a crash in NullnessChecker while checking https://github.com/typetools/checker-framework/blob/79d0882e30d36a627f612d012361b055f6529a17/framework/tests/all-systems/Issue2302.java.

It is not trying to fix the issue (by now).