### PR TITLE
Add type parameters to some collection stubs.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/collection-object-parameters-may-be-null.astub
@@ -90,7 +90,7 @@ package java.util;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 
-class AbstractCollection {
+class AbstractCollection<E> {
     @Pure public boolean contains(@Nullable Object o);
     public boolean remove(@Nullable Object o);
     @Pure public boolean containsAll(Collection<?> c);
@@ -103,14 +103,14 @@ public abstract class AbstractList<E> extends AbstractCollection<E> implements L
     public int lastIndexOf(@Nullable Object o);
 }
 
-class AbstractMap {
+class AbstractMap<K, V> {
     public boolean containsValue(@Nullable Object value);
     public boolean containsKey(@Nullable Object key);
     public @Nullable V get(@Nullable Object key);
     public @Nullable V remove(@Nullable Object key);
 }
 
-class AbstractSet {
+class AbstractSet<E> {
   public boolean removeAll(Collection<?> c);
 }
 
@@ -173,7 +173,7 @@ public class TreeSet<E> extends AbstractSet<E>
     public boolean remove(@Nullable Object o);
 }
 
-class Vector {
+class Vector<E> {
     public synchronized boolean containsAll(Collection<?> c);
     public synchronized boolean removeAll(Collection<?> c);
     public synchronized boolean retainAll(Collection<?> c);


### PR DESCRIPTION
This fixes warnings like:

```
warning: StubParser: annotateTypeParameters: mismatched sizes:  typeParameters (size 0)=[];  typeArguments (size 1)=[E extends Object];  decl=class AbstractCollection {      @Pure     public boolean contains(@Nullable Object o);      public boolean remove(@Nullable Object o);      @Pure     public boolean containsAll(Collection<? extends @Nullable Object> c);      public boolean removeAll(Collection<? extends @Nullable Object> c);      public boolean retainAll(Collection<? extends @Nullable Object> c); };  elt=java.util.AbstractCollection (class com.sun.tools.javac.code.Symbol$ClassSymbol).; for more details, run with -AstubDebug
```