### PR TITLE
Clean up changes from #3193

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagator.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagator.java
@@ -175,7 +175,7 @@ public class KeyForPropagator {
     }
 
     /**
-     * An annotated type merger that merges @KeyFor annotations and only if the type that is
+     * An annotated type replacer that replaces @KeyFor annotations and only if the type that is
      * receiving an annotation has an @UnknownKeyFor annotation or NO key for annotations.
      */
     private class KeyForPropagationReplacer extends AnnotatedTypeReplacer {
@@ -193,15 +193,15 @@ public class KeyForPropagator {
         }
 
         @Override
-        protected void replaceAnnotations(AnnotatedTypeMirror src, AnnotatedTypeMirror dst) {
-            final AnnotationMirror srcKeyFor = src.getAnnotationInHierarchy(UNKNOWN_KEYFOR);
-            final AnnotationMirror dstKeyFor = dst.getAnnotationInHierarchy(UNKNOWN_KEYFOR);
+        protected void replaceAnnotations(AnnotatedTypeMirror from, AnnotatedTypeMirror to) {
+            final AnnotationMirror fromKeyFor = from.getAnnotationInHierarchy(UNKNOWN_KEYFOR);
+            final AnnotationMirror toKeyFor = to.getAnnotationInHierarchy(UNKNOWN_KEYFOR);
 
             boolean toNeedsAnnotation =
-                    dstKeyFor == null || AnnotationUtils.areSame(dstKeyFor, UNKNOWN_KEYFOR);
-            if (srcKeyFor != null && toNeedsAnnotation) {
-                AnnotationBuilder annotationBuilder = new AnnotationBuilder(env, srcKeyFor);
-                dst.replaceAnnotation(annotationBuilder.build());
+                    toKeyFor == null || AnnotationUtils.areSame(toKeyFor, UNKNOWN_KEYFOR);
+            if (fromKeyFor != null && toNeedsAnnotation) {
+                AnnotationBuilder annotationBuilder = new AnnotationBuilder(env, fromKeyFor);
+                to.replaceAnnotation(annotationBuilder.build());
             }
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -347,11 +347,9 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         AnnotatedTypeMirror result = f.type(node);
         assert result instanceof AnnotatedWildcardType;
 
-        // the first time getSuperBound/getExtendsBound is called the bound of this wildcard will be
-        // appropriately initialized where for the type of node, instead of replacing that bound
-        // we merge the annotations onto the initialized bound
-        // This ensures that the structure of the wildcard will match that created by
-        // BoundsInitializer/createType
+        // Instead of directly overwriting the bound, replace each annotation
+        // to ensure that the structure of the wildcard will match that created by
+        // BoundsInitializer/createType.
         if (node.getKind() == Tree.Kind.SUPER_WILDCARD) {
             AnnotatedTypeReplacer.replace(bound, ((AnnotatedWildcardType) result).getSuperBound());
 

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
@@ -23,7 +23,9 @@ import org.checkerframework.javacutil.BugInCF;
 public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
 
     /**
-     * Replaces or adds all annotations from {@code from} to {@code to}.
+     * Replaces or adds all annotations from {@code from} to {@code to}. Annotations from {@code
+     * from} will be used everywhere they exist, but annotations in {@code to} will be kept anywhere
+     * that {@code from} is unannotated.
      *
      * @param from the annotated type mirror from which to take new annotations
      * @param to the annotated type mirror to which the annotations will be added
@@ -37,6 +39,8 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
 
     /**
      * Replaces or adds annotations in {@code top}'s hierarchy from {@code from} to {@code to}.
+     * Annotations from {@code from} will be used everywhere they exist, but annotations in {@code
+     * to} will be kept anywhere that {@code from} is unannotated.
      *
      * @param from the annotated type mirror from which to take new annotations
      * @param to the annotated type mirror to which the annotations will be added
@@ -71,10 +75,10 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     }
 
     @Override
-    protected Void compare(AnnotatedTypeMirror one, AnnotatedTypeMirror two) {
-        assert one != two;
-        if (one != null && two != null) {
-            replaceAnnotations(one, two);
+    protected Void compare(AnnotatedTypeMirror from, AnnotatedTypeMirror to) {
+        assert from != to;
+        if (from != null && to != null) {
+            replaceAnnotations(from, to);
         }
         return null;
     }
@@ -85,19 +89,19 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     }
 
     /**
-     * Replace the annotations in dst with the annotations in src
+     * Replace the annotations in to with the annotations in from, wherever from has an annotation.
      *
-     * @param src the source of the annotations
-     * @param dst the destination of the annotations
+     * @param from the source of the annotations
+     * @param to the destination of the annotations, modified by this method
      */
     protected void replaceAnnotations(
-            final AnnotatedTypeMirror src, final AnnotatedTypeMirror dst) {
+            final AnnotatedTypeMirror from, final AnnotatedTypeMirror to) {
         if (top == null) {
-            dst.replaceAnnotations(src.getAnnotations());
+            to.replaceAnnotations(from.getAnnotations());
         } else {
-            final AnnotationMirror replacement = src.getAnnotationInHierarchy(top);
+            final AnnotationMirror replacement = from.getAnnotationInHierarchy(top);
             if (replacement != null) {
-                dst.replaceAnnotation(src.getAnnotationInHierarchy(top));
+                to.replaceAnnotation(from.getAnnotationInHierarchy(top));
             }
         }
     }


### PR DESCRIPTION
@wmdietl pointed out some inconsistencies in #3193. This PR cleans up those inconsistencies, and some other ones I noticed in the process. From the comments on some of the calls to `AnnotatedTypeMerger`/`AnnotatedTypeReplacer`, it's clear to me that the old name has caused confusion before!

The only code change in this PR is in `StubParser.java`, where I removed a no-op call to `AnnotatedTypeReplacer.replace()`.