### PR TITLE
Remove external links to images

### DIFF
--- a/docs/developer/gsoc-ideas.html
+++ b/docs/developer/gsoc-ideas.html
@@ -5,11 +5,11 @@
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" type="image/png" href=
-  "https://checkerframework.org/favicon-checkerframework.png">
+  "../logo/Checkmark/CFCheckmark_favicon.png">
 </head>
 <body>
 
-<img src="https://checkerframework.org/CFLogo.png" alt="Checker Framework logo" />
+<img src="../logo/Logo/CFLogo.png" alt="Checker Framework logo" />
 
 <h1>GSoC ideas 2020</h1> <!-- omit from toc -->
 


### PR DESCRIPTION
Images are already available locally. This change will prevent unnecessary Internet access and associated privacy concerns. (Imported from Debian packaging)