### PR TITLE
Ignore wildcard type mismatches (Fixes #3128)

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
@@ -111,13 +111,12 @@ public abstract class AnnotatedTypeComparer<R>
 
     @Override
     public R visitTypeVariable(AnnotatedTypeVariable type, AnnotatedTypeMirror p) {
-        R r;
         if (visitedNodes.containsKey(type)) {
             return visitedNodes.get(type);
         }
-
         visitedNodes.put(type, null);
 
+        R r;
         if (p instanceof AnnotatedTypeVariable) {
             AnnotatedTypeVariable tv = (AnnotatedTypeVariable) p;
             r = scan(type.getLowerBound(), tv.getLowerBound());
@@ -135,18 +134,24 @@ public abstract class AnnotatedTypeComparer<R>
 
     @Override
     public R visitWildcard(AnnotatedWildcardType type, AnnotatedTypeMirror p) {
-        assert p instanceof AnnotatedWildcardType
-                : "Unexpected type " + p + " of kind " + p.getKind();
-        AnnotatedWildcardType w = (AnnotatedWildcardType) p;
         if (visitedNodes.containsKey(type)) {
             return visitedNodes.get(type);
         }
-
         visitedNodes.put(type, null);
-        R r = scan(type.getExtendsBound(), w.getExtendsBound());
-        visitedNodes.put(type, r);
-        r = scanAndReduce(type.getSuperBound(), w.getSuperBound(), r);
-        visitedNodes.put(type, r);
+
+        R r;
+        if (p instanceof AnnotatedWildcardType) {
+            AnnotatedWildcardType w = (AnnotatedWildcardType) p;
+            r = scan(type.getExtendsBound(), w.getExtendsBound());
+            visitedNodes.put(type, r);
+            r = scanAndReduce(type.getSuperBound(), w.getSuperBound(), r);
+            visitedNodes.put(type, r);
+        } else {
+            r = scan(type.getExtendsBound(), p.getErased());
+            visitedNodes.put(type, r);
+            r = scanAndReduce(type.getSuperBound(), p.getErased(), r);
+            visitedNodes.put(type, r);
+        }
         return r;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeComparer.java
@@ -135,7 +135,8 @@ public abstract class AnnotatedTypeComparer<R>
 
     @Override
     public R visitWildcard(AnnotatedWildcardType type, AnnotatedTypeMirror p) {
-        assert p instanceof AnnotatedWildcardType : p;
+        assert p instanceof AnnotatedWildcardType
+                : "Unexpected type " + p + " of kind " + p.getKind();
         AnnotatedWildcardType w = (AnnotatedWildcardType) p;
         if (visitedNodes.containsKey(type)) {
             return visitedNodes.get(type);

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
@@ -115,13 +115,7 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     @Override
     public Void visitWildcard(AnnotatedWildcardType from, AnnotatedTypeMirror to) {
         resolvePrimaries(from, to);
-        if (to.getKind() == TypeKind.WILDCARD) {
-            return super.visitWildcard(from, to);
-        } else {
-            // TODO #3128: The to type is something unexpected, likely a captured wildcard.
-            // What is a proper fix for this bug?
-            return null;
-        }
+        return super.visitWildcard(from, to);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeReplacer.java
@@ -115,7 +115,13 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     @Override
     public Void visitWildcard(AnnotatedWildcardType from, AnnotatedTypeMirror to) {
         resolvePrimaries(from, to);
-        return super.visitWildcard(from, to);
+        if (to.getKind() == TypeKind.WILDCARD) {
+            return super.visitWildcard(from, to);
+        } else {
+            // TODO #3128: The to type is something unexpected, likely a captured wildcard.
+            // What is a proper fix for this bug?
+            return null;
+        }
     }
 
     /**

--- a/framework/tests/all-systems/Issue3128.java
+++ b/framework/tests/all-systems/Issue3128.java
@@ -1,0 +1,12 @@
+// Test case for Issue 3128:
+// https://github.com/typetools/checker-framework/issues/3128
+
+class Issue3128 {
+    class One<S> {}
+
+    class Two<U extends Number, V extends One<U>> {}
+
+    One<Two<?, ?>> foo() {
+        return new One<>();
+    }
+}


### PR DESCRIPTION
@smillst This is a rather ugly work-around to the problem.
Alternatively, instead of the assert in `AnnotatedTypeComparer` we could return early, possibly solving the same problem for other subtypes of ATC.
Do you see a better solution? As this is a real crash, I would like to get a fix in for the release.