### PR TITLE
Fix unprintable class when param types are inferred from assignments using -Ainfer=stubs

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -229,7 +229,11 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
 
         String className = getEnclosingClassName(lhs);
         String jaifPath = storage.getJaifPath(className);
-        AClass clazz = storage.getAClass(className, jaifPath);
+        AClass clazz =
+                storage.getAClass(
+                        className,
+                        jaifPath,
+                        (ClassSymbol) TreeUtils.elementFromDeclaration(classTree));
         ExecutableElement methodElt = TreeUtils.elementFromDeclaration(methodTree);
         AMethod method = clazz.methods.getVivify(JVMNames.getJVMMethodSignature(methodElt));
         method.setFieldsFromMethodElement(methodElt);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/scenelib/ASceneWrapper.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/scenelib/ASceneWrapper.java
@@ -163,7 +163,7 @@ public class ASceneWrapper {
     /**
      * Updates the symbol information stored in AClass for the given class. May be called multiple
      * times (and needs to be if the second parameter was null the first time it was called; only
-     * some calls provide the symbol inforamtion).
+     * some calls provide the symbol information).
      *
      * @param aClass the class representation in which the symbol information is to be updated
      * @param classSymbol the source of the symbol information; may be null, in which case this

--- a/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
+++ b/framework/tests/whole-program-inference/non-annotated/ExpectedErrors.java
@@ -234,4 +234,11 @@ public class ExpectedErrors {
             expectsSibling1(field2);
         }
     }
+
+    class AssignParam {
+        public void f(@WholeProgramInferenceBottom Object param) {
+            // :: error: assignment.type.incompatible
+            param = ((@Top Object) null);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #3428.

The mistake was that we missed one of the callsites for `storage.getAClass` that needed to be updated in #2871.

Also fixed a typo in some javadoc.