### PR TITLE
IntelliJ requires use of JDK 11

### DIFF
--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -728,7 +728,7 @@ to run a checker within IntelliJ IDEA on every compile:
 \item Change the project SDK to 11, as explained at
   \url{https://www.jetbrains.com/help/idea/sdk.html#change-project-sdk}.
 
-\item Make sure the language level for your project is 11 (after the last step, it should show up as your SDK default), as explained at
+\item Make sure the language level for your project is 8 or higher, as explained at
 \url{https://www.jetbrains.com/help/idea/project-page.html}.
 
 \item Add the annotated JDK library to the bootclasspath.

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -725,10 +725,10 @@ to run a checker within IntelliJ IDEA on every compile:
 
 \begin{enumerate}
 
-\item Change the project SDK to 1.8, as explained at
+\item Change the project SDK to 11, as explained at
   \url{https://www.jetbrains.com/help/idea/sdk.html#change-project-sdk}.
 
-\item Change the language level for your project to 8, as explained at
+\item Make sure the language level for your project is 11 (after the last step, it should show up as your SDK default), as explained at
 \url{https://www.jetbrains.com/help/idea/project-page.html}.
 
 \item Add the annotated JDK library to the bootclasspath.


### PR DESCRIPTION
This addresses https://github.com/typetools/checker-framework/issues/3201, wherein following the current instructions for setting up Checker on IntelliJ was not sufficient for successful compilation.