### PR TITLE
Address delombok "cannot find symbol" warnings

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -210,9 +210,9 @@ task delombok {
     inputs.files file(srcJava)
     outputs.dir file(srcDelomboked)
 
-    // this dependency is required to ensure the checker-qual jar exists,
+    // This dependency is required to ensure the checker-qual jar exists,
     // to prevent lombok from emitting "cannot find symbol" errors for @This
-    // annotations in the test input code
+    // annotations in the test input code.
     dependsOn project(':checker-qual').tasks.jar
 
     doLast {

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -210,10 +210,15 @@ task delombok {
     inputs.files file(srcJava)
     outputs.dir file(srcDelomboked)
 
+    // this dependency is required to ensure the checker-qual jar exists,
+    // to prevent lombok from emitting "cannot find symbol" errors for @This
+    // annotations in the test input code
+    dependsOn project(':checker-qual').tasks.jar
+
     doLast {
         def collection = files(configurations.testCompileClasspath)
         ant.taskdef(name: 'delombok', classname: 'lombok.delombok.ant.Tasks$Delombok',
-                classpath: configurations.testCompileClasspath.asPath)
+                classpath: collection.asPath)
         ant.delombok(from: srcJava, to: srcDelomboked, classpath: collection.asPath)
     }
 }


### PR DESCRIPTION
Without this change, running `./gradlew clean :framework:delombok` leads to the following type of warning output:

```bash
> Task :framework:delombok
[ant:delombok] /home/mernst/research/types/checker-framework-branch-master/framework/tests/returnsreceiverlombok/BuilderTest.java:6: error: package org.checkerframework.common.returnsreceiver.qual does not exist
[ant:delombok] import org.checkerframework.common.returnsreceiver.qual.*;
[ant:delombok] ^
[ant:delombok] /home/mernst/research/types/checker-framework-branch-master/framework/tests/returnsreceiverlombok/BuilderTest.java:31: error: cannot find symbol
[ant:delombok]     BuilderTest.@This BuilderTestBuilder wrapperX() {
[ant:delombok]                  ^
[ant:delombok]   symbol:   class This
[ant:delombok]   location: class CustomBuilderTestBuilder
```

This change adds a Gradle dependence to ensure the relevant annotation is in the classpath.

Note that even with the above output, the build would succeed.  Ideally we would fail the build on such warnings, but I cannot find a setting for Lombok that would achieve this.

/cc @nimakarimipour 
