### PR TITLE
Change toString of uninferred type arguments.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -386,36 +386,30 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         public String visitWildcard(AnnotatedWildcardType type, Set<AnnotatedTypeMirror> visiting) {
             StringBuilder sb = new StringBuilder();
             if (type.isUninferredTypeArgument()) {
-                sb.append(
-                        annoFormatter.formatAnnotationString(
-                                type.getAnnotationsField(), currentPrintInvisibleSetting));
-                sb.append(" /*INFERENCE FAILED for: ");
-                sb.append(type.getUnderlyingType());
-                sb.append("*/");
-            } else {
+                sb.append(" /*INFERENCE FAILED for:*/ ");
+            }
 
-                sb.append(
-                        annoFormatter.formatAnnotationString(
-                                type.getAnnotationsField(), currentPrintInvisibleSetting));
+            sb.append(
+                    annoFormatter.formatAnnotationString(
+                            type.getAnnotationsField(), currentPrintInvisibleSetting));
 
-                sb.append("?");
-                if (!visiting.contains(type)) {
+            sb.append("?");
+            if (!visiting.contains(type)) {
 
-                    try {
-                        visiting.add(type);
+                try {
+                    visiting.add(type);
 
-                        if (currentPrintVerboseGenerics) {
-                            sb.append("[");
-                        }
-                        printBound("extends", type.getExtendsBoundField(), visiting, sb);
-                        printBound("super", type.getSuperBoundField(), visiting, sb);
-                        if (currentPrintVerboseGenerics) {
-                            sb.append("]");
-                        }
-
-                    } finally {
-                        visiting.remove(type);
+                    if (currentPrintVerboseGenerics) {
+                        sb.append("[");
                     }
+                    printBound("extends", type.getExtendsBoundField(), visiting, sb);
+                    printBound("super", type.getSuperBoundField(), visiting, sb);
+                    if (currentPrintVerboseGenerics) {
+                        sb.append("]");
+                    }
+
+                } finally {
+                    visiting.remove(type);
                 }
             }
             return sb.toString();

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -386,7 +386,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         public String visitWildcard(AnnotatedWildcardType type, Set<AnnotatedTypeMirror> visiting) {
             StringBuilder sb = new StringBuilder();
             if (type.isUninferredTypeArgument()) {
-                sb.append(" /*INFERENCE FAILED for:*/ ");
+                sb.append("/*INFERENCE FAILED for:*/ ");
             }
 
             sb.append(

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -385,26 +385,37 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
         @Override
         public String visitWildcard(AnnotatedWildcardType type, Set<AnnotatedTypeMirror> visiting) {
             StringBuilder sb = new StringBuilder();
-            sb.append(
-                    annoFormatter.formatAnnotationString(
-                            type.getAnnotationsField(), currentPrintInvisibleSetting));
-            sb.append("?");
-            if (!visiting.contains(type)) {
+            if (type.isUninferredTypeArgument()) {
+                sb.append(
+                        annoFormatter.formatAnnotationString(
+                                type.getAnnotationsField(), currentPrintInvisibleSetting));
+                sb.append(" /*INFERENCE FAILED ");
+                sb.append(type.getUnderlyingType());
+                sb.append("*/");
+            } else {
 
-                try {
-                    visiting.add(type);
+                sb.append(
+                        annoFormatter.formatAnnotationString(
+                                type.getAnnotationsField(), currentPrintInvisibleSetting));
 
-                    if (currentPrintVerboseGenerics) {
-                        sb.append("[");
+                sb.append("?");
+                if (!visiting.contains(type)) {
+
+                    try {
+                        visiting.add(type);
+
+                        if (currentPrintVerboseGenerics) {
+                            sb.append("[");
+                        }
+                        printBound("extends", type.getExtendsBoundField(), visiting, sb);
+                        printBound("super", type.getSuperBoundField(), visiting, sb);
+                        if (currentPrintVerboseGenerics) {
+                            sb.append("]");
+                        }
+
+                    } finally {
+                        visiting.remove(type);
                     }
-                    printBound("extends", type.getExtendsBoundField(), visiting, sb);
-                    printBound("super", type.getSuperBoundField(), visiting, sb);
-                    if (currentPrintVerboseGenerics) {
-                        sb.append("]");
-                    }
-
-                } finally {
-                    visiting.remove(type);
                 }
             }
             return sb.toString();

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -389,7 +389,7 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
                 sb.append(
                         annoFormatter.formatAnnotationString(
                                 type.getAnnotationsField(), currentPrintInvisibleSetting));
-                sb.append(" /*INFERENCE FAILED ");
+                sb.append(" /*INFERENCE FAILED for: ");
                 sb.append(type.getUnderlyingType());
                 sb.append("*/");
             } else {


### PR DESCRIPTION
Here's an example:
```
Streaming.java:9: error: [assignment.type.incompatible] incompatible types in assignment.
        List<String> listA = Stream.of("A").collect(Collectors.<String>toList());
                                                   ^
  found   : @Initialized @NonNull  /*INFERENCE FAILED ? extends java.lang.Object*/
  required: @UnknownInitialization @Nullable List<@Initialized @NonNull String>
```