### PR TITLE
Build and test CF Inference under JDK11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,15 @@ jobs:
     fetchDepth: 25
   - bash: ./checker/bin-devel/test-cf-inference.sh
     displayName: test-cf-inference.sh
+- job: cf_inference_jdk11
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: mdernst/cf-ubuntu-jdk11:latest
+  steps:
+    - checkout: self
+      fetchDepth: 25
+    - bash: ./checker/bin-devel/test-cf-inference.sh
+      displayName: test-cf-inference.sh
 - job: plume_lib_jdk8
   pool:
     vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
CF Inference was not able to build under JDK11 before the commit which replaces all usages of deprecated methods (https://github.com/typetools/checker-framework-inference/commit/65aa1cac6df1f9ab20cc75030292c9bde4936fce).

As @wmdietl requested, we should have a job in CI pipeline to build and test CF Inference using JDK11.