### PR TITLE
Make Map.merge annotations less flexible (but sound and usable by most clients); fixes #3046

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,7 +2,7 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = '74a262c925fa25519287b47668e4eec0b2456e96'
+    jdkShaHash = '03c7d2f752fde145ecc1f5232cae0ae9c22019d4'
     if (rootProject.hasProperty("useLocalJdk")) {
         jdkShaHash = 'local'
     }

--- a/checker/jdk/nullness/src/java/util/Map.java
+++ b/checker/jdk/nullness/src/java/util/Map.java
@@ -1203,8 +1203,11 @@ public interface Map<K, V> {
      *         null
      * @since 1.8
      */
+    // It would be more flexible to make the return type of remappingFunction be `@Nullable V`.  A
+    // remappingFunction that returns null is is probably rare, and these annotations accommodate
+    // the majority of uses that don't return null.
     default V merge(K key, V value,
-            BiFunction<? super V, ? super V, ? extends @Nullable V> remappingFunction) {
+            BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
         Objects.requireNonNull(remappingFunction);
         Objects.requireNonNull(value);
         V oldValue = get(key);

--- a/checker/tests/nullness/MapMerge.java
+++ b/checker/tests/nullness/MapMerge.java
@@ -6,12 +6,12 @@ class MapMerge {
     public static void main(String[] args) {
         Map<String, String> map = new HashMap<>();
         map.put("k", "v");
-        // :: (return.type.incompatible)
+        // :: error: (return.type.incompatible)
         map.merge("k", "v", (a, b) -> null).toString();
     }
 
     void foo(Map<String, String> map) {
-        // :: (return.type.incompatible)
+        // :: error: (return.type.incompatible)
         merge(map, "k", "v", (a, b) -> null).toString();
     }
 

--- a/checker/tests/nullness/MapMerge.java
+++ b/checker/tests/nullness/MapMerge.java
@@ -1,0 +1,25 @@
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+class MapMerge {
+    public static void main(String[] args) {
+        Map<String, String> map = new HashMap<>();
+        map.put("k", "v");
+        // :: (return.type.incompatible)
+        map.merge("k", "v", (a, b) -> null).toString();
+    }
+
+    void foo(Map<String, String> map) {
+        // :: (return.type.incompatible)
+        merge(map, "k", "v", (a, b) -> null).toString();
+    }
+
+    <K, V> V merge(
+            Map<K, V> map,
+            K key,
+            V value,
+            BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        return value;
+    }
+}


### PR DESCRIPTION
Merge together with https://github.com/typetools/jdk/pull/32