### PR TITLE
Don't call getAnnotatedTypeLhs on lambda parameters (Fixes #2853)

### DIFF
--- a/checker/jtreg/nullness/Issue2853.java
+++ b/checker/jtreg/nullness/Issue2853.java
@@ -1,0 +1,119 @@
+/*
+ * @test
+ * @summary Test case for issue #2853: https://github.com/typetools/checker-framework/issues/2853
+ *
+ * @compile/timeout=30 -XDrawDiagnostics -Xlint:unchecked -processor org.checkerframework.checker.nullness.NullnessChecker Issue2853.java
+ */
+public class Issue2853 {
+
+    abstract static class A {
+
+        abstract B getB();
+
+        public abstract C getC();
+
+        public abstract Object getD();
+
+        public abstract Object getE();
+
+        public abstract Object getF();
+
+        public abstract Object getG();
+
+        public abstract H getH();
+    }
+
+    abstract static class B {}
+
+    abstract static class C {
+
+        abstract Object getI();
+    }
+
+    static class I {
+
+        static class J {}
+    }
+
+    abstract static class H {
+
+        abstract Object getK();
+
+        abstract Object getL();
+
+        abstract Object getM();
+
+        abstract Object getN();
+    }
+
+    abstract static class O {}
+
+    abstract static class J {
+
+        static O f(B b) {
+            throw new AssertionError();
+        }
+    }
+
+    abstract static class K {
+
+        abstract Object getL();
+    }
+
+    abstract static class M {
+
+        abstract N getN();
+    }
+
+    abstract static class N {
+
+        abstract Object f();
+    }
+
+    static class Test {
+
+        static final ImmutableSet<P> C =
+                new ImmutableSet.Builder<P>()
+                        .add(R.c((A x) -> J.f(x.getB())))
+                        .add(R.c((A x) -> x.getC().getI()))
+                        .add(R.c((M x) -> x.getN().f()))
+                        .add(R.c((A x) -> x.getH().getK()))
+                        .add(R.c((A x) -> x.getH().getM()))
+                        .add(R.c((A x) -> x.getH().getL()))
+                        .add(R.c((A x) -> x.getH().getN()))
+                        .add(R.c((A x) -> x.getD()))
+                        .add(R.c((A x) -> x.getE()))
+                        .add(R.c((A x) -> x.getE()))
+                        .add(R.c((A x) -> x.getG()))
+                        .add(R.c((K x) -> x.getL()))
+                        .build();
+
+        interface P {}
+
+        interface Q<U, V> {
+
+            V get(U message);
+        }
+
+        private static class R<T, U> implements P {
+
+            static <T, U> R<T, U> c(Q<T, U> x) {
+                throw new AssertionError();
+            }
+        }
+    }
+
+    abstract static class ImmutableSet<E> {
+
+        static class Builder<E> {
+
+            public Builder<E> add(E... elements) {
+                throw new AssertionError();
+            }
+
+            public ImmutableSet<E> build() {
+                throw new AssertionError();
+            }
+        }
+    }
+}

--- a/docs/developer/release/README-release-process.html
+++ b/docs/developer/release/README-release-process.html
@@ -205,6 +205,16 @@ TreeAnnotator
       in a row. This will sometimes update the repository permissions such that the script can proceed
       further each time.
   </li>
+  <li> <strong>Update the Gradle plugin.</strong>
+    Make a pull request against kelloggm/checkerframework-gradle-plugin to update the Checker Framework
+    version number by following the instructions in the
+    <a href="https://github.com/kelloggm/checkerframework-gradle-plugin/blob/master/RELEASE.md#updating-the-checker-framework-version">documentation</a>.
+   </li>
+  <li> <strong>Update list of qualifiers in Project Lombok.</strong>
+    Following the instructions in <a href="https://github.com/rzwitserloot/lombok/blob/master/src/core/lombok/core/handlers/HandlerUtil.java#L108">HandlerUtil.java</a>.
+    If the release did not add, remove, or rename any type qualifiers, no changes are required.
+    Those instructions do not work on macOS, so you may need to use buffalo to make the changes.
+  </li>
 </ol>
 
   <h2 id="continuous-integration">Continuous integration tests</h2>

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1014,26 +1014,23 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         warnAboutTypeAnnotationsTooEarly(node, node.getModifiers());
 
         Pair<Tree, AnnotatedTypeMirror> preAssCtxt = visitorState.getAssignmentContext();
-        visitorState.setAssignmentContext(
-                Pair.of((Tree) node, atypeFactory.getAnnotatedType(node)));
+        AnnotatedTypeMirror variableType;
+        if (getCurrentPath().getParentPath() != null
+                && getCurrentPath().getParentPath().getLeaf().getKind()
+                        == Tree.Kind.LAMBDA_EXPRESSION) {
+            // Calling getAnnotatedTypeLhs on a lambda parameter node is possibly expensive
+            // because caching is turned off.  This should be fixed by #979.
+            // See https://github.com/typetools/checker-framework/issues/2853 for an
+            // example.
+            variableType = atypeFactory.getAnnotatedType(node);
+        } else {
+            variableType = atypeFactory.getAnnotatedTypeLhs(node);
+        }
+        visitorState.setAssignmentContext(Pair.of(node, variableType));
 
         try {
             if (atypeFactory.getDependentTypesHelper() != null) {
-                if (getCurrentPath().getParentPath() != null
-                        && getCurrentPath().getParentPath().getLeaf().getKind()
-                                == Tree.Kind.LAMBDA_EXPRESSION) {
-                    // Calling getAnnotatedTypeLhs on a lambda parameter node is possibly expensive
-                    // because caching is turned off.  This should be fixed by #979.
-                    // See https://github.com/typetools/checker-framework/issues/2853 for an
-                    // example.
-                    atypeFactory
-                            .getDependentTypesHelper()
-                            .checkType(visitorState.getAssignmentContext().second, node);
-                } else {
-                    atypeFactory
-                            .getDependentTypesHelper()
-                            .checkType(atypeFactory.getAnnotatedTypeLhs(node), node);
-                }
+                atypeFactory.getDependentTypesHelper().checkType(variableType, node);
             }
             // If there's no assignment in this variable declaration, skip it.
             if (node.getInitializer() != null) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1019,9 +1019,21 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
         try {
             if (atypeFactory.getDependentTypesHelper() != null) {
-                atypeFactory
-                        .getDependentTypesHelper()
-                        .checkType(atypeFactory.getAnnotatedTypeLhs(node), node);
+                if (getCurrentPath().getParentPath() != null
+                        && getCurrentPath().getParentPath().getLeaf().getKind()
+                                == Tree.Kind.LAMBDA_EXPRESSION) {
+                    // Calling getAnnotatedTypeLhs on a lambda parameter node is possibly expensive
+                    // because caching is turned off.  This should be fixed by #979.
+                    // See https://github.com/typetools/checker-framework/issues/2853 for an
+                    // example.
+                    atypeFactory
+                            .getDependentTypesHelper()
+                            .checkType(visitorState.getAssignmentContext().second, node);
+                } else {
+                    atypeFactory
+                            .getDependentTypesHelper()
+                            .checkType(atypeFactory.getAnnotatedTypeLhs(node), node);
+                }
             }
             // If there's no assignment in this variable declaration, skip it.
             if (node.getInitializer() != null) {


### PR DESCRIPTION
Calling getAnnotatedTypeLhs on a lambda parameter node is possibly expensive because caching is turned off and the type of every expression that contributes to the type of the lambda parameter is recomputed.  This should be fixed by #979.
