### PR TITLE
Allow for parallel builds and tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,7 @@ allprojects {
     //   * any new checkers have been added,
     //   * the patch level is 9 (keep the patch level as a single digit), or
     //   * backward-incompatible changes have been made to APIs or elsewhere.
-    version '3.4.0'
+    version '3.4.1-SNAPSHOT'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
These Gradle configuration changes allow for parallel builds and parallel execution of tests (at the test class granularity) on multicore systems.  On my 6-core Mac Mini, this change reduces the time for a clean `./gradlew build` from ~6m50s to ~4m50s.  Improvements to incremental builds will of course depend on individual workflows (and on amount of RAM available, etc.).  If framework tests are run regularly in incremental builds, my feeling is this will yield a nice win for that case.