### PR TITLE
Remove explicit "extends @Nullable Object."

### DIFF
--- a/checker/jdk/nullness/src/java/util/HashMap.java
+++ b/checker/jdk/nullness/src/java/util/HashMap.java
@@ -141,7 +141,7 @@ import org.checkerframework.dataflow.qual.SideEffectFree;
  * @see     Hashtable
  * @since   1.2
  */
-public class HashMap<K extends @Nullable Object, V extends @Nullable Object> extends AbstractMap<K,V>
+public class HashMap<K, V> extends AbstractMap<K,V>
     implements Map<K,V>, Cloneable, Serializable {
 
     private static final long serialVersionUID = 362498820763181265L;

--- a/checker/jdk/nullness/src/java/util/Map.java
+++ b/checker/jdk/nullness/src/java/util/Map.java
@@ -136,7 +136,7 @@ import org.checkerframework.framework.qual.Covariant;
  */
 // Subclasses of this interface/class may opt to prohibit null elements
 @Covariant(0)
-public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
+public interface Map<K, V> {
     // Query Operations
 
     /**
@@ -404,7 +404,7 @@ public interface Map<K extends @Nullable Object, V extends @Nullable Object> {
      * @since 1.2
      */
     @Covariant(0)
-    interface Entry<K extends @Nullable Object, V extends @Nullable Object> {
+    interface Entry<K, V> {
         /**
          * Returns the key corresponding to this entry.
          *


### PR DESCRIPTION
It is supposed to be a no-op. As such, the stub files usually omit it.

Currently, it actually changes behavior in a bad way:
https://github.com/typetools/checker-framework/issues/2995

Until that bug is fixed, this commit serves as a workaround.