### PR TITLE
Allow type arg. inference to return type variable (Fixes #3001)

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -747,8 +747,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             final TypeVariable typeVar = atv.getUnderlyingType();
             if (targets.contains((TypeVariable) TypeAnnotationUtils.unannotatedType(typeVar))) {
                 final AnnotatedTypeMirror inferredType = inferredArgs.get(typeVar);
-                if (inferredType == null
-                        || TypeArgInferenceUtil.containsTypeParameter(inferredType, targets)) {
+                if (inferredType == null) {
                     AnnotatedTypeMirror dummy = typeFactory.getUninferredWildcardType(atv);
                     inferredArgs.put(atv.getUnderlyingType(), dummy);
                 }

--- a/framework/tests/value/Issue3001.java
+++ b/framework/tests/value/Issue3001.java
@@ -1,0 +1,7 @@
+class Issue3001 {
+
+    private <T> T getMember(Class<T> type) {
+        T sym = getMember(type);
+        return sym;
+    }
+}


### PR DESCRIPTION
Type argument inference may infer a type variable that is the same as a type variable for which it is solving.

This fixes the warnings in #3001, but does not implement the feature requested. 