### PR TITLE
Explicitly calling constructors in KeyForAnnotatedTypeFactory

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.KeyForBottom;
@@ -22,6 +23,7 @@ import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.util.NodeUtils;
+import org.checkerframework.framework.flow.CFAbstractAnalysis;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.DefaultTypeHierarchy;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
@@ -33,6 +35,7 @@ import org.checkerframework.framework.util.GraphQualifierHierarchy;
 import org.checkerframework.framework.util.MultiGraphQualifierHierarchy.MultiGraphFactory;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
 
 public class KeyForAnnotatedTypeFactory
@@ -136,6 +139,20 @@ public class KeyForAnnotatedTypeFactory
             }
             return super.isSubtype(subtype, supertype, top);
         }
+    }
+
+    // explicitly calling constructor instead of using reflection
+    @Override
+    protected KeyForAnalysis createFlowAnalysis(
+            List<Pair<VariableElement, KeyForValue>> fieldValues) {
+        return new KeyForAnalysis(checker, this, fieldValues);
+    }
+
+    // explicitly calling constructor instead of using reflection
+    @Override
+    public KeyForTransfer createFlowTransferFunction(
+            CFAbstractAnalysis<KeyForValue, KeyForStore, KeyForTransfer> analysis) {
+        return new KeyForTransfer((KeyForAnalysis) analysis);
     }
 
     /*

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -141,14 +141,14 @@ public class KeyForAnnotatedTypeFactory
         }
     }
 
-    // explicitly calling constructor instead of using reflection
+    /** explicitly calling constructor instead of using reflection */
     @Override
     protected KeyForAnalysis createFlowAnalysis(
             List<Pair<VariableElement, KeyForValue>> fieldValues) {
         return new KeyForAnalysis(checker, this, fieldValues);
     }
 
-    // explicitly calling constructor instead of using reflection
+    /** explicitly calling constructor instead of using reflection */
     @Override
     public KeyForTransfer createFlowTransferFunction(
             CFAbstractAnalysis<KeyForValue, KeyForStore, KeyForTransfer> analysis) {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -141,17 +141,17 @@ public class KeyForAnnotatedTypeFactory
         }
     }
 
-    /** explicitly calling constructor instead of using reflection */
     @Override
     protected KeyForAnalysis createFlowAnalysis(
             List<Pair<VariableElement, KeyForValue>> fieldValues) {
+        // Explicitly call the constructor instead of using reflection.
         return new KeyForAnalysis(checker, this, fieldValues);
     }
 
-    /** explicitly calling constructor instead of using reflection */
     @Override
     public KeyForTransfer createFlowTransferFunction(
             CFAbstractAnalysis<KeyForValue, KeyForStore, KeyForTransfer> analysis) {
+        // Explicitly call the constructor instead of using reflection.
         return new KeyForTransfer((KeyForAnalysis) analysis);
     }
 


### PR DESCRIPTION
This allows the `KeyForAnnotatedTypeFactory` to be reused by other checkers. 
@wmdietl 