### PR TITLE
Make type parameter names in dataflow framework consistent.

### DIFF
--- a/dataflow/manual/content.tex
+++ b/dataflow/manual/content.tex
@@ -343,7 +343,7 @@ following a boolean-valued expression.
 
 \begin{verbatim}
 package org.checkerframework.dataflow.analysis;
-class TransferInput<A extends AbstractValue<A>,
+class TransferInput<V extends AbstractValue<V>,
         S extends Store<S>>
 \end{verbatim}
 
@@ -359,12 +359,12 @@ single store.
 
 \begin{verbatim}
 package class org.checkerframework.dataflow.analysis;
-abstract TransferResult<A extends AbstractValue<A>,
+abstract TransferResult<V extends AbstractValue<V>,
         S extends Store<S>>
-class ConditionalTransferResult<A extends AbstractValue<A>,
+class ConditionalTransferResult<V extends AbstractValue<V>,
         S extends Store<S>>
     extends TransferResult<A, S>
-class RegularTransferResult<A extends AbstractValue<A>,
+class RegularTransferResult<V extends AbstractValue<V>,
         S extends Store<S>>
     extends TransferResult<A, S>
 \end{verbatim}
@@ -376,7 +376,7 @@ A TransferFunction is a NodeVisitor that takes an input and produces an output.
 
 \begin{verbatim}
 package org.checkerframework.dataflow.analysis;
-interface TransferFunction<A extends AbstractValue<A>,
+interface TransferFunction<V extends AbstractValue<V>,
         S extends Store<S>>
     extends NodeVisitor<TransferResult<A, S>, TransferInput<A, S>>
 \end{verbatim}
@@ -426,7 +426,7 @@ analyses are supported.
 
 \begin{verbatim}
 package org.checkerframework.dataflow.analysis;
-class Analysis<A extends AbstractValue<A>,
+class Analysis<V extends AbstractValue<V>,
         S extends Store<S>,
         T extends TransferFunction<A, S>>
 \end{verbatim}
@@ -477,7 +477,7 @@ or after any Tree.
 
 \begin{verbatim}
 package org.checkerframework.dataflow.analysis;
-class AnalysisResult<A extends AbstractValue<A>,
+class AnalysisResult<V extends AbstractValue<V>,
         S extends Store<S>>
 \end{verbatim}
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -400,6 +400,9 @@ public class Analysis<
     /**
      * Updates the value of node {@code node} to the value of the {@code transferResult}. Returns
      * true if the node's value changed, or a store was updated.
+     *
+     * @param node a node
+     * @param transferResult the result type of a transfer function
      */
     protected boolean updateNodeValues(Node node, TransferResult<V, S> transferResult) {
         V newVal = transferResult.getResultValue();
@@ -416,6 +419,9 @@ public class Analysis<
 
     /**
      * Call the transfer function for node {@code node}, and set that node as current node first.
+     *
+     * @param node a node
+     * @param store the input type of a transfer function
      */
     protected TransferResult<V, S> callTransferFunction(Node node, TransferInput<V, S> store) {
         assert transferFunction != null : "@AssumeAssertion(nullness): invariant";
@@ -678,14 +684,18 @@ public class Analysis<
     /**
      * Read the {@link TransferInput} for a particular basic block (or {@code null} if none exists
      * yet).
+     *
+     * @param b a block {@code b}
+     * @return the transfer input for the basic block {@code b}
      */
     public @Nullable TransferInput<V, S> getInput(Block b) {
         return getInputBefore(b);
     }
 
     /**
+     * @param b a block {@code b}
      * @return the transfer input corresponding to the location right before the basic block {@code
-     *     b}.
+     *     b}
      */
     protected @Nullable TransferInput<V, S> getInputBefore(Block b) {
         return inputs.get(b);
@@ -718,6 +728,7 @@ public class Analysis<
     }
 
     /**
+     * @param n a node {@code n}
      * @return the abstract value for {@link Node} {@code n}, or {@code null} if no information is
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.
@@ -743,12 +754,20 @@ public class Analysis<
         return nodeValues.get(n);
     }
 
-    /** Return all current node values. */
+    /**
+     * Return all current node values.
+     *
+     * @return {@link #nodeValues}
+     */
     public IdentityHashMap<Node, V> getNodeValues() {
         return nodeValues;
     }
 
-    /** Set all current node values to the given map. */
+    /**
+     * Set all current node values to the given map.
+     *
+     * @param in the current node values
+     */
     /*package-private*/ void setNodeValues(IdentityHashMap<Node, V> in) {
         assert !isRunning;
         nodeValues.clear();
@@ -756,6 +775,7 @@ public class Analysis<
     }
 
     /**
+     * @param t a {@link Tree} t
      * @return the abstract value for {@link Tree} {@code t}, or {@code null} if no information is
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -403,6 +403,7 @@ public class Analysis<
      *
      * @param node a node
      * @param transferResult the result type of a transfer function
+     * @return true if the node's value changed, or a store was updated
      */
     protected boolean updateNodeValues(Node node, TransferResult<V, S> transferResult) {
         V newVal = transferResult.getResultValue();
@@ -422,6 +423,7 @@ public class Analysis<
      *
      * @param node a node
      * @param store the input type of a transfer function
+     * @return the transfer result for node {@code node}
      */
     protected TransferResult<V, S> callTransferFunction(Node node, TransferInput<V, S> store) {
         assert transferFunction != null : "@AssumeAssertion(nullness): invariant";

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -43,12 +43,12 @@ import org.checkerframework.javacutil.Pair;
  * An implementation of an iterative algorithm to solve a org.checkerframework.dataflow problem,
  * given a control flow graph and a transfer function.
  *
- * @param <A> the abstract value type to be tracked by the analysis
+ * @param <V> the abstract value type to be tracked by the analysis
  * @param <S> the store type used in the analysis
  * @param <T> the transfer function type that is used to approximated runtime behavior
  */
 public class Analysis<
-        A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>> {
+        V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>> {
 
     /** Is the analysis currently running? */
     protected boolean isRunning = false;
@@ -82,19 +82,19 @@ public class Analysis<
     /**
      * The transfer inputs before every basic block (assumed to be 'no information' if not present).
      */
-    protected final IdentityHashMap<Block, TransferInput<A, S>> inputs;
+    protected final IdentityHashMap<Block, TransferInput<V, S>> inputs;
 
     /** The stores after every return statement. */
-    protected final IdentityHashMap<ReturnNode, TransferResult<A, S>> storesAtReturnStatements;
+    protected final IdentityHashMap<ReturnNode, TransferResult<V, S>> storesAtReturnStatements;
 
     /** The worklist used for the fix-point iteration. */
     protected final Worklist worklist;
 
     /** Abstract values of nodes. */
-    protected final IdentityHashMap<Node, A> nodeValues;
+    protected final IdentityHashMap<Node, V> nodeValues;
 
     /** Map from (effectively final) local variable elements to their abstract value. */
-    public final HashMap<Element, A> finalLocalValues;
+    public final HashMap<Element, V> finalLocalValues;
 
     /**
      * The node that is currently handled in the analysis (if it is running). The following
@@ -113,7 +113,7 @@ public class Analysis<
     protected @Nullable Tree currentTree;
 
     /** The current transfer input when the analysis is running. */
-    protected @Nullable TransferInput<A, S> currentInput;
+    protected @Nullable TransferInput<V, S> currentInput;
 
     /** The tree that is currently being looked at. */
     public @Nullable Tree getCurrentTree() {
@@ -216,10 +216,10 @@ public class Analysis<
                     RegularBlock rb = (RegularBlock) b;
 
                     // apply transfer function to contents
-                    TransferInput<A, S> inputBefore = getInputBefore(rb);
+                    TransferInput<V, S> inputBefore = getInputBefore(rb);
                     assert inputBefore != null : "@AssumeAssertion(nullness): invariant";
                     currentInput = inputBefore.copy();
-                    TransferResult<A, S> transferResult = null;
+                    TransferResult<V, S> transferResult = null;
                     Node lastNode = null;
                     boolean addToWorklistAgain = false;
                     for (Node n : rb.getContents()) {
@@ -246,11 +246,11 @@ public class Analysis<
                     ExceptionBlock eb = (ExceptionBlock) b;
 
                     // apply transfer function to content
-                    TransferInput<A, S> inputBefore = getInputBefore(eb);
+                    TransferInput<V, S> inputBefore = getInputBefore(eb);
                     assert inputBefore != null : "@AssumeAssertion(nullness): invariant";
                     currentInput = inputBefore.copy();
                     Node node = eb.getNode();
-                    TransferResult<A, S> transferResult = callTransferFunction(node, currentInput);
+                    TransferResult<V, S> transferResult = callTransferFunction(node, currentInput);
                     boolean addToWorklistAgain = updateNodeValues(node, transferResult);
 
                     // propagate store to successor
@@ -296,9 +296,9 @@ public class Analysis<
                     ConditionalBlock cb = (ConditionalBlock) b;
 
                     // get store before
-                    TransferInput<A, S> inputBefore = getInputBefore(cb);
+                    TransferInput<V, S> inputBefore = getInputBefore(cb);
                     assert inputBefore != null : "@AssumeAssertion(nullness): invariant";
-                    TransferInput<A, S> input = inputBefore.copy();
+                    TransferInput<V, S> input = inputBefore.copy();
 
                     // propagate store to successor
                     Block thenSucc = cb.getThenSuccessor();
@@ -316,7 +316,7 @@ public class Analysis<
                     SpecialBlock sb = (SpecialBlock) b;
                     Block succ = sb.getSuccessor();
                     if (succ != null) {
-                        TransferInput<A, S> input = getInputBefore(b);
+                        TransferInput<V, S> input = getInputBefore(b);
                         assert input != null : "@AssumeAssertion(nullness): invariant";
                         propagateStoresTo(succ, null, input, sb.getFlowRule(), false);
                     }
@@ -335,7 +335,7 @@ public class Analysis<
     protected void propagateStoresTo(
             Block succ,
             @Nullable Node node,
-            TransferInput<A, S> currentInput,
+            TransferInput<V, S> currentInput,
             Store.FlowRule flowRule,
             boolean addToWorklistAgain) {
         switch (flowRule) {
@@ -401,12 +401,12 @@ public class Analysis<
      * Updates the value of node {@code node} to the value of the {@code transferResult}. Returns
      * true if the node's value changed, or a store was updated.
      */
-    protected boolean updateNodeValues(Node node, TransferResult<A, S> transferResult) {
-        A newVal = transferResult.getResultValue();
+    protected boolean updateNodeValues(Node node, TransferResult<V, S> transferResult) {
+        V newVal = transferResult.getResultValue();
         boolean nodeValueChanged = false;
 
         if (newVal != null) {
-            A oldVal = nodeValues.get(node);
+            V oldVal = nodeValues.get(node);
             nodeValues.put(node, newVal);
             nodeValueChanged = !Objects.equals(oldVal, newVal);
         }
@@ -417,7 +417,7 @@ public class Analysis<
     /**
      * Call the transfer function for node {@code node}, and set that node as current node first.
      */
-    protected TransferResult<A, S> callTransferFunction(Node node, TransferInput<A, S> store) {
+    protected TransferResult<V, S> callTransferFunction(Node node, TransferInput<V, S> store) {
         assert transferFunction != null : "@AssumeAssertion(nullness): invariant";
         if (node.isLValue()) {
             // TODO: should the default behavior be to return either a regular
@@ -427,7 +427,7 @@ public class Analysis<
         }
         store.node = node;
         currentNode = node;
-        TransferResult<A, S> transferResult = node.accept(transferFunction, store);
+        TransferResult<V, S> transferResult = node.accept(transferFunction, store);
         currentNode = null;
         if (node instanceof ReturnNode) {
             // save a copy of the store to later check if some property held at
@@ -442,7 +442,7 @@ public class Analysis<
                 LocalVariableNode lhs = (LocalVariableNode) lhst;
                 Element elem = lhs.getElement();
                 if (ElementUtils.isEffectivelyFinal(elem)) {
-                    A resval = transferResult.getResultValue();
+                    V resval = transferResult.getResultValue();
                     if (resval != null) {
                         finalLocalValues.put(elem, resval);
                     }
@@ -679,7 +679,7 @@ public class Analysis<
      * Read the {@link TransferInput} for a particular basic block (or {@code null} if none exists
      * yet).
      */
-    public @Nullable TransferInput<A, S> getInput(Block b) {
+    public @Nullable TransferInput<V, S> getInput(Block b) {
         return getInputBefore(b);
     }
 
@@ -687,7 +687,7 @@ public class Analysis<
      * @return the transfer input corresponding to the location right before the basic block {@code
      *     b}.
      */
-    protected @Nullable TransferInput<A, S> getInputBefore(Block b) {
+    protected @Nullable TransferInput<V, S> getInputBefore(Block b) {
         return inputs.get(b);
     }
 
@@ -722,7 +722,7 @@ public class Analysis<
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.
      */
-    public @Nullable A getValue(Node n) {
+    public @Nullable V getValue(Node n) {
         if (isRunning) {
             // we do not yet have a org.checkerframework.dataflow fact about the current node
             if (currentNode == null
@@ -744,12 +744,12 @@ public class Analysis<
     }
 
     /** Return all current node values. */
-    public IdentityHashMap<Node, A> getNodeValues() {
+    public IdentityHashMap<Node, V> getNodeValues() {
         return nodeValues;
     }
 
     /** Set all current node values to the given map. */
-    /*package-private*/ void setNodeValues(IdentityHashMap<Node, A> in) {
+    /*package-private*/ void setNodeValues(IdentityHashMap<Node, V> in) {
         assert !isRunning;
         nodeValues.clear();
         nodeValues.putAll(in);
@@ -760,7 +760,7 @@ public class Analysis<
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.
      */
-    public @Nullable A getValue(Tree t) {
+    public @Nullable V getValue(Tree t) {
         // we do not yet have a org.checkerframework.dataflow fact about the current node
         if (t == currentTree) {
             return null;
@@ -769,12 +769,12 @@ public class Analysis<
         if (nodesCorrespondingToTree == null) {
             return null;
         }
-        A merged = null;
+        V merged = null;
         for (Node aNode : nodesCorrespondingToTree) {
             if (aNode.isLValue()) {
                 return null;
             }
-            A a = getValue(aNode);
+            V a = getValue(aNode);
             if (merged == null) {
                 merged = a;
             } else if (a != null) {
@@ -826,11 +826,11 @@ public class Analysis<
      * @return the transfer results for each return node in the CFG
      */
     @RequiresNonNull("cfg")
-    public List<Pair<ReturnNode, @Nullable TransferResult<A, S>>> getReturnStatementStores() {
+    public List<Pair<ReturnNode, @Nullable TransferResult<V, S>>> getReturnStatementStores() {
         assert cfg != null : "@AssumeAssertion(nullness): invariant";
-        List<Pair<ReturnNode, @Nullable TransferResult<A, S>>> result = new ArrayList<>();
+        List<Pair<ReturnNode, @Nullable TransferResult<V, S>>> result = new ArrayList<>();
         for (ReturnNode returnNode : cfg.getReturnNodes()) {
-            TransferResult<A, S> store = storesAtReturnStatements.get(returnNode);
+            TransferResult<V, S> store = storesAtReturnStatements.get(returnNode);
             result.add(Pair.of(returnNode, store));
         }
         return result;
@@ -843,7 +843,7 @@ public class Analysis<
      * @return the result of running the analysis
      */
     @RequiresNonNull("cfg")
-    public AnalysisResult<A, S> getResult() {
+    public AnalysisResult<V, S> getResult() {
         assert !isRunning;
         assert cfg != null : "@AssumeAssertion(nullness): invariant";
         return new AnalysisResult<>(

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -402,7 +402,7 @@ public class Analysis<
      * true if the node's value changed, or a store was updated.
      *
      * @param node a node
-     * @param transferResult the result type of a transfer function
+     * @param transferResult the transfer result to use
      * @return true if the node's value changed, or a store was updated
      */
     protected boolean updateNodeValues(Node node, TransferResult<V, S> transferResult) {
@@ -422,7 +422,7 @@ public class Analysis<
      * Call the transfer function for node {@code node}, and set that node as current node first.
      *
      * @param node a node
-     * @param store the input type of a transfer function
+     * @param store the input of a transfer function
      * @return the transfer result for node {@code node}
      */
     protected TransferResult<V, S> callTransferFunction(Node node, TransferInput<V, S> store) {
@@ -687,17 +687,16 @@ public class Analysis<
      * Read the {@link TransferInput} for a particular basic block (or {@code null} if none exists
      * yet).
      *
-     * @param b a block {@code b}
-     * @return the transfer input for the basic block {@code b}
+     * @param b a block
+     * @return the transfer input for the basic block
      */
     public @Nullable TransferInput<V, S> getInput(Block b) {
         return getInputBefore(b);
     }
 
     /**
-     * @param b a block {@code b}
-     * @return the transfer input corresponding to the location right before the basic block {@code
-     *     b}
+     * @param b a block
+     * @return the transfer input corresponding to the location right before the basic block
      */
     protected @Nullable TransferInput<V, S> getInputBefore(Block b) {
         return inputs.get(b);
@@ -777,7 +776,7 @@ public class Analysis<
     }
 
     /**
-     * @param t a {@link Tree} t
+     * @param t a tree
      * @return the abstract value for {@link Tree} {@code t}, or {@code null} if no information is
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -401,7 +401,7 @@ public class Analysis<
      * true if the node's value changed, or a store was updated.
      *
      * @param node a node
-     * @param transferResult the transfer result to use
+     * @param transferResult the new transfer result to use as {@code node}'s value
      * @return true if the node's value changed, or a store was updated
      */
     protected boolean updateNodeValues(Node node, TransferResult<V, S> transferResult) {
@@ -418,7 +418,7 @@ public class Analysis<
     }
 
     /**
-     * Call the transfer function for the given node, and set that node as current node first.
+     * Call the transfer function for node {@code node}, and set that node as current node first.
      *
      * @param node a node
      * @param store the input of a transfer function
@@ -694,7 +694,7 @@ public class Analysis<
      * Read the {@link TransferInput} for a particular basic block (or {@code null} if none exists
      * yet).
      *
-     * @param b a block
+     * @param b a basic block
      * @return the transfer input for the basic block
      */
     public @Nullable TransferInput<V, S> getInput(Block b) {
@@ -705,7 +705,7 @@ public class Analysis<
      * Returns the transfer input corresponding to the location right before the basic block {@code
      * b}.
      *
-     * @param b a block
+     * @param b a basic block
      * @return the transfer input corresponding to the location right before the basic block {@code
      *     b}
      */
@@ -775,7 +775,7 @@ public class Analysis<
     /**
      * Return all current node values.
      *
-     * @return {@link #nodeValues}
+     * @return all current node values
      */
     public IdentityHashMap<Node, V> getNodeValues() {
         return nodeValues;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -419,11 +419,11 @@ public class Analysis<
     }
 
     /**
-     * Call the transfer function for node {@code node}, and set that node as current node first.
+     * Call the transfer function for the given node, and set that node as current node first.
      *
      * @param node a node
      * @param store the input of a transfer function
-     * @return the transfer result for node {@code node}
+     * @return the transfer result for the node
      */
     protected TransferResult<V, S> callTransferFunction(Node node, TransferInput<V, S> store) {
         assert transferFunction != null : "@AssumeAssertion(nullness): invariant";
@@ -730,9 +730,9 @@ public class Analysis<
 
     /**
      * @param n a node
-     * @return the abstract value for {@link Node} {@code n}, or {@code null} if no information is
-     *     available. Note that if the analysis has not finished yet, this value might not represent
-     *     the final value for this node.
+     * @return the abstract value for the node, or {@code null} if no information is available. Note
+     *     that if the analysis has not finished yet, this value might not represent the final value
+     *     for this node.
      */
     public @Nullable V getValue(Node n) {
         if (isRunning) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/Analysis.java
@@ -729,7 +729,7 @@ public class Analysis<
     }
 
     /**
-     * @param n a node {@code n}
+     * @param n a node
      * @return the abstract value for {@link Node} {@code n}, or {@code null} if no information is
      *     available. Note that if the analysis has not finished yet, this value might not represent
      *     the final value for this node.
@@ -777,9 +777,9 @@ public class Analysis<
 
     /**
      * @param t a tree
-     * @return the abstract value for {@link Tree} {@code t}, or {@code null} if no information is
-     *     available. Note that if the analysis has not finished yet, this value might not represent
-     *     the final value for this node.
+     * @return the abstract value for the tree, or {@code null} if no information is available. Note
+     *     that if the analysis has not finished yet, this value might not represent the final value
+     *     for this node.
      */
     public @Nullable V getValue(Tree t) {
         // we do not yet have a org.checkerframework.dataflow fact about the current node

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -157,9 +157,8 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
-     * @param t a {@link Tree} t
-     * @return the abstract value for {@link Tree} {@code t}, or {@code null} if no information is
-     *     available.
+     * @param t a tree
+     * @return the abstract value for the tree, or {@code null} if no information is available.
      */
     public @Nullable V getValue(Tree t) {
         Set<Node> nodes = treeLookup.get(t);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -117,7 +117,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     /**
      * Combine with another analysis result.
      *
-     * @param other a given analysis result
+     * @param other an analysis result to combine with this
      */
     public void combine(AnalysisResult<V, S> other) {
         nodeValues.putAll(other.nodeValues);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -148,7 +148,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
-     * @param n a {@link Node} n
+     * @param n a node
      * @return the abstract value for the node, or {@code null} if no information is available.
      */
     public @Nullable V getValue(Node n) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -149,8 +149,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
 
     /**
      * @param n a {@link Node} n
-     * @return the abstract value for {@link Node} {@code n}, or {@code null} if no information is
-     *     available.
+     * @return the abstract value for the node, or {@code null} if no information is available.
      */
     public @Nullable V getValue(Node n) {
         return nodeValues.get(n);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -49,7 +49,16 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     protected final Map<TransferInput<V, S>, IdentityHashMap<Node, TransferResult<V, S>>>
             analysisCaches;
 
-    /** Initialize with given mappings. */
+    /**
+     * Initialize with given mappings.
+     *
+     * @param nodeValues {@link #nodeValues}
+     * @param stores {@link #stores}
+     * @param treeLookup {@link #treeLookup}
+     * @param unaryAssignNodeLookup {@link #unaryAssignNodeLookup}
+     * @param finalLocalValues {@link #finalLocalValues}
+     * @param analysisCaches {@link #analysisCaches}
+     */
     protected AnalysisResult(
             Map<Node, V> nodeValues,
             IdentityHashMap<Block, TransferInput<V, S>> stores,
@@ -66,7 +75,15 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
         this.analysisCaches = analysisCaches;
     }
 
-    /** Initialize with given mappings and empty cache. */
+    /**
+     * Initialize with given mappings and empty cache.
+     *
+     * @param nodeValues {@link #nodeValues}
+     * @param stores {@link #stores}
+     * @param treeLookup {@link #treeLookup}
+     * @param unaryAssignNodeLookup {@link #unaryAssignNodeLookup}
+     * @param finalLocalValues {@link #finalLocalValues}
+     */
     public AnalysisResult(
             Map<Node, V> nodeValues,
             IdentityHashMap<Block, TransferInput<V, S>> stores,
@@ -82,7 +99,11 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
                 new IdentityHashMap<>());
     }
 
-    /** Initialize empty result with specified cache. */
+    /**
+     * Initialize empty result with specified cache.
+     *
+     * @param analysisCaches {@link #analysisCaches}
+     */
     public AnalysisResult(
             Map<TransferInput<V, S>, IdentityHashMap<Node, TransferResult<V, S>>> analysisCaches) {
         this(
@@ -94,7 +115,11 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
                 analysisCaches);
     }
 
-    /** Combine with another analysis result. */
+    /**
+     * Combine with another analysis result.
+     *
+     * @param other a given analysis result
+     */
     public void combine(AnalysisResult<V, S> other) {
         nodeValues.putAll(other.nodeValues);
         mergeTreeLookup(treeLookup, other.treeLookup);
@@ -123,6 +148,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
+     * @param n a {@link Node} n
      * @return the abstract value for {@link Node} {@code n}, or {@code null} if no information is
      *     available.
      */
@@ -131,6 +157,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
+     * @param t a {@link Tree} t
      * @return the abstract value for {@link Tree} {@code t}, or {@code null} if no information is
      *     available.
      */
@@ -261,6 +288,15 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
      * {@code transferInput} is not in {@code analysisCaches}, this method create new cache and
      * store it in {@code analysisCaches}. The cache is a map from a node to the analysis result of
      * the node.
+     *
+     * @param <V> the abstract value type to be tracked by the analysis
+     * @param <S> the store type used in the analysis
+     * @param node a node
+     * @param before indicate before or after the node
+     * @param transferInput a transfer input
+     * @param nodeValues node values
+     * @param analysisCaches caches of analysis results
+     * @return store immediately before or after the node {@code node}
      */
     public static <V extends AbstractValue<V>, S extends Store<S>> S runAnalysisFor(
             Node node,

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -293,9 +293,9 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> {
      * @param node a node
      * @param before indicate before or after the node
      * @param transferInput a transfer input
-     * @param nodeValues node values
-     * @param analysisCaches caches of analysis results
-     * @return store immediately before or after the node {@code node}
+     * @param nodeValues {@link #nodeValues}
+     * @param analysisCaches {@link #analysisCaches}
+     * @return store immediately before or after the given node
      */
     public static <V extends AbstractValue<V>, S extends Store<S>> S runAnalysisFor(
             Node node,

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -26,10 +26,13 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
     protected final S elseStore;
 
     /**
-     * <em>Exceptions</em>: If the corresponding {@link org.checkerframework.dataflow.cfg.node.Node}
-     * throws an exception, then it is assumed that no special handling is necessary and the store
-     * before the corresponding {@link org.checkerframework.dataflow.cfg.node.Node} will be passed
-     * along any exceptional edge.
+     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
+     * with passing {@code null} to {@link #exceptionalStores}.
+     *
+     * <p><em>Exceptions</em>: If the corresponding {@link
+     * org.checkerframework.dataflow.cfg.node.Node} throws an exception, then it is assumed that no
+     * special handling is necessary and the store before the corresponding {@link
+     * org.checkerframework.dataflow.cfg.node.Node} will be passed along any exceptional edge.
      *
      * <p><em>Aliasing</em>: {@code thenStore} and {@code elseStore} are not allowed to be used
      * anywhere outside of this class (including use through aliases). Complete control over the
@@ -47,7 +50,9 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
     }
 
     /**
-     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store)}.
+     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
+     * with passing {@code false} to {@link #storeChanged} and {@code null} to {@link
+     * #exceptionalStores}.
      *
      * @param value the abstract value produced by the transfer function
      * @param thenStore {@link #thenStore}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -35,6 +35,10 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
      * anywhere outside of this class (including use through aliases). Complete control over the
      * objects is transferred to this class.
      *
+     * @param value the abstract value produced by the transfer function
+     * @param thenStore {@link #thenStore}
+     * @param elseStore {@link #elseStore}
+     * @param storeChanged {@link #storeChanged}
      * @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)
      */
     public ConditionalTransferResult(

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -10,8 +10,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * edge and one for 'else'. The result of {@code getRegularStore} will be the least upper bound of
  * the two underlying stores.
  *
- * @param <V> the {@link AbstractValue} to be tracked by the analysis
- * @param <S> the {@link Store} used to keep track of intermediate results
+ * @param <V> type of the abstract value that is tracked
+ * @param <S> the store type used in the analysis
  */
 public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Store<S>>
         extends TransferResult<V, S> {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -10,6 +10,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * edge and one for 'else'. The result of {@code getRegularStore} will be the least upper bound of
  * the two underlying stores.
  *
+ * @param <V> the {@link AbstractValue} to be tracked by the analysis
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
 public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Store<S>>
@@ -32,7 +33,7 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
      *
      * <p><em>Aliasing</em>: {@code thenStore} and {@code elseStore} are not allowed to be used
      * anywhere outside of this class (including use through aliases). Complete control over the
-     * objects is transfered to this class.
+     * objects is transferred to this class.
      *
      * @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)
      */
@@ -41,12 +42,27 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
         this(value, thenStore, elseStore, null, storeChanged);
     }
 
-    /** @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean) */
+    /**
+     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store)}.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param thenStore {@link #thenStore}
+     * @param elseStore {@link #elseStore}
+     * @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)
+     */
     public ConditionalTransferResult(@Nullable V value, S thenStore, S elseStore) {
         this(value, thenStore, elseStore, false);
     }
 
-    /** @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean) */
+    /**
+     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map)}.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param thenStore {@link #thenStore}
+     * @param elseStore {@link #elseStore}
+     * @param exceptionalStores {@link #exceptionalStores}
+     * @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)
+     */
     public ConditionalTransferResult(
             V value, S thenStore, S elseStore, Map<TypeMirror, S> exceptionalStores) {
         this(value, thenStore, elseStore, exceptionalStores, false);
@@ -69,7 +85,13 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
      *
      * <p><em>Aliasing</em>: {@code thenStore}, {@code elseStore}, and any store in {@code
      * exceptionalStores} are not allowed to be used anywhere outside of this class (including use
-     * through aliases). Complete control over the objects is transfered to this class.
+     * through aliases). Complete control over the objects is transferred to this class.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param thenStore {@link #thenStore}
+     * @param elseStore {@link #elseStore}
+     * @param exceptionalStores {@link #exceptionalStores}
+     * @param storeChanged {@link #storeChanged}
      */
     public ConditionalTransferResult(
             @Nullable V value,

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -12,8 +12,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
-public class ConditionalTransferResult<A extends AbstractValue<A>, S extends Store<S>>
-        extends TransferResult<A, S> {
+public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Store<S>>
+        extends TransferResult<V, S> {
 
     /** Whether the store changed. */
     private final boolean storeChanged;
@@ -37,18 +37,18 @@ public class ConditionalTransferResult<A extends AbstractValue<A>, S extends Sto
      * @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)
      */
     public ConditionalTransferResult(
-            @Nullable A value, S thenStore, S elseStore, boolean storeChanged) {
+            @Nullable V value, S thenStore, S elseStore, boolean storeChanged) {
         this(value, thenStore, elseStore, null, storeChanged);
     }
 
     /** @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean) */
-    public ConditionalTransferResult(@Nullable A value, S thenStore, S elseStore) {
+    public ConditionalTransferResult(@Nullable V value, S thenStore, S elseStore) {
         this(value, thenStore, elseStore, false);
     }
 
     /** @see #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean) */
     public ConditionalTransferResult(
-            A value, S thenStore, S elseStore, Map<TypeMirror, S> exceptionalStores) {
+            V value, S thenStore, S elseStore, Map<TypeMirror, S> exceptionalStores) {
         this(value, thenStore, elseStore, exceptionalStores, false);
     }
 
@@ -72,7 +72,7 @@ public class ConditionalTransferResult<A extends AbstractValue<A>, S extends Sto
      * through aliases). Complete control over the objects is transfered to this class.
      */
     public ConditionalTransferResult(
-            @Nullable A value,
+            @Nullable V value,
             S thenStore,
             S elseStore,
             @Nullable Map<TypeMirror, S> exceptionalStores,

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -27,7 +27,7 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
 
     /**
      * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
-     * with passing {@code null} to {@link #exceptionalStores}.
+     * using {@code null} for {@link #exceptionalStores}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link
      * org.checkerframework.dataflow.cfg.node.Node} throws an exception, then it is assumed that no
@@ -51,7 +51,7 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
 
     /**
      * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
-     * with passing {@code false} to {@link #storeChanged} and {@code null} to {@link
+     * using {@code false} for {@link #storeChanged} and {@code null} for {@link
      * #exceptionalStores}.
      *
      * @param value the abstract value produced by the transfer function
@@ -64,7 +64,8 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
     }
 
     /**
-     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map)}.
+     * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
+     * using {@code false} for {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param thenStore {@link #thenStore}
@@ -82,7 +83,7 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
      * the corresponding {@link org.checkerframework.dataflow.cfg.node.Node} evaluates to {@code
      * true} and {@code elseStore} otherwise.
      *
-     * <p>For the meaning of storeChanged, see {@link
+     * <p>For the meaning of {@code storeChanged}, see {@link
      * org.checkerframework.dataflow.analysis.TransferResult#storeChanged}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -22,8 +22,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     private final boolean storeChanged;
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
-     * {@code null} to {@link #exceptionalStores}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
+     * {@code null} for {@link #exceptionalStores}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link
      * org.checkerframework.dataflow.cfg.node.Node} throws an exception, then it is assumed that no
@@ -44,8 +44,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
-     * {@code null} to {@link #exceptionalStores} and {@code false} to {@link #storeChanged}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
+     * {@code null} for {@link #exceptionalStores} and {@code false} for {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}
@@ -56,8 +56,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
-     * {@code false} to {@link #storeChanged}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
+     * {@code false} for {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}
@@ -74,7 +74,7 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
      * corresponding {@link org.checkerframework.dataflow.cfg.node.Node} is a boolean node, then
      * {@code resultStore} is used for both the 'then' and 'else' edge.
      *
-     * <p>For the meaning of storeChanged, see {@link
+     * <p>For the meaning of {@code storeChanged}, see {@link
      * org.checkerframework.dataflow.analysis.TransferResult#storeChanged}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -9,10 +9,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Implementation of a {@link TransferResult} with just one non-exceptional store. The result of
  * {@code getThenStore} and {@code getElseStore} is equal to the only underlying store.
  *
+ * @param <V> the {@link AbstractValue} to be tracked by the analysis
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
-public class RegularTransferResult<A extends AbstractValue<A>, S extends Store<S>>
-        extends TransferResult<A, S> {
+public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S>>
+        extends TransferResult<V, S> {
 
     /** The regular result store. */
     protected final S store;
@@ -34,18 +35,18 @@ public class RegularTransferResult<A extends AbstractValue<A>, S extends Store<S
      *
      * @see #RegularTransferResult(AbstractValue, Store, Map, boolean)
      */
-    public RegularTransferResult(@Nullable A value, S resultStore, boolean storeChanged) {
+    public RegularTransferResult(@Nullable V value, S resultStore, boolean storeChanged) {
         this(value, resultStore, null, storeChanged);
     }
 
     /** @see #RegularTransferResult(AbstractValue, Store, Map, boolean) */
-    public RegularTransferResult(@Nullable A value, S resultStore) {
+    public RegularTransferResult(@Nullable V value, S resultStore) {
         this(value, resultStore, false);
     }
 
     /** @see #RegularTransferResult(AbstractValue, Store, Map, boolean) */
     public RegularTransferResult(
-            @Nullable A value, S resultStore, Map<TypeMirror, S> exceptionalStores) {
+            @Nullable V value, S resultStore, Map<TypeMirror, S> exceptionalStores) {
         this(value, resultStore, exceptionalStores, false);
     }
 
@@ -69,7 +70,7 @@ public class RegularTransferResult<A extends AbstractValue<A>, S extends Store<S
      * control over the objects is transfered to this class.
      */
     public RegularTransferResult(
-            @Nullable A value,
+            @Nullable V value,
             S resultStore,
             @Nullable Map<TypeMirror, S> exceptionalStores,
             boolean storeChanged) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -9,8 +9,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Implementation of a {@link TransferResult} with just one non-exceptional store. The result of
  * {@code getThenStore} and {@code getElseStore} is equal to the only underlying store.
  *
- * @param <V> the {@link AbstractValue} to be tracked by the analysis
- * @param <S> the {@link Store} used to keep track of intermediate results
+ * @param <V> type of the abstract value that is tracked
+ * @param <S> the store type used in the analysis
  */
 public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S>>
         extends TransferResult<V, S> {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -22,7 +22,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     private final boolean storeChanged;
 
     /**
-     * *
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
+     * {@code null} to {@link #exceptionalStores}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link
      * org.checkerframework.dataflow.cfg.node.Node} throws an exception, then it is assumed that no
@@ -30,8 +31,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
      * org.checkerframework.dataflow.cfg.node.Node} will be passed along any exceptional edge.
      *
      * <p><em>Aliasing</em>: {@code resultStore} is not allowed to be used anywhere outside of this
-     * class (including use through aliases). Complete control over the object is transfered to this
-     * class.
+     * class (including use through aliases). Complete control over the object is transferred to
+     * this class.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}
@@ -43,7 +44,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store)}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
+     * {@code null} to {@link #exceptionalStores} and {@code false} to {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}
@@ -54,7 +56,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map)}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, with passing
+     * {@code false} to {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -22,8 +22,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     private final boolean storeChanged;
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
-     * {@code null} for {@link #exceptionalStores}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using {@code
+     * null} for {@link #exceptionalStores}.
      *
      * <p><em>Exceptions</em>: If the corresponding {@link
      * org.checkerframework.dataflow.cfg.node.Node} throws an exception, then it is assumed that no
@@ -44,8 +44,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
-     * {@code null} for {@link #exceptionalStores} and {@code false} for {@link #storeChanged}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using {@code
+     * null} for {@link #exceptionalStores} and {@code false} for {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}
@@ -56,8 +56,8 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
     }
 
     /**
-     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using
-     * {@code false} for {@link #storeChanged}.
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map, boolean)}, using {@code
+     * false} for {@link #storeChanged}.
      *
      * @param value the abstract value produced by the transfer function
      * @param resultStore {@link #store}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -33,18 +33,34 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
      * class (including use through aliases). Complete control over the object is transfered to this
      * class.
      *
+     * @param value the abstract value produced by the transfer function
+     * @param resultStore {@link #store}
+     * @param storeChanged {@link #storeChanged}
      * @see #RegularTransferResult(AbstractValue, Store, Map, boolean)
      */
     public RegularTransferResult(@Nullable V value, S resultStore, boolean storeChanged) {
         this(value, resultStore, null, storeChanged);
     }
 
-    /** @see #RegularTransferResult(AbstractValue, Store, Map, boolean) */
+    /**
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store)}.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param resultStore {@link #store}
+     * @see #RegularTransferResult(AbstractValue, Store, Map, boolean)
+     */
     public RegularTransferResult(@Nullable V value, S resultStore) {
         this(value, resultStore, false);
     }
 
-    /** @see #RegularTransferResult(AbstractValue, Store, Map, boolean) */
+    /**
+     * Create a new {@link #RegularTransferResult(AbstractValue, Store, Map)}.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param resultStore {@link #store}
+     * @param exceptionalStores {@link #exceptionalStores}
+     * @see #RegularTransferResult(AbstractValue, Store, Map, boolean)
+     */
     public RegularTransferResult(
             @Nullable V value, S resultStore, Map<TypeMirror, S> exceptionalStores) {
         this(value, resultStore, exceptionalStores, false);
@@ -68,6 +84,11 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
      * <p><em>Aliasing</em>: {@code resultStore} and any store in {@code exceptionalStores} are not
      * allowed to be used anywhere outside of this class (including use through aliases). Complete
      * control over the objects is transfered to this class.
+     *
+     * @param value the abstract value produced by the transfer function
+     * @param resultStore {@link #store}
+     * @param exceptionalStores {@link #exceptionalStores}
+     * @param storeChanged {@link #storeChanged}
      */
     public RegularTransferResult(
             @Nullable V value,

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferFunction.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferFunction.java
@@ -24,10 +24,11 @@ import org.checkerframework.dataflow.cfg.node.NodeVisitor;
  * modify) the stores contained in the argument passed; the ownership is transfered from the caller
  * to that function.
  *
+ * @param <V> the {@link AbstractValue} to be tracked by the analysis
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
-public interface TransferFunction<A extends AbstractValue<A>, S extends Store<S>>
-        extends NodeVisitor<TransferResult<A, S>, TransferInput<A, S>> {
+public interface TransferFunction<V extends AbstractValue<V>, S extends Store<S>>
+        extends NodeVisitor<TransferResult<V, S>, TransferInput<V, S>> {
 
     /**
      * @return the initial store to be used by the org.checkerframework.dataflow analysis. {@code

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferFunction.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferFunction.java
@@ -24,8 +24,8 @@ import org.checkerframework.dataflow.cfg.node.NodeVisitor;
  * modify) the stores contained in the argument passed; the ownership is transfered from the caller
  * to that function.
  *
- * @param <V> the {@link AbstractValue} to be tracked by the analysis
- * @param <S> the {@link Store} used to keep track of intermediate results
+ * @param <V> type of the abstract value that is tracked
+ * @param <S> the store type used in the analysis
  */
 public interface TransferFunction<V extends AbstractValue<V>, S extends Store<S>>
         extends NodeVisitor<TransferResult<V, S>, TransferInput<V, S>> {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -12,9 +12,10 @@ import org.checkerframework.dataflow.cfg.node.Node;
  * <p>A {@code TransferInput} contains one or two stores. If two stores are present, one belongs to
  * 'then', and the other to 'else'.
  *
+ * @param <V> the {@link AbstractValue} to be tracked by the analysis
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
-public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
+public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
 
     /** The corresponding node. */
     // TODO: explain when the node is changed.
@@ -51,7 +52,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
     protected final @Nullable S elseStore;
 
     /** The corresponding analysis class to get intermediate flow results. */
-    protected final Analysis<A, S, ?> analysis;
+    protected final Analysis<V, S, ?> analysis;
 
     /**
      * Create a {@link TransferInput}, given a {@link TransferResult} and a node-value mapping.
@@ -63,7 +64,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      */
-    public TransferInput(Node n, Analysis<A, S, ?> analysis, TransferResult<A, S> to) {
+    public TransferInput(Node n, Analysis<V, S, ?> analysis, TransferResult<V, S> to) {
         node = n;
         this.analysis = analysis;
         if (to.containsTwoStores()) {
@@ -85,7 +86,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      */
-    public TransferInput(@Nullable Node n, Analysis<A, S, ?> analysis, S s) {
+    public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s) {
         node = n;
         this.analysis = analysis;
         store = s;
@@ -98,7 +99,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
      * <p><em>Aliasing</em>: The two stores {@code s1} and {@code s2} will be stored internally and
      * are not allowed to be used elsewhere. Full control of them is transferred to this object.
      */
-    public TransferInput(@Nullable Node n, Analysis<A, S, ?> analysis, S s1, S s2) {
+    public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s1, S s2) {
         node = n;
         this.analysis = analysis;
         thenStore = s1;
@@ -107,7 +108,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
     }
 
     /** Copy constructor. */
-    protected TransferInput(TransferInput<A, S> from) {
+    protected TransferInput(TransferInput<V, S> from) {
         this.node = from.node;
         this.analysis = from.analysis;
         if (from.store == null) {
@@ -133,7 +134,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
      *     Furthermore, {@code n} cannot be a l-value node. Returns {@code null} if no value if
      *     available.
      */
-    public @Nullable A getValueOfSubNode(Node n) {
+    public @Nullable V getValueOfSubNode(Node n) {
         return analysis.getValue(n);
     }
 
@@ -190,7 +191,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
     }
 
     /** @return an exact copy of this store. */
-    public TransferInput<A, S> copy() {
+    public TransferInput<V, S> copy() {
         return new TransferInput<>(this);
     }
 
@@ -200,7 +201,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
      * <p><em>Important</em>: This method must fulfill the same contract as {@code leastUpperBound}
      * of {@link Store}.
      */
-    public TransferInput<A, S> leastUpperBound(TransferInput<A, S> other) {
+    public TransferInput<V, S> leastUpperBound(TransferInput<V, S> other) {
         if (store == null) {
             S newThenStore = getThenStore().leastUpperBound(other.getThenStore());
             S newElseStore = getElseStore().leastUpperBound(other.getElseStore());
@@ -220,7 +221,7 @@ public class TransferInput<A extends AbstractValue<A>, S extends Store<S>> {
     public boolean equals(@Nullable Object o) {
         if (o instanceof TransferInput) {
             @SuppressWarnings("unchecked")
-            TransferInput<A, S> other = (TransferInput<A, S>) o;
+            TransferInput<V, S> other = (TransferInput<V, S>) o;
             if (containsTwoStores()) {
                 if (other.containsTwoStores()) {
                     return getThenStore().equals(other.getThenStore())

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -12,8 +12,8 @@ import org.checkerframework.dataflow.cfg.node.Node;
  * <p>A {@code TransferInput} contains one or two stores. If two stores are present, one belongs to
  * 'then', and the other to 'else'.
  *
- * @param <V> the {@link AbstractValue} to be tracked by the analysis
- * @param <S> the {@link Store} used to keep track of intermediate results
+ * @param <V> type of the abstract value that is tracked
+ * @param <S> the store type used in the analysis
  */
 public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -63,6 +63,10 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      *
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
+     *
+     * @param n a node {@code n}
+     * @param analysis {@link #analysis}
+     * @param to a transfer result {@code to}
      */
     public TransferInput(Node n, Analysis<V, S, ?> analysis, TransferResult<V, S> to) {
         node = n;
@@ -85,6 +89,10 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      *
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
+     *
+     * @param n a node {@code n}
+     * @param analysis {@link #analysis}
+     * @param s a store {@code s}
      */
     public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s) {
         node = n;
@@ -98,6 +106,11 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      *
      * <p><em>Aliasing</em>: The two stores {@code s1} and {@code s2} will be stored internally and
      * are not allowed to be used elsewhere. Full control of them is transferred to this object.
+     *
+     * @param n a node {@code n}
+     * @param analysis {@link #analysis}
+     * @param s1 'then' result store
+     * @param s2 'else' result store
      */
     public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s1, S s2) {
         node = n;
@@ -107,7 +120,11 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
         store = null;
     }
 
-    /** Copy constructor. */
+    /**
+     * Copy constructor.
+     *
+     * @param from a {@link TransferInput} to copy
+     */
     protected TransferInput(TransferInput<V, S> from) {
         this.node = from.node;
         this.analysis = from.analysis;
@@ -129,6 +146,7 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
+     * @param n a node {@code n}
      * @return the abstract value of {@link Node} {@code n}, which is required to be a 'sub-node'
      *     (that is, a direct or indirect child) of the node this transfer input is associated with.
      *     Furthermore, {@code n} cannot be a l-value node. Returns {@code null} if no value if
@@ -200,6 +218,9 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      *
      * <p><em>Important</em>: This method must fulfill the same contract as {@code leastUpperBound}
      * of {@link Store}.
+     *
+     * @param other a transfer input
+     * @return the result transfer input containing the least upper bound
      */
     public TransferInput<V, S> leastUpperBound(TransferInput<V, S> other) {
         if (store == null) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -64,9 +64,9 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      *
-     * @param n a node {@code n}
+     * @param n a node
      * @param analysis {@link #analysis}
-     * @param to a transfer result {@code to}
+     * @param to a transfer result
      */
     public TransferInput(Node n, Analysis<V, S, ?> analysis, TransferResult<V, S> to) {
         node = n;
@@ -90,9 +90,9 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      *
-     * @param n a node {@code n}
+     * @param n a node
      * @param analysis {@link #analysis}
-     * @param s a store {@code s}
+     * @param s a store
      */
     public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s) {
         node = n;
@@ -107,7 +107,7 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * <p><em>Aliasing</em>: The two stores {@code s1} and {@code s2} will be stored internally and
      * are not allowed to be used elsewhere. Full control of them is transferred to this object.
      *
-     * @param n a node {@code n}
+     * @param n a node
      * @param analysis {@link #analysis}
      * @param s1 'then' result store
      * @param s2 'else' result store
@@ -146,7 +146,7 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
     }
 
     /**
-     * @param n a node {@code n}
+     * @param n a node
      * @return the abstract value of {@link Node} {@code n}, which is required to be a 'sub-node'
      *     (that is, a direct or indirect child) of the node this transfer input is associated with.
      *     Furthermore, {@code n} cannot be a l-value node. Returns {@code null} if no value if

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -240,7 +240,7 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * of {@link Store}.
      *
      * @param other a transfer input
-     * @return the result transfer input containing the least upper bound
+     * @return the least upper bound of this and {@code other}
      */
     public TransferInput<V, S> leastUpperBound(TransferInput<V, S> other) {
         if (store == null) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferInput.java
@@ -64,7 +64,7 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      *
-     * @param n a node
+     * @param n {@link #node}
      * @param analysis {@link #analysis}
      * @param to a transfer result
      */
@@ -90,9 +90,9 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      * <p>The node-value mapping {@code nodeValues} is provided by the analysis and is only read
      * from within this {@link TransferInput}.
      *
-     * @param n a node
+     * @param n {@link #node}
      * @param analysis {@link #analysis}
-     * @param s a store
+     * @param s {@link #store}
      */
     public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s) {
         node = n;
@@ -109,8 +109,8 @@ public class TransferInput<V extends AbstractValue<V>, S extends Store<S>> {
      *
      * @param n a node
      * @param analysis {@link #analysis}
-     * @param s1 'then' result store
-     * @param s2 'else' result store
+     * @param s1 {@link #thenStore}
+     * @param s2 {@link #elseStore}
      */
     public TransferInput(@Nullable Node n, Analysis<V, S, ?> analysis, S s1, S s2) {
         node = n;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -13,9 +13,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>A {@code TransferResult} contains one or two stores (for 'then' and 'else'), and zero or more
  * stores with a cause ({@link TypeMirror}).
  *
+ * @param <V> the {@link AbstractValue} to be tracked by the analysis
  * @param <S> the {@link Store} used to keep track of intermediate results
  */
-public abstract class TransferResult<A extends AbstractValue<A>, S extends Store<S>> {
+public abstract class TransferResult<V extends AbstractValue<V>, S extends Store<S>> {
 
     /**
      * The stores in case the basic block throws an exception (or {@code null} if the corresponding
@@ -28,19 +29,19 @@ public abstract class TransferResult<A extends AbstractValue<A>, S extends Store
      * The abstract value of the {@link org.checkerframework.dataflow.cfg.node.Node} associated with
      * this {@link TransferResult}, or {@code null} if no value has been produced.
      */
-    protected @Nullable A resultValue;
+    protected @Nullable V resultValue;
 
-    public TransferResult(@Nullable A resultValue, @Nullable Map<TypeMirror, S> exceptionalStores) {
+    public TransferResult(@Nullable V resultValue, @Nullable Map<TypeMirror, S> exceptionalStores) {
         this.resultValue = resultValue;
         this.exceptionalStores = exceptionalStores;
     }
 
     /** @return the abstract value produced by the transfer function, {@code null} otherwise */
-    public @Nullable A getResultValue() {
+    public @Nullable V getResultValue() {
         return resultValue;
     }
 
-    public void setResultValue(A resultValue) {
+    public void setResultValue(V resultValue) {
         this.resultValue = resultValue;
     }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -32,13 +32,6 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
     protected final @Nullable Map<TypeMirror, S> exceptionalStores;
 
     /**
-     * Create a new TransferResult.
-     *
-     * @param resultValue the abstract value of the node, or {@code null} if no value has been
-     *     produced
-     * @param exceptionalStores the stores to use if the basic block throws an exception
-     */
-    /**
      * Create a {@link #TransferResult(AbstractValue, Map)}, given {@link #resultValue} and {@link
      * #exceptionalStores}.
      *

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -31,6 +31,16 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
      */
     protected @Nullable V resultValue;
 
+    /**
+     * Create a {@link TransferResult(AbstractValue, Map)}, given {@link #resultValue} and {@link
+     * #exceptionalStores}.
+     *
+     * @param resultValue the abstract value of the {@link
+     *     org.checkerframework.dataflow.cfg.node.Node} associated with this {@link TransferResult}
+     * @param exceptionalStores the stores in case the basic block throws an exception (or {@code
+     *     null} if the corresponding {@link org.checkerframework.dataflow.cfg.node.Node} does not
+     *     throw any exceptions)
+     */
     public TransferResult(@Nullable V resultValue, @Nullable Map<TypeMirror, S> exceptionalStores) {
         this.resultValue = resultValue;
         this.exceptionalStores = exceptionalStores;
@@ -41,6 +51,12 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
         return resultValue;
     }
 
+    /**
+     * Set the value of {@link #resultValue}.
+     *
+     * @param resultValue the abstract value of the {@link
+     *     org.checkerframework.dataflow.cfg.node.Node} associated with this {@link TransferResult}
+     */
     public void setResultValue(V resultValue) {
         this.resultValue = resultValue;
     }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -32,8 +32,7 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
     protected final @Nullable Map<TypeMirror, S> exceptionalStores;
 
     /**
-     * Create a {@link #TransferResult(AbstractValue, Map)}, given {@link #resultValue} and {@link
-     * #exceptionalStores}.
+     * Create a new TransferResult, given {@link #resultValue} and {@link #exceptionalStores}.
      *
      * @param resultValue the abstract value of the {@link
      *     org.checkerframework.dataflow.cfg.node.Node} associated with this {@link TransferResult}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -13,8 +13,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>A {@code TransferResult} contains one or two stores (for 'then' and 'else'), and zero or more
  * stores with a cause ({@link TypeMirror}).
  *
- * @param <V> the {@link AbstractValue} to be tracked by the analysis
- * @param <S> the {@link Store} used to keep track of intermediate results
+ * @param <V> type of the abstract value that is tracked
+ * @param <S> the store type used in the analysis
  */
 public abstract class TransferResult<V extends AbstractValue<V>, S extends Store<S>> {
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -32,7 +32,7 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
     protected @Nullable V resultValue;
 
     /**
-     * Create a {@link TransferResult(AbstractValue, Map)}, given {@link #resultValue} and {@link
+     * Create a {@link #TransferResult(AbstractValue, Map)}, given {@link #resultValue} and {@link
      * #exceptionalStores}.
      *
      * @param resultValue the abstract value of the {@link

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -31,12 +31,15 @@ import org.checkerframework.dataflow.cfg.node.Node;
  * {@link CFGVisualizer} are already implemented in this abstract class, but can be overridden if
  * necessary.
  *
+ * @param <V> the abstract value type to be tracked by the analysis
+ * @param <S> the store type used in the analysis
+ * @param <T> the transfer function type that is used to approximated runtime behavior
  * @see DOTCFGVisualizer
  * @see StringCFGVisualizer
  */
 public abstract class AbstractCFGVisualizer<
-                A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
-        implements CFGVisualizer<A, S, T> {
+                V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>>
+        implements CFGVisualizer<V, S, T> {
 
     /**
      * Initialized in {@link #init(Map)}. If its value is {@code true}, {@link CFGVisualizer}
@@ -69,7 +72,7 @@ public abstract class AbstractCFGVisualizer<
      * @return the representation of the control flow graph
      */
     protected String visualizeGraph(
-            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis) {
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<V, S, T> analysis) {
         return visualizeGraphHeader()
                 + visualizeGraphWithoutHeaderAndFooter(cfg, entry, analysis)
                 + visualizeGraphFooter();
@@ -84,7 +87,7 @@ public abstract class AbstractCFGVisualizer<
      * @return the String representation of the control flow graph
      */
     protected String visualizeGraphWithoutHeaderAndFooter(
-            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis) {
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<V, S, T> analysis) {
         Set<Block> visited = new HashSet<>();
         StringBuilder sbGraph = new StringBuilder();
         Queue<Block> workList = new ArrayDeque<>();
@@ -174,7 +177,7 @@ public abstract class AbstractCFGVisualizer<
      * @return the String representation of the block
      */
     protected String visualizeBlockHelper(
-            Block bb, @Nullable Analysis<A, S, T> analysis, String escapeString) {
+            Block bb, @Nullable Analysis<V, S, T> analysis, String escapeString) {
         StringBuilder sbBlock = new StringBuilder();
         sbBlock.append(loopOverBlockContents(bb, analysis, escapeString));
 
@@ -227,7 +230,7 @@ public abstract class AbstractCFGVisualizer<
      * @return the String representation of the contents of the block
      */
     protected String loopOverBlockContents(
-            Block bb, @Nullable Analysis<A, S, T> analysis, String separator) {
+            Block bb, @Nullable Analysis<V, S, T> analysis, String separator) {
 
         List<Node> contents = addBlockContent(bb);
         StringJoiner sjBlockContents = new StringJoiner(separator);
@@ -269,11 +272,11 @@ public abstract class AbstractCFGVisualizer<
      * @return the String representation of the transfer input of the block
      */
     protected String visualizeBlockTransferInputHelper(
-            Block bb, Analysis<A, S, T> analysis, String escapeString) {
+            Block bb, Analysis<V, S, T> analysis, String escapeString) {
         assert analysis != null
                 : "analysis should be non-null when visualizing the transfer input of a block.";
 
-        TransferInput<A, S> input = analysis.getInput(bb);
+        TransferInput<V, S> input = analysis.getInput(bb);
         assert input != null : "@AssumeAssertion(nullness): well-behaved analysis";
 
         StringBuilder sbStore = new StringBuilder();
@@ -372,7 +375,7 @@ public abstract class AbstractCFGVisualizer<
      * @return the String representation of the nodes
      */
     protected abstract String visualizeNodes(
-            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<A, S, T> analysis);
+            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<V, S, T> analysis);
 
     /**
      * Generate the String representation of an edge.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -33,7 +33,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
  *
  * @param <V> the abstract value type to be tracked by the analysis
  * @param <S> the store type used in the analysis
- * @param <T> the transfer function type that is used to approximated runtime behavior
+ * @param <T> the transfer function type that is used to approximate runtime behavior
  * @see DOTCFGVisualizer
  * @see StringCFGVisualizer
  */

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -15,9 +15,13 @@ import org.checkerframework.dataflow.cfg.node.Node;
 /**
  * Perform some visualization on a control flow graph. The particular operations depend on the
  * implementation.
+ *
+ * @param <V> the abstract value type to be tracked by the analysis
+ * @param <S> the store type used in the analysis
+ * @param <T> the transfer function type that is used to approximated runtime behavior
  */
 public interface CFGVisualizer<
-        A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>> {
+        V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>> {
     /**
      * Initialization method guaranteed to be called once before the first invocation of {@link
      * #visualize}.
@@ -43,7 +47,7 @@ public interface CFGVisualizer<
      *     String representation of the CFG ({@link StringCFGVisualizer})
      */
     @Nullable Map<String, Object> visualize(
-            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis);
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<V, S, T> analysis);
 
     /**
      * Delegate the visualization responsibility to the passed {@link Store} instance, which will
@@ -70,7 +74,7 @@ public interface CFGVisualizer<
      * @param value the value of the local variable
      * @return the String representation of the local variable
      */
-    String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value);
+    String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of the current
@@ -79,7 +83,7 @@ public interface CFGVisualizer<
      * @param value the value of the current object {@code this}
      * @return the String representation of {@code this}
      */
-    String visualizeStoreThisVal(A value);
+    String visualizeStoreThisVal(V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of fields
@@ -89,7 +93,7 @@ public interface CFGVisualizer<
      * @param value the value of the field
      * @return the String representation of the field
      */
-    String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value);
+    String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of arrays
@@ -99,7 +103,7 @@ public interface CFGVisualizer<
      * @param value the value of the array
      * @return the String representation of the array
      */
-    String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value);
+    String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of pure method
@@ -109,7 +113,7 @@ public interface CFGVisualizer<
      * @param value the value of the pure method call
      * @return the String representation of the pure method call
      */
-    String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value);
+    String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the value of class names
@@ -119,7 +123,7 @@ public interface CFGVisualizer<
      * @param value the value of the class name
      * @return the String representation of the class name
      */
-    String visualizeStoreClassVals(FlowExpressions.ClassName className, A value);
+    String visualizeStoreClassVals(FlowExpressions.ClassName className, V value);
 
     /**
      * Called by {@code CFAbstractStore#internalVisualize()} to visualize the specific information
@@ -148,7 +152,7 @@ public interface CFGVisualizer<
      * @param analysis the current analysis
      * @return the String representation of the given block
      */
-    String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis);
+    String visualizeBlock(Block bb, @Nullable Analysis<V, S, T> analysis);
 
     /**
      * Visualize a SpecialBlock.
@@ -174,7 +178,7 @@ public interface CFGVisualizer<
      * @param analysis the current analysis
      * @return the String representation of the transferInput of the given block
      */
-    String visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis);
+    String visualizeBlockTransferInput(Block bb, Analysis<V, S, T> analysis);
 
     /**
      * Visualize a Node based on the analysis.
@@ -183,7 +187,7 @@ public interface CFGVisualizer<
      * @param analysis the current analysis
      * @return the String representation of the given node
      */
-    String visualizeBlockNode(Node t, @Nullable Analysis<A, S, T> analysis);
+    String visualizeBlockNode(Node t, @Nullable Analysis<V, S, T> analysis);
 
     /** Shutdown method called once from the shutdown hook of the {@code BaseTypeChecker}. */
     void shutdown();

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGVisualizer.java
@@ -18,7 +18,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
  *
  * @param <V> the abstract value type to be tracked by the analysis
  * @param <S> the store type used in the analysis
- * @param <T> the transfer function type that is used to approximated runtime behavior
+ * @param <T> the transfer function type that is used to approximate runtime behavior
  */
 public interface CFGVisualizer<
         V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>> {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -29,8 +29,8 @@ import org.checkerframework.javacutil.UserError;
 /** Generate a graph description in the DOT language of a control graph. */
 @SuppressWarnings("initialization.fields.uninitialized") // uses init method
 public class DOTCFGVisualizer<
-                A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
-        extends AbstractCFGVisualizer<A, S, T> {
+                V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>>
+        extends AbstractCFGVisualizer<V, S, T> {
 
     /** The output directory. */
     protected String outDir;
@@ -59,7 +59,7 @@ public class DOTCFGVisualizer<
 
     @Override
     public @Nullable Map<String, Object> visualize(
-            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis) {
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<V, S, T> analysis) {
 
         String dotGraph = visualizeGraph(cfg, entry, analysis);
         String dotFileName = dotOutputFileName(cfg.underlyingAST);
@@ -82,7 +82,7 @@ public class DOTCFGVisualizer<
     @SuppressWarnings("enhancedfor.type.incompatible")
     @Override
     public String visualizeNodes(
-            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<A, S, T> analysis) {
+            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<V, S, T> analysis) {
 
         StringBuilder sbDotNodes = new StringBuilder();
         sbDotNodes.append(lineSeparator);
@@ -128,7 +128,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis) {
+    public String visualizeBlock(Block bb, @Nullable Analysis<V, S, T> analysis) {
         return super.visualizeBlockHelper(bb, analysis, leftJustifiedTerminator);
     }
 
@@ -144,7 +144,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis) {
+    public String visualizeBlockTransferInput(Block bb, Analysis<V, S, T> analysis) {
         return super.visualizeBlockTransferInputHelper(bb, analysis, leftJustifiedTerminator);
     }
 
@@ -207,7 +207,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeBlockNode(Node t, @Nullable Analysis<A, S, T> analysis) {
+    public String visualizeBlockNode(Node t, @Nullable Analysis<V, S, T> analysis) {
         StringBuilder sbBlockNode = new StringBuilder();
         sbBlockNode
                 .append(escapeDoubleQuotes(t))
@@ -215,7 +215,7 @@ public class DOTCFGVisualizer<
                 .append(getNodeSimpleName(t))
                 .append(" ]");
         if (analysis != null) {
-            A value = analysis.getValue(t);
+            V value = analysis.getValue(t);
             if (value != null) {
                 sbBlockNode.append("    > ").append(escapeDoubleQuotes(value));
             }
@@ -224,12 +224,12 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreThisVal(A value) {
+    public String visualizeStoreThisVal(V value) {
         return storeEntryIndent + "this > " + value + leftJustifiedTerminator;
     }
 
     @Override
-    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
+    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, V value) {
         return storeEntryIndent
                 + localVar
                 + " > "
@@ -238,7 +238,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
+    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, V value) {
         return storeEntryIndent
                 + fieldAccess
                 + " > "
@@ -247,7 +247,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
+    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, V value) {
         return storeEntryIndent
                 + arrayValue
                 + " > "
@@ -256,7 +256,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
+    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, V value) {
         return storeEntryIndent
                 + escapeDoubleQuotes(methodCall)
                 + " > "
@@ -265,7 +265,7 @@ public class DOTCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
+    public String visualizeStoreClassVals(FlowExpressions.ClassName className, V value) {
         return storeEntryIndent
                 + className
                 + " > "

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/StringCFGVisualizer.java
@@ -19,12 +19,12 @@ import org.checkerframework.dataflow.cfg.node.Node;
 
 /** Generate the String representation of a control flow graph. */
 public class StringCFGVisualizer<
-                A extends AbstractValue<A>, S extends Store<S>, T extends TransferFunction<A, S>>
-        extends AbstractCFGVisualizer<A, S, T> {
+                V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>>
+        extends AbstractCFGVisualizer<V, S, T> {
 
     @Override
     public Map<String, Object> visualize(
-            ControlFlowGraph cfg, Block entry, @Nullable Analysis<A, S, T> analysis) {
+            ControlFlowGraph cfg, Block entry, @Nullable Analysis<V, S, T> analysis) {
         String stringGraph = visualizeGraph(cfg, entry, analysis);
         Map<String, Object> res = new HashMap<>();
         res.put("stringGraph", stringGraph);
@@ -34,7 +34,7 @@ public class StringCFGVisualizer<
     @SuppressWarnings("enhancedfor.type.incompatible")
     @Override
     public String visualizeNodes(
-            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<A, S, T> analysis) {
+            Set<Block> blocks, ControlFlowGraph cfg, @Nullable Analysis<V, S, T> analysis) {
         StringBuilder sbStringNodes = new StringBuilder();
         sbStringNodes.append(lineSeparator);
 
@@ -67,7 +67,7 @@ public class StringCFGVisualizer<
     }
 
     @Override
-    public String visualizeBlock(Block bb, @Nullable Analysis<A, S, T> analysis) {
+    public String visualizeBlock(Block bb, @Nullable Analysis<V, S, T> analysis) {
         return super.visualizeBlockHelper(bb, analysis, lineSeparator);
     }
 
@@ -85,16 +85,16 @@ public class StringCFGVisualizer<
     }
 
     @Override
-    public String visualizeBlockTransferInput(Block bb, Analysis<A, S, T> analysis) {
+    public String visualizeBlockTransferInput(Block bb, Analysis<V, S, T> analysis) {
         return super.visualizeBlockTransferInputHelper(bb, analysis, lineSeparator);
     }
 
     @Override
-    public String visualizeBlockNode(Node t, @Nullable Analysis<A, S, T> analysis) {
+    public String visualizeBlockNode(Node t, @Nullable Analysis<V, S, T> analysis) {
         StringBuilder sbBlockNode = new StringBuilder();
         sbBlockNode.append(t.toString()).append("   [ ").append(getNodeSimpleName(t)).append(" ]");
         if (analysis != null) {
-            A value = analysis.getValue(t);
+            V value = analysis.getValue(t);
             if (value != null) {
                 sbBlockNode.append(" > ").append(value.toString());
             }
@@ -103,32 +103,32 @@ public class StringCFGVisualizer<
     }
 
     @Override
-    public String visualizeStoreThisVal(A value) {
+    public String visualizeStoreThisVal(V value) {
         return storeEntryIndent + "this > " + value + lineSeparator;
     }
 
     @Override
-    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, A value) {
+    public String visualizeStoreLocalVar(FlowExpressions.LocalVariable localVar, V value) {
         return storeEntryIndent + localVar + " > " + value + lineSeparator;
     }
 
     @Override
-    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, A value) {
+    public String visualizeStoreFieldVals(FlowExpressions.FieldAccess fieldAccess, V value) {
         return storeEntryIndent + fieldAccess + " > " + value + lineSeparator;
     }
 
     @Override
-    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, A value) {
+    public String visualizeStoreArrayVal(FlowExpressions.ArrayAccess arrayValue, V value) {
         return storeEntryIndent + arrayValue + " > " + value + lineSeparator;
     }
 
     @Override
-    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, A value) {
+    public String visualizeStoreMethodVals(FlowExpressions.MethodCall methodCall, V value) {
         return storeEntryIndent + methodCall + " > " + value + lineSeparator;
     }
 
     @Override
-    public String visualizeStoreClassVals(FlowExpressions.ClassName className, A value) {
+    public String visualizeStoreClassVals(FlowExpressions.ClassName className, V value) {
         return storeEntryIndent + className + " > " + value + lineSeparator;
     }
 


### PR DESCRIPTION
Currently, we both use `A extends AbstractValue<A>` and `V extends AbstractValue<V>` in dataflow framework. This PR changes all the usages of `A` to `V`.