### PR TITLE
Without -AconservativeUninferredTypeArguments, NEVER issue error about uninferred type arguments

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1369,9 +1369,12 @@ public abstract class SourceChecker extends AbstractTypeProcessor
                 return;
             } else if (this.processingEnv.getOptions().containsKey("nomsgtext")) {
                 for (Object arg : args) {
-                    if (arg != null && arg instanceof AnnotatedTypeMirror.AnnotatedWildcardType) {
-                        if (((AnnotatedTypeMirror.AnnotatedWildcardType) arg)
-                                .isUninferredTypeArgument()) {
+                    if (arg != null && arg instanceof String) {
+                        if (((String) arg).contains("INFERENCE FAILED")) {
+                            return;
+                        }
+                    } else if (arg != null && arg instanceof AnnotatedTypeMirror) {
+                        if (((AnnotatedTypeMirror) arg).containsUninferredTypeArguments()) {
                             return;
                         }
                     }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -54,6 +54,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.qual.AnnotatedFor;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.CFContext;
 import org.checkerframework.framework.util.CheckerMain;
 import org.checkerframework.framework.util.OptionConfiguration;
@@ -1368,8 +1369,11 @@ public abstract class SourceChecker extends AbstractTypeProcessor
                 return;
             } else if (this.processingEnv.getOptions().containsKey("nomsgtext")) {
                 for (Object arg : args) {
-                    if (arg != null && arg.toString().contains("INFERENCE FAILED")) {
-                        return;
+                    if (arg != null && arg instanceof AnnotatedTypeMirror.AnnotatedWildcardType) {
+                        if (((AnnotatedTypeMirror.AnnotatedWildcardType) arg)
+                                .isUninferredTypeArgument()) {
+                            return;
+                        }
                     }
                 }
             }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1359,9 +1359,20 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         }
 
         // TODO: when #979 is fixed, remove this hack
-        if (!this.hasOption("conservativeUninferredTypeArguments")
-                && messageText.contains("INFERENCE FAILED")) {
-            return;
+        if (this.processingEnv.getOptions() != null
+                && !this.processingEnv
+                        .getOptions()
+                        .containsKey("conservativeUninferredTypeArguments")) {
+
+            if (messageText.contains("INFERENCE FAILED")) {
+                return;
+            } else if (this.processingEnv.getOptions().containsKey("nomsgtext")) {
+                for (Object arg : args) {
+                    if (arg != null && arg.toString().contains("INFERENCE FAILED")) {
+                        return;
+                    }
+                }
+            }
         }
 
         if (source instanceof Element) {

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1365,17 +1365,27 @@ public abstract class SourceChecker extends AbstractTypeProcessor
                         .getOptions()
                         .containsKey("conservativeUninferredTypeArguments")) {
 
-            if (messageText.contains("INFERENCE FAILED")) {
-                return;
-            } else if (this.processingEnv.getOptions().containsKey("nomsgtext")) {
-                for (Object arg : args) {
-                    if (arg != null && arg instanceof String) {
-                        if (((String) arg).contains("INFERENCE FAILED")) {
-                            return;
-                        }
-                    } else if (arg != null && arg instanceof AnnotatedTypeMirror) {
-                        if (((AnnotatedTypeMirror) arg).containsUninferredTypeArguments()) {
-                            return;
+            // This is a hack to avoid test failures from Issue1218.java in framework/tests/value.
+            // More generally, the problem is that this suppression is too broad: if there is a
+            // error that will be issued unrelated to type argument inference, but type argument
+            // inference still failed, then the error WILL be suppressed.
+            //
+            // It would be better if there was a way to determine precisely when the failure of
+            // type argument inference is the CAUSE of an error, rather than checking if one
+            // of the types contains a type argument inference failure.
+            if (!"varargs.type.incompatible".equals(msgKey)) {
+                if (messageText.contains("INFERENCE FAILED")) {
+                    return;
+                } else if (this.processingEnv.getOptions().containsKey("nomsgtext")) {
+                    for (Object arg : args) {
+                        if (arg instanceof String) {
+                            if (((String) arg).contains("INFERENCE FAILED")) {
+                                return;
+                            }
+                        } else if (arg instanceof AnnotatedTypeMirror) {
+                            if (((AnnotatedTypeMirror) arg).containsUninferredTypeArguments()) {
+                                return;
+                            }
                         }
                     }
                 }

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1358,6 +1358,12 @@ public abstract class SourceChecker extends AbstractTypeProcessor
             messageText = messageText.replaceAll("\n", LINE_SEPARATOR);
         }
 
+        // TODO: when #979 is fixed, remove this hack
+        if (!this.hasOption("conservativeUninferredTypeArguments")
+                && messageText.contains("INFERENCE FAILED")) {
+            return;
+        }
+
         if (source instanceof Element) {
             messager.printMessage(kind, messageText, (Element) source);
         } else if (source instanceof Tree) {

--- a/framework/tests/all-systems/java8inference/InvoicingPipeline.java
+++ b/framework/tests/all-systems/java8inference/InvoicingPipeline.java
@@ -1,0 +1,68 @@
+import java.io.Serializable;
+
+public class InvoicingPipeline {
+
+    public static class PCollection<T> implements PValue {
+
+        public <OutputT extends POutput> OutputT apply(
+                String name, PTransform<? super PCollection<T>, OutputT> t) {
+            return null;
+        }
+    }
+
+    public abstract static class PTransform<InputT extends PInput, OutputT extends POutput> {
+        public abstract void expand(InputT input);
+    }
+
+    static interface PInput {}
+
+    static interface POutput {}
+
+    interface PValue extends PInput, POutput {}
+
+    static class BillingEvent {
+
+        InvoiceGroupingKey getInvoiceGroupingKey() {
+            return null;
+        }
+    }
+
+    public static class MapElements<InputT, OutputT>
+            extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
+        public static <OutputT> MapElements<?, OutputT> into(
+                final TypeDescriptor<OutputT> outputType) {
+            return null;
+        }
+
+        public static <InputT, OutputT> MapElements<InputT, OutputT> via(
+                final ProcessFunction<InputT, OutputT> fn) {
+            return null;
+        }
+
+        public void expand(PCollection<? extends InputT> input) {}
+    }
+
+    static class TypeDescriptor<T> {
+        public static <T> TypeDescriptor<T> of(Class<T> type) {
+            return null;
+        }
+    }
+
+    static class InvoiceGroupingKey {}
+
+    @FunctionalInterface
+    public interface ProcessFunction<InputT, OutputT> extends Serializable {
+        OutputT apply(InputT input) throws Exception;
+    }
+
+    private static class GenerateInvoiceRows
+            extends PTransform<PCollection<BillingEvent>, PCollection<String>> {
+        @Override
+        public void expand(PCollection<BillingEvent> input) {
+            input.apply(
+                    "Map to invoicing key",
+                    MapElements.into(TypeDescriptor.of(InvoiceGroupingKey.class))
+                            .via(BillingEvent::getInvoiceGroupingKey));
+        }
+    }
+}

--- a/framework/tests/all-systems/java8inference/InvoicingPipeline.java
+++ b/framework/tests/all-systems/java8inference/InvoicingPipeline.java
@@ -1,5 +1,6 @@
 import java.io.Serializable;
 
+@SuppressWarnings("nullness")
 public class InvoicingPipeline {
 
     public static class PCollection<T> implements PValue {


### PR DESCRIPTION
This is an extension to the [hack](https://github.com/typetools/checker-framework/issues/979#issuecomment-279578221) that prevents most errors related to #979, which did not prevent the CF from issuing errors involving method references (and possibly in other scenarios we don't know about). The test case in this PR was provided by @msridhar in a [comment](https://github.com/typetools/checker-framework/issues/3001#issuecomment-570026011) on #3001.

The technique I'm using is to check the message to be printed in the error reporter, and not issue it if it includes the text about inference failing added by [`DefaultAnnotatedTypeFormatter`](https://github.com/typetools/checker-framework/blob/master/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java#L389) to wildcards for which inference has failed, which @mernst suggested.