### PR TITLE
Correct supertypes of CopyOnWriteArraySet.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -216,7 +216,7 @@ public class CopyOnWriteArrayList<E>
 }
 
 public class CopyOnWriteArraySet<E>
-    implements List<E>, RandomAccess, Cloneable, java.io.Serializable {
+    implements Set<E>, java.io.Serializable {
     public boolean removeAll(Collection<?> c);
     public boolean retainAll(Collection<?> c);
 }


### PR DESCRIPTION
This fixes the warnings reported by StubParser.