### PR TITLE
Explicitly override createSupportedTypeQualifiers in CompilerMessagesAnnotatedTypeFactory

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/compilermsgs/CompilerMessagesAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/compilermsgs/CompilerMessagesAnnotatedTypeFactory.java
@@ -1,6 +1,11 @@
 package org.checkerframework.checker.compilermsgs;
 
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
+import org.checkerframework.checker.compilermsgs.qual.UnknownCompilerMessageKey;
 import org.checkerframework.checker.propkey.PropertyKeyAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.type.treeannotator.ListTreeAnnotator;
@@ -15,6 +20,12 @@ public class CompilerMessagesAnnotatedTypeFactory extends PropertyKeyAnnotatedTy
         // If we ever add code to this constructor, it needs to:
         //   * call a superclass constructor that does not call postInit(), and
         //   * call postInit() itself.
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new LinkedHashSet<>(
+                Arrays.asList(CompilerMessageKey.class, UnknownCompilerMessageKey.class));
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
@@ -5,6 +5,9 @@ import com.sun.source.tree.CompoundAssignmentTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -14,6 +17,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.interning.qual.InternMethod;
 import org.checkerframework.checker.interning.qual.Interned;
+import org.checkerframework.checker.interning.qual.InternedDistinct;
 import org.checkerframework.checker.interning.qual.PolyInterned;
 import org.checkerframework.checker.interning.qual.UnknownInterned;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
@@ -72,6 +76,16 @@ public class InterningAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         addAliasedAnnotation("com.sun.istack.internal.Interned", INTERNED);
 
         this.postInit();
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new LinkedHashSet<>(
+                Arrays.asList(
+                        UnknownInterned.class,
+                        Interned.class,
+                        PolyInterned.class,
+                        InternedDistinct.class));
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
@@ -11,8 +11,20 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.checker.signature.qual.BinaryName;
+import org.checkerframework.checker.signature.qual.BinaryNameInUnnamedPackage;
+import org.checkerframework.checker.signature.qual.ClassGetName;
+import org.checkerframework.checker.signature.qual.ClassGetSimpleName;
 import org.checkerframework.checker.signature.qual.DotSeparatedIdentifiers;
+import org.checkerframework.checker.signature.qual.FieldDescriptor;
+import org.checkerframework.checker.signature.qual.FieldDescriptorForPrimitive;
+import org.checkerframework.checker.signature.qual.FieldDescriptorForPrimitiveOrArrayInUnnamedPackage;
+import org.checkerframework.checker.signature.qual.FqBinaryName;
+import org.checkerframework.checker.signature.qual.FullyQualifiedName;
+import org.checkerframework.checker.signature.qual.Identifier;
+import org.checkerframework.checker.signature.qual.IdentifierOrArray;
 import org.checkerframework.checker.signature.qual.InternalForm;
+import org.checkerframework.checker.signature.qual.MethodDescriptor;
+import org.checkerframework.checker.signature.qual.PolySignature;
 import org.checkerframework.checker.signature.qual.SignatureBottom;
 import org.checkerframework.checker.signature.qual.SignatureUnknown;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
@@ -66,7 +78,24 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     @Override
     protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
-        return getBundledTypeQualifiers(SignatureUnknown.class, SignatureBottom.class);
+        return getBundledTypeQualifiers(
+                SignatureUnknown.class,
+                SignatureBottom.class,
+                BinaryName.class,
+                BinaryNameInUnnamedPackage.class,
+                ClassGetName.class,
+                ClassGetSimpleName.class,
+                DotSeparatedIdentifiers.class,
+                FieldDescriptor.class,
+                FieldDescriptorForPrimitive.class,
+                FieldDescriptorForPrimitiveOrArrayInUnnamedPackage.class,
+                FqBinaryName.class,
+                FullyQualifiedName.class,
+                Identifier.class,
+                IdentifierOrArray.class,
+                InternalForm.class,
+                MethodDescriptor.class,
+                PolySignature.class);
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/tainting/TaintingAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/tainting/TaintingAnnotatedTypeFactory.java
@@ -19,6 +19,7 @@ public class TaintingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** Default constructor. */
     public TaintingAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
+        this.postInit();
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/tainting/TaintingAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/tainting/TaintingAnnotatedTypeFactory.java
@@ -1,0 +1,29 @@
+package org.checkerframework.checker.tainting;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.checkerframework.checker.tainting.qual.PolyTainted;
+import org.checkerframework.checker.tainting.qual.Tainted;
+import org.checkerframework.checker.tainting.qual.Untainted;
+import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+
+/**
+ * Only overridden so that the supported qualifiers can be explicitly specified, because this
+ * checker is used during the build process.
+ */
+public class TaintingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
+
+    /** Default constructor. */
+    public TaintingAnnotatedTypeFactory(BaseTypeChecker checker) {
+        super(checker);
+    }
+
+    @Override
+    protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
+        return new LinkedHashSet<>(
+                Arrays.asList(Untainted.class, Tainted.class, PolyTainted.class));
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/stub/ToIndexFileConverter.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/ToIndexFileConverter.java
@@ -619,8 +619,8 @@ public class ToIndexFileConverter extends GenericVisitorAdapter<Void, AElement> 
      * @return fully qualified name of class that {@code className} identifies in the current
      *     context, or null if resolution fails
      */
-    private @BinaryName String resolve(@BinaryName String className) {
-        @BinaryName String qualifiedName;
+    private @ClassGetName String resolve(@BinaryName String className) {
+        @ClassGetName String qualifiedName;
         Class<?> resolved = null;
 
         if (pkgName == null) {


### PR DESCRIPTION
#2828 added code that caused an exception to be thrown if no supported type qualifiers are found for a given checker. The CompilerMessagesChecker extends another checker, which in my experience causes the usual reflective-loading mechanism to behave strangely.

In #2871, the PR's tests are [failing](https://dev.azure.com/typetools/checker-framework/_build/results?buildId=2487&view=logs&j=e7da885e-38cc-54b9-8049-a12030020bfb&t=9f830bd7-3da0-547c-7985-0984f9314dee) because the CompilerMessagesChecker is failing to initialize itself, with the error message indicating that no supported type qualifiers were found. I have no idea why #2871 triggered that problem; it doesn't touch that part of the code.

Regardless, that failure is fixed locally by merging in the changes from this PR. I considered adding them to #2871, but that seems wrong: these have nothing to do with whole-program inference, which is the subject of that PR. That PR does add some minor changes to `AnnotatedTypeFactory`, where the error is raised, but that code is purely additive and in logic that shouldn't be run until after a checker is initialized, so I can't imagine how it would trigger this crash.