### PR TITLE
Fix memory leak in QualifierDefaults

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -717,8 +717,6 @@ subprojects {
             if (isJava8) {
                 jvmArgs "-Xbootclasspath/p:${configurations.javacJar.asPath}"
             } else {
-                // Without this, the test throw "java.lang.OutOfMemoryError: Java heap space"
-                forkEvery(1)
                 jvmArgs += [
                         "--illegal-access=warn",
                         "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -466,7 +466,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor
      *
      * @see #activeOptions
      */
-    private static final String OPTION_SEPARATOR = "_";
+    protected static final String OPTION_SEPARATOR = "_";
 
     /**
      * The checker that called this one, whether that be a BaseTypeChecker (used as a compound

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -62,6 +62,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.util.CFContext;
 import org.checkerframework.framework.util.CheckerMain;
 import org.checkerframework.framework.util.OptionConfiguration;
+import org.checkerframework.framework.util.defaults.QualifierDefaults;
 import org.checkerframework.javacutil.AbstractTypeProcessor;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.AnnotationUtils;
@@ -465,7 +466,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor
      *
      * @see #activeOptions
      */
-    protected static final String OPTION_SEPARATOR = "_";
+    private static final String OPTION_SEPARATOR = "_";
 
     /**
      * The checker that called this one, whether that be a BaseTypeChecker (used as a compound
@@ -2525,5 +2526,11 @@ public abstract class SourceChecker extends AbstractTypeProcessor
         } catch (IOException e) {
             System.out.println("IOException while reading git.properties: " + e.getMessage());
         }
+    }
+
+    @Override
+    public void typeProcessingOver() {
+        super.typeProcessingOver();
+        QualifierDefaults.clearCache();
     }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -1170,4 +1170,15 @@ public class QualifierDefaults {
 
         return boundType;
     }
+
+    /**
+     * Clear all the underlying cached Elements.
+     *
+     * <p>Implementations of {@link org.checkerframework.javacutil.AbstractTypeProcessor
+     * AbstractTypeProcessor} should consider calling this method after processing to prevent memory
+     * leaks.
+     */
+    public static void clearCache() {
+        elementToBoundType.clear();
+    }
 }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AbstractTypeProcessor.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AbstractTypeProcessor.java
@@ -78,7 +78,7 @@ public abstract class AbstractTypeProcessor extends AbstractProcessor {
      * Method {@link #typeProcessingOver} must be invoked exactly once, after the last invocation of
      * {@link #typeProcess(TypeElement, TreePath)}.
      */
-    private static boolean hasInvokedTypeProcessingOver = false;
+    private boolean hasInvokedTypeProcessingOver = false;
 
     /** The TaskListener registered for completion of attribution. */
     private final AttributionTaskListener listener = new AttributionTaskListener();


### PR DESCRIPTION
@wmdietl @xingweitian 
This PR should fix the memory leak mentioned in https://github.com/opprop/checker-framework-inference/pull/263#issuecomment-618216146

The basic idea is to clear all cached `Element`s after each processor finished its job.