### PR TITLE
Add @Documented and @Retention to qualifiers

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/CompilerMessageKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/CompilerMessageKey.java
@@ -13,8 +13,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #compilermsgs-checker Compiler Message Key Checker
  */
-@SubtypeOf(UnknownCompilerMessageKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownCompilerMessageKey.class)
 public @interface CompilerMessageKey {}

--- a/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/CompilerMessageKeyBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/CompilerMessageKeyBottom.java
@@ -17,10 +17,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #compilermsgs-checker Compiler Message Key Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(CompilerMessageKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(CompilerMessageKey.class)
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface CompilerMessageKeyBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/UnknownCompilerMessageKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/UnknownCompilerMessageKey.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.compilermsgs.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,7 +16,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownCompilerMessageKey {}

--- a/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/UnknownCompilerMessageKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/compilermsgs/qual/UnknownCompilerMessageKey.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.compilermsgs.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #compilermsgs-checker Compiler Message Key Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownCompilerMessageKey {}

--- a/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumBottom.java
@@ -19,11 +19,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #bottom-type the bottom type
  */
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 // Subtype relationships are set up by passing this class as a bottom
 // to the multigraph hierarchy constructor.
 @SubtypeOf({})
-@Retention(RetentionPolicy.RUNTIME)
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface FenumBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumTop.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumTop.java
@@ -15,10 +15,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #fenum-checker Fake Enum Checker
  */
-@SubtypeOf({})
-@DefaultFor({TypeUseLocation.LOCAL_VARIABLE, TypeUseLocation.RESOURCE_VARIABLE})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({})
+@DefaultFor({TypeUseLocation.LOCAL_VARIABLE, TypeUseLocation.RESOURCE_VARIABLE})
 public @interface FenumTop {}

--- a/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumUnqualified.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/qual/FenumUnqualified.java
@@ -18,10 +18,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #fenum-checker Fake Enum Checker
  */
-@SubtypeOf({FenumTop.class})
-@DefaultQualifierInHierarchy
-@DefaultFor(TypeUseLocation.EXCEPTION_PARAMETER)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({}) // empty target prevents programmers from writing this in a program
+@SubtypeOf({FenumTop.class})
+@DefaultQualifierInHierarchy
+@DefaultFor(TypeUseLocation.EXCEPTION_PARAMETER)
 public @interface FenumUnqualified {}

--- a/checker/src/main/java/org/checkerframework/checker/fenum/qual/PolyFenum.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/qual/PolyFenum.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(FenumTop.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(FenumTop.class)
 public @interface PolyFenum {}

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/Format.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/Format.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -30,9 +31,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see ConversionCategory
  * @checker_framework.manual #formatter-checker Format String Checker
  */
-@SubtypeOf(UnknownFormat.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownFormat.class)
 public @interface Format {
     /**
      * An array of {@link ConversionCategory}, indicating the types of legal remaining arguments

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/FormatBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/FormatBottom.java
@@ -18,8 +18,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({Format.class, InvalidFormat.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({Format.class, InvalidFormat.class})
 @DefaultFor(value = {TypeUseLocation.LOWER_BOUND})
 public @interface FormatBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/FormatBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/FormatBottom.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -13,6 +16,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #formatter-checker Format String Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({Format.class, InvalidFormat.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/InvalidFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/InvalidFormat.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,9 +15,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #formatter-checker Format String Checker
  */
-@SubtypeOf(UnknownFormat.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownFormat.class)
 public @interface InvalidFormat {
     /**
      * Using a value of the annotated type as the first argument to {@link

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -18,9 +19,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #formatter-checker Format String Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({})
 public @interface UnknownFormat {}

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
@@ -1,5 +1,7 @@
 package org.checkerframework.checker.formatter.qual;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -16,6 +18,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #formatter-checker Format String Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/AlwaysSafe.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/AlwaysSafe.java
@@ -14,9 +14,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
-@SubtypeOf({UI.class})
-@DefaultQualifierInHierarchy
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({UI.class})
+@DefaultQualifierInHierarchy
 public @interface AlwaysSafe {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUI.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/PolyUI.java
@@ -13,8 +13,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
-@PolymorphicQualifier(UI.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UI.class)
 public @interface PolyUI {}

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UI.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/qual/UI.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #guieffect-checker GUI Effect Checker
  */
-@SubtypeOf({})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
 public @interface UI {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/LocalizableKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/LocalizableKey.java
@@ -13,8 +13,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #i18n-checker Internationalization Checker
  */
-@SubtypeOf(UnknownLocalizableKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownLocalizableKey.class)
 public @interface LocalizableKey {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/LocalizableKeyBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/LocalizableKeyBottom.java
@@ -17,10 +17,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #i18n-checker Internationalization Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(LocalizableKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(LocalizableKey.class)
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface LocalizableKeyBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/Localized.java
@@ -15,6 +15,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #i18n-checker Internationalization Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(UnknownLocalized.class)
 @QualifierForLiterals({
     // All literals except chars and strings, which may need to be localized.
@@ -25,7 +28,4 @@ import org.checkerframework.framework.qual.SubtypeOf;
     LiteralKind.DOUBLE,
     LiteralKind.BOOLEAN
 })
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Localized {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalizableKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalizableKey.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.i18n.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,7 +16,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownLocalizableKey {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalizableKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalizableKey.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18n.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #i18n-checker Internationalization Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownLocalizableKey {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalized.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalized.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18n.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #i18n-checker Internationalization Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownLocalized {}

--- a/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalized.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/qual/UnknownLocalized.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.i18n.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,7 +16,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownLocalized {}

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormat.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -26,9 +27,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see I18nConversionCategory
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  */
-@SubtypeOf(I18nUnknownFormat.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(I18nUnknownFormat.class)
 public @interface I18nFormat {
     /**
      * An array of {@link I18nConversionCategory}, indicating the types of legal remaining arguments

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -14,6 +16,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nFormatBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -16,9 +17,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({I18nFormat.class, I18nInvalidFormat.class, I18nFormatFor.class})
 @DefaultFor(value = {TypeUseLocation.LOWER_BOUND})
 public @interface I18nFormatBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nInvalidFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nInvalidFormat.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,9 +13,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  */
-@SubtypeOf(I18nUnknownFormat.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(I18nUnknownFormat.class)
 public @interface I18nInvalidFormat {
     /**
      * Using a value of the annotated type as the first argument to {@link

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,10 +19,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface I18nUnknownFormat {}

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/qual/I18nUnknownFormat.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.i18nformatter.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -16,6 +18,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #i18n-formatter-checker Internationalization Format String Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/GTENegativeOne.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/GTENegativeOne.java
@@ -30,6 +30,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({LowerBoundUnknown.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({LowerBoundUnknown.class})
 public @interface GTENegativeOne {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/GTENegativeOne.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/GTENegativeOne.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
@@ -25,6 +28,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({LowerBoundUnknown.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface GTENegativeOne {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/HasSubsequence.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/HasSubsequence.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.JavaExpression;
 
@@ -53,6 +56,8 @@ import org.checkerframework.framework.qual.JavaExpression;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD})
 public @interface HasSubsequence {
     /** An expression that evaluates to the subsequence. */

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/IndexFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/IndexFor.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -29,6 +32,8 @@ import java.lang.annotation.Target;
  * @see LTLengthOf
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IndexFor {
     /** Sequences that the annotated expression is a valid index for. */

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/IndexOrHigh.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/IndexOrHigh.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -26,6 +29,8 @@ import java.lang.annotation.Target;
  * @see LTLengthOf
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IndexOrHigh {
     /**

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/IndexOrLow.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/IndexOrLow.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -25,6 +28,8 @@ import java.lang.annotation.Target;
  * @see LTLengthOf
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IndexOrLow {
     /** Sequences that the annotated expression is a valid index for (or it's -1). */

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LTEqLengthOf.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LTEqLengthOf.java
@@ -18,10 +18,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf(UpperBoundUnknown.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UpperBoundUnknown.class)
 public @interface LTEqLengthOf {
     /** Sequences, each of which is at least as long as the annotated expression's value. */
     @JavaExpression

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LTLengthOf.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LTLengthOf.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -30,9 +31,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see IndexFor
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf(LTEqLengthOf.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(LTEqLengthOf.class)
 public @interface LTLengthOf {
     /** Sequences, each of which is longer than the annotated expression's value. */
     @JavaExpression

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LTOMLengthOf.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LTOMLengthOf.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -20,9 +21,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf(LTLengthOf.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(LTLengthOf.class)
 public @interface LTOMLengthOf {
     /**
      * Sequences, each of whose lengths is at least 1 larger than the annotated expression's value.

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LengthOf.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LengthOf.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -20,6 +23,8 @@ import java.lang.annotation.Target;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 // Has target of METHOD so that it is stored as a declaration annotation and SameLen Checker can
 // read it.
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER, ElementType.METHOD})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LengthOf.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LengthOf.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-// Has target of METHOD so that it is stored as a declaration annotation and SameLen Checker can
+// Has target of METHOD so that it is stored as a declaration annotation and the SameLen Checker can
 // read it.
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER, ElementType.METHOD})
 public @interface LengthOf {

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThan.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThan.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -23,9 +24,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *   <li>{@code @LessThan({"a", "b"})} is not related to {@code @LessThan({"a", "c"})}.
  * </ul>
  */
-@SubtypeOf({LessThanUnknown.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({LessThanUnknown.class})
 // TODO: I chose to implement less than rather than greater than because in most of the case studies
 // false positives, the bigger value is final or effectively final, so it can appear in a dependent
 // annotation without causing soundness issues.

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThan.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThan.java
@@ -23,6 +23,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *   <li>{@code @LessThan({"a", "b"}) <: @LessThan({"a"})}
  *   <li>{@code @LessThan({"a", "b"})} is not related to {@code @LessThan({"a", "c"})}.
  * </ul>
+ *
+ * @checker_framework.manual #index-inequalities Index Chceker Inequalities
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanBottom.java
@@ -10,7 +10,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 /**
  * The bottom type in the LessThan type system. Programmers should rarely write this type.
  *
- * @checker_framework.manual #index-checker Index Checker
+ * @checker_framework.manual #index-inequalities Index Chceker Inequalities
  * @checker_framework.manual #bottom-type the bottom type
  */
 @Documented

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,7 +13,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf({LessThan.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({LessThan.class})
 public @interface LessThanBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
@@ -13,4 +13,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
+/**
+ * The top qualifier for the LessThan type hierarchy. It indicates that no other expression is known
+ * to be larger than the annotated one.
+ *
+ * @checker_framework.manual #index-inequalities Index Chceker Inequalities
+ */
 public @interface LessThanUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,8 +8,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 public @interface LessThanUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LessThanUnknown.java
@@ -8,15 +8,15 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
-@SubtypeOf({})
-@DefaultQualifierInHierarchy
 /**
  * The top qualifier for the LessThan type hierarchy. It indicates that no other expression is known
  * to be larger than the annotated one.
  *
  * @checker_framework.manual #index-inequalities Index Chceker Inequalities
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface LessThanUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf({Positive.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({Positive.class})
 public @interface LowerBoundBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,6 +13,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/LowerBoundUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,8 +14,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface LowerBoundUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/NegativeIndexFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/NegativeIndexFor.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -28,9 +29,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf(SearchIndexFor.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(SearchIndexFor.class)
 public @interface NegativeIndexFor {
     /**
      * Sequences for which this value is a "negative index"; that is, the expression is in the range

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/NonNegative.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/NonNegative.java
@@ -21,6 +21,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({GTENegativeOne.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({GTENegativeOne.class})
 public @interface NonNegative {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/NonNegative.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/NonNegative.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
@@ -16,6 +19,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({GTENegativeOne.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface NonNegative {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyIndex.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyIndex.java
@@ -21,7 +21,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @see PolyLowerBound
  */
 @Documented
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @PolymorphicQualifier(UpperBoundUnknown.class)
 public @interface PolyIndex {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLength.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLength.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
@@ -12,6 +15,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolyLength {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLength.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLength.java
@@ -17,6 +17,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UpperBoundUnknown.class)
 public @interface PolyLength {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLowerBound.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLowerBound.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
@@ -10,6 +12,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Retention(RetentionPolicy.RUNTIME)
 @PolymorphicQualifier(LowerBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolyLowerBound {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLowerBound.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyLowerBound.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,7 +13,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@PolymorphicQualifier(LowerBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(LowerBoundUnknown.class)
 public @interface PolyLowerBound {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolySameLen.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolySameLen.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
@@ -10,6 +13,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @PolymorphicQualifier(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolySameLen {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolySameLen.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolySameLen.java
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@PolymorphicQualifier(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(SameLenUnknown.class)
 public @interface PolySameLen {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyUpperBound.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyUpperBound.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
@@ -10,6 +13,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolyUpperBound {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/PolyUpperBound.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/PolyUpperBound.java
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@PolymorphicQualifier(UpperBoundUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UpperBoundUnknown.class)
 public @interface PolyUpperBound {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/Positive.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/Positive.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
@@ -20,6 +23,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({NonNegative.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Positive {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/Positive.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/Positive.java
@@ -25,6 +25,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({NonNegative.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({NonNegative.class})
 public @interface Positive {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.JavaExpression;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -12,6 +15,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface SameLen {

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLen.java
@@ -17,8 +17,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf(SameLenUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(SameLenUnknown.class)
 public @interface SameLen {
     /** A list of other sequences with the same length. */
     @JavaExpression

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(SameLen.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(SameLen.class)
 public @interface SameLenBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenUnknown.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -12,6 +14,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SameLenUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface SameLenUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(NegativeIndexFor.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(NegativeIndexFor.class)
 public @interface SearchIndexBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexFor.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -16,9 +17,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
-@SubtypeOf(SearchIndexUnknown.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(SearchIndexUnknown.class)
 public @interface SearchIndexFor {
     /**
      * Sequences for which the annotated expression has the type of the result of a call to {@link

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexUnknown.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,6 +13,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SearchIndexUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,8 +14,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface SearchIndexUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #index-substringindex Index Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(SubstringIndexFor.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(SubstringIndexFor.class)
 public @interface SubstringIndexBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexFor.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -30,9 +31,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-substringindex Index Checker
  */
-@SubtypeOf(SubstringIndexUnknown.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(SubstringIndexUnknown.class)
 public @interface SubstringIndexFor {
     /**
      * Sequences, each of which is longer than the annotated expression plus the corresponding

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,8 +14,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-substringindex Index Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface SubstringIndexUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/SubstringIndexUnknown.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,6 +13,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-substringindex Index Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #index-checker Index Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(LTOMLengthOf.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(LTOMLengthOf.class)
 public @interface UpperBoundBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundUnknown.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.index.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,6 +13,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/qual/UpperBoundUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.index.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,8 +14,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #index-checker Index Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface UpperBoundUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/initialization/qual/FBCBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/qual/FBCBottom.java
@@ -16,9 +16,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #initialization-checker Initialization Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf({UnderInitialization.class, Initialized.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({UnderInitialization.class, Initialized.class})
 public @interface FBCBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/initialization/qual/Initialized.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/qual/Initialized.java
@@ -23,6 +23,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #initialization-checker Initialization Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(UnknownInitialization.class)
 @DefaultQualifierInHierarchy
 @DefaultFor({
@@ -30,7 +33,4 @@ import org.checkerframework.framework.qual.TypeUseLocation;
     TypeUseLocation.IMPLICIT_LOWER_BOUND,
     TypeUseLocation.EXCEPTION_PARAMETER
 })
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Initialized {}

--- a/checker/src/main/java/org/checkerframework/checker/initialization/qual/UnderInitialization.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/qual/UnderInitialization.java
@@ -36,10 +36,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #underinitialization-examples Examples of the @UnderInitialization
  *     annotation
  */
-@SubtypeOf(UnknownInitialization.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownInitialization.class)
 public @interface UnderInitialization {
     /**
      * The type-frame down to which the expression (of this type) has been initialized at least

--- a/checker/src/main/java/org/checkerframework/checker/initialization/qual/UnknownInitialization.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/qual/UnknownInitialization.java
@@ -36,11 +36,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #initialization-checker Initialization Checker
  */
-@SubtypeOf({})
-@DefaultFor({TypeUseLocation.LOCAL_VARIABLE, TypeUseLocation.RESOURCE_VARIABLE})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultFor({TypeUseLocation.LOCAL_VARIABLE, TypeUseLocation.RESOURCE_VARIABLE})
 public @interface UnknownInitialization {
     /**
      * The type-frame down to which the expression (of this type) has been initialized at least

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/InternMethod.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/InternMethod.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Target;
 /**
  * Method declaration annotation used to indicate that this method may be invoked on an uninterned
  * object and that it returns an interned object.
+ *
+ * @checker_framework.manual #interning-checker Interning Checker
  */
 @Documented
 @Target(ElementType.METHOD)

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/InternMethod.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/InternMethod.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * object and that it returns an interned object.
  */
 @Documented
-@Inherited
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface InternMethod {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/Interned.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/Interned.java
@@ -30,6 +30,9 @@ import org.checkerframework.framework.qual.TypeKind;
  * @see org.checkerframework.checker.interning.InterningChecker
  * @checker_framework.manual #interning-checker Interning Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(UnknownInterned.class)
 @QualifierForLiterals({LiteralKind.PRIMITIVE, LiteralKind.STRING}) // everything but NULL
 @DefaultFor(
@@ -43,7 +46,4 @@ import org.checkerframework.framework.qual.TypeKind;
             TypeKind.LONG,
             TypeKind.SHORT
         })
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Interned {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/InternedDistinct.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/InternedDistinct.java
@@ -19,9 +19,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @see org.checkerframework.checker.interning.InterningChecker
  * @checker_framework.manual #interning-checker Interning Checker
  */
-@SubtypeOf(Interned.class)
-@DefaultFor(value = {TypeUseLocation.LOWER_BOUND})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(Interned.class)
+@DefaultFor(value = {TypeUseLocation.LOWER_BOUND})
 public @interface InternedDistinct {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/PolyInterned.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/PolyInterned.java
@@ -17,8 +17,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #interning-checker Interning Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
-@PolymorphicQualifier(UnknownInterned.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownInterned.class)
 public @interface PolyInterned {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/UnknownInterned.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/UnknownInterned.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.interning.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,7 +21,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownInterned {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/UnknownInterned.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/UnknownInterned.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.interning.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,9 +19,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see org.checkerframework.checker.interning.InterningChecker
  * @checker_framework.manual #interning-checker Interning Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownInterned {}

--- a/checker/src/main/java/org/checkerframework/checker/interning/qual/UsesObjectEquals.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/qual/UsesObjectEquals.java
@@ -22,7 +22,7 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #interning-checker Interning Checker
  */
 @Documented
-@Inherited
-@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
 public @interface UsesObjectEquals {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardSatisfied.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardSatisfied.java
@@ -29,11 +29,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #lock-checker Lock Checker
  * @checker_framework.manual #lock-checker-polymorphism-example Lock Checker polymorphism example
  */
-@SubtypeOf(GuardedByUnknown.class) // TODO: Should @GuardSatisfied be in its own hierarchy?
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@TargetLocations({TypeUseLocation.RECEIVER, TypeUseLocation.PARAMETER, TypeUseLocation.RETURN})
 @Target(ElementType.TYPE_USE)
+@TargetLocations({TypeUseLocation.RECEIVER, TypeUseLocation.PARAMETER, TypeUseLocation.RETURN})
+@SubtypeOf(GuardedByUnknown.class) // TODO: Should @GuardSatisfied be in its own hierarchy?
 public @interface GuardSatisfied {
     /**
      * The index on the GuardSatisfied polymorphic qualifier. Defaults to -1 so that the user can

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedBy.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedBy.java
@@ -34,8 +34,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #lock-checker Lock Checker
  * @checker_framework.manual #lock-examples-guardedby Example use of @GuardedBy
  */
-@SubtypeOf(GuardedByUnknown.class)
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(GuardedByUnknown.class)
 @DefaultQualifierInHierarchy
 @DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER})
 // These are required because the default for local variables is @GuardedByUnknown, but if the local
@@ -53,8 +55,6 @@ import org.checkerframework.framework.qual.TypeUseLocation;
             TypeKind.SHORT
         },
         types = {java.lang.String.class, Void.class})
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface GuardedBy {
     /**
      * The Java value expressions that need to be held.

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedByBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedByBottom.java
@@ -18,9 +18,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #lock-checker Lock Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf({GuardedBy.class, GuardSatisfied.class})
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
-@Retention(RetentionPolicy.RUNTIME)
+@SubtypeOf({GuardedBy.class, GuardSatisfied.class})
 public @interface GuardedByBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedByUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/GuardedByUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.lock.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,8 +19,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #lock-checker Lock Checker
  */
-@SubtypeOf({})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultInUncheckedCodeFor({TypeUseLocation.RECEIVER})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultInUncheckedCodeFor({TypeUseLocation.RECEIVER})
 public @interface GuardedByUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/Holding.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/Holding.java
@@ -21,8 +21,8 @@ import org.checkerframework.framework.qual.PreconditionAnnotation;
  * @checker_framework.manual #lock-examples-holding Example use of @Holding
  */
 @Documented
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @PreconditionAnnotation(qualifier = LockHeld.class)
 public @interface Holding {
     /**

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockHeld.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockHeld.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.lock.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -19,7 +18,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @SubtypeOf(LockPossiblyHeld.class) // This is the bottom type in this hierarchy
 @InvisibleQualifier
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
 public @interface LockHeld {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockHeld.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockHeld.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.lock.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -16,8 +17,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see LockPossiblyHeld
  * @checker_framework.manual #lock-checker Lock Checker
  */
-@SubtypeOf(LockPossiblyHeld.class) // This is the bottom type in this hierarchy
-@InvisibleQualifier
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
+@SubtypeOf(LockPossiblyHeld.class) // This is the bottom type in this hierarchy
+@InvisibleQualifier
 public @interface LockHeld {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.lock.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,7 +24,6 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  */
 @InvisibleQualifier
 @SubtypeOf({}) // The top type in the hierarchy
-@Documented
 @DefaultQualifierInHierarchy
 @DefaultFor(value = TypeUseLocation.LOWER_BOUND, types = Void.class)
 @QualifierForLiterals(LiteralKind.NULL)

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockPossiblyHeld.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.lock.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -22,6 +23,9 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @see LockHeld
  * @checker_framework.manual #lock-checker Lock Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
 @InvisibleQualifier
 @SubtypeOf({}) // The top type in the hierarchy
 @DefaultQualifierInHierarchy
@@ -29,6 +33,4 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @QualifierForLiterals(LiteralKind.NULL)
 @DefaultQualifierInHierarchyInUncheckedCode
 @DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER, TypeUseLocation.LOWER_BOUND})
-@Retention(RetentionPolicy.RUNTIME)
-@Target({})
 public @interface LockPossiblyHeld {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/LockingFree.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/LockingFree.java
@@ -27,6 +27,6 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InheritedAnnotation
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@InheritedAnnotation
 public @interface LockingFree {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/MayReleaseLocks.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/MayReleaseLocks.java
@@ -22,6 +22,6 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InheritedAnnotation
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@InheritedAnnotation
 public @interface MayReleaseLocks {}

--- a/checker/src/main/java/org/checkerframework/checker/lock/qual/ReleasesNoLocks.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/qual/ReleasesNoLocks.java
@@ -36,6 +36,6 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InheritedAnnotation
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@InheritedAnnotation
 public @interface ReleasesNoLocks {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/KeyFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/KeyFor.java
@@ -36,10 +36,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see EnsuresKeyForIf
  * @checker_framework.manual #map-key-checker Map Key Checker
  */
-@SubtypeOf(UnknownKeyFor.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownKeyFor.class)
 public @interface KeyFor {
     /**
      * Java expression(s) that evaluate to a map for which the annotated type is a key.

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/MonotonicNonNull.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/MonotonicNonNull.java
@@ -47,8 +47,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @checker_framework.manual #nullness-checker Nullness Checker
  */
 @Documented
-@SubtypeOf(Nullable.class)
-@Target(ElementType.TYPE_USE)
-@MonotonicQualifier(NonNull.class)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE_USE)
+@SubtypeOf(Nullable.class)
+@MonotonicQualifier(NonNull.class)
 public @interface MonotonicNonNull {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/NonNull.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/NonNull.java
@@ -37,6 +37,9 @@ import org.checkerframework.framework.qual.UpperBoundFor;
  * @checker_framework.manual #nullness-checker Nullness Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(MonotonicNonNull.class)
 @QualifierForLiterals(LiteralKind.STRING)
 @DefaultQualifierInHierarchy
@@ -54,7 +57,4 @@ import org.checkerframework.framework.qual.UpperBoundFor;
             TypeKind.BYTE
         })
 @DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER, TypeUseLocation.LOWER_BOUND})
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface NonNull {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -25,11 +25,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @see org.checkerframework.checker.nullness.NullnessChecker
  * @checker_framework.manual #nullness-checker Nullness Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({})
 @QualifierForLiterals(LiteralKind.NULL)
 @DefaultFor(types = Void.class)
 @DefaultInUncheckedCodeFor({TypeUseLocation.RETURN, TypeUseLocation.UPPER_BOUND})
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Nullable {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/PolyKeyFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/PolyKeyFor.java
@@ -20,7 +20,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(UnknownKeyFor.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownKeyFor.class)
 public @interface PolyKeyFor {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/PolyNull.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/PolyNull.java
@@ -19,7 +19,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(Nullable.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(Nullable.class)
 public @interface PolyNull {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.nullness.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -21,11 +22,12 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #map-key-checker Map Key Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
 @DefaultFor(value = TypeUseLocation.LOWER_BOUND, types = Void.class)
 @QualifierForLiterals(LiteralKind.NULL)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownKeyFor {}

--- a/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/qual/UnknownKeyFor.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.nullness.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -27,7 +26,6 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @DefaultQualifierInHierarchy
 @DefaultFor(value = TypeUseLocation.LOWER_BOUND, types = Void.class)
 @QualifierForLiterals(LiteralKind.NULL)
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownKeyFor {}

--- a/checker/src/main/java/org/checkerframework/checker/optional/qual/PolyPresent.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/qual/PolyPresent.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(MaybePresent.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(MaybePresent.class)
 public @interface PolyPresent {}

--- a/checker/src/main/java/org/checkerframework/checker/propkey/qual/PropertyKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/propkey/qual/PropertyKey.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #propkey-checker Property File Checker
  */
-@SubtypeOf(UnknownPropertyKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownPropertyKey.class)
 public @interface PropertyKey {}

--- a/checker/src/main/java/org/checkerframework/checker/propkey/qual/PropertyKeyBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/propkey/qual/PropertyKeyBottom.java
@@ -17,10 +17,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #propkey-checker Property File Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf(PropertyKey.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf(PropertyKey.class)
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface PropertyKeyBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/propkey/qual/UnknownPropertyKey.java
+++ b/checker/src/main/java/org/checkerframework/checker/propkey/qual/UnknownPropertyKey.java
@@ -13,9 +13,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #propkey-checker Property File Checker
  */
-@SubtypeOf({})
-@DefaultQualifierInHierarchy
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface UnknownPropertyKey {}

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/PartialRegex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/PartialRegex.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.regex.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -16,10 +17,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #regex-checker Regex Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({}) // empty target prevents programmers from writing this in a program
 @InvisibleQualifier
 @SubtypeOf(org.checkerframework.checker.regex.qual.UnknownRegex.class)
-@Target({}) // empty target prevents programmers from writing this in a program
 public @interface PartialRegex {
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/PartialRegex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/PartialRegex.java
@@ -1,5 +1,7 @@
 package org.checkerframework.checker.regex.qual;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -14,6 +16,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #regex-checker Regex Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf(org.checkerframework.checker.regex.qual.UnknownRegex.class)
 @Target({}) // empty target prevents programmers from writing this in a program

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/PolyRegex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/PolyRegex.java
@@ -18,7 +18,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(UnknownRegex.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownRegex.class)
 public @interface PolyRegex {}

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/Regex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/Regex.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.regex.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,6 +18,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #regex-checker Regex Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(UnknownRegex.class)

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/RegexBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/RegexBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.regex.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -16,10 +17,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #regex-checker Regex Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @InvisibleQualifier
 @SubtypeOf({Regex.class, org.checkerframework.checker.regex.qual.PartialRegex.class})
 @DefaultFor(value = {TypeUseLocation.LOWER_BOUND})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface RegexBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/RegexBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/RegexBottom.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.regex.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -14,6 +16,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #regex-checker Regex Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({Regex.class, org.checkerframework.checker.regex.qual.PartialRegex.class})
 @DefaultFor(value = {TypeUseLocation.LOWER_BOUND})

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/UnknownRegex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/UnknownRegex.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.regex.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,10 +16,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #regex-checker Regex Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @InvisibleQualifier
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface UnknownRegex {}

--- a/checker/src/main/java/org/checkerframework/checker/regex/qual/UnknownRegex.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/qual/UnknownRegex.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.regex.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -13,6 +15,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #regex-checker Regex Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @DefaultQualifierInHierarchy
 @SubtypeOf({})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
@@ -35,8 +35,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({ClassGetName.class, FqBinaryName.class})
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface BinaryName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryName.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -30,6 +33,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({ClassGetName.class, FqBinaryName.class})
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -19,6 +22,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({BinaryName.class, InternalForm.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\$[A-Za-z_0-9]+)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/BinaryNameInUnnamedPackage.java
@@ -24,7 +24,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({BinaryName.class, InternalForm.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\$[A-Za-z_0-9]+)*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface BinaryNameInUnnamedPackage {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -26,6 +29,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetName.java
@@ -31,9 +31,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =
                 "(^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*|\\$[A-Za-z_0-9]+)*$)|^\\[+([BCDFIJSZ]|L[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*|\\$[A-Za-z_0-9]+)*;)$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface ClassGetName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
@@ -16,7 +16,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(stringPatterns = "^(|[A-Za-z_][A-Za-z_0-9]*)(\\[\\])*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface ClassGetSimpleName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/ClassGetSimpleName.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,6 +14,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(stringPatterns = "^(|[A-Za-z_][A-Za-z_0-9]*)(\\[\\])*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -15,6 +18,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({FullyQualifiedName.class, BinaryName.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/DotSeparatedIdentifiers.java
@@ -20,7 +20,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({FullyQualifiedName.class, BinaryName.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface DotSeparatedIdentifiers {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
@@ -30,9 +30,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =
                 "^\\[*([BCDFIJSZ]|L[A-Za-z_][A-Za-z_0-9]*(/[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*;)$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FieldDescriptor {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptor.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -25,6 +28,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
@@ -19,7 +19,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.class, Identifier.class})
 @QualifierForLiterals(stringPatterns = "^[BCDFIJSZ]$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FieldDescriptorForPrimitive {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitive.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -14,6 +17,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.class, Identifier.class})
 @QualifierForLiterals(stringPatterns = "^[BCDFIJSZ]$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
@@ -22,9 +22,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({ClassGetName.class, FieldDescriptor.class})
 @QualifierForLiterals(
         stringPatterns =
                 "^([BCDFIJSZ]|\\[+[BCDFIJSZ]|\\[L[A-Za-z_][A-Za-z_0-9]*(\\$[A-Za-z_0-9]+)*;)$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FieldDescriptorForPrimitiveOrArrayInUnnamedPackage {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -17,6 +20,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({ClassGetName.class, FieldDescriptor.class})
 @QualifierForLiterals(
         stringPatterns =

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FqBinaryName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FqBinaryName.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -25,6 +28,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FqBinaryName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FqBinaryName.java
@@ -30,9 +30,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns =
                 "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*(\\[\\])*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FqBinaryName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
@@ -45,8 +45,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(FqBinaryName.class)
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\[\\])*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface FullyQualifiedName {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/FullyQualifiedName.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -40,6 +43,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(FqBinaryName.class)
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\.[A-Za-z_][A-Za-z_0-9]*)*(\\[\\])*$")

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
@@ -20,6 +20,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 })
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@QualifierForLiterals(stringPatterns = "^([A-Za-z_][A-Za-z_0-9]*)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@QualifierForLiterals(stringPatterns = "^([A-Za-z_][A-Za-z_0-9]*)$")
 public @interface Identifier {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/Identifier.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -15,6 +18,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
     BinaryNameInUnnamedPackage.class,
     IdentifierOrArray.class
 })
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @QualifierForLiterals(stringPatterns = "^([A-Za-z_][A-Za-z_0-9]*)$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Identifier {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
@@ -17,7 +17,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({FullyQualifiedName.class, ClassGetSimpleName.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\[\\])*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface IdentifierOrArray {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/IdentifierOrArray.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -12,6 +15,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({FullyQualifiedName.class, ClassGetSimpleName.class})
 @QualifierForLiterals(stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(\\[\\])*$")
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
@@ -26,8 +26,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(/[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface InternalForm {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/InternalForm.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -21,6 +24,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * @see BinaryName
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @QualifierForLiterals(
         stringPatterns = "^[A-Za-z_][A-Za-z_0-9]*(/[A-Za-z_][A-Za-z_0-9]*)*(\\$[A-Za-z_0-9]+)*$")

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/MethodDescriptor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/MethodDescriptor.java
@@ -29,6 +29,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf(SignatureUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(SignatureUnknown.class)
 public @interface MethodDescriptor {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/MethodDescriptor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/MethodDescriptor.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
@@ -24,6 +27,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(SignatureUnknown.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface MethodDescriptor {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/PolySignature.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/PolySignature.java
@@ -19,7 +19,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(SignatureUnknown.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(SignatureUnknown.class)
 public @interface PolySignature {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureBottom.java
@@ -1,6 +1,8 @@
 package org.checkerframework.checker.signature.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -13,6 +15,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #signature-checker Signature Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({FieldDescriptorForPrimitive.class, MethodDescriptor.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #signature-checker Signature Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({FieldDescriptorForPrimitive.class, MethodDescriptor.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({FieldDescriptorForPrimitive.class, MethodDescriptor.class})
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
 public @interface SignatureBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureUnknown.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -14,8 +15,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({}) // empty target prevents programmers from writing this in a program
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({}) // empty target prevents programmers from writing this in a program
 public @interface SignatureUnknown {}

--- a/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureUnknown.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/qual/SignatureUnknown.java
@@ -1,5 +1,7 @@
 package org.checkerframework.checker.signature.qual;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -12,6 +14,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #signature-checker Signature Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({}) // empty target prevents programmers from writing this in a program

--- a/checker/src/main/java/org/checkerframework/checker/signedness/qual/PolySigned.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/qual/PolySigned.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(UnknownSignedness.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownSignedness.class)
 public @interface PolySigned {}

--- a/checker/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.signedness.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
@@ -14,6 +17,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #signedness-checker Signedness Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf({SignednessGlb.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/checker/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
@@ -19,7 +19,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@SubtypeOf({SignednessGlb.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({SignednessGlb.class})
 public @interface SignednessBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/tainting/qual/PolyTainted.java
+++ b/checker/src/main/java/org/checkerframework/checker/tainting/qual/PolyTainted.java
@@ -14,7 +14,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(Tainted.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(Tainted.class)
 public @interface PolyTainted {}

--- a/checker/src/main/java/org/checkerframework/checker/tainting/qual/Untainted.java
+++ b/checker/src/main/java/org/checkerframework/checker/tainting/qual/Untainted.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.tainting.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #tainting-checker Tainting Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Tainted.class)
 @QualifierForLiterals(LiteralKind.STRING)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@Retention(RetentionPolicy.RUNTIME)
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface Untainted {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Acceleration.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Acceleration.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Acceleration {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Angle.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Angle.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Angle {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Area.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Area.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Area {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Current.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Current.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Current {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Length.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Length.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Length {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Luminance.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Luminance.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Luminance {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Mass.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Mass.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Mass {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/MixedUnits.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/MixedUnits.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({}) // forbids a programmer from writing it in a program
+@SubtypeOf(UnknownUnits.class)
 public @interface MixedUnits {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/PolyUnit.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/PolyUnit.java
@@ -38,7 +38,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@PolymorphicQualifier(UnknownUnits.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownUnits.class)
 public @interface PolyUnit {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Speed.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Speed.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Speed {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Substance.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Substance.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Substance {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Temperature.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Temperature.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Temperature {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/Time.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/Time.java
@@ -12,8 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SubtypeOf(UnknownUnits.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(UnknownUnits.class)
 public @interface Time {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/UnitsBottom.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/UnitsBottom.java
@@ -16,10 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #units-checker Units Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@SubtypeOf({}) // needs to be done programmatically
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({}) // needs to be done programmatically
+@DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface UnitsBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/UnitsMultiple.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/UnitsMultiple.java
@@ -1,6 +1,9 @@
 package org.checkerframework.checker.units.qual;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Define the relation between a base unit and the current unit.
@@ -10,6 +13,8 @@ import java.lang.annotation.Annotation;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 public @interface UnitsMultiple {
     /** @return the base unit to use */
     Class<? extends Annotation> quantity();

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/UnknownUnits.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/UnknownUnits.java
@@ -1,5 +1,6 @@
 package org.checkerframework.checker.units.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownUnits {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/UnknownUnits.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/UnknownUnits.java
@@ -1,6 +1,5 @@
 package org.checkerframework.checker.units.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,7 +16,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface UnknownUnits {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/cd.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/cd.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Luminance.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface cd {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/degrees.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/degrees.java
@@ -12,9 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Angle.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface degrees {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/g.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/g.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Mass.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface g {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/h.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/h.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Time.class)
 // TODO: support arbitrary factors?
 // @UnitsMultiple(quantity=s.class, factor=3600)
+@SuppressWarnings("checkstyle:typename")
 public @interface h {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/kg.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/kg.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Mass.class)
 @UnitsMultiple(quantity = g.class, prefix = Prefix.kilo)
+@SuppressWarnings("checkstyle:typename")
 public @interface kg {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/km.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/km.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Length.class)
 @UnitsMultiple(quantity = m.class, prefix = Prefix.kilo)
+@SuppressWarnings("checkstyle:typename")
 public @interface km {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/km2.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/km2.java
@@ -12,9 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Area.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface km2 {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/kmPERh.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/kmPERh.java
@@ -12,9 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Speed.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface kmPERh {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/m.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/m.java
@@ -12,7 +12,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
@@ -22,6 +21,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 // If you want an alias for "m", e.g. "Meter", simply create that
 // annotation and add this meta-annotation:
 // @UnitsMultiple(quantity=m.class, prefix=Prefix.one)
+@SuppressWarnings("checkstyle:typename")
 public @interface m {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/m2.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/m2.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Area.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface m2 {
     // does this make sense? Is it multiple of (m^2)? Or (multiple of m)^2?
     Prefix value() default Prefix.one;

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/mPERs.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/mPERs.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Speed.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface mPERs {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/mPERs2.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/mPERs2.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Acceleration.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface mPERs2 {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/min.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/min.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Time.class)
+@SuppressWarnings("checkstyle:typename")
 // TODO: @UnitsMultiple(quantity=s.class, factor=60)
 public @interface min {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/mm.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/mm.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Length.class)
 @UnitsMultiple(quantity = m.class, prefix = Prefix.milli)
+@SuppressWarnings("checkstyle:typename")
 public @interface mm {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/mm2.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/mm2.java
@@ -12,9 +12,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Area.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface mm2 {}

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/mol.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/mol.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Substance.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface mol {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/radians.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/radians.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Angle.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface radians {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/main/java/org/checkerframework/checker/units/qual/s.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/qual/s.java
@@ -12,11 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #units-checker Units Checker
  */
-@SuppressWarnings("checkstyle:typename")
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(Time.class)
+@SuppressWarnings("checkstyle:typename")
 public @interface s {
     Prefix value() default Prefix.one;
 }

--- a/checker/src/testannotations/java/org/springframework/lang/NonNull.java
+++ b/checker/src/testannotations/java/org/springframework/lang/NonNull.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(value = {ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
-@Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
 public @interface NonNull {}

--- a/checker/src/testannotations/java/org/springframework/lang/Nullable.java
+++ b/checker/src/testannotations/java/org/springframework/lang/Nullable.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(value = {ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
-@Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
 public @interface Nullable {}

--- a/docs/examples/subtyping-extension/qual/Encrypted.java
+++ b/docs/examples/subtyping-extension/qual/Encrypted.java
@@ -1,12 +1,17 @@
 package qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 /** Denotes that the representation of an object is encrypted. */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @SubtypeOf(PossiblyUnencrypted.class)
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/docs/examples/subtyping-extension/qual/Encrypted.java
+++ b/docs/examples/subtyping-extension/qual/Encrypted.java
@@ -12,7 +12,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 /** Denotes that the representation of an object is encrypted. */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(PossiblyUnencrypted.class)
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface Encrypted {}

--- a/docs/examples/subtyping-extension/qual/PossiblyUnencrypted.java
+++ b/docs/examples/subtyping-extension/qual/PossiblyUnencrypted.java
@@ -1,5 +1,6 @@
 package qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,8 +9,9 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** Denotes that the representation of an object might not be encrypted. */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PossiblyUnencrypted {}

--- a/docs/examples/subtyping-extension/qual/PossiblyUnencrypted.java
+++ b/docs/examples/subtyping-extension/qual/PossiblyUnencrypted.java
@@ -1,11 +1,14 @@
 package qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** Denotes that the representation of an object might not be encrypted. */
+@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/docs/examples/units-extension/qual/Frequency.java
+++ b/docs/examples/units-extension/qual/Frequency.java
@@ -9,7 +9,11 @@ import org.checkerframework.checker.units.qual.UnitsRelations;
 import org.checkerframework.checker.units.qual.UnknownUnits;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-/** Units of frequency, such as hertz (@{@link Hz}). */
+/**
+ * Units of frequency, such as hertz (@{@link Hz}).
+ *
+ * @checker_framework.manual #units-checker Units Checker
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/docs/examples/units-extension/qual/Hz.java
+++ b/docs/examples/units-extension/qual/Hz.java
@@ -9,7 +9,11 @@ import org.checkerframework.checker.units.qual.Prefix;
 import org.checkerframework.checker.units.qual.UnitsRelations;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-/** Hertz (Hz), a unit of frequency. */
+/**
+ * Hertz (Hz), a unit of frequency.
+ *
+ * @checker_framework.manual #units-checker Units Checker
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/docs/examples/units-extension/qual/kHz.java
+++ b/docs/examples/units-extension/qual/kHz.java
@@ -10,7 +10,11 @@ import org.checkerframework.checker.units.qual.UnitsMultiple;
 import org.checkerframework.checker.units.qual.UnitsRelations;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-/** Kilohertz (kHz), a unit of frequency, and an alias of @Hz(Prefix.kilo). */
+/**
+ * Kilohertz (kHz), a unit of frequency, and an alias of @Hz(Prefix.kilo).
+ *
+ * @checker_framework.manual #units-checker Units Checker
+ */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -31,8 +31,8 @@ import org.checkerframework.common.subtyping.qual.Unqualified;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 @Documented
-@SubtypeOf(Unqualified.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(Unqualified.class)
 public @interface Encrypted {}
 \end{Verbatim}
 

--- a/docs/manual/units-checker.tex
+++ b/docs/manual/units-checker.tex
@@ -168,9 +168,9 @@ Here is an example of a new unit annotation.
 \begin{alltt}
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target(\{ElementType.TYPE_USE, ElementType.TYPE_PARAMETER\})
 @SubtypeOf(\ttlcb{}Time.class\ttrcb{})
 @UnitsMultiple(quantity=s.class, prefix=Prefix.nano)
-@Target(\{ElementType.TYPE_USE, ElementType.TYPE_PARAMETER\})
 public @interface ns \ttlcb{}\ttrcb{}
 \end{alltt}
 

--- a/docs/manual/warnings.tex
+++ b/docs/manual/warnings.tex
@@ -297,20 +297,20 @@ example, ``a.f was checked above and no subsequent side effect can affect it''.
 Here are some terse examples from libraries in \href{https://github.com/plume-lib/}{plume-lib}:
 
 \begin{Verbatim}
-@SuppressWarnings("purity") // side effect to local state of type BitSet
 @SuppressWarnings("cast") // cast is redundant (except when checking nullness)
 @SuppressWarnings("interning") // FbType.FREE is interned but is not annotated
 @SuppressWarnings("interning") // equality testing optimization
 @SuppressWarnings("nullness") // used portion of array is non-null
 @SuppressWarnings("nullness") // oi.factory is a static method, so null first argument is OK
+@SuppressWarnings("purity") // side effect to local state of type BitSet
 \end{Verbatim}
 
 A particularly good (and concise) justification is to reference an issue in
 the issue tracker, as in these two from \href{https://plse.cs.washington.edu/daikon/}{Daikon}:
 
 \begin{Verbatim}
-@SuppressWarnings("keyfor") // https://tinyurl.com/cfissue/877
 @SuppressWarnings("flowexpr.parse.error") // https://tinyurl.com/cfissue/862
+@SuppressWarnings("keyfor") // https://tinyurl.com/cfissue/877
 \end{Verbatim}
 
 \noindent

--- a/docs/tutorial/src/myqual/Encrypted.java
+++ b/docs/tutorial/src/myqual/Encrypted.java
@@ -7,6 +7,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 /** Denotes that the representation of an object is encrypted. */
 @Documented
-@SubtypeOf(PossiblyUnencrypted.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(PossiblyUnencrypted.class)
 public @interface Encrypted {}

--- a/docs/tutorial/src/myqual/PolyEncrypted.java
+++ b/docs/tutorial/src/myqual/PolyEncrypted.java
@@ -7,6 +7,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 
 /** Denotes that the representation of an object is encrypted. */
 @Documented
-@PolymorphicQualifier
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier
 public @interface PolyEncrypted {}

--- a/docs/tutorial/src/myqual/PossiblyUnencrypted.java
+++ b/docs/tutorial/src/myqual/PossiblyUnencrypted.java
@@ -8,7 +8,7 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 /** Denotes that the representation of an object might not be encrypted. */
 @Documented
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface PossiblyUnencrypted {}

--- a/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeAliased.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeAliased.java
@@ -18,11 +18,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #aliasing-checker Aliasing Checker
  */
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 @DefaultFor(
         value = {TypeUseLocation.UPPER_BOUND, TypeUseLocation.LOWER_BOUND},
         types = Void.class)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
-@SubtypeOf({})
 public @interface MaybeAliased {}

--- a/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeLeaked.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeLeaked.java
@@ -1,6 +1,5 @@
 package org.checkerframework.common.aliasing.qual;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -19,7 +18,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #aliasing-checker Aliasing Checker
  */
-@Documented
 @DefaultQualifierInHierarchy
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})

--- a/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeLeaked.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/qual/MaybeLeaked.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.aliasing.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -18,9 +19,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #aliasing-checker Aliasing Checker
  */
-@DefaultQualifierInHierarchy
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({})
+@DefaultQualifierInHierarchy
 @SubtypeOf({LeakedToResult.class})
 @InvisibleQualifier
 public @interface MaybeLeaked {}

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassBound.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassBound.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,9 +13,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  */
-@SubtypeOf({UnknownClass.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({UnknownClass.class})
 public @interface ClassBound {
     /**
      * The <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-13.html#jls-13.1">binary

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassVal.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  */
-@SubtypeOf({UnknownClass.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({UnknownClass.class})
 public @interface ClassVal {
     /**
      * The <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-13.html#jls-13.1">binary

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassValBottom.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassValBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InvisibleQualifier
-@SubtypeOf({ClassVal.class, ClassBound.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@InvisibleQualifier
+@SubtypeOf({ClassVal.class, ClassBound.class})
 public @interface ClassValBottom {}

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassValBottom.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/ClassValBottom.java
@@ -1,6 +1,8 @@
 package org.checkerframework.common.reflection.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -13,6 +15,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({ClassVal.class, ClassBound.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodVal.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,9 +18,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #methodval-and-classval-checkers MethodVal Checker
  */
-@SubtypeOf({UnknownMethod.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({UnknownMethod.class})
 public @interface MethodVal {
     /**
      * The <a href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-13.html#jls-13.1">binary

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodValBottom.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodValBottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #methodval-and-classval-checkers MethodVal Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InvisibleQualifier
-@SubtypeOf({MethodVal.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@InvisibleQualifier
+@SubtypeOf({MethodVal.class})
 public @interface MethodValBottom {}

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodValBottom.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/MethodValBottom.java
@@ -1,6 +1,8 @@
 package org.checkerframework.common.reflection.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -13,6 +15,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #methodval-and-classval-checkers MethodVal Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({MethodVal.class})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownClass.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownClass.java
@@ -1,6 +1,8 @@
 package org.checkerframework.common.reflection.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -16,6 +18,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownClass.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownClass.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,10 +19,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #methodval-and-classval-checkers ClassVal Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InvisibleQualifier
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@InvisibleQualifier
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 public @interface UnknownClass {}

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownMethod.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownMethod.java
@@ -1,6 +1,8 @@
 package org.checkerframework.common.reflection.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -17,6 +19,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #methodval-and-classval-checkers MethodVal Checker
  */
+@Retention(RetentionPolicy.RUNTIME)
 @InvisibleQualifier
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})

--- a/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownMethod.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/qual/UnknownMethod.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.reflection.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -19,10 +20,11 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #methodval-and-classval-checkers MethodVal Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
-@InvisibleQualifier
-@SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@InvisibleQualifier
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 public @interface UnknownMethod {}

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.subtyping.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -23,6 +24,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @see org.checkerframework.framework.type.QualifierHierarchy#getBottomAnnotations()
  */
+@Documented
 @SubtypeOf({})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Bottom.java
@@ -23,6 +23,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * the bottom qualifier to the qualifier hierarchy.
  *
  * @see org.checkerframework.framework.type.QualifierHierarchy#getBottomAnnotations()
+ * @checker_framework.manual #subtyping-checker Subtyping Checker
  */
 @Documented
 @SubtypeOf({})

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Unqualified.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Unqualified.java
@@ -16,6 +16,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * <p>Only use this qualifier when experimenting with very simple type systems. For any more
  * realistic type systems, introduce a top and bottom qualifier that gets stored in bytecode.
+ *
+ * @checker_framework.manual #subtyping-checker Subtyping Checker
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE) // don't store in class file

--- a/framework/src/main/java/org/checkerframework/common/subtyping/qual/Unqualified.java
+++ b/framework/src/main/java/org/checkerframework/common/subtyping/qual/Unqualified.java
@@ -1,5 +1,8 @@
 package org.checkerframework.common.subtyping.qual;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -11,15 +14,14 @@ import org.checkerframework.framework.qual.SubtypeOf;
  * <p>This annotation may not be written in source code; it is an implementation detail of the
  * checker.
  *
- * <p>Note that because of the missing RetentionPolicy, the qualifier will not be stored in
- * bytecode.
- *
  * <p>Only use this qualifier when experimenting with very simple type systems. For any more
  * realistic type systems, introduce a top and bottom qualifier that gets stored in bytecode.
  */
+@Documented
+@Retention(RetentionPolicy.SOURCE) // don't store in class file
+@Target({}) // empty target prevents programmers from writing this in a program.
 @InvisibleQualifier
 @SubtypeOf({})
-@Target({}) // empty target prevents programmers from writing this in a program
 // At the moment this is done in SubtypingATF to prevent errors in checker-framework-inference
 // @DefaultFor(TypeUseLocation.OTHERWISE)
 public @interface Unqualified {}

--- a/framework/src/main/java/org/checkerframework/common/util/report/qual/ReportUnqualified.java
+++ b/framework/src/main/java/org/checkerframework/common/util/report/qual/ReportUnqualified.java
@@ -1,6 +1,9 @@
 package org.checkerframework.common.util.report.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -9,12 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
 /**
  * An annotation intended solely for representing an unqualified type in the qualifier hierarchy for
  * the Report Checker.
- *
- * <p>Note that because of the missing RetentionPolicy, the qualifier will not be stored in
- * bytecode.
  */
+@Documented
+@Retention(RetentionPolicy.SOURCE) // do not store in class file
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface ReportUnqualified {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/ArrayLen.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/ArrayLen.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -17,9 +18,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({UnknownVal.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({UnknownVal.class})
 public @interface ArrayLen {
     /** The possible lengths of the array. */
     int[] value();

--- a/framework/src/main/java/org/checkerframework/common/value/qual/ArrayLenRange.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/ArrayLenRange.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf(UnknownVal.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf(UnknownVal.class)
 public @interface ArrayLenRange {
     /** Smallest value in the range, inclusive. */
     int from() default 0;

--- a/framework/src/main/java/org/checkerframework/common/value/qual/BoolVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/BoolVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,9 +13,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({UnknownVal.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({UnknownVal.class})
 public @interface BoolVal {
     /** The values that the expression might evaluate to. */
     boolean[] value();

--- a/framework/src/main/java/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/BottomVal.java
@@ -1,6 +1,8 @@
 package org.checkerframework.common.value.qual;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
@@ -26,6 +28,7 @@ import org.checkerframework.framework.qual.TypeUseLocation;
     IntRangeFromGTENegativeOne.class,
     IntRangeFromNonNegative.class
 })
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface BottomVal {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/BottomVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/BottomVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,7 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  * @checker_framework.manual #bottom-type the bottom type
  */
-@InvisibleQualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 @SubtypeOf({
     ArrayLen.class,
     BoolVal.class,
@@ -28,7 +32,5 @@ import org.checkerframework.framework.qual.TypeUseLocation;
     IntRangeFromGTENegativeOne.class,
     IntRangeFromNonNegative.class
 })
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@InvisibleQualifier
 public @interface BottomVal {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/DoubleVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/DoubleVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({UnknownVal.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({UnknownVal.class})
 public @interface DoubleVal {
     /** The values that the expression might evaluate to. */
     double[] value();

--- a/framework/src/main/java/org/checkerframework/common/value/qual/EnsuresMinLenIf.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/EnsuresMinLenIf.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,9 +19,10 @@ import org.checkerframework.framework.qual.QualifierArgument;
  * @see MinLen
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@ConditionalPostconditionAnnotation(qualifier = MinLen.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@ConditionalPostconditionAnnotation(qualifier = MinLen.class)
 @InheritedAnnotation
 public @interface EnsuresMinLenIf {
     /**

--- a/framework/src/main/java/org/checkerframework/common/value/qual/IntRange.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/IntRange.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -20,9 +21,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf(UnknownVal.class)
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf(UnknownVal.class)
 public @interface IntRange {
     /** Smallest value in the range, inclusive. */
     long from() default Long.MIN_VALUE;

--- a/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromGTENegativeOne.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromGTENegativeOne.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,7 +26,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf(UnknownVal.class)
+@Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({})
+@SubtypeOf(UnknownVal.class)
 public @interface IntRangeFromGTENegativeOne {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromNonNegative.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromNonNegative.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,7 +26,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf(UnknownVal.class)
+@Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({})
+@SubtypeOf(UnknownVal.class)
 public @interface IntRangeFromNonNegative {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromPositive.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/IntRangeFromPositive.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -25,7 +26,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf(UnknownVal.class)
+@Documented
 @Retention(RetentionPolicy.SOURCE)
 @Target({})
+@SubtypeOf(UnknownVal.class)
 public @interface IntRangeFromPositive {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/IntVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/IntVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -13,9 +14,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({UnknownVal.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({UnknownVal.class})
 public @interface IntVal {
     /** The values that the expression might evaluate to. */
     long[] value();

--- a/framework/src/main/java/org/checkerframework/common/value/qual/MinLen.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/MinLen.java
@@ -1,6 +1,9 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -12,6 +15,8 @@ import java.lang.annotation.Target;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface MinLen {
     /** The minimum number of elements in this sequence. */

--- a/framework/src/main/java/org/checkerframework/common/value/qual/MinLenFieldInvariant.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/MinLenFieldInvariant.java
@@ -1,7 +1,10 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.FieldInvariant;
 
@@ -11,6 +14,8 @@ import org.checkerframework.framework.qual.FieldInvariant;
  *
  * @checker_framework.manual #field-invariants Field invariants
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Target(ElementType.TYPE)
 public @interface MinLenFieldInvariant {

--- a/framework/src/main/java/org/checkerframework/common/value/qual/MinLenFieldInvariant.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/MinLenFieldInvariant.java
@@ -16,8 +16,8 @@ import org.checkerframework.framework.qual.FieldInvariant;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Inherited
 @Target(ElementType.TYPE)
+@Inherited
 public @interface MinLenFieldInvariant {
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/value/qual/PolyValue.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/PolyValue.java
@@ -1,6 +1,9 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
@@ -10,6 +13,8 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
 @PolymorphicQualifier(UnknownVal.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface PolyValue {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/PolyValue.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/PolyValue.java
@@ -15,6 +15,6 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@PolymorphicQualifier(UnknownVal.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(UnknownVal.class)
 public @interface PolyValue {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/StaticallyExecutable.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/StaticallyExecutable.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,6 +13,7 @@ import java.lang.annotation.Target;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface StaticallyExecutable {}

--- a/framework/src/main/java/org/checkerframework/common/value/qual/StringVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/StringVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -12,9 +13,10 @@ import org.checkerframework.framework.qual.SubtypeOf;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({UnknownVal.class})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({UnknownVal.class})
 public @interface StringVal {
     /** The values that the expression might evaluate to. */
     String[] value();

--- a/framework/src/main/java/org/checkerframework/common/value/qual/UnknownVal.java
+++ b/framework/src/main/java/org/checkerframework/common/value/qual/UnknownVal.java
@@ -1,5 +1,6 @@
 package org.checkerframework.common.value.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -15,9 +16,10 @@ import org.checkerframework.framework.qual.TypeUseLocation;
  *
  * @checker_framework.manual #constant-value-checker Constant Value Checker
  */
-@SubtypeOf({})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_PARAMETER, ElementType.TYPE_USE})
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 @DefaultInUncheckedCodeFor(TypeUseLocation.PARAMETER)
 public @interface UnknownVal {}

--- a/framework/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/AnnotatedFor.java
@@ -25,8 +25,8 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #compiling-libraries Compiling partially-annotated libraries
  */
 @Documented
-@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
 @Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.PACKAGE})
 public @interface AnnotatedFor {
     /**
      * @return the type systems for which the class has been annotated. Legal arguments are any

--- a/framework/src/main/java/org/checkerframework/framework/qual/CFComment.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/CFComment.java
@@ -24,6 +24,8 @@ import java.lang.annotation.RetentionPolicy;
  * <p>As a matter of style, programmers should use this annotation on the most deeply nested element
  * to which the comment applies (e.g., local variable rather than method, and method rather than
  * class).
+ *
+ * @checker_framework.manual #library-tips-dont-change-the-code Don't change the code
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)

--- a/framework/src/main/java/org/checkerframework/framework/qual/ConditionalPostconditionAnnotation.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/ConditionalPostconditionAnnotation.java
@@ -54,8 +54,8 @@ import java.lang.annotation.Target;
  * @see QualifierArgument
  */
 @Documented
-@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
 public @interface ConditionalPostconditionAnnotation {
     /**
      * The qualifier that will be established as a postcondition.

--- a/framework/src/main/java/org/checkerframework/framework/qual/Covariant.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/Covariant.java
@@ -28,8 +28,8 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #covariant-type-parameters Covariant type parameters
  */
 @Documented
-@Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
 public @interface Covariant {
     /** The zero-based indices of the type parameters that should be treated covariantly. */
     int[] value();

--- a/framework/src/main/java/org/checkerframework/framework/qual/DefaultQualifierForUse.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/DefaultQualifierForUse.java
@@ -3,6 +3,8 @@ package org.checkerframework.framework.qual;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -10,6 +12,7 @@ import java.lang.annotation.Target;
  * unannotated uses of the type.
  */
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface DefaultQualifierForUse {
     /** Qualifier to add to all unannotated uses of the type with this declaration annotation. */

--- a/framework/src/main/java/org/checkerframework/framework/qual/FieldInvariant.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/FieldInvariant.java
@@ -23,9 +23,9 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #field-invariants Field invariants
  */
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 @Inherited
-@Retention(RetentionPolicy.RUNTIME)
 public @interface FieldInvariant {
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/qual/FromByteCode.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/FromByteCode.java
@@ -1,5 +1,6 @@
 package org.checkerframework.framework.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,6 +12,7 @@ import java.lang.annotation.Target;
  * AnnotatedTypeFactory. (If a method is already annotated with @FromStubFile, this annotation is
  * not added.)
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
 @SubtypeOf({})

--- a/framework/src/main/java/org/checkerframework/framework/qual/FromStubFile.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/FromStubFile.java
@@ -1,5 +1,6 @@
 package org.checkerframework.framework.qual;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,6 +10,7 @@ import java.lang.annotation.Target;
  * If a method is annotated with this declaration annotation, then its signature was read from a
  * stub file. It is added by the StubParser and is not visible to the end user.
  */
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
 public @interface FromStubFile {}

--- a/framework/src/main/java/org/checkerframework/framework/qual/JavaExpression.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/JavaExpression.java
@@ -14,6 +14,6 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #java-expressions-as-arguments Syntax of Java expressions
  */
 @Documented
-@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
 public @interface JavaExpression {}

--- a/framework/src/main/java/org/checkerframework/framework/qual/MonotonicQualifier.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/MonotonicQualifier.java
@@ -36,8 +36,8 @@ import java.lang.annotation.Target;
  * expressions of the target type.
  */
 @Documented
-@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
 public @interface MonotonicQualifier {
     Class<? extends Annotation> value();
 }

--- a/framework/src/main/java/org/checkerframework/framework/qual/NoDefaultQualifierForUse.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/NoDefaultQualifierForUse.java
@@ -3,6 +3,8 @@ package org.checkerframework.framework.qual;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
  * should be applied based on the location of the type or some other defaulting rule.
  */
 @Documented
+@Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface NoDefaultQualifierForUse {
     /** Top qualifier in hierarchies for which no default annotation for use should be applied. */

--- a/framework/src/main/java/org/checkerframework/framework/qual/NoDefaultQualifierForUse.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/NoDefaultQualifierForUse.java
@@ -11,6 +11,8 @@ import java.lang.annotation.Target;
  * Declaration annotation applied to type declarations to specify that the annotation on the type
  * declaration should not be applied to unannotated uses of the type. Instead, another default
  * should be applied based on the location of the type or some other defaulting rule.
+ *
+ * @checker_framework.manual #creating-debugging-options Debugging Options
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/framework/src/main/java/org/checkerframework/framework/qual/PolymorphicQualifier.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/PolymorphicQualifier.java
@@ -17,8 +17,8 @@ import java.lang.annotation.Target;
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism
  */
 @Documented
-@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
 public @interface PolymorphicQualifier {
     /**
      * Indicates which type system this annotation refers to (optional, and usually unnecessary).

--- a/framework/src/main/java/org/checkerframework/framework/qual/PostconditionAnnotation.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/PostconditionAnnotation.java
@@ -51,8 +51,8 @@ import java.lang.annotation.Target;
  * @see QualifierArgument
  */
 @Documented
-@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
 public @interface PostconditionAnnotation {
     /**
      * The qualifier that will be established as a postcondition.

--- a/framework/src/main/java/org/checkerframework/framework/qual/PreconditionAnnotation.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/PreconditionAnnotation.java
@@ -53,8 +53,8 @@ import java.lang.annotation.Target;
  * @see QualifierArgument
  */
 @Documented
-@Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE})
 public @interface PreconditionAnnotation {
     /** The qualifier that must be established as a precondition. */
     Class<? extends Annotation> qualifier();

--- a/framework/src/main/java/org/checkerframework/framework/qual/QualifierArgument.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/QualifierArgument.java
@@ -34,8 +34,8 @@ import java.lang.annotation.Target;
  * @see PreconditionAnnotation
  */
 @Documented
-@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
 public @interface QualifierArgument {
     /**
      * Specifies the name of the argument of the qualifier, that is passed the values held in the

--- a/framework/src/main/java/org/checkerframework/framework/qual/UpperBoundFor.java
+++ b/framework/src/main/java/org/checkerframework/framework/qual/UpperBoundFor.java
@@ -14,6 +14,8 @@ import java.lang.annotation.Target;
  *   <li>a use of a particular type.
  *   <li>a use of a particular kind of type.
  * </ul>
+ *
+ * @checker_framework.manual #upper-bound-for-use Upper bound of qualifiers on uses of a given type
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/framework/src/main/java/org/checkerframework/framework/source/SupportedLintOptions.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SupportedLintOptions.java
@@ -23,10 +23,10 @@ import java.lang.annotation.Target;
  * @see org.checkerframework.framework.source.SupportedOptions
  * @checker_framework.manual #creating-compiler-interface The checker class: Compiler interface
  */
-@Inherited
 @Documented
-@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
 public @interface SupportedLintOptions {
     String[] value();
 }

--- a/framework/src/main/java/org/checkerframework/framework/source/SupportedOptions.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SupportedOptions.java
@@ -18,10 +18,10 @@ import java.lang.annotation.Target;
  * @see SupportedLintOptions
  * @see javax.annotation.processing.SupportedOptions
  */
-@Inherited
 @Documented
-@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
 public @interface SupportedOptions {
     String[] value();
 }

--- a/framework/src/main/java/org/checkerframework/framework/source/SuppressWarningsKeys.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SuppressWarningsKeys.java
@@ -27,10 +27,10 @@ import java.lang.annotation.Target;
  * most-concrete class up to SourceChecker? That would make the behavior consistent with e.g. our
  * SupportedOptions. Is there ever a reason where that would be unwanted?
  */
-@Inherited
 @Documented
-@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
 public @interface SuppressWarningsKeys {
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/PurityUnqualified.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/PurityUnqualified.java
@@ -12,6 +12,8 @@ import org.checkerframework.framework.qual.SubtypeOf;
 /**
  * An annotation intended solely for representing an unqualified type in the qualifier hierarchy for
  * the Purity Checker.
+ *
+ * @checker_framework.manual #purity-checker Purity Checker
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE) // do not store in class file

--- a/framework/src/main/java/org/checkerframework/framework/util/PurityUnqualified.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/PurityUnqualified.java
@@ -1,6 +1,9 @@
 package org.checkerframework.framework.util;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
@@ -9,13 +12,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
 /**
  * An annotation intended solely for representing an unqualified type in the qualifier hierarchy for
  * the Purity Checker.
- *
- * <p>Note that because of the missing RetentionPolicy, the qualifier will not be stored in
- * bytecode.
  */
-// TODO: set it to store in source rather than having missing RetentionPolicy.
-@InvisibleQualifier
+@Documented
+@Retention(RetentionPolicy.SOURCE) // do not store in class file
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@InvisibleQualifier
 public @interface PurityUnqualified {}

--- a/framework/src/test/java/lubglb/quals/A.java
+++ b/framework/src/test/java/lubglb/quals/A.java
@@ -8,9 +8,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@DefaultQualifierInHierarchy
-@SubtypeOf({})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@DefaultQualifierInHierarchy
+@SubtypeOf({})
 public @interface A {}

--- a/framework/src/test/java/lubglb/quals/B.java
+++ b/framework/src/test/java/lubglb/quals/B.java
@@ -9,9 +9,9 @@ import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-@SubtypeOf({A.class})
-@DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({A.class})
+@DefaultInUncheckedCodeFor({TypeUseLocation.PARAMETER})
 public @interface B {}

--- a/framework/src/test/java/lubglb/quals/C.java
+++ b/framework/src/test/java/lubglb/quals/C.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({A.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({A.class})
 public @interface C {}

--- a/framework/src/test/java/lubglb/quals/D.java
+++ b/framework/src/test/java/lubglb/quals/D.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({C.class, B.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({C.class, B.class})
 public @interface D {}

--- a/framework/src/test/java/lubglb/quals/E.java
+++ b/framework/src/test/java/lubglb/quals/E.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({C.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({C.class})
 public @interface E {}

--- a/framework/src/test/java/lubglb/quals/F.java
+++ b/framework/src/test/java/lubglb/quals/F.java
@@ -10,10 +10,10 @@ import org.checkerframework.framework.qual.DefaultInUncheckedCodeFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-@SubtypeOf({D.class, E.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({D.class, E.class})
 @DefaultFor({TypeUseLocation.LOWER_BOUND})
 @DefaultInUncheckedCodeFor({TypeUseLocation.RETURN})
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface F {}

--- a/framework/src/test/java/lubglb/quals/Poly.java
+++ b/framework/src/test/java/lubglb/quals/Poly.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
 @Documented
-@PolymorphicQualifier(A.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(A.class)
 public @interface Poly {}

--- a/framework/src/test/java/testchecker/quals/H1Bot.java
+++ b/framework/src/test/java/testchecker/quals/H1Bot.java
@@ -9,9 +9,9 @@ import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-@SubtypeOf({H1S1.class, H1S2.class, H1Invalid.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultFor({TypeUseLocation.LOWER_BOUND})
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H1S1.class, H1S2.class, H1Invalid.class})
+@DefaultFor({TypeUseLocation.LOWER_BOUND})
 public @interface H1Bot {}

--- a/framework/src/test/java/testchecker/quals/H1Invalid.java
+++ b/framework/src/test/java/testchecker/quals/H1Invalid.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({H1Top.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H1Top.class})
 public @interface H1Invalid {}

--- a/framework/src/test/java/testchecker/quals/H1Poly.java
+++ b/framework/src/test/java/testchecker/quals/H1Poly.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
-@PolymorphicQualifier(H1Top.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(H1Top.class)
 public @interface H1Poly {}

--- a/framework/src/test/java/testchecker/quals/H1S1.java
+++ b/framework/src/test/java/testchecker/quals/H1S1.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({H1Top.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H1Top.class})
 public @interface H1S1 {}

--- a/framework/src/test/java/testchecker/quals/H1S2.java
+++ b/framework/src/test/java/testchecker/quals/H1S2.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({H1Top.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H1Top.class})
 public @interface H1S2 {}

--- a/framework/src/test/java/testchecker/quals/H1Top.java
+++ b/framework/src/test/java/testchecker/quals/H1Top.java
@@ -8,9 +8,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({})
-@DefaultQualifierInHierarchy
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
+@DefaultQualifierInHierarchy
 public @interface H1Top {}

--- a/framework/src/test/java/testchecker/quals/H2Bot.java
+++ b/framework/src/test/java/testchecker/quals/H2Bot.java
@@ -9,9 +9,9 @@ import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-@SubtypeOf({H2S1.class, H2S2.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H2S1.class, H2S2.class})
+@DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface H2Bot {}

--- a/framework/src/test/java/testchecker/quals/H2Poly.java
+++ b/framework/src/test/java/testchecker/quals/H2Poly.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
-@PolymorphicQualifier(H2Top.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier(H2Top.class)
 public @interface H2Poly {}

--- a/framework/src/test/java/testchecker/quals/H2S1.java
+++ b/framework/src/test/java/testchecker/quals/H2S1.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({H2Top.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H2Top.class})
 public @interface H2S1 {}

--- a/framework/src/test/java/testchecker/quals/H2S2.java
+++ b/framework/src/test/java/testchecker/quals/H2S2.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({H2Top.class})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({H2Top.class})
 public @interface H2S2 {}

--- a/framework/src/test/java/testchecker/quals/H2Top.java
+++ b/framework/src/test/java/testchecker/quals/H2Top.java
@@ -8,9 +8,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf({})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({})
 @DefaultQualifierInHierarchy
 public @interface H2Top {}

--- a/framework/src/test/java/testlib/nontopdefault/qual/NTDBottom.java
+++ b/framework/src/test/java/testlib/nontopdefault/qual/NTDBottom.java
@@ -11,11 +11,11 @@ import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
-@SubtypeOf({NTDMiddle.class, NTDSide.class})
-@DefaultInUncheckedCodeFor({TypeUseLocation.LOWER_BOUND})
-@DefaultFor({TypeUseLocation.LOWER_BOUND})
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
+@SubtypeOf({NTDMiddle.class, NTDSide.class})
+@DefaultInUncheckedCodeFor({TypeUseLocation.LOWER_BOUND})
+@DefaultFor({TypeUseLocation.LOWER_BOUND})
 public @interface NTDBottom {}

--- a/framework/src/test/java/testlib/nontopdefault/qual/NTDMiddle.java
+++ b/framework/src/test/java/testlib/nontopdefault/qual/NTDMiddle.java
@@ -10,10 +10,10 @@ import org.checkerframework.framework.qual.DefaultQualifierInHierarchyInUnchecke
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** Middle is the default type in hierarchy. */
-@SubtypeOf(NTDTop.class)
-@DefaultQualifierInHierarchy
-@DefaultQualifierInHierarchyInUncheckedCode
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(NTDTop.class)
+@DefaultQualifierInHierarchy
+@DefaultQualifierInHierarchyInUncheckedCode
 public @interface NTDMiddle {}

--- a/framework/src/test/java/testlib/nontopdefault/qual/NTDSide.java
+++ b/framework/src/test/java/testlib/nontopdefault/qual/NTDSide.java
@@ -7,8 +7,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
-@SubtypeOf(NTDTop.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(NTDTop.class)
 public @interface NTDSide {}

--- a/framework/src/test/java/testlib/nontopdefault/qual/NTDTop.java
+++ b/framework/src/test/java/testlib/nontopdefault/qual/NTDTop.java
@@ -9,13 +9,13 @@ import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({})
 @DefaultFor({
     TypeUseLocation.LOCAL_VARIABLE,
     TypeUseLocation.IMPLICIT_UPPER_BOUND,
     TypeUseLocation.RECEIVER
 })
-@Documented
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 public @interface NTDTop {}

--- a/framework/src/test/java/testlib/util/EnsuresOdd.java
+++ b/framework/src/test/java/testlib/util/EnsuresOdd.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.PostconditionAnnotation;
  * A postcondition annotation to indicate that a method ensures certain expressions to be {@link
  * Odd}.
  */
-@PostconditionAnnotation(qualifier = Odd.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@PostconditionAnnotation(qualifier = Odd.class)
 @InheritedAnnotation
 public @interface EnsuresOdd {
     String[] value();

--- a/framework/src/test/java/testlib/util/EnsuresOddIf.java
+++ b/framework/src/test/java/testlib/util/EnsuresOddIf.java
@@ -12,10 +12,10 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
  * A conditional postcondition annotation to indicate that a method ensures certain expressions to
  * be {@link Odd} given a certain result (either true or false).
  */
-@ConditionalPostconditionAnnotation(qualifier = Odd.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@ConditionalPostconditionAnnotation(qualifier = Odd.class)
 @InheritedAnnotation
 public @interface EnsuresOddIf {
     String[] expression();

--- a/framework/src/test/java/testlib/util/RequiresOdd.java
+++ b/framework/src/test/java/testlib/util/RequiresOdd.java
@@ -11,10 +11,10 @@ import org.checkerframework.framework.qual.PreconditionAnnotation;
  * A precondition annotation to indicate that a method requires certain expressions to be {@link
  * Odd}.
  */
-@PreconditionAnnotation(qualifier = Odd.class)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@PreconditionAnnotation(qualifier = Odd.class)
 public @interface RequiresOdd {
     String[] value();
 }

--- a/framework/src/test/java/typedecldefault/quals/PolyTypeDeclDefault.java
+++ b/framework/src/test/java/typedecldefault/quals/PolyTypeDeclDefault.java
@@ -7,7 +7,7 @@ import org.checkerframework.framework.qual.PolymorphicQualifier;
 
 /** A polymorphic qualifier for the TyepDeclDefault type system. */
 @Documented
-@PolymorphicQualifier
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@PolymorphicQualifier
 public @interface PolyTypeDeclDefault {}

--- a/framework/src/test/java/typedecldefault/quals/PolyTypeDeclDefault.java
+++ b/framework/src/test/java/typedecldefault/quals/PolyTypeDeclDefault.java
@@ -1,6 +1,8 @@
 package typedecldefault.quals;
 
 import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
 /** A polymorphic qualifier for the TyepDeclDefault type system. */

--- a/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultBottom.java
+++ b/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultBottom.java
@@ -1,5 +1,6 @@
 package typedecldefault.quals;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -10,9 +11,10 @@ import org.checkerframework.framework.qual.QualifierForLiterals;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** TypeDeclDefault bottom qualifier. */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf(TypeDeclDefaultMiddle.class)
 @QualifierForLiterals(LiteralKind.STRING)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@Retention(RetentionPolicy.RUNTIME)
 @DefaultQualifierInHierarchy
 public @interface TypeDeclDefaultBottom {}

--- a/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultMiddle.java
+++ b/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultMiddle.java
@@ -1,5 +1,6 @@
 package typedecldefault.quals;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,7 +8,8 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.SubtypeOf;
 
 /** TypeDeclDefault middle qualifier. */
-@SubtypeOf(TypeDeclDefaultTop.class)
-@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf(TypeDeclDefaultTop.class)
 public @interface TypeDeclDefaultMiddle {}

--- a/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultTop.java
+++ b/framework/src/test/java/typedecldefault/quals/TypeDeclDefaultTop.java
@@ -1,6 +1,8 @@
 package typedecldefault.quals;
 
 import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
 import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
 import org.checkerframework.framework.qual.TypeUseLocation;

--- a/framework/src/testannotations/java/android/support/annotation/IntRange.java
+++ b/framework/src/testannotations/java/android/support/annotation/IntRange.java
@@ -1,8 +1,10 @@
 package android.support.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+@Documented
 @Retention(RetentionPolicy.CLASS)
 public @interface IntRange {
     long from() default Long.MIN_VALUE;


### PR DESCRIPTION
This pull request adds `@Documented` and `@Retention` to most annotation defitinitions.  It also puts meta-annotations in canonical order, and it adds some missing documentation.