### PR TITLE
Check primary annotations before checking if there are any uninferred type arguments.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -461,6 +461,9 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     @Override
     public Boolean visitDeclared_Declared(
             AnnotatedDeclaredType subtype, AnnotatedDeclaredType supertype, Void p) {
+        if (!isPrimarySubtype(subtype, supertype)) {
+            return false;
+        }
         if (subtype.atypeFactory.ignoreUninferredTypeArguments
                 && (subtype.containsUninferredTypeArguments()
                         || supertype.containsUninferredTypeArguments())) {
@@ -470,10 +473,6 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
         }
         AnnotatedDeclaredType subtypeAsSuper =
                 AnnotatedTypes.castedAsSuper(subtype.atypeFactory, subtype, supertype);
-
-        if (!isPrimarySubtype(subtypeAsSuper, supertype)) {
-            return false;
-        }
 
         if (visitHistory.contains(subtypeAsSuper, supertype, currentTop)) {
             return true;


### PR DESCRIPTION
This PR tries to improve #3044.
I don't know why primary annotations are not checked (directly return true) when sub or supertype contains uninferred type arguments.