### PR TITLE
Stop the building with using the unsupported versions of Java.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ switch (JavaVersion.current()) {
     case JavaVersion.VERSION_11:
         break; // Supported versions
     default:
-        logger.error("Build the Checker Framework with JDK 8 or JDK 11." +
+        throw new GradleException("Build the Checker Framework with JDK 8 or JDK 11." +
                 " Found version " + JavaVersion.current().majorVersion);
 }
 


### PR DESCRIPTION
> The build should already give a useful error message for incorrect JDK versions:
> https://github.com/typetools/checker-framework/blob/master/build.gradle#L69
> 
> As this doesn't seem to be the case, something in the build file should be updated, raising that error also for `cloneAndBuildDependencies`.
> 
> _Originally posted by @wmdietl in https://github.com/typetools/checker-framework/issues/3041#issuecomment-572641427_

 
Now we have a very clear output on the terminal when using the unsupported versions of Java. Previously, `log.error()` would not stop the building, a long output would be generated.

New output:
```bash
(origin/typetools-improve-gradle)⚡ [1] % ./gradlew cloneAndBuildDependencies

FAILURE: Build failed with an exception.

* Where:
Build file 'checker-framework/build.gradle' line: 71

* What went wrong:
A problem occurred evaluating root project 'checker-framework'.
> Build the Checker Framework with JDK 8 or JDK 11. Found version 13

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

```