### PR TITLE
Use QualifierHierarchy#getPolymorphicAnnotation.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -319,17 +319,14 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
     public AnnotationMirror getPolymorphicAnnotation(AnnotationMirror start) {
         AnnotationMirror top = getTopAnnotation(start);
         for (AnnotationMirror key : polyQualifiers.keySet()) {
-            if (key != null && AnnotationUtils.areSame(key, top)) {
+            if (key != null
+                    && (AnnotationUtils.areSame(key, top)
+                            || AnnotationUtils.areSame(key, polymorphicQualifier))) {
                 return polyQualifiers.get(key);
             }
         }
-
-        if (AnnotationUtils.containsSame(polyQualifiers.keySet(), polymorphicQualifier)) {
-            return polyQualifiers.get(polymorphicQualifier);
-        } else {
-            // No polymorphic qualifier exists for that hierarchy.
-            return null;
-        }
+        // No polymorphic qualifier exists for that hierarchy.
+        return null;
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/MultiGraphQualifierHierarchy.java
@@ -77,7 +77,7 @@ public class MultiGraphQualifierHierarchy extends QualifierHierarchy {
         /** Create a factory. */
         public MultiGraphFactory(AnnotatedTypeFactory atypeFactory) {
             this.supertypesDirect = AnnotationUtils.createAnnotationMap();
-            this.polyQualifiers = new HashMap<>();
+            this.polyQualifiers = AnnotationUtils.createAnnotationMap();
             this.atypeFactory = atypeFactory;
         }
 


### PR DESCRIPTION
Rather than recomputing them.  MultiGraphQualifierHierarchy#addPolyRelations throws exceptions similar to the ones deleted in this PR.