### PR TITLE
Remove links to com.sun.tools.java in Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,8 +352,9 @@ task allJavadoc(type: Javadoc, group: "Documentation") {
         exec {
             // Javadoc for to com.sun.tools.java.* is not publicly available, so these links are broken.
             // This command removes those links.
+            workingDir "${rootDir}/docs/api"
             executable "${plumeScriptsHome}/preplace"
-            args += ['-debug', '<a href="https://docs.oracle.com/javase/9/docs/api/com/sun/tools/javac/.*?>(.*?)</a>', '\\1', "${rootDir}/docs/api"]
+            args += ['<a href="https://docs.oracle.com/javase/9/docs/api/com/sun/tools/javac/.*?>(.*?)</a>', '\\1']
 
         }
         copy {

--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ task htmlValidate(type: Exec, group: 'Format') {
 //   in the subproject or `./gradlew :checker:javadoc` at the top level.
 task allJavadoc(type: Javadoc, group: "Documentation") {
     description = 'Generates a global API documentation for all the modules'
-    dependsOn(':checker:shadowJar')
+    dependsOn(':checker:shadowJar', 'getPlumeScripts')
     destinationDir = file("${rootDir}/docs/api")
     source(project(':checker').sourceSets.main.allJava, project(':framework').sourceSets.main.allJava,
             project(':dataflow').sourceSets.main.allJava, project(':javacutil').sourceSets.main.allJava)
@@ -349,6 +349,13 @@ task allJavadoc(type: Javadoc, group: "Documentation") {
         classpath += configurations.javacJar
     }
     doLast {
+        exec {
+            // Javadoc for to com.sun.tools.java.* is not publicly available, so these links are broken.
+            // This command removes those links.
+            executable "${plumeScriptsHome}/preplace"
+            args += ['-debug', '<a href="https://docs.oracle.com/javase/9/docs/api/com/sun/tools/javac/.*?>(.*?)</a>', '\\1', "${rootDir}/docs/api"]
+
+        }
         copy {
             from 'docs/logo/Checkmark/CFCheckmark_favicon.png'
             rename('CFCheckmark_favicon.png', 'favicon-checkerframework.png')


### PR DESCRIPTION
The Javadoc for to com.sun.tools.java.* is not publicly available, so these links are broken.  This pull request removes links to them in the Checker Framework Javadoc.