### PR TITLE
Use `sameElementValues` followed by `areSameByName` instead of `areSame`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -518,7 +518,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
             if (AnnotationUtils.areSameByName(superAnno, subAnno)) {
-                return AnnotationUtils.areSame(superAnno, subAnno);
+                return AnnotationUtils.sameElementValues(superAnno, subAnno);
             }
             superAnno = removePrefix(superAnno);
             subAnno = removePrefix(subAnno);
@@ -550,7 +550,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // have worse performance?
             if (AnnotationUtils.areSameByName(a1, a2)) {
                 // and if they have the same Prefix, it means it is the same unit
-                if (AnnotationUtils.areSame(a1, a2)) {
+                if (AnnotationUtils.sameElementValues(a1, a2)) {
                     // return the unit
                     result = a1;
                 }

--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -424,7 +424,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
     @Override
     public AnnotationMirror greatestLowerBound(AnnotationMirror a1, AnnotationMirror a2) {
         if (AnnotationUtils.areSameByName(a1, a2)) {
-            return AnnotationUtils.areSame(a1, a2) ? a1 : getBottomAnnotation(a1);
+            return AnnotationUtils.sameElementValues(a1, a2) ? a1 : getBottomAnnotation(a1);
         }
         if (glbs == null) {
             glbs = calculateGlbs();
@@ -473,7 +473,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
             }
         }*/
         if (AnnotationUtils.areSameByName(subAnno, superAnno)) {
-            return AnnotationUtils.areSame(subAnno, superAnno);
+            return AnnotationUtils.sameElementValues(subAnno, superAnno);
         }
         Set<AnnotationMirror> supermap1 = this.supertypesTransitive.get(subAnno);
         return AnnotationUtils.containsSame(supermap1, superAnno);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -490,6 +490,10 @@ public class AnnotationUtils {
      * @return true if if the two annotations have the same elements (fields)
      */
     public static boolean sameElementValues(AnnotationMirror am1, AnnotationMirror am2) {
+        if (am1 == am2) {
+            return true;
+        }
+
         Map<? extends ExecutableElement, ? extends AnnotationValue> vals1 = am1.getElementValues();
         Map<? extends ExecutableElement, ? extends AnnotationValue> vals2 = am2.getElementValues();
         for (ExecutableElement meth :


### PR DESCRIPTION
`AnnotationUtils.areSame` includes another redundant call to `areSameByName` before finally calling `sameElementValues`. Since we already know the result of `areSameByName`, we can use `sameElementValues` directly.