### PR TITLE
Evaluate only when needed

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -352,8 +352,10 @@ public class ValueTransfer extends CFTransfer {
 
     /** Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}. */
     private boolean isIntRangeOrIntegralUnknownVal(Node node, TransferInput<CFValue, CFStore> p) {
-        AnnotationMirror anno = getValueAnnotation(p.getValueOfSubNode(node));
-        return isIntRange(node, p) || isIntegralUnknownVal(node, anno);
+        if (isIntRange(node, p)){
+            return true;
+        }
+        return isIntegralUnknownVal(node, getValueAnnotation(p.getValueOfSubNode(node)));
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -350,7 +350,7 @@ public class ValueTransfer extends CFTransfer {
                 && TypesUtils.isIntegral(node.getType());
     }
 
-    /** Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}. */
+    /* Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}. */
     private boolean isIntRangeOrIntegralUnknownVal(Node node, TransferInput<CFValue, CFStore> p) {
         if (isIntRange(node, p)) {
             return true;

--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -352,7 +352,7 @@ public class ValueTransfer extends CFTransfer {
 
     /** Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}. */
     private boolean isIntRangeOrIntegralUnknownVal(Node node, TransferInput<CFValue, CFStore> p) {
-        if (isIntRange(node, p)){
+        if (isIntRange(node, p)) {
             return true;
         }
         return isIntegralUnknownVal(node, getValueAnnotation(p.getValueOfSubNode(node)));

--- a/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTransfer.java
@@ -350,7 +350,13 @@ public class ValueTransfer extends CFTransfer {
                 && TypesUtils.isIntegral(node.getType());
     }
 
-    /* Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}. */
+    /**
+     * Returns true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}.
+     *
+     * @param node the node to inspect
+     * @param p storage
+     * @return true if this node is annotated with {@code @IntRange} or {@code @UnknownVal}
+     */
     private boolean isIntRangeOrIntegralUnknownVal(Node node, TransferInput<CFValue, CFStore> p) {
         if (isIntRange(node, p)) {
             return true;


### PR DESCRIPTION
Tiny improvement that shortcircuits evaluating getValueAnnotation(p.getValueOfSubNode(... if not needed.