### PR TITLE
Throw an exception if SubtypeOf meta-annotation refers to qualifier not in hierarchy.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
@@ -2,9 +2,7 @@ package org.checkerframework.checker.formatter;
 
 import com.sun.source.tree.LiteralTree;
 import com.sun.source.tree.Tree;
-import java.lang.annotation.Annotation;
 import java.util.IllegalFormatException;
-import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.formatter.qual.ConversionCategory;
 import org.checkerframework.checker.formatter.qual.Format;
@@ -52,11 +50,6 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         super(checker);
 
         this.postInit();
-    }
-
-    @Override
-    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return getBundledTypeQualifiers(UnknownFormat.class, FormatBottom.class);
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/qual/UnknownFormat.java
@@ -1,12 +1,15 @@
 package org.checkerframework.checker.formatter.qual;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.DefaultQualifierInHierarchy;
 import org.checkerframework.framework.qual.InvisibleQualifier;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
 
 /**
  * The top qualifier.
@@ -21,8 +24,9 @@ import org.checkerframework.framework.qual.SubtypeOf;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({})
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @InvisibleQualifier
 @SubtypeOf({})
 @DefaultQualifierInHierarchy
+@TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
 public @interface UnknownFormat {}

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
@@ -72,6 +72,11 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
         this.postInit();
     }
 
+    /**
+     * Builds a map from a translation file key to its value in the file.
+     *
+     * @return Map from a translation file key to its value in the file
+     */
     private Map<String, String> buildLookup() {
         Map<String, String> result = new HashMap<>();
 

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
@@ -5,14 +5,12 @@ import com.sun.source.tree.Tree;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
-import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import org.checkerframework.checker.i18nformatter.qual.I18nConversionCategory;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
@@ -72,11 +70,6 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
         super(checker);
 
         this.postInit();
-    }
-
-    @Override
-    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return getBundledTypeQualifiers(I18nUnknownFormat.class, I18nFormatBottom.class);
     }
 
     private Map<String, String> buildLookup() {

--- a/checker/src/test/java/testlib/lubglb/FormatterLubGlbChecker.java
+++ b/checker/src/test/java/testlib/lubglb/FormatterLubGlbChecker.java
@@ -4,15 +4,22 @@ package testlib.lubglb;
 // https://github.com/typetools/checker-framework/issues/691
 // https://github.com/typetools/checker-framework/issues/756
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.util.Elements;
+import org.checkerframework.checker.formatter.FormatterAnnotatedTypeFactory;
 import org.checkerframework.checker.formatter.FormatterChecker;
 import org.checkerframework.checker.formatter.FormatterTreeUtil;
+import org.checkerframework.checker.formatter.FormatterVisitor;
 import org.checkerframework.checker.formatter.qual.ConversionCategory;
 import org.checkerframework.checker.formatter.qual.Format;
 import org.checkerframework.checker.formatter.qual.FormatBottom;
 import org.checkerframework.checker.formatter.qual.InvalidFormat;
 import org.checkerframework.checker.formatter.qual.UnknownFormat;
+import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.AnnotationBuilder;
@@ -24,6 +31,40 @@ import org.checkerframework.javacutil.AnnotationUtils;
  * also tests the implementation of LUB computation in the Formatter Checker.
  */
 public class FormatterLubGlbChecker extends FormatterChecker {
+
+    @Override
+    protected BaseTypeVisitor<?> createSourceVisitor() {
+        return new FormatterVisitor(this) {
+            @Override
+            protected FormatterLubGlbAnnotatedTypeFactory createTypeFactory() {
+                return new FormatterLubGlbAnnotatedTypeFactory(checker);
+            }
+        };
+    }
+
+    /** FormatterLubGlbAnnotatedTypeFactory */
+    private static class FormatterLubGlbAnnotatedTypeFactory extends FormatterAnnotatedTypeFactory {
+
+        /**
+         * Constructor
+         *
+         * @param checker checker
+         */
+        public FormatterLubGlbAnnotatedTypeFactory(BaseTypeChecker checker) {
+            super(checker);
+            postInit();
+        }
+
+        @Override
+        protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+            return new HashSet<>(
+                    Arrays.asList(
+                            FormatBottom.class,
+                            Format.class,
+                            InvalidFormat.class,
+                            UnknownFormat.class));
+        }
+    }
 
     @SuppressWarnings("checkstyle:localvariablename")
     @Override

--- a/checker/src/test/java/testlib/lubglb/I18nFormatterLubGlbChecker.java
+++ b/checker/src/test/java/testlib/lubglb/I18nFormatterLubGlbChecker.java
@@ -4,16 +4,23 @@ package testlib.lubglb;
 // https://github.com/typetools/checker-framework/issues/723
 // https://github.com/typetools/checker-framework/issues/756
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.util.Elements;
+import org.checkerframework.checker.i18nformatter.I18nFormatterAnnotatedTypeFactory;
 import org.checkerframework.checker.i18nformatter.I18nFormatterChecker;
 import org.checkerframework.checker.i18nformatter.I18nFormatterTreeUtil;
+import org.checkerframework.checker.i18nformatter.I18nFormatterVisitor;
 import org.checkerframework.checker.i18nformatter.qual.I18nConversionCategory;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormat;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormatBottom;
 import org.checkerframework.checker.i18nformatter.qual.I18nFormatFor;
 import org.checkerframework.checker.i18nformatter.qual.I18nInvalidFormat;
 import org.checkerframework.checker.i18nformatter.qual.I18nUnknownFormat;
+import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.javacutil.AnnotationBuilder;
@@ -26,6 +33,41 @@ import org.checkerframework.javacutil.AnnotationUtils;
  * tests the implementation of LUB computation in the I18n Format String Checker.
  */
 public class I18nFormatterLubGlbChecker extends I18nFormatterChecker {
+    @Override
+    protected BaseTypeVisitor<?> createSourceVisitor() {
+        return new I18nFormatterVisitor(this) {
+            @Override
+            protected I18nFormatterAnnotatedTypeFactory createTypeFactory() {
+                return new I18nFormatterLubGlbAnnotatedTypeFactory(checker);
+            }
+        };
+    }
+
+    /** I18nFormatterLubGlbAnnotatedTypeFactory */
+    private static class I18nFormatterLubGlbAnnotatedTypeFactory
+            extends I18nFormatterAnnotatedTypeFactory {
+
+        /**
+         * Constructor
+         *
+         * @param checker checker
+         */
+        public I18nFormatterLubGlbAnnotatedTypeFactory(BaseTypeChecker checker) {
+            super(checker);
+            postInit();
+        }
+
+        @Override
+        protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+            return new HashSet<>(
+                    Arrays.asList(
+                            I18nUnknownFormat.class,
+                            I18nFormatBottom.class,
+                            I18nFormat.class,
+                            I18nInvalidFormat.class,
+                            I18nFormatFor.class));
+        }
+    }
 
     @SuppressWarnings("checkstyle:localvariablename")
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -677,7 +677,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                     typeQualifier.getAnnotation(SubtypeOf.class).value();
             for (Class<? extends Annotation> superQualifier : superQualifiers) {
                 if (!supportedTypeQualifiers.contains(superQualifier)) {
-                    continue;
+                    throw new BugInCF(
+                            "Found unsupported qualifier in SubTypeOf: %s on qualifier: %s",
+                            superQualifier.getCanonicalName(), typeQualifier.getCanonicalName());
                 }
                 AnnotationMirror superAnno = AnnotationBuilder.fromClass(elements, superQualifier);
                 factory.addSubtype(typeQualifierAnno, superAnno);


### PR DESCRIPTION
Also, fix the I18nFormatterLubGlb and FormatterLubGlb Checkers.