### PR TITLE
Fix manual error to solve issue3258

### DIFF
--- a/docs/manual/purity-checker.tex
+++ b/docs/manual/purity-checker.tex
@@ -10,7 +10,7 @@ All checkers utilize purity annotations on called methods.
 You do not need to run the Purity Checker directly.
 However you may run just the Purity Checker by
 supplying the following command-line options to javac:
-\code{-processor org.checkerframework.util.PurityChecker}.
+\code{-processor org.checkerframework.framework.util.PurityChecker}. # correct Class 
 
 
 \sectionAndLabel{Purity annotations}{purity-annotations}


### PR DESCRIPTION
Tha class name for PurityChecker is writen wrongly on page 125.
org.checkerframework.util.PurityChecker -> org.checkerframework.framework.util.PurityChecker 