### PR TITLE
Enable daikon_jdk11 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,15 +82,15 @@ jobs:
     fetchDepth: 25
   - bash: ./checker/bin-devel/test-daikon.sh
     displayName: test-daikon.sh
-#- job: daikon_jdk11
-#  pool:
-#    vmImage: 'ubuntu-latest'
-#  container: mdernst/cf-ubuntu-jdk11:latest
-#  steps:
-#  - checkout: self
-#    fetchDepth: 25
-#  - bash: ./checker/bin-devel/test-daikon.sh
-#    displayName: test-daikon.sh
+- job: daikon_jdk11
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk11:latest
+  steps:
+  - checkout: self
+    fetchDepth: 25
+  - bash: ./checker/bin-devel/test-daikon.sh
+    displayName: test-daikon.sh
 - job: guava_jdk8
   pool:
     vmImage: 'ubuntu-latest'


### PR DESCRIPTION
As #3223 discussed:

Since Daikon can compile under Java 11 now, to be consistent with travis (`daikon_jdk11` did not comment out in .travis.yml), we should enable it again.