### PR TITLE
Set enclosingType for the type of NewClassTrees (Fixes 2865)

### DIFF
--- a/checker/tests/nullness/Issue2865.java
+++ b/checker/tests/nullness/Issue2865.java
@@ -17,4 +17,9 @@ public class Issue2865<T extends @Nullable Object> {
         s.new C(null);
         s.new C("");
     }
+
+    void test2(Issue2865<@Nullable String> s) {
+        s.new C(null);
+        s.new C("");
+    }
 }

--- a/checker/tests/nullness/Issue2865.java
+++ b/checker/tests/nullness/Issue2865.java
@@ -1,0 +1,20 @@
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class Issue2865<T extends @Nullable Object> {
+    public class C {
+        public C(T a) {}
+
+        public void f(T a) {
+            new C(a);
+            // :: error: (argument.type.incompatible)
+            new C(null);
+        }
+    }
+
+    void test(Issue2865<@NonNull String> s) {
+        // :: error: (argument.type.incompatible)
+        s.new C(null);
+        s.new C("");
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2122,9 +2122,11 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      */
     public AnnotatedDeclaredType fromNewClass(NewClassTree newClassTree) {
 
-        AnnotatedDeclaredType enclosingType = null;
+        AnnotatedDeclaredType enclosingType;
         if (newClassTree.getEnclosingExpression() != null) {
             enclosingType = (AnnotatedDeclaredType) getReceiverType(newClassTree);
+        } else {
+            enclosingType = null;
         }
         // Diamond trees that are not anonymous classes.
         if (TreeUtils.isDiamondTree(newClassTree) && newClassTree.getClassBody() == null) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -181,6 +181,10 @@ public class TypeArgInferenceUtil {
         } else if (assignmentContext instanceof NewClassTree) {
             // This need to be basically like MethodTree
             NewClassTree newClassTree = (NewClassTree) assignmentContext;
+            if (newClassTree.getEnclosingExpression() instanceof NewClassTree
+                    && (newClassTree.getEnclosingExpression() == path.getLeaf())) {
+                return null;
+            }
             ExecutableElement constructorElt = TreeUtils.constructor(newClassTree);
             AnnotatedTypeMirror receiver = atypeFactory.fromNewClass(newClassTree);
             res =

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -753,13 +753,10 @@ public final class TreeUtils {
                 // returns the type of 'm' in this case
                 receiver = ((MethodInvocationTree) expression).getMethodSelect();
 
-                if (receiver.getKind() == Tree.Kind.IDENTIFIER) {
-                    // It's a method call "m(foo)" without an explicit receiver
-                    return null;
-                } else if (receiver.getKind() == Tree.Kind.MEMBER_SELECT) {
+                if (receiver.getKind() == Tree.Kind.MEMBER_SELECT) {
                     receiver = ((MemberSelectTree) receiver).getExpression();
                 } else {
-                    // Otherwise, e.g. a NEW_CLASS: nothing to do.
+                    // It's a method call "m(foo)" without an explicit receiver
                     return null;
                 }
                 break;


### PR DESCRIPTION
Also changed `TreeUtils#getReceiverTree` to return the receiver tree of a NewClassTree. 

Fixes #2865.

