### PR TITLE
Refactor checkMethodInvocability to allow changes to error messages

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2641,14 +2641,26 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     atypeFactory.getTypeHierarchy().isSubtype(treeReceiver, methodReceiver);
             commonAssignmentCheckEndDiagnostic(success, null, methodReceiver, treeReceiver, node);
             if (!success) {
-                checker.reportError(
-                        node,
-                        "method.invocation.invalid",
-                        TreeUtils.elementFromUse(node),
-                        treeReceiver.toString(),
-                        methodReceiver.toString());
+                reportMethodInvocabilityError(node, treeReceiver, methodReceiver);
             }
         }
+    }
+
+    /**
+     * Report a method invocability error. Allows checkers to change how the message is output.
+     *
+     * @param node the AST node at which to report the error
+     * @param found the actual type of the receiver
+     * @param expected the expected type of the receiver
+     */
+    protected void reportMethodInvocabilityError(
+            MethodInvocationTree node, AnnotatedTypeMirror found, AnnotatedTypeMirror expected) {
+        checker.reportError(
+                node,
+                "method.invocation.invalid",
+                TreeUtils.elementFromUse(node),
+                found.toString(),
+                expected.toString());
     }
 
     /**


### PR DESCRIPTION
This change will allow me to avoid some nasty code in the Object Construction Checker that has to parse strings to construct custom error messages: https://github.com/kelloggm/object-construction-checker/blob/master/object-construction-checker/src/main/java/org/checkerframework/checker/objectconstruction/ObjectConstructionChecker.java#L87

See also https://github.com/kelloggm/object-construction-checker/issues/140