### PR TITLE
Remove comment about Node in ConditionalBlock

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/block/ConditionalBlock.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/block/ConditionalBlock.java
@@ -1,9 +1,8 @@
 package org.checkerframework.dataflow.cfg.block;
 
 import org.checkerframework.dataflow.analysis.Store;
-import org.checkerframework.dataflow.cfg.node.Node;
 
-/** Represents a conditional basic block that contains exactly one boolean {@link Node}. */
+/** Represents a conditional basic block. */
 public interface ConditionalBlock extends Block {
 
     /**


### PR DESCRIPTION
I don't see any Node in it.
If this change is not correct, then the documentation should be updated to say where the Node is and how to access it.