### PR TITLE
Do not do inference on temporary variables in whole-program inference

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -284,7 +284,11 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
                             + lhs.getClass());
         }
 
-        // Do not attempt to infer types for temporary variables.
+        // Do not attempt to infer types for fields that do not have valid
+        // names. For example, compiler-generated temporary variables will
+        // have invalid names. Recording facts about fields with
+        // invalid names causes jaif-based WPI to crash when reading the .jaif
+        // file, and stub-based WPI to generate unparseable stub files.
         // See https://github.com/typetools/checker-framework/issues/3442
         if (!SourceVersion.isIdentifier(fieldName)) {
             return;

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -9,6 +9,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.VarSymbol;
 import java.util.List;
 import java.util.Map;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
@@ -281,6 +282,12 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
             throw new BugInCF(
                     "updateFromFieldAssignment received an unexpected node type: "
                             + lhs.getClass());
+        }
+
+        // Do not attempt to infer types for temporary variables.
+        // See https://github.com/typetools/checker-framework/issues/3442
+        if (!SourceVersion.isIdentifier(fieldName)) {
+            return;
         }
 
         // If the inferred field has a declaration annotation with the

--- a/framework/tests/whole-program-inference/non-annotated/Tempvars.java
+++ b/framework/tests/whole-program-inference/non-annotated/Tempvars.java
@@ -1,0 +1,8 @@
+// test case for https://github.com/typetools/checker-framework/issues/3442
+
+public class Tempvars {
+    static {
+        int i = 0;
+        i++;
+    }
+}


### PR DESCRIPTION
fixes #3442 for both -Ainfer=stubs and -Ainfer=jaifs