### PR TITLE
A follow-up of #3395: Remove the wrong escapeString

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/AbstractCFGVisualizer.java
@@ -368,7 +368,7 @@ public abstract class AbstractCFGVisualizer<
             sbStore.append(", else=");
             sbStore.append(visualizeStore(elseStore));
         }
-        sbStore.insert(0, escapeString + "~~~~~~~~~" + escapeString);
+        sbStore.insert(0, "~~~~~~~~~" + escapeString);
         return sbStore.toString();
     }
 


### PR DESCRIPTION
Make the behavior of `visualizeBlockTransferInputBeforeHelper` and `visualizeBlockTransferInputAfterHelper` consistent.