### PR TITLE
firstKey/lastKey return a key into the map.

### DIFF
--- a/checker/jdk/nullness/src/java/util/SortedMap.java
+++ b/checker/jdk/nullness/src/java/util/SortedMap.java
@@ -223,7 +223,7 @@ public interface SortedMap<K, V> extends Map<K,V> {
      * @throws NoSuchElementException if this map is empty
      */
     @SideEffectFree
-    K firstKey();
+    @KeyFor("this") K firstKey();
 
     /**
      * Returns the last (highest) key currently in this map.
@@ -232,7 +232,7 @@ public interface SortedMap<K, V> extends Map<K,V> {
      * @throws NoSuchElementException if this map is empty
      */
     @SideEffectFree
-    K lastKey();
+    @KeyFor("this") K lastKey();
 
     /**
      * Returns a {@link Set} view of the keys contained in this map.

--- a/checker/jdk/nullness/src/java/util/TreeMap.java
+++ b/checker/jdk/nullness/src/java/util/TreeMap.java
@@ -299,14 +299,14 @@ public class TreeMap<K, V>
     /**
      * @throws NoSuchElementException {@inheritDoc}
      */
-    public K firstKey() {
+    public @KeyFor("this") K firstKey() {
         return key(getFirstEntry());
     }
 
     /**
      * @throws NoSuchElementException {@inheritDoc}
      */
-    public K lastKey() {
+    public @KeyFor("this") K lastKey() {
         return key(getLastEntry());
     }
 


### PR DESCRIPTION
This avoids the following kind of false positive:

```java
import java.util.TreeMap;

class Demo {
  String foo(TreeMap<String, String> m) {
    return m.get(m.firstKey());
  }
}
```

Corresponding jdk PR: https://github.com/typetools/jdk/pull/33