### PR TITLE
If a type has an uninferred type arg, only check primary annotations

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -753,6 +754,7 @@ public abstract class AnnotatedTypeMirror {
      * always be a call to shallowCopy(true).
      *
      * @see #shallowCopy(boolean)
+     * @return a shallow copy of this type with annotations.
      */
     public abstract AnnotatedTypeMirror shallowCopy();
 
@@ -789,6 +791,13 @@ public abstract class AnnotatedTypeMirror {
                 }
             };
 
+    /**
+     * Create an {@link AnnotatedDeclaredType} with the underlying type of {@link Object}. It
+     * includes any annotations placed by {@link AnnotatedTypeFactory#fromElement(Element)}.
+     *
+     * @param atypeFactory type factory to use
+     * @return AnnotatedDeclaredType for Object
+     */
     protected static AnnotatedDeclaredType createTypeOfObject(AnnotatedTypeFactory atypeFactory) {
         AnnotatedDeclaredType objectType =
                 atypeFactory.fromElement(

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
+import org.checkerframework.framework.type.visitor.SimpleAnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
@@ -754,6 +755,39 @@ public abstract class AnnotatedTypeMirror {
      * @see #shallowCopy(boolean)
      */
     public abstract AnnotatedTypeMirror shallowCopy();
+
+    /**
+     * @return whether this type or any component type is a wildcard type for which Java 7 type
+     *     inference is insufficient. See issue 979, or the documentation on AnnotatedWildcardType.
+     */
+    public boolean containsUninferredTypeArguments() {
+        return uninferredTypeArgumentScanner.visit(this);
+    }
+
+    /** The implementation of the visitor for #containsUninferredTypeArguments */
+    private final SimpleAnnotatedTypeScanner<Boolean, Void> uninferredTypeArgumentScanner =
+            new SimpleAnnotatedTypeScanner<Boolean, Void>() {
+                @Override
+                protected Boolean defaultAction(AnnotatedTypeMirror type, Void aVoid) {
+                    if (type.getKind() == TypeKind.WILDCARD) {
+                        return ((AnnotatedWildcardType) type).isUninferredTypeArgument();
+                    }
+                    return false;
+                }
+
+                @Override
+                public Boolean reduce(Boolean r1, Boolean r2) {
+                    if (r1 == null && r2 == null) {
+                        return false;
+                    } else if (r1 == null) {
+                        return r2;
+                    } else if (r2 == null) {
+                        return r1;
+                    } else {
+                        return r1 || r2;
+                    }
+                }
+            };
 
     protected static AnnotatedDeclaredType createTypeOfObject(AnnotatedTypeFactory atypeFactory) {
         AnnotatedDeclaredType objectType =

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -154,6 +154,25 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     @Override
     public boolean isSubtype(
             final AnnotatedTypeMirror subtype, final AnnotatedTypeMirror supertype) {
+        if (subtype.atypeFactory.ignoreUninferredTypeArguments
+                && (subtype.containsUninferredTypeArguments()
+                        || supertype.containsUninferredTypeArguments())) {
+            if (ignoreUninferredTypeArgument(subtype) || ignoreUninferredTypeArgument(supertype)) {
+                // If either is an uninferred type argument don't check primary annotations.
+                return true;
+            }
+            // Check primary annotations.
+            for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
+                AnnotationMirror subAnno = subtype.getAnnotationInHierarchy(top);
+                AnnotationMirror superAnno = supertype.getAnnotationInHierarchy(top);
+                if (subAnno != null
+                        && superAnno != null
+                        && !qualifierHierarchy.isSubtype(subAnno, superAnno)) {
+                    return false;
+                }
+            }
+            return true;
+        }
         for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
             if (!isSubtype(subtype, supertype, top)) {
                 return false;

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -154,25 +154,6 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     @Override
     public boolean isSubtype(
             final AnnotatedTypeMirror subtype, final AnnotatedTypeMirror supertype) {
-        if (subtype.atypeFactory.ignoreUninferredTypeArguments
-                && (subtype.containsUninferredTypeArguments()
-                        || supertype.containsUninferredTypeArguments())) {
-            if (ignoreUninferredTypeArgument(subtype) || ignoreUninferredTypeArgument(supertype)) {
-                // If either is an uninferred type argument don't check primary annotations.
-                return true;
-            }
-            // Check primary annotations.
-            for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
-                AnnotationMirror subAnno = subtype.getAnnotationInHierarchy(top);
-                AnnotationMirror superAnno = supertype.getAnnotationInHierarchy(top);
-                if (subAnno != null
-                        && superAnno != null
-                        && !qualifierHierarchy.isSubtype(subAnno, superAnno)) {
-                    return false;
-                }
-            }
-            return true;
-        }
         for (final AnnotationMirror top : qualifierHierarchy.getTopAnnotations()) {
             if (!isSubtype(subtype, supertype, top)) {
                 return false;
@@ -480,6 +461,13 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     @Override
     public Boolean visitDeclared_Declared(
             AnnotatedDeclaredType subtype, AnnotatedDeclaredType supertype, Void p) {
+        if (subtype.atypeFactory.ignoreUninferredTypeArguments
+                && (subtype.containsUninferredTypeArguments()
+                        || supertype.containsUninferredTypeArguments())) {
+            // Calling castedAsSuper may cause the uninferredTypeArguments to be lost. So, just
+            // return true here.
+            return true;
+        }
         AnnotatedDeclaredType subtypeAsSuper =
                 AnnotatedTypes.castedAsSuper(subtype.atypeFactory, subtype, supertype);
 

--- a/framework/tests/all-systems/java8inference/Issue3032.java
+++ b/framework/tests/all-systems/java8inference/Issue3032.java
@@ -1,0 +1,47 @@
+import java.io.Serializable;
+
+public class Issue3032 {
+    public static class PCollection<T> implements PValue {
+        public <OutputT extends POutput> OutputT apply(
+                String name, PTransform<? super PCollection<T>, OutputT> t) {
+            throw new RuntimeException();
+        }
+    }
+
+    public abstract static class PTransform<InputT extends PInput, OutputT extends POutput> {}
+
+    interface PInput {}
+
+    interface POutput {}
+
+    interface PValue extends PInput, POutput {}
+
+    static class BillingEvent {
+        InvoiceGroupingKey getInvoiceGroupingKey() {
+            throw new RuntimeException();
+        }
+    }
+
+    public static class MapElements<InputT, OutputT>
+            extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
+        public static <InputT, OutputT> MapElements<InputT, OutputT> via(
+                final ProcessFunction<InputT, OutputT> fn) {
+            throw new RuntimeException();
+        }
+    }
+
+    static class InvoiceGroupingKey {}
+
+    @FunctionalInterface
+    public interface ProcessFunction<InputT, OutputT> extends Serializable {
+        OutputT apply(InputT input) throws Exception;
+    }
+
+    private static class GenerateInvoiceRows
+            extends PTransform<PCollection<BillingEvent>, PCollection<String>> {
+        public void expand(PCollection<BillingEvent> input) {
+            input.apply(
+                    "Map to invoicing key", MapElements.via(BillingEvent::getInvoiceGroupingKey));
+        }
+    }
+}


### PR DESCRIPTION
This suppresses more warnings related to #979. 
This fixes #3032.