### PR TITLE
Remove the static annotationNameCache from AnnotationUtils

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 ---------------------------------------------------------------------------
 
+Version 3.1.0, January 2, 2020
+
 Command-line option -AprintGitProperties prints information about the git
 repository from which the Checker Framework was compiled.
 

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundAnnotatedTypeFactory.java
@@ -43,7 +43,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
 import org.checkerframework.framework.type.treeannotator.TreeAnnotator;
 import org.checkerframework.javacutil.AnnotationBuilder;
-import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
 /**
@@ -148,7 +147,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror valueType, AnnotatedTypeMirror type) {
         AnnotationMirror anm = getLowerBoundAnnotationFromValueType(valueType);
         if (!type.isAnnotatedInHierarchy(UNKNOWN)) {
-            if (!AnnotationUtils.areSameByClass(anm, LowerBoundUnknown.class)) {
+            if (!areSameByClass(anm, LowerBoundUnknown.class)) {
                 type.addAnnotation(anm);
             }
             return;
@@ -205,7 +204,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (possibleValues == null) {
             // possibleValues is null if there is no IntVal annotation on the type - such as
             // when there is a BottomVal annotation. In that case, give this the LBC's bottom type.
-            if (AnnotationUtils.containsSameByClass(valueType.getAnnotations(), BottomVal.class)) {
+            if (containsSameByClass(valueType.getAnnotations(), BottomVal.class)) {
                 return BOTTOM;
             }
             return UNKNOWN;
@@ -323,8 +322,7 @@ public class LowerBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         private void handleBitWiseComplement(
                 AnnotatedTypeMirror searchIndexType, AnnotatedTypeMirror typeDst) {
-            if (AnnotationUtils.containsSameByClass(
-                    searchIndexType.getAnnotations(), NegativeIndexFor.class)) {
+            if (containsSameByClass(searchIndexType.getAnnotations(), NegativeIndexFor.class)) {
                 typeDst.addAnnotation(NN);
             }
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundTransfer.java
@@ -204,7 +204,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
         long intLiteral = integerLiteral.longValue();
 
         if (intLiteral == 0) {
-            if (AnnotationUtils.areSameByClass(otherAnno, NonNegative.class)) {
+            if (aTypeFactory.areSameByClass(otherAnno, NonNegative.class)) {
                 List<Node> internals = splitAssignments(otherNode);
                 for (Node internal : internals) {
                     Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, internal);
@@ -212,7 +212,7 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
                 }
             }
         } else if (intLiteral == -1) {
-            if (AnnotationUtils.areSameByClass(otherAnno, GTENegativeOne.class)) {
+            if (aTypeFactory.areSameByClass(otherAnno, GTENegativeOne.class)) {
                 List<Node> internals = splitAssignments(otherNode);
                 for (Node internal : internals) {
                     Receiver rec = FlowExpressions.internalReprOf(aTypeFactory, internal);
@@ -437,16 +437,16 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
          *      nn + * -> *
          *      pos + gte-1 -> nn
          */
-        if (AnnotationUtils.areSameByClass(leftAnno, Positive.class)
-                && AnnotationUtils.areSameByClass(rightAnno, Positive.class)) {
+        if (aTypeFactory.areSameByClass(leftAnno, Positive.class)
+                && aTypeFactory.areSameByClass(rightAnno, Positive.class)) {
             return POS;
         }
 
-        if (AnnotationUtils.areSameByClass(leftAnno, NonNegative.class)) {
+        if (aTypeFactory.areSameByClass(leftAnno, NonNegative.class)) {
             return rightAnno;
         }
 
-        if (AnnotationUtils.areSameByClass(rightAnno, NonNegative.class)) {
+        if (aTypeFactory.areSameByClass(rightAnno, NonNegative.class)) {
             return leftAnno;
         }
 
@@ -806,15 +806,15 @@ public class LowerBoundTransfer extends IndexAbstractTransfer {
     }
 
     private boolean isPositive(AnnotationMirror anm) {
-        return AnnotationUtils.areSameByClass(anm, Positive.class);
+        return aTypeFactory.areSameByClass(anm, Positive.class);
     }
 
     private boolean isNonNegative(AnnotationMirror anm) {
-        return AnnotationUtils.areSameByClass(anm, NonNegative.class) || isPositive(anm);
+        return aTypeFactory.areSameByClass(anm, NonNegative.class) || isPositive(anm);
     }
 
     private boolean isGTEN1(AnnotationMirror anm) {
-        return AnnotationUtils.areSameByClass(anm, GTENegativeOne.class) || isNonNegative(anm);
+        return aTypeFactory.areSameByClass(anm, GTENegativeOne.class) || isNonNegative(anm);
     }
 
     private AnnotationMirror getLowerBoundAnnotation(

--- a/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/lowerbound/LowerBoundVisitor.java
@@ -14,7 +14,6 @@ import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.source.Result;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * Implements the actual checks to make sure that array accesses aren't too low. Will issue a
@@ -80,8 +79,8 @@ public class LowerBoundVisitor extends BaseTypeVisitor<LowerBoundAnnotatedTypeFa
                 anm = null;
             }
             if (anm == null
-                    || !(AnnotationUtils.areSameByClass(anm, NonNegative.class)
-                            || AnnotationUtils.areSameByClass(anm, Positive.class))) {
+                    || !(atypeFactory.areSameByClass(anm, NonNegative.class)
+                            || atypeFactory.areSameByClass(anm, Positive.class))) {
                 checker.report(
                         Result.failure(
                                 FROM_NOT_NN, subSeq.from, anm == null ? "@LowerBoundUnknown" : anm),

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -205,9 +205,9 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
             } else {
                 // the glb is either one of the annotations (if the other is top), or bottom.
-                if (AnnotationUtils.areSameByClass(a1, SameLenUnknown.class)) {
+                if (areSameByClass(a1, SameLenUnknown.class)) {
                     return a2;
-                } else if (AnnotationUtils.areSameByClass(a2, SameLenUnknown.class)) {
+                } else if (areSameByClass(a2, SameLenUnknown.class)) {
                     return a1;
                 } else {
                     return BOTTOM;
@@ -233,12 +233,12 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
             } else {
                 // the lub is either one of the annotations (if the other is bottom), or top.
-                if (AnnotationUtils.areSameByClass(a1, SameLenBottom.class)) {
+                if (areSameByClass(a1, SameLenBottom.class)) {
                     return a2;
-                } else if (AnnotationUtils.areSameByClass(a2, SameLenBottom.class)) {
+                } else if (areSameByClass(a2, SameLenBottom.class)) {
                     return a1;
-                } else if (AnnotationUtils.areSameByClass(a1, PolySameLen.class)
-                        && AnnotationUtils.areSameByClass(a2, PolySameLen.class)) {
+                } else if (areSameByClass(a1, PolySameLen.class)
+                        && areSameByClass(a2, PolySameLen.class)) {
                     return a1;
                 } else {
                     return UNKNOWN;
@@ -248,12 +248,12 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameByClass(subAnno, SameLenBottom.class)) {
+            if (areSameByClass(subAnno, SameLenBottom.class)) {
                 return true;
-            } else if (AnnotationUtils.areSameByClass(superAnno, SameLenUnknown.class)) {
+            } else if (areSameByClass(superAnno, SameLenUnknown.class)) {
                 return true;
-            } else if (AnnotationUtils.areSameByClass(subAnno, PolySameLen.class)) {
-                return AnnotationUtils.areSameByClass(superAnno, PolySameLen.class);
+            } else if (areSameByClass(subAnno, PolySameLen.class)) {
+                return areSameByClass(superAnno, PolySameLen.class);
             } else if (AnnotationUtils.hasElementValue(subAnno, "value")
                     && AnnotationUtils.hasElementValue(superAnno, "value")) {
                 List<String> subArrays = getValueOfAnnotationWithStringArgument(subAnno);
@@ -296,9 +296,9 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     Receiver rec = FlowExpressions.internalReprOf(this.atypeFactory, sequenceTree);
                     if (mayAppearInSameLen(rec)) {
                         String recString = rec.toString();
-                        if (AnnotationUtils.areSameByClass(sequenceAnno, SameLenUnknown.class)) {
+                        if (areSameByClass(sequenceAnno, SameLenUnknown.class)) {
                             sequenceAnno = createSameLen(Collections.singletonList(recString));
-                        } else if (AnnotationUtils.areSameByClass(sequenceAnno, SameLen.class)) {
+                        } else if (areSameByClass(sequenceAnno, SameLen.class)) {
                             // Add the sequence whose length is being used to the annotation.
                             List<String> exprs =
                                     getValueOfAnnotationWithStringArgument(sequenceAnno);
@@ -388,7 +388,7 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             }
         }
         for (AnnotationMirror anno : annos) {
-            if (AnnotationUtils.areSameByClass(anno, SameLen.class)) {
+            if (areSameByClass(anno, SameLen.class)) {
                 exprs.addAll(getValueOfAnnotationWithStringArgument(anno));
             }
         }

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -30,7 +30,6 @@ import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.FlowExpressionParseUtil;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 /**
  * The transfer function for the SameLen checker. Contains three cases:
@@ -132,8 +131,7 @@ public class SameLenTransfer extends CFTransfer {
                 FlowExpressions.internalReprOf(analysis.getTypeFactory(), node.getExpression());
 
         if (IndexUtil.isSequenceType(node.getTarget().getType())
-                || (rightAnno != null
-                        && AnnotationUtils.areSameByClass(rightAnno, SameLen.class))) {
+                || (rightAnno != null && aTypeFactory.areSameByClass(rightAnno, SameLen.class))) {
 
             AnnotationMirror rightAnnoOrUnknown = rightAnno == null ? UNKNOWN : rightAnno;
 

--- a/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/searchindex/SearchIndexAnnotatedTypeFactory.java
@@ -102,8 +102,8 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     new HashSet<>(ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a1));
             combinedArrays.addAll(ValueCheckerUtils.getValueOfAnnotationWithStringArgument(a2));
 
-            if (AnnotationUtils.areSameByClass(a1, NegativeIndexFor.class)
-                    || AnnotationUtils.areSameByClass(a2, NegativeIndexFor.class)) {
+            if (areSameByClass(a1, NegativeIndexFor.class)
+                    || areSameByClass(a2, NegativeIndexFor.class)) {
                 return createNegativeIndexFor(Arrays.asList(combinedArrays.toArray(new String[0])));
             } else {
                 return createSearchIndexFor(Arrays.asList(combinedArrays.toArray(new String[0])));
@@ -143,8 +143,8 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 return UNKNOWN;
             }
 
-            if (AnnotationUtils.areSameByClass(a1, SearchIndexFor.class)
-                    || AnnotationUtils.areSameByClass(a2, SearchIndexFor.class)) {
+            if (areSameByClass(a1, SearchIndexFor.class)
+                    || areSameByClass(a2, SearchIndexFor.class)) {
                 return createSearchIndexFor(
                         Arrays.asList(arrayIntersection.toArray(new String[0])));
             } else {
@@ -155,16 +155,16 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameByClass(superAnno, SearchIndexUnknown.class)) {
+            if (areSameByClass(superAnno, SearchIndexUnknown.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, SearchIndexBottom.class)) {
+            if (areSameByClass(subAnno, SearchIndexBottom.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, SearchIndexUnknown.class)) {
+            if (areSameByClass(subAnno, SearchIndexUnknown.class)) {
                 return false;
             }
-            if (AnnotationUtils.areSameByClass(superAnno, SearchIndexBottom.class)) {
+            if (areSameByClass(superAnno, SearchIndexBottom.class)) {
                 return false;
             }
 
@@ -177,8 +177,8 @@ public class SearchIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // Subtyping requires:
             //  * subtype is NegativeIndexFor or supertype is SearchIndexFor
             //  * subtype's arrays are a superset of supertype's arrays
-            return ((AnnotationUtils.areSameByClass(subAnno, NegativeIndexFor.class)
-                            || AnnotationUtils.areSameByClass(superAnno, SearchIndexFor.class))
+            return ((areSameByClass(subAnno, NegativeIndexFor.class)
+                            || areSameByClass(superAnno, SearchIndexFor.class))
                     && subArrays.containsAll(superArrays));
         }
     }

--- a/checker/src/main/java/org/checkerframework/checker/index/substringindex/SubstringIndexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/substringindex/SubstringIndexAnnotatedTypeFactory.java
@@ -126,16 +126,16 @@ public class SubstringIndexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
 
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
-            if (AnnotationUtils.areSameByClass(superAnno, SubstringIndexUnknown.class)) {
+            if (areSameByClass(superAnno, SubstringIndexUnknown.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, SubstringIndexBottom.class)) {
+            if (areSameByClass(subAnno, SubstringIndexBottom.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, SubstringIndexUnknown.class)) {
+            if (areSameByClass(subAnno, SubstringIndexUnknown.class)) {
                 return false;
             }
-            if (AnnotationUtils.areSameByClass(superAnno, SubstringIndexBottom.class)) {
+            if (areSameByClass(superAnno, SubstringIndexBottom.class)) {
                 return false;
             }
 

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -223,7 +223,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     private void addUpperBoundTypeFromValueType(
             AnnotatedTypeMirror valueType, AnnotatedTypeMirror type) {
-        if (AnnotationUtils.containsSameByClass(valueType.getAnnotations(), BottomVal.class)) {
+        if (containsSameByClass(valueType.getAnnotations(), BottomVal.class)) {
             type.replaceAnnotation(BOTTOM);
         }
     }
@@ -323,7 +323,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * The last argument should be Positive.class, NonNegative.class, or GTENegativeOne.class.
      */
     public boolean hasLowerBoundTypeByClass(Node node, Class<? extends Annotation> classOfType) {
-        return AnnotationUtils.areSameByClass(
+        return areSameByClass(
                 getLowerBoundAnnotatedTypeFactory()
                         .getAnnotatedType(node.getTree())
                         .getAnnotationInHierarchy(getLowerBoundAnnotatedTypeFactory().UNKNOWN),
@@ -482,8 +482,7 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         private void addAnnotationForBitwiseComplement(
                 AnnotatedTypeMirror searchIndexType, AnnotatedTypeMirror typeDst) {
-            if (AnnotationUtils.containsSameByClass(
-                    searchIndexType.getAnnotations(), NegativeIndexFor.class)) {
+            if (containsSameByClass(searchIndexType.getAnnotations(), NegativeIndexFor.class)) {
                 AnnotationMirror nif = searchIndexType.getAnnotation(NegativeIndexFor.class);
                 List<String> arrays = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(nif);
                 List<String> negativeOnes = Collections.nCopies(arrays.size(), "-1");

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -220,6 +220,9 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /**
      * Checks if valueType contains a {@link org.checkerframework.common.value.qual.BottomVal}
      * annotation. If so, adds an {@link UpperBoundBottom} annotation to type.
+     *
+     * @param valueType annotated type from the {@link ValueAnnotatedTypeFactory}
+     * @param type annotated type from this factory that is side effected
      */
     private void addUpperBoundTypeFromValueType(
             AnnotatedTypeMirror valueType, AnnotatedTypeMirror type) {
@@ -321,6 +324,10 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /**
      * Returns true iff the given node has the passed Lower Bound qualifier according to the LBC.
      * The last argument should be Positive.class, NonNegative.class, or GTENegativeOne.class.
+     *
+     * @param node the given node
+     * @param classOfType Positive.class, NonNegative.class, or GTENegativeOne.class
+     * @return true iff the given node has the passed Lower Bound qualifier according to the LBC
      */
     public boolean hasLowerBoundTypeByClass(Node node, Class<? extends Annotation> classOfType) {
         return areSameByClass(

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -77,7 +77,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
     @Override
     public Void visitAnnotation(AnnotationTree node, Void p) {
         AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
-        if (AnnotationUtils.areSameByClass(anno, LTLengthOf.class)) {
+        if (atypeFactory.areSameByClass(anno, LTLengthOf.class)) {
             List<? extends ExpressionTree> args = node.getArguments();
             if (args.size() == 2) {
                 // If offsets are provided, there must be the same number of them as there are
@@ -96,7 +96,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
                     return null;
                 }
             }
-        } else if (AnnotationUtils.areSameByClass(anno, HasSubsequence.class)) {
+        } else if (atypeFactory.areSameByClass(anno, HasSubsequence.class)) {
             // Check that the arguments to a HasSubsequence annotation are valid flow expressions,
             // and issue an error if one of them is not.
 

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -270,7 +270,7 @@ public abstract class InitializationAnnotatedTypeFactory<
      * @return true if {@code anno} is {@link UnderInitialization}
      */
     public boolean isFree(AnnotationMirror anno) {
-        return AnnotationUtils.areSameByClass(anno, UnderInitialization.class);
+        return areSameByClass(anno, UnderInitialization.class);
     }
 
     /**
@@ -280,7 +280,7 @@ public abstract class InitializationAnnotatedTypeFactory<
      * @return true if {@code anno} is {@link UnknownInitialization}
      */
     public boolean isUnclassified(AnnotationMirror anno) {
-        return AnnotationUtils.areSameByClass(anno, UnknownInitialization.class);
+        return areSameByClass(anno, UnknownInitialization.class);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -157,7 +157,7 @@ public class InitializationVisitor<
                     if (atypeFactory.isUnclassified(a)) {
                         continue; // unclassified is allowed
                     }
-                    if (AnnotationUtils.areSameByClass(a, c)) {
+                    if (atypeFactory.areSameByClass(a, c)) {
                         checker.report(Result.failure(COMMITMENT_INVALID_FIELD_TYPE, node), node);
                         break;
                     }
@@ -318,7 +318,7 @@ public class InitializationVisitor<
             for (Class<? extends Annotation> c :
                     atypeFactory.getInvalidConstructorReturnTypeAnnotations()) {
                 for (AnnotationMirror a : returnTypeAnnotations) {
-                    if (AnnotationUtils.areSameByClass(a, c)) {
+                    if (atypeFactory.areSameByClass(a, c)) {
                         checker.report(
                                 Result.failure(COMMITMENT_INVALID_CONSTRUCTOR_RETURN_TYPE, node),
                                 node);

--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
@@ -42,7 +42,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.Heuristics;
 import org.checkerframework.javacutil.AnnotationBuilder;
-import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
@@ -290,7 +289,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
             Set<AnnotationMirror> bounds = atypeFactory.getTypeDeclarationBounds(typeMirror);
             // Don't issue an invalid type warning for creations of objects of interned classes;
             // instead, issue an interned.object.creation if required.
-            if (AnnotationUtils.containsSameByClass(bounds, Interned.class)) {
+            if (atypeFactory.containsSameByClass(bounds, Interned.class)) {
                 ParameterizedExecutableType fromUse = atypeFactory.constructorFromUse(newClassTree);
                 AnnotatedExecutableType constructor = fromUse.executableType;
                 if (!checkCreationOfInternedObject(newClassTree, constructor)) {
@@ -826,7 +825,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
         }
         if (classElt != null) {
             Set<AnnotationMirror> bound = atypeFactory.getTypeDeclarationBounds(tm);
-            return AnnotationUtils.containsSameByClass(bound, Interned.class);
+            return atypeFactory.containsSameByClass(bound, Interned.class);
         }
         return false;
     }

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
@@ -129,7 +129,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
                 TreeUtils.annotationsFromTypeAnnotationTrees(
                         variableTree.getModifiers().getAnnotations());
         for (AnnotationMirror anno : annos) {
-            if (AnnotationUtils.areSameByClass(anno, GuardedBy.class)
+            if (atypeFactory.areSameByClass(anno, GuardedBy.class)
                     || AnnotationUtils.areSameByName(anno, "net.jcip.annotations.GuardedBy")
                     || AnnotationUtils.areSameByName(
                             anno, "javax.annotation.concurrent.GuardedBy")) {
@@ -285,21 +285,21 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         // Consider only a @GuardSatisfied primary annotation - hence use primaryGb instead of
         // effectiveGb.
         if (primaryGb != null
-                && AnnotationUtils.areSameByClass(primaryGb, checkerGuardSatisfiedClass)) {
+                && atypeFactory.areSameByClass(primaryGb, checkerGuardSatisfiedClass)) {
             AnnotationMirror primaryGbOnMethodDefinition =
                     methodDefinitionReceiver.getAnnotationInHierarchy(
                             atypeFactory.GUARDEDBYUNKNOWN);
             if (primaryGbOnMethodDefinition != null
-                    && AnnotationUtils.areSameByClass(
+                    && atypeFactory.areSameByClass(
                             primaryGbOnMethodDefinition, checkerGuardSatisfiedClass)) {
                 return true;
             }
         }
 
-        if (AnnotationUtils.areSameByClass(effectiveGb, checkerGuardedByClass)) {
+        if (atypeFactory.areSameByClass(effectiveGb, checkerGuardedByClass)) {
             Set<AnnotationMirror> annos = methodDefinitionReceiver.getAnnotations();
             AnnotationMirror guardSatisfied =
-                    AnnotationUtils.getAnnotationByClass(annos, checkerGuardSatisfiedClass);
+                    atypeFactory.getAnnotationByClass(annos, checkerGuardSatisfiedClass);
             if (guardSatisfied != null) {
                 ExpressionTree receiverTree = TreeUtils.getReceiverTree(methodInvocationTree);
                 if (receiverTree == null) {
@@ -722,8 +722,8 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
                         if (arg1Anno != null && arg2Anno != null) {
                             boolean bothAreGSwithNoIndex = false;
 
-                            if (AnnotationUtils.areSameByClass(arg1Anno, checkerGuardSatisfiedClass)
-                                    && AnnotationUtils.areSameByClass(
+                            if (atypeFactory.areSameByClass(arg1Anno, checkerGuardSatisfiedClass)
+                                    && atypeFactory.areSameByClass(
                                             arg2Anno, checkerGuardSatisfiedClass)) {
                                 if (atypeFactory.getGuardSatisfiedIndex(arg1Anno) == -1
                                         && atypeFactory.getGuardSatisfiedIndex(arg2Anno) == -1) {
@@ -961,7 +961,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
         if (amList != null) {
             for (AnnotationMirror annotationMirror : amList) {
-                if (AnnotationUtils.areSameByClass(annotationMirror, checkerGuardSatisfiedClass)) {
+                if (atypeFactory.areSameByClass(annotationMirror, checkerGuardSatisfiedClass)) {
                     issueErrorIfGuardSatisfiedAnnotationInUnsupportedLocation(tree);
                 }
             }
@@ -1185,11 +1185,11 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         if (gbAnno == null) {
             throw new BugInCF("LockVisitor.checkLock: gbAnno cannot be null");
         }
-        if (AnnotationUtils.areSameByClass(gbAnno, GuardedByUnknown.class)
-                || AnnotationUtils.areSameByClass(gbAnno, GuardedByBottom.class)) {
+        if (atypeFactory.areSameByClass(gbAnno, GuardedByUnknown.class)
+                || atypeFactory.areSameByClass(gbAnno, GuardedByBottom.class)) {
             checker.report(Result.failure("lock.not.held", "unknown lock " + gbAnno), tree);
             return;
-        } else if (AnnotationUtils.areSameByClass(gbAnno, GuardSatisfied.class)) {
+        } else if (atypeFactory.areSameByClass(gbAnno, GuardSatisfied.class)) {
             return;
         }
 
@@ -1235,7 +1235,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         QualifierHierarchy hierarchy = atypeFactory.getQualifierHierarchy();
         AnnotationMirror lockAnno =
                 hierarchy.findAnnotationInSameHierarchy(annos, atypeFactory.LOCKHELD);
-        return lockAnno != null && AnnotationUtils.areSameByClass(lockAnno, LockHeld.class);
+        return lockAnno != null && atypeFactory.areSameByClass(lockAnno, LockHeld.class);
     }
 
     private List<LockExpression> getLockExpressions(

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForTransfer.java
@@ -49,7 +49,7 @@ public class KeyForTransfer extends CFAbstractTransfer<KeyForValue, KeyForStore,
             final KeyForValue previousKeyValue = in.getValueOfSubNode(node.getArgument(0));
             if (previousKeyValue != null) {
                 for (AnnotationMirror prevAm : previousKeyValue.getAnnotations()) {
-                    if (prevAm != null && AnnotationUtils.areSameByClass(prevAm, KeyFor.class)) {
+                    if (prevAm != null && factory.areSameByClass(prevAm, KeyFor.class)) {
                         keyForMaps.addAll(getKeys(prevAm));
                     }
                 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForValue.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForValue.java
@@ -46,7 +46,8 @@ public class KeyForValue extends CFAbstractValue<KeyForValue> {
             Set<AnnotationMirror> annotations,
             TypeMirror underlyingType) {
         super(analysis, annotations, underlyingType);
-        AnnotationMirror keyfor = AnnotationUtils.getAnnotationByClass(annotations, KeyFor.class);
+        AnnotationMirror keyfor =
+                analysis.getTypeFactory().getAnnotationByClass(annotations, KeyFor.class);
         if (keyfor != null
                 && (underlyingType.getKind() == TypeKind.TYPEVAR
                         || underlyingType.getKind() == TypeKind.WILDCARD)) {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
@@ -178,7 +178,7 @@ public class NullnessTransfer
                     secondValue != null
                             ? secondValue.getAnnotations()
                             : AnnotationUtils.createAnnotationSet();
-            if (AnnotationUtils.containsSameByClass(secondAnnos, PolyNull.class)) {
+            if (nullnessTypeFactory.containsSameByClass(secondAnnos, PolyNull.class)) {
                 thenStore = thenStore == null ? res.getThenStore() : thenStore;
                 elseStore = elseStore == null ? res.getElseStore() : elseStore;
                 thenStore.setPolyNullNull(true);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -147,7 +147,7 @@ public class NullnessVisitor
     private boolean containsSameByName(
             Set<Class<? extends Annotation>> quals, AnnotationMirror anno) {
         for (Class<? extends Annotation> q : quals) {
-            if (AnnotationUtils.areSameByClass(anno, q)) {
+            if (atypeFactory.areSameByClass(anno, q)) {
                 return true;
             }
         }

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -282,7 +282,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     private boolean isUnitsMultiple(AnnotationMirror metaAnno) {
-        return AnnotationUtils.areSameByClass(metaAnno, UnitsMultiple.class);
+        return areSameByClass(metaAnno, UnitsMultiple.class);
     }
 
     /**
@@ -295,7 +295,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         AnnotationMirror am = AnnotationBuilder.fromClass(elements, qual);
 
         for (AnnotationMirror ama : am.getAnnotationType().asElement().getAnnotationMirrors()) {
-            if (AnnotationUtils.areSameByClass(ama, unitsRelationsAnnoClass)) {
+            if (areSameByClass(ama, unitsRelationsAnnoClass)) {
                 Name theclassname = AnnotationUtils.getElementValueClassName(ama, "value", true);
                 Class<?> valueElement;
                 try {

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -300,6 +300,12 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         return null;
     }
 
+    /**
+     * Returns true if {@code metaAnno} is {@link UnitsMultiple}.
+     *
+     * @param metaAnno an annotation mirror
+     * @return true if {@code metaAnno} is {@link UnitsMultiple}
+     */
     private boolean isUnitsMultiple(AnnotationMirror metaAnno) {
         return areSameByClass(metaAnno, UnitsMultiple.class);
     }

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotationClassLoader.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotationClassLoader.java
@@ -6,6 +6,7 @@ import org.checkerframework.checker.units.qual.UnitsMultiple;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.AnnotationClassLoader;
 import org.checkerframework.javacutil.AnnotationBuilder;
+import org.checkerframework.javacutil.AnnotationUtils;
 
 public class UnitsAnnotationClassLoader extends AnnotationClassLoader {
 
@@ -37,7 +38,7 @@ public class UnitsAnnotationClassLoader extends AnnotationClassLoader {
             // if the annotation is a SI prefix multiple of some base unit, then return false
             // classic Units checker does not need to load the annotations of SI prefix multiples of
             // base units
-            if (checker.getTypeFactory().areSameByClass(metaAnno, UnitsMultiple.class)) {
+            if (AnnotationUtils.areSameByClass(metaAnno, UnitsMultiple.class)) {
                 return false;
             }
         }

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotationClassLoader.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotationClassLoader.java
@@ -6,7 +6,6 @@ import org.checkerframework.checker.units.qual.UnitsMultiple;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.AnnotationClassLoader;
 import org.checkerframework.javacutil.AnnotationBuilder;
-import org.checkerframework.javacutil.AnnotationUtils;
 
 public class UnitsAnnotationClassLoader extends AnnotationClassLoader {
 
@@ -38,7 +37,7 @@ public class UnitsAnnotationClassLoader extends AnnotationClassLoader {
             // if the annotation is a SI prefix multiple of some base unit, then return false
             // classic Units checker does not need to load the annotations of SI prefix multiples of
             // base units
-            if (AnnotationUtils.areSameByClass(metaAnno, UnitsMultiple.class)) {
+            if (checker.getTypeFactory().areSameByClass(metaAnno, UnitsMultiple.class)) {
                 return false;
             }
         }

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
@@ -118,9 +118,9 @@ public class AliasingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         private boolean isLeakedQualifier(AnnotationMirror anno) {
-            return AnnotationUtils.areSameByClass(anno, MaybeLeaked.class)
-                    || AnnotationUtils.areSameByClass(anno, NonLeaked.class)
-                    || AnnotationUtils.areSameByClass(anno, LeakedToResult.class);
+            return areSameByClass(anno, MaybeLeaked.class)
+                    || areSameByClass(anno, NonLeaked.class)
+                    || areSameByClass(anno, LeakedToResult.class);
         }
 
         @Override

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
@@ -112,6 +112,12 @@ public class AliasingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             return newtops;
         }
 
+        /**
+         * Returns true is {@code anno} is annotation in the Leaked hierarchy.
+         *
+         * @param anno an annotation
+         * @return true is {@code anno} is annotation in the Leaked hierarchy
+         */
         private boolean isLeakedQualifier(AnnotationMirror anno) {
             return areSameByClass(anno, MaybeLeaked.class)
                     || areSameByClass(anno, NonLeaked.class)

--- a/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/ClassValAnnotatedTypeFactory.java
@@ -88,9 +88,8 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * @param anno any AnnotationMirror
      * @return list of classnames in anno
      */
-    public static List<String> getClassNamesFromAnnotation(AnnotationMirror anno) {
-        if (AnnotationUtils.areSameByClass(anno, ClassBound.class)
-                || AnnotationUtils.areSameByClass(anno, ClassVal.class)) {
+    public List<String> getClassNamesFromAnnotation(AnnotationMirror anno) {
+        if (areSameByClass(anno, ClassBound.class) || areSameByClass(anno, ClassVal.class)) {
             return AnnotationUtils.getElementValueArray(anno, "value", String.class, true);
         }
         return new ArrayList<>();
@@ -129,8 +128,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 lubClassNames.addAll(a2ClassNames);
 
                 // If either annotation is a ClassBound, the lub must also be a class bound.
-                if (AnnotationUtils.areSameByClass(a1, ClassBound.class)
-                        || AnnotationUtils.areSameByClass(a2, ClassBound.class)) {
+                if (areSameByClass(a1, ClassBound.class) || areSameByClass(a2, ClassBound.class)) {
                     return createClassBound(new ArrayList<>(lubClassNames));
                 } else {
                     return createClassVal(new ArrayList<>(lubClassNames));
@@ -157,8 +155,7 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 // For example:
                 // GLB( @ClassVal(a,b), @ClassBound(a,c)) is @ClassVal(a)
                 // because @ClassBound(a) is not a subtype of @ClassVal(a,b)
-                if (AnnotationUtils.areSameByClass(a1, ClassVal.class)
-                        || AnnotationUtils.areSameByClass(a2, ClassVal.class)) {
+                if (areSameByClass(a1, ClassVal.class) || areSameByClass(a2, ClassVal.class)) {
                     return createClassVal(new ArrayList<>(glbClassNames));
                 } else {
                     return createClassBound(new ArrayList<>(glbClassNames));
@@ -174,16 +171,16 @@ public class ClassValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
             if (AnnotationUtils.areSame(subAnno, superAnno)
-                    || AnnotationUtils.areSameByClass(superAnno, UnknownClass.class)
-                    || AnnotationUtils.areSameByClass(subAnno, ClassValBottom.class)) {
+                    || areSameByClass(superAnno, UnknownClass.class)
+                    || areSameByClass(subAnno, ClassValBottom.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, UnknownClass.class)
-                    || AnnotationUtils.areSameByClass(superAnno, ClassValBottom.class)) {
+            if (areSameByClass(subAnno, UnknownClass.class)
+                    || areSameByClass(superAnno, ClassValBottom.class)) {
                 return false;
             }
-            if (AnnotationUtils.areSameByClass(superAnno, ClassVal.class)
-                    && AnnotationUtils.areSameByClass(subAnno, ClassBound.class)) {
+            if (areSameByClass(superAnno, ClassVal.class)
+                    && areSameByClass(subAnno, ClassBound.class)) {
                 return false;
             }
 

--- a/framework/src/main/java/org/checkerframework/common/reflection/ClassValVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/ClassValVisitor.java
@@ -47,7 +47,8 @@ class ClassNameValidator extends BaseTypeValidator {
         classVal = classVal == null ? type.getAnnotation(ClassBound.class) : classVal;
         if (classVal != null) {
             List<String> classNames =
-                    ClassValAnnotatedTypeFactory.getClassNamesFromAnnotation(classVal);
+                    ((ClassValAnnotatedTypeFactory) atypeFactory)
+                            .getClassNamesFromAnnotation(classVal);
             for (String className : classNames) {
                 if (!isLegalClassName(className)) {
                     checker.report(Result.failure("illegal.classname", className, type), tree);

--- a/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/MethodValAnnotatedTypeFactory.java
@@ -186,16 +186,16 @@ public class MethodValAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
             if (AnnotationUtils.areSame(subAnno, superAnno)
-                    || AnnotationUtils.areSameByClass(superAnno, UnknownMethod.class)
-                    || AnnotationUtils.areSameByClass(subAnno, MethodValBottom.class)) {
+                    || areSameByClass(superAnno, UnknownMethod.class)
+                    || areSameByClass(subAnno, MethodValBottom.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subAnno, UnknownMethod.class)
-                    || AnnotationUtils.areSameByClass(superAnno, MethodValBottom.class)) {
+            if (areSameByClass(subAnno, UnknownMethod.class)
+                    || areSameByClass(superAnno, MethodValBottom.class)) {
                 return false;
             }
-            assert AnnotationUtils.areSameByClass(subAnno, MethodVal.class)
-                            && AnnotationUtils.areSameByClass(superAnno, MethodVal.class)
+            assert areSameByClass(subAnno, MethodVal.class)
+                            && areSameByClass(superAnno, MethodVal.class)
                     : "Unexpected annotation in MethodVal";
             List<MethodSignature> subSignatures = getListOfMethodSignatures(subAnno);
             List<MethodSignature> superSignatures = getListOfMethodSignatures(superAnno);

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -914,9 +914,6 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         this.messages = getMessages();
 
         this.visitor = createSourceVisitor();
-
-        // TODO: hack to clear out static caches.
-        AnnotationUtils.clear();
     }
 
     /**
@@ -1137,6 +1134,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor
                 swTree);
     }
 
+    private final String suppressWarningsClassName = SuppressWarnings.class.getCanonicalName();
     /**
      * Finds the tree that is a {@code @SuppressWarnings} annotation.
      *
@@ -1154,9 +1152,9 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         }
 
         for (AnnotationTree annotationTree : annotations) {
-            if (AnnotationUtils.areSameByClass(
+            if (AnnotationUtils.areSameByName(
                     TreeUtils.annotationFromAnnotationTree(annotationTree),
-                    SuppressWarnings.class)) {
+                    suppressWarningsClassName)) {
                 return annotationTree;
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -374,8 +374,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /** Size of the annotationClassNames cache. */
     private static final int ANNOTATION_CACHE_SIZE = 500;
 
-    /** Maps classes representing AnnotationMirrors to their names. */
+    /** Maps classes representing AnnotationMirrors to their canonical names. */
     private final Map<Class<? extends Annotation>, String> annotationClassNames;
+
     /**
      * Constructs a factory from the given {@link ProcessingEnvironment} instance and syntax tree
      * root. (These parameters are required so that the factory may conduct the appropriate

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -371,6 +371,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     /** The Object.getClass method. */
     protected final ExecutableElement objectGetClass;
 
+    /** Size of the annotationClassNames cache. */
     private static final int ANNOTATION_CACHE_SIZE = 500;
 
     /** Maps classes representing AnnotationMirrors to their names. */
@@ -3820,6 +3821,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @return true if annoclass is the class of am
      */
     public boolean areSameByClass(AnnotationMirror am, Class<? extends Annotation> annoClass) {
+        if (!shouldCache) {
+            return AnnotationUtils.areSameByName(am, annoClass.getCanonicalName());
+        }
         String canonicalName = annotationClassNames.get(annoClass);
         if (canonicalName == null) {
             canonicalName = annoClass.getCanonicalName();

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -331,7 +331,7 @@ public abstract class AnnotatedTypeMirror {
      */
     public AnnotationMirror getAnnotation(Class<? extends Annotation> annoClass) {
         for (AnnotationMirror annoMirror : annotations) {
-            if (AnnotationUtils.areSameByClass(annoMirror, annoClass)) {
+            if (atypeFactory.areSameByClass(annoMirror, annoClass)) {
                 return annoMirror;
             }
         }
@@ -408,7 +408,7 @@ public abstract class AnnotatedTypeMirror {
      */
     public AnnotationMirror getEffectiveAnnotation(Class<? extends Annotation> annoClass) {
         for (AnnotationMirror annoMirror : getEffectiveAnnotations()) {
-            if (AnnotationUtils.areSameByClass(annoMirror, annoClass)) {
+            if (atypeFactory.areSameByClass(annoMirror, annoClass)) {
                 return annoMirror;
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -54,7 +54,7 @@ import org.checkerframework.javacutil.UserError;
  */
 public class AnnotationClassLoader {
     // For issuing errors to the user
-    private final BaseTypeChecker checker;
+    protected final BaseTypeChecker checker;
 
     // For loading from a source package directory
     private final String packageName;

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotationClassLoader.java
@@ -58,7 +58,7 @@ import org.plumelib.reflection.Signatures;
  * org.checkerframework.checker.units.UnitsAnnotationClassLoader} for an example.
  */
 public class AnnotationClassLoader {
-    // For issuing errors to the user
+    /** For issuing errors to the user */
     protected final BaseTypeChecker checker;
 
     // For loading from a source package directory

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -96,7 +96,6 @@ import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
 import org.checkerframework.framework.util.dependenttypes.DependentTypesTreeAnnotator;
 import org.checkerframework.framework.util.typeinference.TypeArgInferenceUtil;
 import org.checkerframework.javacutil.AnnotationBuilder;
-import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.CollectionUtils;
 import org.checkerframework.javacutil.Pair;
@@ -767,8 +766,7 @@ public abstract class GenericAnnotatedTypeFactory<
             Store store = getStoreBefore(tree);
             Value value = store.getValue(receiver);
             if (value != null) {
-                annotationMirror =
-                        AnnotationUtils.getAnnotationByClass(value.getAnnotations(), clazz);
+                annotationMirror = getAnnotationByClass(value.getAnnotations(), clazz);
             }
         }
         // If the specific annotation wasn't in the store, look in the type factory.

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -807,7 +807,7 @@ public class DependentTypesHelper {
 
     private boolean isExpressionAnno(AnnotationMirror am) {
         for (Class<? extends Annotation> clazz : annoToElements.keySet()) {
-            if (AnnotationUtils.areSameByClass(am, clazz)) {
+            if (factory.areSameByClass(am, clazz)) {
                 return true;
             }
         }
@@ -954,7 +954,7 @@ public class DependentTypesHelper {
      */
     private List<String> getListOfExpressionElements(AnnotationMirror am) {
         for (Class<? extends Annotation> clazz : annoToElements.keySet()) {
-            if (AnnotationUtils.areSameByClass(am, clazz)) {
+            if (factory.areSameByClass(am, clazz)) {
                 return annoToElements.get(clazz);
             }
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -805,6 +805,13 @@ public class DependentTypesHelper {
         }
     }
 
+    /**
+     * Returns true if {@code am} is an expression annotation, that is an annotation whose value is
+     * a Java expression.
+     *
+     * @param am an annotation
+     * @return true if {@code am} is an expression annotation
+     */
     private boolean isExpressionAnno(AnnotationMirror am) {
         for (Class<? extends Annotation> clazz : annoToElements.keySet()) {
             if (factory.areSameByClass(am, clazz)) {

--- a/framework/src/test/java/testlib/flowexpression/FlowExpressionAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/flowexpression/FlowExpressionAnnotatedTypeFactory.java
@@ -40,12 +40,10 @@ public class FlowExpressionAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
 
         @Override
         public boolean isSubtype(AnnotationMirror subtype, AnnotationMirror supertype) {
-            if (AnnotationUtils.areSameByClass(supertype, FETop.class)
-                    || AnnotationUtils.areSameByClass(subtype, FEBot.class)) {
+            if (areSameByClass(supertype, FETop.class) || areSameByClass(subtype, FEBot.class)) {
                 return true;
             }
-            if (AnnotationUtils.areSameByClass(subtype, FETop.class)
-                    || AnnotationUtils.areSameByClass(supertype, FEBot.class)) {
+            if (areSameByClass(subtype, FETop.class) || areSameByClass(supertype, FEBot.class)) {
                 return false;
             }
             List<String> subtypeExpressions =

--- a/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/testlib/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
@@ -97,16 +97,14 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
 
         @Override
         public AnnotationMirror leastUpperBound(AnnotationMirror a1, AnnotationMirror a2) {
-            if ((AnnotationUtils.areSameByClass(a1, Sibling1.class)
-                            && AnnotationUtils.areSameByClass(a2, Sibling2.class))
-                    || (AnnotationUtils.areSameByClass(a1, Sibling2.class)
-                            && AnnotationUtils.areSameByClass(a2, Sibling1.class))
-                    || (AnnotationUtils.areSameByClass(a1, Sibling1.class)
-                            && AnnotationUtils.areSameByClass(a2, SiblingWithFields.class))
-                    || (AnnotationUtils.areSameByClass(a1, SiblingWithFields.class)
-                            && AnnotationUtils.areSameByClass(a2, Sibling2.class))
-                    || (AnnotationUtils.areSameByClass(a1, Sibling2.class)
-                            && AnnotationUtils.areSameByClass(a2, SiblingWithFields.class))) {
+            if ((areSameByClass(a1, Sibling1.class) && areSameByClass(a2, Sibling2.class))
+                    || (areSameByClass(a1, Sibling2.class) && areSameByClass(a2, Sibling1.class))
+                    || (areSameByClass(a1, Sibling1.class)
+                            && areSameByClass(a2, SiblingWithFields.class))
+                    || (areSameByClass(a1, SiblingWithFields.class)
+                            && areSameByClass(a2, Sibling2.class))
+                    || (areSameByClass(a1, Sibling2.class)
+                            && areSameByClass(a2, SiblingWithFields.class))) {
                 return PARENT;
             }
             return super.leastUpperBound(a1, a2);
@@ -115,49 +113,47 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
         @Override
         public boolean isSubtype(AnnotationMirror subAnno, AnnotationMirror superAnno) {
             if (AnnotationUtils.areSame(subAnno, superAnno)
-                    || AnnotationUtils.areSameByClass(superAnno, UnknownClass.class)
-                    || AnnotationUtils.areSameByClass(subAnno, WholeProgramInferenceBottom.class)
-                    || AnnotationUtils.areSameByClass(superAnno, Top.class)) {
+                    || areSameByClass(superAnno, UnknownClass.class)
+                    || areSameByClass(subAnno, WholeProgramInferenceBottom.class)
+                    || areSameByClass(superAnno, Top.class)) {
                 return true;
             }
 
-            if (AnnotationUtils.areSameByClass(subAnno, UnknownClass.class)
-                    || AnnotationUtils.areSameByClass(
-                            superAnno, WholeProgramInferenceBottom.class)) {
+            if (areSameByClass(subAnno, UnknownClass.class)
+                    || areSameByClass(superAnno, WholeProgramInferenceBottom.class)) {
                 return false;
             }
 
-            if (AnnotationUtils.areSameByClass(subAnno, Top.class)) {
+            if (areSameByClass(subAnno, Top.class)) {
                 return false;
             }
 
-            if (AnnotationUtils.areSameByClass(subAnno, ImplicitAnno.class)
-                    && (AnnotationUtils.areSameByClass(superAnno, Sibling1.class)
-                            || AnnotationUtils.areSameByClass(superAnno, Sibling2.class)
-                            || AnnotationUtils.areSameByClass(
-                                    superAnno, SiblingWithFields.class))) {
+            if (areSameByClass(subAnno, ImplicitAnno.class)
+                    && (areSameByClass(superAnno, Sibling1.class)
+                            || areSameByClass(superAnno, Sibling2.class)
+                            || areSameByClass(superAnno, SiblingWithFields.class))) {
                 return true;
             }
 
-            if ((AnnotationUtils.areSameByClass(subAnno, Sibling1.class)
-                            || AnnotationUtils.areSameByClass(subAnno, Sibling2.class)
-                            || AnnotationUtils.areSameByClass(subAnno, ImplicitAnno.class)
-                            || AnnotationUtils.areSameByClass(subAnno, SiblingWithFields.class))
-                    && AnnotationUtils.areSameByClass(superAnno, Parent.class)) {
+            if ((areSameByClass(subAnno, Sibling1.class)
+                            || areSameByClass(subAnno, Sibling2.class)
+                            || areSameByClass(subAnno, ImplicitAnno.class)
+                            || areSameByClass(subAnno, SiblingWithFields.class))
+                    && areSameByClass(superAnno, Parent.class)) {
                 return true;
             }
 
-            if ((AnnotationUtils.areSameByClass(subAnno, Sibling1.class)
-                            || AnnotationUtils.areSameByClass(subAnno, Sibling2.class)
-                            || AnnotationUtils.areSameByClass(subAnno, ImplicitAnno.class)
-                            || AnnotationUtils.areSameByClass(subAnno, SiblingWithFields.class)
-                            || AnnotationUtils.areSameByClass(subAnno, Parent.class))
-                    && AnnotationUtils.areSameByClass(superAnno, DefaultType.class)) {
+            if ((areSameByClass(subAnno, Sibling1.class)
+                            || areSameByClass(subAnno, Sibling2.class)
+                            || areSameByClass(subAnno, ImplicitAnno.class)
+                            || areSameByClass(subAnno, SiblingWithFields.class)
+                            || areSameByClass(subAnno, Parent.class))
+                    && areSameByClass(superAnno, DefaultType.class)) {
                 return true;
             }
 
-            if (AnnotationUtils.areSameByClass(subAnno, SiblingWithFields.class)
-                    && AnnotationUtils.areSameByClass(superAnno, SiblingWithFields.class)) {
+            if (areSameByClass(subAnno, SiblingWithFields.class)
+                    && areSameByClass(superAnno, SiblingWithFields.class)) {
                 List<String> subVal1 =
                         AnnotationUtils.getElementValueArray(subAnno, "value", String.class, true);
                 List<String> supVal1 =

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -42,22 +42,6 @@ public class AnnotationUtils {
         throw new AssertionError("Class AnnotationUtils cannot be instantiated.");
     }
 
-    /** Clear the static caches. */
-    // TODO: hack to clear out static state.
-    public static void clear() {
-        annotationClassNames.clear();
-    }
-
-    // **********************************************************************
-    // Factory Methods to create instances of AnnotationMirror
-    // **********************************************************************
-
-    private static final int ANNOTATION_CACHE_SIZE = 500;
-
-    /** Maps classes representing AnnotationMirrors to their names. */
-    private static final Map<Class<? extends Annotation>, String> annotationClassNames =
-            Collections.synchronizedMap(CollectionUtils.createLRUCache(ANNOTATION_CACHE_SIZE));
-
     // **********************************************************************
     // Helper methods to handle annotations.  mainly workaround
     // AnnotationMirror.equals undesired property
@@ -159,12 +143,7 @@ public class AnnotationUtils {
      */
     public static boolean areSameByClass(
             AnnotationMirror am, Class<? extends Annotation> annoClass) {
-        String canonicalName = annotationClassNames.get(annoClass);
-        if (canonicalName == null) {
-            canonicalName = annoClass.getCanonicalName();
-            assert canonicalName != null : "@AssumeAssertion(nullness): assumption";
-            annotationClassNames.put(annoClass, canonicalName);
-        }
+        String canonicalName = annoClass.getCanonicalName();
         return areSameByName(am, canonicalName);
     }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -144,6 +144,7 @@ public class AnnotationUtils {
     public static boolean areSameByClass(
             AnnotationMirror am, Class<? extends Annotation> annoClass) {
         String canonicalName = annoClass.getCanonicalName();
+        assert canonicalName != null : "@AssumeAssertion(nullness): assumption";
         return areSameByName(am, canonicalName);
     }
 


### PR DESCRIPTION
* Also adds version of areSameByClass, containsSameByClass, and getAnnotationByClass to AnnotatedTypeFactory that use a (non-static) cache.
 * Replace most calls to the AnnotationUtil methods with calls to the AnnotatedTypeFactory versions. 

I didn't change the Value Checker because #2987 replaced most of those calls with calls to areSameByName.  So, that PR should be merged first.