### PR TITLE
Run CFI tests under JDK 11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,15 @@ jobs:
     fetchDepth: 25
   - bash: ./checker/bin-devel/test-cf-inference.sh
     displayName: test-cf-inference.sh
+- job: cf_inference_jdk11
+  pool:
+    vmImage: 'ubuntu-16.04'
+  container: mdernst/cf-ubuntu-jdk11:latest
+  steps:
+  - checkout: self
+    fetchDepth: 25
+  - bash: ./checker/bin-devel/test-cf-inference.sh
+    displayName: test-cf-inference.sh
 - job: plume_lib_jdk8
   pool:
     vmImage: 'ubuntu-16.04'


### PR DESCRIPTION
This should be assigned to @zcai1, but GitHub doesn't let me do that.

This is not ready to merge until:
 * the tests pass, and
 * the CFI CI jobs run tests under JDK 11, because we don't want to block commits to the CF repository due to a problem in the CFI repository.