### PR TITLE
Annotate Object.equals(Object) overrides as accepting null.

### DIFF
--- a/checker/jdk/nullness/src/java/net/URL.java
+++ b/checker/jdk/nullness/src/java/net/URL.java
@@ -865,7 +865,7 @@ public final class URL implements java.io.Serializable {
      * @return  {@code true} if the objects are the same;
      *          {@code false} otherwise.
      */
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (!(obj instanceof URL))
             return false;
         URL u2 = (URL)obj;

--- a/checker/jdk/nullness/src/java/text/MessageFormat.java
+++ b/checker/jdk/nullness/src/java/text/MessageFormat.java
@@ -1101,7 +1101,7 @@ public class MessageFormat extends Format {
     /**
      * Equality comparison between two message format objects
      */
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj)                      // quick check
             return true;
         if (obj == null || getClass() != obj.getClass())

--- a/checker/jdk/nullness/src/java/util/Collections.java
+++ b/checker/jdk/nullness/src/java/util/Collections.java
@@ -1202,7 +1202,7 @@ public class Collections {
         private static final long serialVersionUID = -9215047833775013803L;
 
         UnmodifiableSet(Set<? extends E> s)     {super(s);}
-        public boolean equals(Object o) {return o == this || c.equals(o);}
+        public boolean equals(@Nullable Object o) {return o == this || c.equals(o);}
         public int hashCode()           {return c.hashCode();}
     }
 
@@ -1379,7 +1379,7 @@ public class Collections {
             this.list = list;
         }
 
-        public boolean equals(Object o) {return o == this || list.equals(o);}
+        public boolean equals(@Nullable Object o) {return o == this || list.equals(o);}
         public int hashCode()           {return list.hashCode();}
 
         public E get(int index) {return list.get(index);}
@@ -1571,7 +1571,7 @@ public class Collections {
             return values;
         }
 
-        public boolean equals(Object o) {return o == this || m.equals(o);}
+        public boolean equals(@Nullable Object o) {return o == this || m.equals(o);}
         public int hashCode()           {return m.hashCode();}
         public String toString()        {return m.toString();}
 
@@ -1806,7 +1806,7 @@ public class Collections {
                 }
                 return true;
             }
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (o == this)
                     return true;
 
@@ -1837,7 +1837,7 @@ public class Collections {
                     throw new UnsupportedOperationException();
                 }
                 public int hashCode()    {return e.hashCode();}
-                public boolean equals(Object o) {
+                public boolean equals(@Nullable Object o) {
                     if (this == o)
                         return true;
                     if (!(o instanceof Map.Entry))
@@ -2235,7 +2235,7 @@ public class Collections {
             super(s, mutex);
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o)
                 return true;
             synchronized (mutex) {return c.equals(o);}
@@ -2508,7 +2508,7 @@ public class Collections {
             this.list = list;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o)
                 return true;
             synchronized (mutex) {return list.equals(o);}
@@ -2736,7 +2736,7 @@ public class Collections {
             }
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (this == o)
                 return true;
             synchronized (mutex) {return m.equals(o);}
@@ -3312,7 +3312,7 @@ public class Collections {
         }
 
         public E element()              {return queue.element();}
-        public boolean equals(Object o) {return o == this || c.equals(o);}
+        public boolean equals(@Nullable Object o) {return o == this || c.equals(o);}
         public int hashCode()           {return c.hashCode();}
         public E peek()                 {return queue.peek();}
         public E poll()                 {return queue.poll();}
@@ -3365,7 +3365,7 @@ public class Collections {
 
         CheckedSet(Set<E> s, Class<E> elementType) { super(s, elementType); }
 
-        public boolean equals(Object o) { return o == this || c.equals(o); }
+        public boolean equals(@Nullable Object o) { return o == this || c.equals(o); }
         public int hashCode()           { return c.hashCode(); }
     }
 
@@ -3562,7 +3562,7 @@ public class Collections {
             this.list = list;
         }
 
-        public boolean equals(Object o)  { return o == this || list.equals(o); }
+        public boolean equals(@Nullable Object o)  { return o == this || list.equals(o); }
         public int hashCode()            { return list.hashCode(); }
         public E get(int index)          { return list.get(index); }
         public E remove(int index)       { return list.remove(index); }
@@ -3749,7 +3749,7 @@ public class Collections {
         public void clear()                    { m.clear(); }
         public Set<K> keySet()                 { return m.keySet(); }
         public Collection<V> values()          { return m.values(); }
-        public boolean equals(Object o)        { return o == this || m.equals(o); }
+        public boolean equals(@Nullable Object o)        { return o == this || m.equals(o); }
         public int hashCode()                  { return m.hashCode(); }
         public String toString()               { return m.toString(); }
 
@@ -3996,7 +3996,7 @@ public class Collections {
                 return modified;
             }
 
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (o == this)
                     return true;
                 if (!(o instanceof Set))
@@ -4043,7 +4043,7 @@ public class Collections {
                         " value into map with value type " + valueType;
                 }
 
-                public boolean equals(Object o) {
+                public boolean equals(@Nullable Object o) {
                     if (o == this)
                         return true;
                     if (!(o instanceof Map.Entry))
@@ -4620,7 +4620,7 @@ public class Collections {
             throw new IndexOutOfBoundsException("Index: "+index);
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return (o instanceof List) && ((List<?>)o).isEmpty();
         }
 
@@ -4753,7 +4753,7 @@ public class Collections {
         @SideEffectFree
         public Set<Map.Entry<K,V>> entrySet()      {return emptySet();}
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return (o instanceof Map) && ((Map<?,?>)o).isEmpty();
         }
 
@@ -5369,7 +5369,7 @@ public class Collections {
             return cmp.compare(t2, t1);
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return (o == this) ||
                 (o instanceof ReverseComparator2 &&
                  cmp.equals(((ReverseComparator2)o).cmp));
@@ -5660,7 +5660,7 @@ public class Collections {
         public <T> T[] toArray(T[] a)     { return s.toArray(a); }
         public String toString()          { return s.toString(); }
         public int hashCode()             { return s.hashCode(); }
-        public boolean equals(Object o)   { return o == this || s.equals(o); }
+        public boolean equals(@Nullable Object o)   { return o == this || s.equals(o); }
         public boolean containsAll(Collection<?> c) {return s.containsAll(c);}
         public boolean removeAll(Collection<?> c)   {return s.removeAll(c);}
         public boolean retainAll(Collection<?> c)   {return s.retainAll(c);}

--- a/checker/jdk/nullness/src/java/util/HashMap.java
+++ b/checker/jdk/nullness/src/java/util/HashMap.java
@@ -309,7 +309,7 @@ public class HashMap<K extends @Nullable Object, V extends @Nullable Object> ext
             return oldValue;
         }
 
-        public final boolean equals(Object o) {
+        public final boolean equals(@Nullable Object o) {
             if (o == this)
                 return true;
             if (o instanceof Map.Entry) {

--- a/checker/jdk/nullness/src/java/util/Hashtable.java
+++ b/checker/jdk/nullness/src/java/util/Hashtable.java
@@ -1300,7 +1300,7 @@ public class Hashtable<K extends @NonNull Object, V extends @NonNull Object>
             return oldValue;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (!(o instanceof Map.Entry))
                 return false;
             Map.Entry<?,?> e = (Map.Entry<?,?>)o;

--- a/checker/jdk/nullness/src/java/util/IdentityHashMap.java
+++ b/checker/jdk/nullness/src/java/util/IdentityHashMap.java
@@ -657,7 +657,7 @@ public class IdentityHashMap<K, V>
      * @see Object#equals(Object)
      */
     @Pure
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (o == this) {
             return true;
         } else if (o instanceof IdentityHashMap) {
@@ -904,7 +904,7 @@ public class IdentityHashMap<K, V>
                 return oldValue;
             }
 
-            public boolean equals(Object o) {
+            public boolean equals(@Nullable Object o) {
                 if (index < 0)
                     return super.equals(o);
 

--- a/checker/jdk/nullness/src/java/util/Locale.java
+++ b/checker/jdk/nullness/src/java/util/Locale.java
@@ -775,7 +775,7 @@ public final class Locale implements Cloneable, Serializable {
         }
 
         @Override
-        public boolean equals(Object obj) {
+        public boolean equals(@Nullable Object obj) {
             if (this == obj) {
                 return true;
             }

--- a/checker/jdk/nullness/src/java/util/Map.java
+++ b/checker/jdk/nullness/src/java/util/Map.java
@@ -578,7 +578,7 @@ public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
      * @param o object to be compared for equality with this map
      * @return <tt>true</tt> if the specified object is equal to this map
      */
-    boolean equals(Object o);
+    boolean equals(@Nullable Object o);
 
     /**
      * Returns the hash code value for this map.  The hash code of a map is

--- a/checker/jdk/nullness/src/java/util/Optional.java
+++ b/checker/jdk/nullness/src/java/util/Optional.java
@@ -321,7 +321,7 @@ public final @NonNull class Optional<T> {
      * otherwise {@code false}
      */
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
         }

--- a/checker/jdk/nullness/src/java/util/TreeMap.java
+++ b/checker/jdk/nullness/src/java/util/TreeMap.java
@@ -2156,7 +2156,7 @@ public class TreeMap<K, V>
             return oldValue;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (!(o instanceof Map.Entry))
                 return false;
             Map.Entry<?,?> e = (Map.Entry<?,?>)o;

--- a/checker/jdk/nullness/src/java/util/WeakHashMap.java
+++ b/checker/jdk/nullness/src/java/util/WeakHashMap.java
@@ -746,7 +746,7 @@ public class WeakHashMap<K, V>
             return oldValue;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (!(o instanceof Map.Entry))
                 return false;
             Map.Entry<?,?> e = (Map.Entry<?,?>)o;

--- a/checker/jdk/nullness/src/java/util/concurrent/ConcurrentHashMap.java
+++ b/checker/jdk/nullness/src/java/util/concurrent/ConcurrentHashMap.java
@@ -646,7 +646,7 @@ public class ConcurrentHashMap<K extends @NonNull Object, V extends @NonNull Obj
             throw new UnsupportedOperationException();
         }
 
-        public final boolean equals(Object o) {
+        public final boolean equals(@Nullable Object o) {
             Object k, v, u; Map.Entry<?,?> e;
             return ((o instanceof Map.Entry) &&
                     (k = (e = (Map.Entry<?,?>)o).getKey()) != null &&
@@ -1356,7 +1356,7 @@ public class ConcurrentHashMap<K extends @NonNull Object, V extends @NonNull Obj
      * @param o object to be compared for equality with this map
      * @return {@code true} if the specified object is equal to this map
      */
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         if (o != this) {
             if (!(o instanceof Map))
                 return false;
@@ -3507,7 +3507,7 @@ public class ConcurrentHashMap<K extends @NonNull Object, V extends @NonNull Obj
         public int hashCode()    { return key.hashCode() ^ val.hashCode(); }
         public String toString() { return key + "=" + val; }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             Object k, v; Map.Entry<?,?> e;
             return ((o instanceof Map.Entry) &&
                     (k = (e = (Map.Entry<?,?>)o).getKey()) != null &&
@@ -4659,7 +4659,7 @@ public class ConcurrentHashMap<K extends @NonNull Object, V extends @NonNull Obj
             return h;
         }
 
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             Set<?> c;
             return ((o instanceof Set) &&
                     ((c = (Set<?>)o) == this ||
@@ -4809,7 +4809,7 @@ public class ConcurrentHashMap<K extends @NonNull Object, V extends @NonNull Obj
             return h;
         }
 
-        public final boolean equals(Object o) {
+        public final boolean equals(@Nullable Object o) {
             Set<?> c;
             return ((o instanceof Set) &&
                     ((c = (Set<?>)o) == this ||

--- a/checker/jdk/nullness/src/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/checker/jdk/nullness/src/java/util/concurrent/ConcurrentSkipListSet.java
@@ -306,7 +306,7 @@ public class ConcurrentSkipListSet<E extends @NonNull Object>
      * @param o the object to be compared for equality with this set
      * @return {@code true} if the specified object is equal to this set
      */
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         // Override AbstractSet version to avoid calling size()
         if (o == this)
             return true;

--- a/checker/jdk/nullness/src/java/util/jar/Attributes.java
+++ b/checker/jdk/nullness/src/java/util/jar/Attributes.java
@@ -281,7 +281,7 @@ public class Attributes implements Map<Object,Object>, Cloneable {
      * @param o the Object to be compared
      * @return true if the specified Object is equal to this Map
      */
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return map.equals(o);
     }
 
@@ -511,7 +511,7 @@ public class Attributes implements Map<Object,Object>, Cloneable {
          * @return true if this attribute name is equal to the
          *         specified attribute object
          */
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             if (o instanceof Name) {
                 Comparator<String> c = ASCIICaseInsensitiveComparator.CASE_INSENSITIVE_ORDER;
                 return c.compare(name, ((Name)o).name) == 0;


### PR DESCRIPTION
Most overrides are already annotated that way, but I noticed that
Map.equals(Object) was not, and I grepped through for other instances.