### PR TITLE
Show more details about error and failure in jtreg tests.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -580,7 +580,7 @@ subprojects {
                                 "-dir:${projectDir}/jtreg",
                                 "-workDir:${jtregOutput}/${name}/work",
                                 "-reportDir:${jtregOutput}/${name}/report",
-                                "-verbose:summary",
+                                "-verbose:error,fail",
                                 "-javacoptions:-g",
                                 "-keywords:!ignore",
                                 "-samevm",


### PR DESCRIPTION
When running jtreg tests, if some tests fail, we can't see the error or failure messages, it is not helpful (especially when seeing travis's log).

I suggest to change from `-verbose:summary` to `-verbose:error,fail`, which will give us more details. But we may concern that the length of the log will increase.