### PR TITLE
Fix incorrect handling of non-chained accumulations in the generic accumulation checker

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationTransfer.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationTransfer.java
@@ -13,6 +13,7 @@ import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
 import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
+import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
@@ -75,18 +76,21 @@ public class AccumulationTransfer extends CFTransfer {
         List<String> valuesAsList = Arrays.asList(values);
         // If dataflow has already recorded information about the target, fetch it and integrate
         // it into the list of values in the new annotation.
-        CFValue flowValue = result.getResultValue();
-        if (flowValue != null) {
-            Set<AnnotationMirror> flowAnnos = flowValue.getAnnotations();
-            assert flowAnnos.size() <= 1;
-            for (AnnotationMirror anno : flowAnnos) {
-                List<String> oldFlowValues =
-                        ValueCheckerUtils.getValueOfAnnotationWithStringArgument(anno);
-                if (oldFlowValues != null) {
-                    // valuesAsList cannot have its length changed -- it is backed by an array.
-                    // getValueOfAnnotationWithStringArgument returns a new, modifiable list.
-                    oldFlowValues.addAll(valuesAsList);
-                    valuesAsList = oldFlowValues;
+        Receiver target = FlowExpressions.internalReprOf(typeFactory, node);
+        if (CFAbstractStore.canInsertReceiver(target)) {
+            CFValue flowValue = result.getRegularStore().getValue(target);
+            if (flowValue != null) {
+                Set<AnnotationMirror> flowAnnos = flowValue.getAnnotations();
+                assert flowAnnos.size() <= 1;
+                for (AnnotationMirror anno : flowAnnos) {
+                    List<String> oldFlowValues =
+                            ValueCheckerUtils.getValueOfAnnotationWithStringArgument(anno);
+                    if (oldFlowValues != null) {
+                        // valuesAsList cannot have its length changed -- it is backed by an array.
+                        // getValueOfAnnotationWithStringArgument returns a new, modifiable list.
+                        oldFlowValues.addAll(valuesAsList);
+                        valuesAsList = oldFlowValues;
+                    }
                 }
             }
         }

--- a/framework/tests/accumulation/SimpleInference.java
+++ b/framework/tests/accumulation/SimpleInference.java
@@ -3,7 +3,11 @@ import testaccumulation.qual.*;
 class SimpleInference {
     void build(@TestAccumulation({"a"}) SimpleInference this) {}
 
+    void doublebuild(@TestAccumulation({"a", "b"}) SimpleInference this) {}
+
     void a() {}
+
+    void b() {}
 
     static void doStuffCorrect() {
         SimpleInference s = new SimpleInference();
@@ -11,9 +15,23 @@ class SimpleInference {
         s.build();
     }
 
+    static void doStuffCorrect2() {
+        SimpleInference s = new SimpleInference();
+        s.a();
+        s.b();
+        s.doublebuild();
+    }
+
     static void doStuffWrong() {
         SimpleInference s = new SimpleInference();
         // :: error: method.invocation.invalid
         s.build();
+    }
+
+    static void doStuffWrong2() {
+        SimpleInference s = new SimpleInference();
+        s.a();
+        // :: error: method.invocation.invalid
+        s.doublebuild();
     }
 }


### PR DESCRIPTION
For some reason, we didn't have a direct test for this - it was only tested in the original Object Construction Checker as part of the predicate tests. I discovered it while working on generic predicate support, but the issue is independent of predicates.

Without the change here, the checker issues a spurious error on line 22 of `SimpleInference.java`, because it fails to accumulate both `a` and `b`.