### PR TITLE
Add `@Nullable` to return types of `IdentityHashMap`.

### DIFF
--- a/checker/jdk/nullness/src/java/util/IdentityHashMap.java
+++ b/checker/jdk/nullness/src/java/util/IdentityHashMap.java
@@ -344,7 +344,7 @@ public class IdentityHashMap<K, V>
      */
     @SuppressWarnings("unchecked")
     @Pure
-    public V get(Object key) {
+    public @Nullable V get(Object key) {
         Object k = maskNull(key);
         Object[] tab = table;
         int len = tab.length;
@@ -443,7 +443,7 @@ public class IdentityHashMap<K, V>
      * @see     #containsKey(Object)
      */
     @EnsuresKeyFor(value="#1", map="this")
-    public V put(K key, V value) {
+    public @Nullable V put(K key, V value) {
         Object k = maskNull(key);
         Object[] tab = table;
         int len = tab.length;
@@ -535,7 +535,7 @@ public class IdentityHashMap<K, V>
      *         (A <tt>null</tt> return can also indicate that the map
      *         previously associated <tt>null</tt> with <tt>key</tt>.)
      */
-    public V remove(Object key) {
+    public @Nullable V remove(Object key) {
         Object k = maskNull(key);
         Object[] tab = table;
         int len = tab.length;


### PR DESCRIPTION
The public APIs in this class otherwise look fully annotated, with the exception of some missing `@Nullable` annotations on `Object` parameters, which are being addressed in https://github.com/typetools/checker-framework/pull/3063