### PR TITLE
Fixes to `collection-object-parameters-may-be-null.astub`:

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -88,6 +88,7 @@
 package java.util;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.qual.Pure;
 
 class AbstractCollection {
     @Pure public boolean contains(@Nullable Object o);
@@ -215,7 +216,8 @@ public class CopyOnWriteArrayList<E>
 }
 
 public class CopyOnWriteArraySet<E>
-    implements Set<E>, java.io.Serializable {
+    extends AbstractSet<E>
+    implements java.io.Serializable {
     public boolean removeAll(Collection<?> c);
     public boolean retainAll(Collection<?> c);
 }


### PR DESCRIPTION
- Import `@Pure`.
- Fix mistake from #3234: `CopyOnWriteArraySet` has `extends AbstractSet`, not `implements Set`.

These address StubParser warnings.