### PR TITLE
Replace anno for primitives as well during replacer and refactor copier

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -109,7 +109,6 @@ public class AnnotatedTypeCopier
         }
 
         final AnnotatedDeclaredType copy = (AnnotatedDeclaredType) makeCopy(original);
-        maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
         if (original.wasRaw()) {
@@ -141,7 +140,6 @@ public class AnnotatedTypeCopier
         }
 
         final AnnotatedIntersectionType copy = (AnnotatedIntersectionType) makeCopy(original);
-        maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
         if (original.supertypes != null) {
@@ -164,7 +162,6 @@ public class AnnotatedTypeCopier
         }
 
         final AnnotatedUnionType copy = (AnnotatedUnionType) makeCopy(original);
-        maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
         if (original.alternatives != null) {
@@ -187,7 +184,6 @@ public class AnnotatedTypeCopier
         }
 
         final AnnotatedExecutableType copy = (AnnotatedExecutableType) makeCopy(original);
-        maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
         copy.setElement(original.getElement());
@@ -230,7 +226,6 @@ public class AnnotatedTypeCopier
         }
 
         final AnnotatedArrayType copy = (AnnotatedArrayType) makeCopy(original);
-        maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
         copy.setComponentType(visit(original.getComponentType(), originalToCopy));

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -108,12 +108,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedDeclaredType copy =
-                (AnnotatedDeclaredType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedDeclaredType copy = (AnnotatedDeclaredType) makeCopy(original);
         maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
@@ -145,12 +140,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedIntersectionType copy =
-                (AnnotatedIntersectionType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedIntersectionType copy = (AnnotatedIntersectionType) makeCopy(original);
         maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
@@ -173,12 +163,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedUnionType copy =
-                (AnnotatedUnionType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedUnionType copy = (AnnotatedUnionType) makeCopy(original);
         maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
@@ -201,12 +186,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedExecutableType copy =
-                (AnnotatedExecutableType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedExecutableType copy = (AnnotatedExecutableType) makeCopy(original);
         maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
@@ -249,12 +229,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedArrayType copy =
-                (AnnotatedArrayType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedArrayType copy = (AnnotatedArrayType) makeCopy(original);
         maybeCopyPrimaryAnnotations(original, copy);
         originalToCopy.put(original, copy);
 
@@ -271,13 +246,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedTypeVariable copy =
-                (AnnotatedTypeVariable)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
-        maybeCopyPrimaryAnnotations(original, copy);
+        final AnnotatedTypeVariable copy = (AnnotatedTypeVariable) makeCopy(original);
         originalToCopy.put(original, copy);
 
         if (original.getUpperBoundField() != null) {
@@ -297,7 +266,7 @@ public class AnnotatedTypeCopier
     public AnnotatedTypeMirror visitPrimitive(
             AnnotatedPrimitiveType original,
             IdentityHashMap<AnnotatedTypeMirror, AnnotatedTypeMirror> originalToCopy) {
-        return makeCopy(original);
+        return makeOrReturnCopy(original, originalToCopy);
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeCopier.java
@@ -108,8 +108,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedDeclaredType copy = (AnnotatedDeclaredType) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedDeclaredType copy = makeOrReturnCopy(original, originalToCopy);
 
         if (original.wasRaw()) {
             copy.setWasRaw();
@@ -139,8 +138,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedIntersectionType copy = (AnnotatedIntersectionType) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedIntersectionType copy = makeOrReturnCopy(original, originalToCopy);
 
         if (original.supertypes != null) {
             final List<AnnotatedDeclaredType> copySupertypes = new ArrayList<>();
@@ -161,8 +159,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedUnionType copy = (AnnotatedUnionType) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedUnionType copy = makeOrReturnCopy(original, originalToCopy);
 
         if (original.alternatives != null) {
             final List<AnnotatedDeclaredType> copyAlternatives = new ArrayList<>();
@@ -183,8 +180,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedExecutableType copy = (AnnotatedExecutableType) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedExecutableType copy = makeOrReturnCopy(original, originalToCopy);
 
         copy.setElement(original.getElement());
 
@@ -225,8 +221,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedArrayType copy = (AnnotatedArrayType) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedArrayType copy = makeOrReturnCopy(original, originalToCopy);
 
         copy.setComponentType(visit(original.getComponentType(), originalToCopy));
 
@@ -241,8 +236,7 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedTypeVariable copy = (AnnotatedTypeVariable) makeCopy(original);
-        originalToCopy.put(original, copy);
+        final AnnotatedTypeVariable copy = makeOrReturnCopy(original, originalToCopy);
 
         if (original.getUpperBoundField() != null) {
             // TODO: figure out why asUse is needed here and remove it.
@@ -286,18 +280,11 @@ public class AnnotatedTypeCopier
             return originalToCopy.get(original);
         }
 
-        final AnnotatedWildcardType copy =
-                (AnnotatedWildcardType)
-                        AnnotatedTypeMirror.createType(
-                                original.getUnderlyingType(),
-                                original.atypeFactory,
-                                original.isDeclaration());
+        final AnnotatedWildcardType copy = makeOrReturnCopy(original, originalToCopy);
+
         if (original.isUninferredTypeArgument()) {
             copy.setUninferredTypeArgument();
         }
-
-        maybeCopyPrimaryAnnotations(original, copy);
-        originalToCopy.put(original, copy);
 
         if (original.getExtendsBoundField() != null) {
             copy.setExtendsBound(visit(original.getExtendsBoundField(), originalToCopy).asUse());


### PR DESCRIPTION
This change is need for AnnotatedTypeCopierWithReplacement to behave correctly for primitives.
Similar to visitNull, we want the primitives to have the annotations to be replaced.

This PR also includes a small refactoring of the AnnotatedTypeCopier.