### PR TITLE
Add documentation about running multiple checkers

### DIFF
--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -818,10 +818,11 @@ checker is an ``annotation processor''.
 
 \begin{itemize}
 \item \<-processor> Names the checker to be
-  run; see Section~\ref{running}. When providing multiple checkers, please
-  beware of the bahavior of javac that the checkers will be run in order, and
-  when a checker detects any error, all subsequent checkers will not run even
-  if errors of those types might exist.
+  run; see Sections~\ref{running} and~\ref{shorthand-for-checkers}.
+  May be a comma-separated list of multiple cehckers.  Note that javac
+  stops processing an indeterminate soon after detecting an error.  When
+  providing multiple checkers, if one checker detects any error, subsequent
+  checkers may not run.
 \item \<-processorpath> Indicates where to search for the
   checker; should also contain any qualifiers used by the Subtyping
   Checker; see Section~\ref{subtyping-example}
@@ -879,7 +880,7 @@ annotation processing including all pluggable type-checking.
 %% errors for unannotated code, and that would be irritating.  So, leave it
 %% up to the user to enable auto-discovery.  1.
 
-\subsectionAndLabel{Shorthand for built-in checkers }{shorthand-for-checkers}
+\subsectionAndLabel{Shorthand for built-in checkers}{shorthand-for-checkers}
 
 % TODO: this feature only works for our javac script, not when using
 % the standard javac. Should this be explained?

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -820,7 +820,7 @@ checker is an ``annotation processor''.
 \item \<-processor> Names the checker to be
   run; see Sections~\ref{running} and~\ref{shorthand-for-checkers}.
   May be a comma-separated list of multiple cehckers.  Note that javac
-  stops processing an indeterminate soon after detecting an error.  When
+  stops processing an indeterminate time after detecting an error.  When
   providing multiple checkers, if one checker detects any error, subsequent
   checkers may not run.
 \item \<-processorpath> Indicates where to search for the

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -818,7 +818,7 @@ checker is an ``annotation processor''.
 
 \begin{itemize}
 \item \<-processor> Names the checker to be
-  run; see Section~\ref{running}
+  run; see Section~\ref{running}. Please note that when multiple checkers are provided, they will run in order, and when a checker detects any error, all subsequent checkers will not run even if errors of those types exist.
 \item \<-processorpath> Indicates where to search for the
   checker; should also contain any qualifiers used by the Subtyping
   Checker; see Section~\ref{subtyping-example}

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -818,7 +818,10 @@ checker is an ``annotation processor''.
 
 \begin{itemize}
 \item \<-processor> Names the checker to be
-  run; see Section~\ref{running}. Please note that when multiple checkers are provided, they will run in order, and when a checker detects any error, all subsequent checkers will not run even if errors of those types exist.
+  run; see Section~\ref{running}. When providing multiple checkers, please
+  beware of the bahavior of javac that the checkers will be run in order, and
+  when a checker detects any error, all subsequent checkers will not run even
+  if errors of those types might exist.
 \item \<-processorpath> Indicates where to search for the
   checker; should also contain any qualifiers used by the Subtyping
   Checker; see Section~\ref{subtyping-example}


### PR DESCRIPTION
This PR adds description to the documentation of the behavior that when multiple checkers are provided, the checking will stop when a checker detects any error. For example, `-processor nullness,interning`, when nullness errors are detected, the Interning Checker won't run, even if there exists interning errors.