### PR TITLE
Correct method type argument inference with null; fixes #3056; fixes #3150.

### DIFF
--- a/checker/jtreg/nullness/issue824/Class2.java
+++ b/checker/jtreg/nullness/issue824/Class2.java
@@ -13,7 +13,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class Class2<X> extends Class1<X> {
     void call(Class1<@Nullable X> class1, Gen<@Nullable X> gen) {
-        class1.methodTypeParam(null); // False negative #979
+        class1.methodTypeParam(null);
         class1.classTypeParam(null);
 
         class1.wildcardExtends(gen);

--- a/checker/jtreg/nullness/issue824/Class2.out
+++ b/checker/jtreg/nullness/issue824/Class2.out
@@ -1,9 +1,10 @@
 Class2.java:14:39: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:15:22: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:15:47: compiler.err.proc.messager: (type.argument.type.incompatible)
+Class2.java:16:31: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:19:31: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:20:29: compiler.err.proc.messager: (type.argument.type.incompatible)
 Class2.java:20:30: compiler.err.proc.messager: (argument.type.incompatible)
 Class2.java:24:16: compiler.err.proc.messager: (override.return.invalid)
 Class2.java:25:37: compiler.err.proc.messager: (type.argument.type.incompatible)
-8 errors
+9 errors

--- a/checker/tests/nullness/Issue3150.java
+++ b/checker/tests/nullness/Issue3150.java
@@ -1,5 +1,3 @@
-// @skip-test until the bug is fixed
-
 // Test case for https://tinyurl.com/cfissue/3150 .
 
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -7,9 +5,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 class Issue3150 {
     void foo(@Nullable Object nble, @NonNull Object nn) {
-        // :: error: (argument.type.incompatible)
+        // :: error: (type.argument.type.incompatible)
         requireNonNull1(null);
-        // :: error: (argument.type.incompatible)
+        // :: error: (type.argument.type.incompatible)
         requireNonNull1(nble);
         requireNonNull1("hello");
         requireNonNull1(nn);

--- a/checker/tests/nullness/ObjectsRequireNonNullElse.java
+++ b/checker/tests/nullness/ObjectsRequireNonNullElse.java
@@ -1,5 +1,3 @@
-// @skip-test until the bug is fixed
-
 // Test case for https://tinyurl.com/cfissue/3149 .
 
 // @below-java11-jdk-skip-test

--- a/checker/tests/nullness/ObjectsRequireNonNullElse.java
+++ b/checker/tests/nullness/ObjectsRequireNonNullElse.java
@@ -1,5 +1,5 @@
 // Test case for https://tinyurl.com/cfissue/3149 .
-
+// @skip-test jdk annotations are wrong.
 // @below-java11-jdk-skip-test
 
 import static java.util.Objects.requireNonNullElse;

--- a/checker/tests/nullness/ObjectsRequireNonNullElse.java
+++ b/checker/tests/nullness/ObjectsRequireNonNullElse.java
@@ -1,5 +1,4 @@
-// Test case for https://tinyurl.com/cfissue/3149 .
-// @skip-test jdk annotations are wrong.
+// Test case for https://tinyurl.com/cfissue/3056 and https://tinyurl.com/cfissue/3149 .
 // @below-java11-jdk-skip-test
 
 import static java.util.Objects.requireNonNullElse;

--- a/checker/tests/nullness/generics/MethodTypeVars.java
+++ b/checker/tests/nullness/generics/MethodTypeVars.java
@@ -10,8 +10,7 @@ public class MethodTypeVars {
         Object a = A.badMethod(null);
         Object b = A.badMethod(new Object());
 
-        // TODO: false negative. See #979
-        //// :: error: (type.argument.type.incompatible)
+        // :: error: (type.argument.type.incompatible)
         A.goodMethod(null);
         A.goodMethod(new Object());
     }

--- a/checker/tests/nullness/java8inference/Issue887.java
+++ b/checker/tests/nullness/java8inference/Issue887.java
@@ -7,8 +7,7 @@ import org.checkerframework.checker.nullness.qual.*;
 
 public abstract class Issue887 {
     void test() {
-        // TODO: false negative
-        //// :: error: (argument.type.incompatible) :: error: (type.argument.type.incompatible)
+        // :: error: (argument.type.incompatible) :: error: (type.argument.type.incompatible)
         method(foo(null).get(0));
         methodNullable(fooNullable(null).get(0));
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -18,9 +18,7 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic.Kind;
 import org.checkerframework.framework.source.SourceChecker;
@@ -201,11 +199,6 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
     }
 
     /**
-     * Holds an AnnotatedTypeMirror whose underlying type is {@code Object} and annotations are
-     * copied from null. It's lazily initialized in #handleNullTypeArguments.
-     */
-    private AnnotatedTypeMirror objectWithAnnosFromNull = null;
-    /**
      * If one of the inferredArgs are NullType, then re-run inference ignoring null method
      * arguments. Then lub the result of the second inference with the NullType and put the new
      * result back into inferredArgs.
@@ -244,14 +237,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
                 if (withoutNullResult == null) {
                     // withoutNullResult is null when the only constraint on a type argument is
                     // where a method argument is null.
-                    if (objectWithAnnosFromNull == null) {
-                        Elements elements = typeFactory.getProcessingEnv().getElementUtils();
-                        TypeMirror objectTM = elements.getTypeElement("java.lang.Object").asType();
-                        objectWithAnnosFromNull =
-                                AnnotatedTypeMirror.createType(objectTM, typeFactory, false);
-                        objectWithAnnosFromNull.addAnnotations(result.getAnnotations());
-                    }
-                    withoutNullResult = objectWithAnnosFromNull;
+                    withoutNullResult = atv.getUpperBound().deepCopy();
                 }
                 AnnotatedTypeMirror lub =
                         AnnotatedTypes.leastUpperBound(typeFactory, withoutNullResult, result);


### PR DESCRIPTION
Fixes #3150.   (~#3149~ is partially fixed by this pull request because the annotations in the JDK are wrong.  I'll fix them in a different pull request and enable the test.)