### PR TITLE
Add test for polymorphic qualifiers in SubtypeOf

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,7 @@ task requireJavadoc(type: JavaExec) {
 
 
 /**
- * Creates a task named taskName that runs javadoc.
+ * Creates a task named taskName that runs javadoc with the -Xdoclint:all option.
  *
  * @param taskName the name of the task to create
  * @param taskDescription description of the task

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -727,9 +727,9 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                             "Found unsupported qualifier in SubTypeOf: %s on qualifier: %s",
                             superQualifier.getCanonicalName(), typeQualifier.getCanonicalName());
                 }
-                // This is currently not supported. Polymorphic qualifiers cannot have lower bounds
-                // Failed to so causes a NPE when building qualifier hierarchy
                 if (superQualifier.getAnnotation(PolymorphicQualifier.class) != null) {
+                    // This is currently not supported. No qualifier can have a polymorphic
+                    // qualifier as super qualifier.
                     throw new BugInCF(
                             "Found polymorphic qualifier in SubTypeOf: %s on qualifier: %s",
                             superQualifier.getCanonicalName(), typeQualifier.getCanonicalName());


### PR DESCRIPTION
While polymorphic qualifiers cannot have [`SubtypeOf`](https://github.com/typetools/checker-framework/blob/11262c72ef210d756b117c186fe62dff969e0832/framework/src/main/java/org/checkerframework/framework/qual/SubtypeOf.java), it should also not appears *in* the parameters of `SubtypeOf` of any other qualifiers. Otherwise, if a user do that, when building the qualifier hierarchy for the visitor, the constructor will try to find the subtype of the polymorphic qualifier (and it does not exists in the mapping), thus result into a NPE.