### PR TITLE
Add parameters to the output dot file's name.

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -180,16 +180,20 @@ public class DOTCFGVisualizer<
             CFGMethod cfgMethod = (CFGMethod) ast;
             String clsName = cfgMethod.getClassTree().getSimpleName().toString();
             String methodName = cfgMethod.getMethod().getName().toString();
+            String params = cfgMethod.getMethod().getParameters().toString();
             outFile.append(clsName);
-            outFile.append("-");
+            outFile.append("::");
             outFile.append(methodName);
+            outFile.append("(");
+            outFile.append(params);
+            outFile.append(")");
 
             srcLoc.append("<");
             srcLoc.append(clsName);
             srcLoc.append("::");
             srcLoc.append(methodName);
             srcLoc.append("(");
-            srcLoc.append(cfgMethod.getMethod().getParameters());
+            srcLoc.append(params);
             srcLoc.append(")::");
             srcLoc.append(((JCTree) cfgMethod.getMethod()).pos);
             srcLoc.append(">");

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -183,7 +183,6 @@ public class DOTCFGVisualizer<
             String clsName = cfgMethod.getClassTree().getSimpleName().toString();
             String methodName = cfgMethod.getMethod().getName().toString();
             StringJoiner params = new StringJoiner(",");
-            params.setEmptyValue("");
             for (VariableTree tree : cfgMethod.getMethod().getParameters()) {
                 params.add(tree.getType().toString());
             }
@@ -194,6 +193,7 @@ public class DOTCFGVisualizer<
                 outFile.append("-");
                 outFile.append(params);
             }
+
             srcLoc.append("<");
             srcLoc.append(clsName);
             srcLoc.append("::");

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/DOTCFGVisualizer.java
@@ -1,5 +1,6 @@
 package org.checkerframework.dataflow.cfg;
 
+import com.sun.source.tree.VariableTree;
 import com.sun.tools.javac.tree.JCTree;
 import java.io.BufferedWriter;
 import java.io.FileWriter;
@@ -9,6 +10,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import org.checkerframework.checker.nullness.qual.KeyFor;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.AbstractValue;
@@ -180,14 +182,18 @@ public class DOTCFGVisualizer<
             CFGMethod cfgMethod = (CFGMethod) ast;
             String clsName = cfgMethod.getClassTree().getSimpleName().toString();
             String methodName = cfgMethod.getMethod().getName().toString();
-            String params = cfgMethod.getMethod().getParameters().toString();
+            StringJoiner params = new StringJoiner(",");
+            params.setEmptyValue("");
+            for (VariableTree tree : cfgMethod.getMethod().getParameters()) {
+                params.add(tree.getType().toString());
+            }
             outFile.append(clsName);
-            outFile.append("::");
+            outFile.append("-");
             outFile.append(methodName);
-            outFile.append("(");
-            outFile.append(params);
-            outFile.append(")");
-
+            if (params.length() != 0) {
+                outFile.append("-");
+                outFile.append(params);
+            }
             srcLoc.append("<");
             srcLoc.append(clsName);
             srcLoc.append("::");


### PR DESCRIPTION
As https://github.com/typetools/checker-framework/pull/3490#discussion_r459773537 mentioned, to handle the overloaded methods, we also add parameters to the output dot file's name.

If we have two methods: `test(String a, String b)` and `test(String a, String b, String c)` in class `Test`, now the output dot files are:
~~`Test::test(String a, String b)-Nullness.dot` and~~
~~`Test::test(String a, String b, String c)-Nullness.dot`.~~
`Test-test-String,String-Nullness.dot` and
`Test-test-String,String,String-Nullness.dot` and
