### PR TITLE
Prevent local classes from being written to stub files

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -74,10 +74,14 @@ public final class SceneToStubWriter {
     private SceneToStubWriter() {}
 
     /**
-     * A pattern matching the name of an anonymous inner class, or a class nested within one. An
-     * anonymous inner class has a basename like Outer$1.
+     * A pattern matching the name of an anonymous inner class, a local class, or a class nested
+     * within one of these types of classes. An anonymous inner class has a basename like Outer$1
+     * and a local class has a basename like Oute$1Inner. See <a
+     * href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-13.html#jls-13.1">Java Language
+     * Specification, section 13.1</a>.
      */
-    private static final Pattern anonymousInnerClassPattern = Pattern.compile("\\$\\d+(\\$|$)");
+    private static final Pattern anonymousInnerClassOrLocalClassPattern =
+            Pattern.compile("\\$\\d+");
 
     /** How far to indent when writing members of a stub file. */
     private static final String INDENT = "  ";
@@ -675,9 +679,9 @@ public final class SceneToStubWriter {
             return false;
         }
 
-        // Do not attempt to print stubs for anonymous inner classes or their inner classes, because
-        // the stub parser cannot read them.
-        if (anonymousInnerClassPattern.matcher(basename).find()) {
+        // Do not attempt to print stubs for anonymous inner classes, local classes, or their inner
+        // classes, because the stub parser cannot read them.
+        if (anonymousInnerClassOrLocalClassPattern.matcher(basename).find()) {
             return false;
         }
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -76,7 +76,7 @@ public final class SceneToStubWriter {
     /**
      * A pattern matching the name of an anonymous inner class, a local class, or a class nested
      * within one of these types of classes. An anonymous inner class has a basename like Outer$1
-     * and a local class has a basename like Oute$1Inner. See <a
+     * and a local class has a basename like Outer$1Inner. See <a
      * href="https://docs.oracle.com/javase/specs/jls/se11/html/jls-13.html#jls-13.1">Java Language
      * Specification, section 13.1</a>.
      */

--- a/framework/tests/whole-program-inference/non-annotated/LocalClassTest.java
+++ b/framework/tests/whole-program-inference/non-annotated/LocalClassTest.java
@@ -1,0 +1,11 @@
+// test case for https://github.com/typetools/checker-framework/issues/3461
+
+import testlib.wholeprograminference.qual.Sibling1;
+
+public class LocalClassTest {
+    public void method() {
+        class Local {
+            Object o = (@Sibling1 Object) null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3461 

Local classes can't be parsed by the stub file reader, so this prevents them from being written. Even before #3441, which introduced the crash in #3461, local classes caused problems with whole program inference.