### PR TITLE
Provide a stub for `Collection.removeAll`.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -118,6 +118,7 @@ public interface Collection<E> extends Iterable<E> {
     boolean contains(@Nullable Object o);
     boolean remove(@Nullable Object o);
     boolean containsAll(Collection<?> c);
+    boolean removeAll(Collection<?> c);
     boolean retainAll(Collection<?> c);
 }
 


### PR DESCRIPTION
However, note that this currently has no effect because of #3236.