### PR TITLE
Remove TypecheckResult.fromCompilationResultsExpectedDiagnostics()

### DIFF
--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
@@ -169,32 +169,4 @@ public class TypecheckResult {
                 missingDiagnostics,
                 new ArrayList<>(unexpectedDiagnostics));
     }
-
-    public static TypecheckResult fromCompilationResultsExpectedDiagnostics(
-            TestConfiguration configuration,
-            CompilationResult result,
-            List<TestDiagnostic> expectedDiagnostics) {
-
-        boolean usingAnomsgtxt = configuration.getOptions().containsKey("-Anomsgtext");
-        final Set<TestDiagnostic> actualDiagnostics =
-                TestDiagnosticUtils.fromJavaxDiagnosticList(
-                        result.getDiagnostics(), usingAnomsgtxt);
-
-        final Set<TestDiagnostic> unexpectedDiagnostics = new LinkedHashSet<>();
-        unexpectedDiagnostics.addAll(actualDiagnostics);
-        unexpectedDiagnostics.removeAll(expectedDiagnostics);
-
-        final List<TestDiagnostic> missingDiagnostics = new ArrayList<>(expectedDiagnostics);
-        missingDiagnostics.removeAll(actualDiagnostics);
-
-        boolean testFailed = !unexpectedDiagnostics.isEmpty() || !missingDiagnostics.isEmpty();
-
-        return new TypecheckResult(
-                configuration,
-                result,
-                expectedDiagnostics,
-                testFailed,
-                missingDiagnostics,
-                new ArrayList<>(unexpectedDiagnostics));
-    }
 }


### PR DESCRIPTION
It was undocumented and identical to fromCompilationResults()

Merge together with https://github.com/typetools/checker-framework-inference/pull/163