### PR TITLE
Make mergeStubsIntoType protected instead of private

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1306,7 +1306,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @param elt the element from which to read stub types
      * @return the type, side-effected to add the stub types
      */
-    private AnnotatedTypeMirror mergeStubsIntoType(
+    protected AnnotatedTypeMirror mergeStubsIntoType(
             @Nullable AnnotatedTypeMirror type, Element elt) {
         AnnotatedTypeMirror stubType = stubTypes.getAnnotatedTypeMirror(elt);
         if (stubType != null) {


### PR DESCRIPTION
`-AmergeStubsWithSource` uses GLB when merging stubs with source. For most checkers, this is the right choice - we want the "strongest" type that's true of both the stub file and source.

Custom checkers, however, might want custom logic here (and I have one in mind that does, but I can't talk about it publicly). This PR makes it possible for a new checker to change that behavior (e.g. to LUB instead of GLB).