### PR TITLE
Don't include annotations in primitive type simple names

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -215,7 +215,7 @@ public class ElementUtils {
                 return ((DeclaredType) type).asElement().getSimpleName().toString();
             default:
                 if (type.getKind().isPrimitive()) {
-                    return type.toString();
+                    return TypeAnnotationUtils.unannotatedType(type).toString();
                 }
         }
         throw new BugInCF("ElementUtils: unhandled type kind: %s, type: %s", type.getKind(), type);


### PR DESCRIPTION
Originally part of #2871, but @wmdietl suggested it should be a separate PR.