### PR TITLE
Add inputs and outputs for copyJdk11Files task

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -58,13 +58,15 @@ task cloneTypetoolsJdk() {
 }
 
 task copyJdk11Files(dependsOn: cloneTypetoolsJdk, group: 'Build') {
+    def inputDir = "${jdkHome}/src"
     def outputDir = "${buildDir}/jdk/jdk11"
     description "Copy annotated jdk 11 files to ${outputDir}"
 
+    inputs.dir file(inputDir)
     outputs.dir file(outputDir)
 
     doLast {
-        FileTree tree = fileTree(dir: "${jdkHome}/src/")
+        FileTree tree = fileTree(dir: inputDir)
         SortedSet<String> annotatedForFiles = new TreeSet<>();
         tree.visit { FileVisitDetails fvd ->
             if (!fvd.file.isDirectory() && fvd.file.name.matches(".*\\.java")) {

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -58,7 +58,11 @@ task cloneTypetoolsJdk() {
 }
 
 task copyJdk11Files(dependsOn: cloneTypetoolsJdk, group: 'Build') {
-    description "Copy annotated jdk 11 files to ${buildDir}/jdk/jdk11/"
+    def outputDir = "${buildDir}/jdk/jdk11"
+    description "Copy annotated jdk 11 files to ${outputDir}"
+
+    outputs.dir file(outputDir)
+
     doLast {
         FileTree tree = fileTree(dir: "${jdkHome}/src/")
         SortedSet<String> annotatedForFiles = new TreeSet<>();
@@ -76,7 +80,7 @@ task copyJdk11Files(dependsOn: cloneTypetoolsJdk, group: 'Build') {
         int jdkDirStringSize = absolutejdkHome.size()
         copy {
             from(jdkHome)
-            into("${buildDir}/jdk/jdk11/")
+            into(outputDir)
             for (String filename : annotatedForFiles) {
                 include filename.substring(jdkDirStringSize)
             }


### PR DESCRIPTION
Fixes #3111

The inputs are a bit conservative (it's the entire `${jdkHome}/src` directory), but I didn't see an easy way to narrow it down.