### PR TITLE
Use range create effectively. depends on #3004

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -930,18 +930,17 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
             } else if (AnnotationUtils.areSameByClass(superAnno, DoubleVal.class)
                     && AnnotationUtils.areSameByClass(subAnno, IntVal.class)) {
-                List<Double> subValues = convertLongListToDoubleList(getIntValues(subAnno));
                 List<Double> superValues = getDoubleValues(superAnno);
+                List<Double> subValues = convertLongListToDoubleList(getIntValues(subAnno));
                 return superValues.containsAll(subValues);
             } else if ((AnnotationUtils.areSameByClass(superAnno, IntRange.class)
                             && AnnotationUtils.areSameByClass(subAnno, IntVal.class))
                     || (AnnotationUtils.areSameByClass(superAnno, ArrayLenRange.class)
                             && AnnotationUtils.areSameByClass(subAnno, ArrayLen.class))) {
-                List<Long> subValues = getArrayLenOrIntValue(subAnno);
                 Range superRange = getRange(superAnno);
-                long subMinVal = Collections.min(subValues);
-                long subMaxVal = Collections.max(subValues);
-                return subMinVal >= superRange.from && subMaxVal <= superRange.to;
+                List<Long> subValues = getArrayLenOrIntValue(subAnno);
+                Range subRange = Range.create(subValues);
+                return superRange.contains(subRange);
             } else if (AnnotationUtils.areSameByClass(superAnno, DoubleVal.class)
                     && AnnotationUtils.areSameByClass(subAnno, IntRange.class)) {
                 Range subRange = getRange(subAnno);
@@ -974,9 +973,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     && AnnotationUtils.areSameByClass(subAnno, StringVal.class)) {
                 // StringVal is a subtype of ArrayLen, if all the strings have one of the correct
                 // lengths
-                List<String> subValues = getStringValues(subAnno);
                 List<Integer> superValues = getArrayLength(superAnno);
-
+                List<String> subValues = getStringValues(subAnno);
                 for (String value : subValues) {
                     if (!superValues.contains(value.length())) {
                         return false;
@@ -987,8 +985,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                     && AnnotationUtils.areSameByClass(subAnno, StringVal.class)) {
                 // StringVal is a subtype of ArrayLenRange, if all the strings have a length in the
                 // range.
-                List<String> subValues = getStringValues(subAnno);
                 Range superRange = getRange(superAnno);
+                List<String> subValues = getStringValues(subAnno);
                 for (String value : subValues) {
                     if (!superRange.contains(value.length())) {
                         return false;

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -680,29 +680,33 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             // If both bounds of the new range are bigger than the old range, then returned range
             // should use the lower bound of the new range and a MAX_VALUE.
             if ((newRange.from >= oldRange.from && newRange.to >= oldRange.to)) {
-                if (lubRange.to < Byte.MAX_VALUE) {
-                    return Range.create(newRange.from, Byte.MAX_VALUE);
-                } else if (lubRange.to < Short.MAX_VALUE) {
-                    return Range.create(newRange.from, Short.MAX_VALUE);
-                } else if (lubRange.to < Integer.MAX_VALUE) {
-                    return Range.create(newRange.from, Integer.MAX_VALUE);
+                long max = lubRange.to;
+                if (max < Byte.MAX_VALUE) {
+                    max = Byte.MAX_VALUE;
+                } else if (max < Short.MAX_VALUE) {
+                    max = Short.MAX_VALUE;
+                } else if (max < Integer.MAX_VALUE) {
+                    max = Integer.MAX_VALUE;
                 } else {
-                    return Range.create(newRange.from, Long.MAX_VALUE);
+                    max = Long.MAX_VALUE;
                 }
+                return Range.create(newRange.from, max);
             }
 
             // If both bounds of the old range are bigger than the new range, then returned range
             // should use a MIN_VALUE and the upper bound of the new range.
             if ((newRange.from <= oldRange.from && newRange.to <= oldRange.to)) {
-                if (lubRange.from > Byte.MIN_VALUE) {
-                    return Range.create(Byte.MIN_VALUE, newRange.to);
-                } else if (lubRange.from > Short.MIN_VALUE) {
-                    return Range.create(Short.MIN_VALUE, newRange.to);
-                } else if (lubRange.from > Integer.MIN_VALUE) {
-                    return Range.create(Integer.MIN_VALUE, newRange.to);
+                long min = lubRange.from;
+                if (min > Byte.MIN_VALUE) {
+                    min = Byte.MIN_VALUE;
+                } else if (min > Short.MIN_VALUE) {
+                    min = Short.MIN_VALUE;
+                } else if (min > Integer.MIN_VALUE) {
+                    min = Integer.MIN_VALUE;
                 } else {
-                    return Range.create(Long.MIN_VALUE, newRange.to);
+                    min = Long.MIN_VALUE;
                 }
+                return Range.create(min, newRange.to);
             }
 
             if (lubRange.isWithin(Byte.MIN_VALUE + 1, Byte.MAX_VALUE)


### PR DESCRIPTION
This improvement is about using the one-pass for min and max in Range.create(Collection) and the  contains() where it fits.
Again, this change contains #3000 also.