### PR TITLE
Improve Azure instructions in developer manual

### DIFF
--- a/docs/developer/developer-manual.html
+++ b/docs/developer/developer-manual.html
@@ -285,7 +285,7 @@ We recommend Azure Pipelines.
 <ul>
   <li>Browse to <a href="https://dev.azure.com/">dev.azure.com</a>.
       (You might need to create a (free) account.)</li>
-  <li>Click "Create a project to get started"</li>
+  <li>Click "Create a project to get started" and enter an appropriate name</li>
   <li>Click "public".</li>
   <li>Click "create project"</li>
   <li>At the left, click the blue rocket labeled "pipelines"</li>
@@ -295,6 +295,8 @@ We recommend Azure Pipelines.
   <li>Click "Select a repository"</li>
   <li>Choose <em>MYUSERID</em>/checker-framework</li>
   <li>Choose the default radio button, "only selected repositories".  <b>Do not</b> choose "all repositories".</li>
+  <li>Choose "Existing Azure Pipelines YAML file"</li>
+  <li>Select "/azure-pipelines.yml" in the dropdown menu</li>
   <li>Approve and install.</li>
   <li>Click "run".</li>
 </ul>


### PR DESCRIPTION
There seems to be an extra step in creating an Azure pipeline not in the developer manual. I added instructions for this step (I'm not sure exactly sure if they're correct or not).