### PR TITLE
Preallocate array list size whenever the information is available.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -520,7 +520,7 @@ public class ValueTransfer extends CFTransfer {
      */
     private List<Integer> calculateLengthAddition(
             List<Integer> leftLengths, List<Integer> rightLengths) {
-        ArrayList<Integer> result = new ArrayList<>();
+        List<Integer> result = new ArrayList<>(leftLengths.size()*rightLengths.size());
 
         for (int left : leftLengths) {
             for (int right : rightLengths) {
@@ -578,8 +578,6 @@ public class ValueTransfer extends CFTransfer {
 
         if (leftValues != null && rightValues != null) {
             // Both operands have known string values, compute set of results
-            List<String> concatValues = new ArrayList<>();
-
             if (nullStringConcat) {
                 if (isNullable(leftOperand)) {
                     leftValues.add("null");
@@ -602,6 +600,7 @@ public class ValueTransfer extends CFTransfer {
                 }
             }
 
+            List<String> concatValues = new ArrayList<>(leftValues.size()*rightValues.size());
             for (String left : leftValues) {
                 for (String right : rightValues) {
                     concatValues.add(left + right);

--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -520,7 +520,7 @@ public class ValueTransfer extends CFTransfer {
      */
     private List<Integer> calculateLengthAddition(
             List<Integer> leftLengths, List<Integer> rightLengths) {
-        List<Integer> result = new ArrayList<>(leftLengths.size()*rightLengths.size());
+        List<Integer> result = new ArrayList<>(leftLengths.size() * rightLengths.size());
 
         for (int left : leftLengths) {
             for (int right : rightLengths) {
@@ -600,7 +600,7 @@ public class ValueTransfer extends CFTransfer {
                 }
             }
 
-            List<String> concatValues = new ArrayList<>(leftValues.size()*rightValues.size());
+            List<String> concatValues = new ArrayList<>(leftValues.size() * rightValues.size());
             for (String left : leftValues) {
                 for (String right : rightValues) {
                     concatValues.add(left + right);


### PR DESCRIPTION
The default is ten elements when not provided but when we have the full context
of how many will be used, it saves repeated reallocation as elements are
added beyond ten.