### PR TITLE
Mark correct tree as artificial

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -3408,7 +3408,7 @@ public class CFGBuilder {
                 extendWithNode(variableNode);
 
                 ExpressionTree variableUse = treeBuilder.buildVariableUse(variable);
-                handleArtificialTree(variable);
+                handleArtificialTree(variableUse);
 
                 LocalVariableNode variableUseNode = new LocalVariableNode(variableUse);
                 variableUseNode.setInSource(false);


### PR DESCRIPTION
Tree `variable` was already marked a few lines earlier.
The line above created the new `ExpressionTree variableUse`, so I assume that that tree should be marked as artificial.