### PR TITLE
Remove `@Covariant` from `Map`.

### DIFF
--- a/checker/jdk/nullness/src/java/util/Map.java
+++ b/checker/jdk/nullness/src/java/util/Map.java
@@ -135,7 +135,6 @@ import org.checkerframework.framework.qual.Covariant;
  * @since 1.2
  */
 // Subclasses of this interface/class may opt to prohibit null elements
-@Covariant(0)
 public interface Map<K, V> {
     // Query Operations
 


### PR DESCRIPTION
It, like `List` (https://github.com/typetools/checker-framework/issues/2047), is not covariant:

```
import java.util.HashMap;
import java.util.Map;
import org.checkerframework.checker.nullness.qual.Nullable;

class MapCovariant {
  public static void main(String[] args) {
    Map<String, String> map = new HashMap<String, String>();
    Map<@Nullable String, String> sameMap = map;
    sameMap.put(null, "");
    map.keySet().iterator().next().toString(); // NPE
  }
}
```