### PR TITLE
Remove code that doesn't do anything in WPIScenesStorage

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -12,9 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
-import javax.lang.model.type.MirroredTypesException;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.BinaryName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -363,22 +361,6 @@ public class WholeProgramInferenceScenesStorage {
             TypeKind atmKind = atm.getUnderlyingType().getKind();
             if (hasMatchingTypeKind(atmKind, types)) {
                 return true;
-            }
-
-            try {
-                Class<?>[] names = defaultFor.types();
-                for (Class<?> c : names) {
-                    TypeMirror underlyingtype = atm.getUnderlyingType();
-                    while (underlyingtype instanceof javax.lang.model.type.ArrayType) {
-                        underlyingtype =
-                                ((javax.lang.model.type.ArrayType) underlyingtype)
-                                        .getComponentType();
-                    }
-                    if (c.getCanonicalName().equals(atm.getUnderlyingType().toString())) {
-                        return true;
-                    }
-                }
-            } catch (MirroredTypesException e) {
             }
         }
 


### PR DESCRIPTION
@mernst noticed the `catch` block in the removed code that didn't do anything and asked me to investigate it. It turns out that the only time the `try` block was entered at all (in our tests) leads to that empty `catch` block, which eventually leads to the `return false` - meaning that the whole section of code isn't actually accomplishing anything of value. I don't know why it was originally written, but I think we should remove it.