### PR TITLE
Account for recursive type variables in enclosing types (Fixes #3058)

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -844,8 +844,6 @@ public abstract class AnnotatedTypeMirror {
             if (encl.getKind() == TypeKind.DECLARED) {
                 this.enclosingType =
                         (AnnotatedDeclaredType) createType(encl, atypeFactory, declaration);
-                // Force instantiation of type arguments of enclosing type.
-                this.enclosingType.getTypeArguments();
             } else if (encl.getKind() != TypeKind.NONE) {
                 throw new BugInCF(
                         "AnnotatedDeclaredType: unsupported enclosing type: "

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -978,20 +978,27 @@ public class BoundsInitializer {
         public abstract BoundPathNode copy();
     }
 
+    /** Represents an enclosing type in a path. */
     private static class EnclosingNode extends BoundPathNode {
 
+        /** Create an enclosing node. */
         EnclosingNode() {
             kind = Kind.Enclosing;
             typeKind = TypeKind.DECLARED;
         }
 
+        /**
+         * Create a copy of the node.
+         *
+         * @param template node to copy
+         */
         EnclosingNode(EnclosingNode template) {
             super(template);
         }
 
         @Override
         public void setType(AnnotatedTypeMirror parent, AnnotatedTypeVariable replacement) {
-            // Do nothing
+            // An enclosing type cannot be a type variable, so do nothing.
         }
 
         @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -938,9 +938,13 @@ public class BoundsInitializer {
             UpperBound,
             LowerBound,
             ArrayComponent,
+            /** Intersection kind */
             Intersection,
+            /** Union kind */
             Union,
+            /** TypeArg kind */
             TypeArg,
+            /** Enclosing kind */
             Enclosing
         }
 
@@ -1011,7 +1015,7 @@ public class BoundsInitializer {
             return new EnclosingNode(this);
         }
     }
-
+    /** Represents an extends type in a path. */
     private static class ExtendsNode extends BoundPathNode {
 
         ExtendsNode() {

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -329,6 +329,11 @@ public class BoundsInitializer {
         @Override
         public Void visitDeclared(AnnotatedDeclaredType type, Void aVoid) {
             initializeTypeArgs(type);
+            if (type.enclosingType != null) {
+                final BoundPathNode node = addPathNode(new EnclosingNode());
+                visit(type.enclosingType);
+                removePathNode(node);
+            }
             return null;
         }
 
@@ -935,7 +940,8 @@ public class BoundsInitializer {
             ArrayComponent,
             Intersection,
             Union,
-            TypeArg
+            TypeArg,
+            Enclosing
         }
 
         public Kind kind;
@@ -970,6 +976,33 @@ public class BoundsInitializer {
         public abstract AnnotatedTypeMirror getType(final AnnotatedTypeMirror parent);
 
         public abstract BoundPathNode copy();
+    }
+
+    private static class EnclosingNode extends BoundPathNode {
+
+        EnclosingNode() {
+            kind = Kind.Enclosing;
+            typeKind = TypeKind.DECLARED;
+        }
+
+        EnclosingNode(EnclosingNode template) {
+            super(template);
+        }
+
+        @Override
+        public void setType(AnnotatedTypeMirror parent, AnnotatedTypeVariable replacement) {
+            // Do nothing
+        }
+
+        @Override
+        public AnnotatedDeclaredType getType(final AnnotatedTypeMirror parent) {
+            return ((AnnotatedDeclaredType) parent).getEnclosingType();
+        }
+
+        @Override
+        public BoundPathNode copy() {
+            return new EnclosingNode(this);
+        }
     }
 
     private static class ExtendsNode extends BoundPathNode {

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -930,13 +930,20 @@ public class BoundsInitializer {
         }
     }
 
-    // BoundPathNode's are a step in a "type path" that are used to
+    /** BoundPathNode's are a step in a "type path". */
     private abstract static class BoundPathNode {
+
+        /** Kinds of {@link BoundPathNode}s. */
         enum Kind {
+            /** Intersection kind */
             Extends,
+            /** Intersection kind */
             Super,
+            /** Intersection kind */
             UpperBound,
+            /** Intersection kind */
             LowerBound,
+            /** Intersection kind */
             ArrayComponent,
             /** Intersection kind */
             Intersection,

--- a/framework/tests/all-systems/Issue3055.java
+++ b/framework/tests/all-systems/Issue3055.java
@@ -1,0 +1,14 @@
+class Issue3055 {
+
+    class C1<T extends C1<T>.Bound> {
+        class Bound {}
+    }
+
+    class C2<T extends C2.Bound> {
+        class Bound {}
+    }
+
+    class C3<T extends C3<?>.Bound> {
+        class Bound {}
+    }
+}


### PR DESCRIPTION
 Fixes #3058 

(Note, I'll open a separate pull request that adds documentation to so of the classes enclosed in BoundsInitializer.)