### PR TITLE
Make CFG construction more deterministic

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/block/ExceptionBlockImpl.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/block/ExceptionBlockImpl.java
@@ -1,8 +1,8 @@
 package org.checkerframework.dataflow.cfg.block;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import javax.lang.model.type.TypeMirror;
@@ -22,7 +22,7 @@ public class ExceptionBlockImpl extends SingleSuccessorBlockImpl implements Exce
     /** Create an empty exceptional block. */
     public ExceptionBlockImpl() {
         super(BlockType.EXCEPTION_BLOCK);
-        exceptionalSuccessors = new HashMap<>();
+        exceptionalSuccessors = new LinkedHashMap<>();
     }
 
     /** Set the node. */
@@ -43,7 +43,7 @@ public class ExceptionBlockImpl extends SingleSuccessorBlockImpl implements Exce
     public void addExceptionalSuccessor(BlockImpl b, TypeMirror cause) {
         Set<Block> blocks = exceptionalSuccessors.get(cause);
         if (blocks == null) {
-            blocks = new HashSet<>();
+            blocks = new LinkedHashSet<>();
             exceptionalSuccessors.put(cause, blocks);
         }
         blocks.add(b);


### PR DESCRIPTION
I have observed two runs of CFG construction that print differently.  Although the structure of the CFG is the same, the difference in printed output is a nuisance.