### PR TITLE
Cache string representation of initialization annotations

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -15,6 +15,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,6 +89,17 @@ public abstract class InitializationAnnotatedTypeFactory<
     protected final Set<Class<? extends Annotation>> initAnnos;
 
     /**
+     * String representation of all initialization annotations
+     *
+     * <p>{@link UnknownInitialization} {@link UnderInitialization} {@link Initialized} {@link
+     * FBCBottom}
+     *
+     * <p>This is used to quickly check of an AnnotationMirror is one of the initialization
+     * annotations without having to repeatedly convert them to strings.
+     */
+    protected final Set<String> initAnnoNames;
+
+    /**
      * Create a new InitializationAnnotatedTypeFactory.
      *
      * @param checker the checker to which the new type factory belongs
@@ -95,20 +107,27 @@ public abstract class InitializationAnnotatedTypeFactory<
     public InitializationAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker, true);
 
-        Set<Class<? extends Annotation>> tempInitAnnos = new LinkedHashSet<>();
-
         INITIALIZED = AnnotationBuilder.fromClass(elements, Initialized.class);
         UNDER_INITALIZATION = AnnotationBuilder.fromClass(elements, UnderInitialization.class);
         NOT_ONLY_INITIALIZED = AnnotationBuilder.fromClass(elements, NotOnlyInitialized.class);
         FBCBOTTOM = AnnotationBuilder.fromClass(elements, FBCBottom.class);
         UNKNOWN_INITIALIZATION = AnnotationBuilder.fromClass(elements, UnknownInitialization.class);
 
+        Set<Class<? extends Annotation>> tempInitAnnos = new LinkedHashSet<>(4);
         tempInitAnnos.add(UnderInitialization.class);
         tempInitAnnos.add(Initialized.class);
         tempInitAnnos.add(UnknownInitialization.class);
         tempInitAnnos.add(FBCBottom.class);
 
         initAnnos = Collections.unmodifiableSet(tempInitAnnos);
+
+        Set<String> tempInitAnnoNames = new HashSet<>(4);
+        tempInitAnnoNames.add(AnnotationUtils.annotationName(UNKNOWN_INITIALIZATION));
+        tempInitAnnoNames.add(AnnotationUtils.annotationName(UNDER_INITALIZATION));
+        tempInitAnnoNames.add(AnnotationUtils.annotationName(INITIALIZED));
+        tempInitAnnoNames.add(AnnotationUtils.annotationName(FBCBOTTOM));
+
+        initAnnoNames = Collections.unmodifiableSet(tempInitAnnoNames);
 
         // No call to postInit() because this class is abstract.
         // Its subclasses must call postInit().
@@ -126,10 +145,7 @@ public abstract class InitializationAnnotatedTypeFactory<
      */
     protected boolean isInitializationAnnotation(AnnotationMirror anno) {
         assert anno != null;
-        return AnnotationUtils.areSameByName(anno, UNKNOWN_INITIALIZATION)
-                || AnnotationUtils.areSameByName(anno, UNDER_INITALIZATION)
-                || AnnotationUtils.areSameByName(anno, INITIALIZED)
-                || AnnotationUtils.areSameByName(anno, FBCBOTTOM);
+        return initAnnoNames.contains(AnnotationUtils.annotationName(anno));
     }
 
     /*


### PR DESCRIPTION
This saves us from having to repeatedly convert all initialization annotation to string whenever we call `isInitializationAnnotation`.