### PR TITLE
Improve error message of inconsistent.constructor.type

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -721,10 +721,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     qualifierHierarchy.findAnnotationInHierarchy(constructorAnnotations, top);
             if (!qualifierHierarchy.isSubtype(top, constructorAnno)) {
                 checker.report(
-                        Result.warning(
-                                "inconsistent.constructor.type",
-                                constructorAnno,
-                                qualifierHierarchy.getTopAnnotation(constructorAnno)),
+                        Result.warning("inconsistent.constructor.type", constructorAnno, top),
                         constructorElement);
             }
         }

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -721,7 +721,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     qualifierHierarchy.findAnnotationInHierarchy(constructorAnnotations, top);
             if (!qualifierHierarchy.isSubtype(top, constructorAnno)) {
                 checker.report(
-                        Result.warning("inconsistent.constructor.type", constructorAnno),
+                        Result.warning(
+                                "inconsistent.constructor.type",
+                                constructorAnno,
+                                qualifierHierarchy.getTopAnnotation(constructorAnno)),
                         constructorElement);
             }
         }

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -43,7 +43,7 @@ contracts.precondition.expression.parameter.name=The precondition %s on the decl
 contracts.postcondition.expression.parameter.name=The postcondition %s on the declaration of method '%s' refers to formal parameter '%s' by name. Please use "#%s" instead of "%s".
 contracts.conditional.postcondition.expression.parameter.name=The conditional postcondition %s on the declaration of method '%s' refers to formal parameter '%s' by name. Please use "#%s" instead of "%s".
 
-inconsistent.constructor.type=Constructor type (%s) cannot be statically verified.
+inconsistent.constructor.type=Constructor type (%s) is a subtype of the top type (%s), therefore it cannot be statically verified.
 super.invocation.invalid=Constructor of type %s cannot call %s of type %s.
 this.invocation.invalid=Constructor of type %s cannot call %s of type %s.
 method.invocation.invalid=call to %s not allowed on the given receiver.\nfound   : %s\nrequired: %s


### PR DESCRIPTION
The error message of key `inconsistent.constructor.type` seems not clear enough, thus updated to improve it.
Update: explicit show user the cause: not returning types with top qualifier