### PR TITLE
Deprecate SystemUtil.join

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     // File Utilities takes priority over this version, in the fat jar
     // file. :-( So update it and re-build it locally when updating this.
     implementation 'org.plumelib:reflection-util:0.2.2'
+    implementation 'org.plumelib:plume-util:1.1.5'
 
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation project(':framework-test')

--- a/checker/jtreg/nullness/defaultsPersist/ReferenceInfoUtil.java
+++ b/checker/jtreg/nullness/defaultsPersist/ReferenceInfoUtil.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.SystemUtil;
 
 public class ReferenceInfoUtil {
 
@@ -159,7 +158,8 @@ public class ReferenceInfoUtil {
 
     public static String positionCompareStr(
             TypeAnnotation.Position p1, TypeAnnotation.Position p2) {
-        return SystemUtil.joinLines(
+        return String.join(
+                System.lineSeparator(),
                 "type = " + p1.type + ", " + p2.type,
                 "offset = " + p1.offset + ", " + p2.offset,
                 "lvarOffset = " + p1.lvarOffset + ", " + p2.lvarOffset,
@@ -234,7 +234,8 @@ class ComparisonException extends RuntimeException {
     }
 
     public String toString() {
-        return SystemUtil.joinLines(
+        return String.join(
+                System.lineSeparator(),
                 super.toString(),
                 "\tExpected: "
                         + expected.size()

--- a/checker/jtreg/nullness/inheritDeclAnnoPersist/Extends.java
+++ b/checker/jtreg/nullness/inheritDeclAnnoPersist/Extends.java
@@ -37,7 +37,8 @@ public class Extends {
 
 class TestWrapper {
     public static String wrap(String... method) {
-        return SystemUtil.joinLines(
-                "class Test extends Super {", SystemUtil.joinLines(method), "}");
+        return String.join(
+                System.lineSeparator(),
+                SystemUtil.concatenate("class Test extends Super {", method, "}"));
     }
 }

--- a/checker/jtreg/nullness/inheritDeclAnnoPersist/Implements.java
+++ b/checker/jtreg/nullness/inheritDeclAnnoPersist/Implements.java
@@ -1,5 +1,3 @@
-import org.checkerframework.javacutil.SystemUtil;
-
 /*
  * @test
  * @summary Test that inherited declaration annotations are stored in bytecode.
@@ -23,7 +21,10 @@ public class Implements {
 
 class TestWrapper {
     public static String wrap(String... method) {
-        return SystemUtil.joinLines(
-                "class Test extends AbstractClass {", SystemUtil.joinLines(method), "}");
+        return String.join(
+                System.lineSeparator(),
+                "class Test extends AbstractClass {",
+                String.join(System.lineSeparator(), method),
+                "}");
     }
 }

--- a/checker/jtreg/nullness/inheritDeclAnnoPersist/ReferenceInfoUtil.java
+++ b/checker/jtreg/nullness/inheritDeclAnnoPersist/ReferenceInfoUtil.java
@@ -12,7 +12,6 @@ import com.sun.tools.classfile.RuntimeAnnotations_attribute;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
-import org.checkerframework.javacutil.SystemUtil;
 
 public class ReferenceInfoUtil {
 
@@ -123,7 +122,8 @@ class ComparisonException extends RuntimeException {
                 throw new RuntimeException(e);
             }
         }
-        return SystemUtil.joinLines(
+        return String.join(
+                System.lineSeparator(),
                 super.toString(),
                 "\tExpected: "
                         + expected.size()

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation project(':javacutil')
     implementation project(':checker-qual')
+    implementation 'org.plumelib:plume-util:1.1.5'
 }
 
 shadowJar {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/UnderlyingAST.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/UnderlyingAST.java
@@ -4,7 +4,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Represents an abstract syntax tree of type {@link Tree} that underlies a given control flow
@@ -68,7 +68,7 @@ public abstract class UnderlyingAST {
 
         @Override
         public String toString() {
-            return SystemUtil.joinLines("CFGMethod(", method, ")");
+            return UtilPlume.joinLines("CFGMethod(", method, ")");
         }
     }
 
@@ -132,7 +132,7 @@ public abstract class UnderlyingAST {
 
         @Override
         public String toString() {
-            return SystemUtil.joinLines("CFGLambda(", lambda, ")");
+            return UtilPlume.joinLines("CFGLambda(", lambda, ")");
         }
     }
 
@@ -161,7 +161,7 @@ public abstract class UnderlyingAST {
 
         @Override
         public String toString() {
-            return SystemUtil.joinLines("CFGStatement(", code, ")");
+            return UtilPlume.joinLines("CFGStatement(", code, ")");
         }
     }
 }

--- a/docs/developer/release/maven-artifacts/dataflow-pom.xml
+++ b/docs/developer/release/maven-artifacts/dataflow-pom.xml
@@ -20,6 +20,13 @@
             <version>${checkerframeworkversion}</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.plumelib</groupId>
+            <artifactId>plume-util</artifactId>
+            <!-- Keep version number in sync with ../../../../dataflow/build.gradle . -->
+            <version>1.1.5</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <name>Dataflow</name>

--- a/docs/developer/release/maven-artifacts/framework-test-pom.xml
+++ b/docs/developer/release/maven-artifacts/framework-test-pom.xml
@@ -21,6 +21,13 @@
             <version>4.13</version>
             <type>jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.plumelib</groupId>
+            <artifactId>plume-util</artifactId>
+            <!-- Keep version number in sync with ../../../../framework-test/build.gradle . -->
+            <version>1.1.5</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
 
     <name>Checker Framework Testing Library</name>

--- a/framework-test/build.gradle
+++ b/framework-test/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation project(':javacutil')
     implementation project(':checker-qual')
 
+    implementation 'org.plumelib:plume-util:1.1.5'
+
     if (Jvm.current().toolsJar) {
         tagletImplementation files(Jvm.current().toolsJar)
     }

--- a/framework-test/src/main/java/org/checkerframework/framework/test/ImmutableTestConfiguration.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/ImmutableTestConfiguration.java
@@ -7,7 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Represents all of the information needed to execute the Javac compiler for a given set of test
@@ -91,11 +91,11 @@ public class ImmutableTestConfiguration implements TestConfiguration {
 
     @Override
     public String toString() {
-        return SystemUtil.joinLines(
+        return UtilPlume.joinLines(
                 "TestConfigurationBuilder:",
-                "testSourceFiles=" + SystemUtil.join(" ", testSourceFiles),
-                "processors=" + SystemUtil.join(", ", processors),
-                "options=" + SystemUtil.join(", ", getFlatOptions()),
+                "testSourceFiles=" + UtilPlume.join(" ", testSourceFiles),
+                "processors=" + String.join(", ", processors),
+                "options=" + String.join(", ", getFlatOptions()),
                 "shouldEmitDebugInfo=" + shouldEmitDebugInfo);
     }
 }

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestConfigurationBuilder.java
@@ -14,6 +14,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Used to create an instance of TestConfiguration, TestConfigurationBuilder follows the standard
@@ -410,11 +411,11 @@ public class TestConfigurationBuilder {
 
     @Override
     public String toString() {
-        return SystemUtil.joinLines(
+        return UtilPlume.joinLines(
                 "TestConfigurationBuilder:",
-                "testSourceFiles=" + SystemUtil.join(" ", testSourceFiles),
-                "processors=" + SystemUtil.join(", ", processors),
-                "options=" + SystemUtil.join(", ", options.getOptionsAsList()),
+                "testSourceFiles=" + UtilPlume.join(" ", testSourceFiles),
+                "processors=" + String.join(", ", processors),
+                "options=" + String.join(", ", options.getOptionsAsList()),
                 "shouldEmitDebugInfo=" + shouldEmitDebugInfo);
     }
 

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
@@ -25,6 +25,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.javacutil.SystemUtil;
 import org.junit.Assert;
+import org.plumelib.util.UtilPlume;
 
 public class TestUtilities {
 
@@ -330,19 +331,19 @@ public class TestUtilities {
             pw.println("#Missing: " + missing.size() + "      #Unexpected: " + unexpected.size());
 
             pw.println("Expected:");
-            pw.println(SystemUtil.joinLines(expected));
+            pw.println(UtilPlume.joinLines(expected));
             pw.println();
 
             pw.println("Actual:");
-            pw.println(SystemUtil.joinLines(actual));
+            pw.println(UtilPlume.joinLines(actual));
             pw.println();
 
             pw.println("Missing:");
-            pw.println(SystemUtil.joinLines(missing));
+            pw.println(UtilPlume.joinLines(missing));
             pw.println();
 
             pw.println("Unexpected:");
-            pw.println(SystemUtil.joinLines(unexpected));
+            pw.println(UtilPlume.joinLines(unexpected));
             pw.println();
 
             pw.println();

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
@@ -27,6 +27,7 @@ import org.checkerframework.javacutil.SystemUtil;
 import org.junit.Assert;
 import org.plumelib.util.UtilPlume;
 
+/** Utilities for testing. */
 public class TestUtilities {
 
     public static final boolean IS_AT_LEAST_9_JVM;

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
@@ -12,6 +12,7 @@ import javax.tools.ToolProvider;
 import org.checkerframework.framework.test.diagnostics.JavaDiagnosticReader;
 import org.checkerframework.framework.test.diagnostics.TestDiagnostic;
 import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /** Used by the Checker Framework test suite to run the framework and generate a test result. */
 public class TypecheckExecutor {
@@ -82,7 +83,7 @@ public class TypecheckExecutor {
                     "javac "
                             + String.join(" ", options)
                             + " "
-                            + SystemUtil.join(" ", configuration.getTestSourceFiles()));
+                            + UtilPlume.join(" ", configuration.getTestSourceFiles()));
         }
 
         JavaCompiler.CompilationTask task =

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckResult.java
@@ -9,7 +9,7 @@ import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import org.checkerframework.framework.test.diagnostics.TestDiagnostic;
 import org.checkerframework.framework.test.diagnostics.TestDiagnosticUtils;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Represents the test results from typechecking one or more java files using the given
@@ -106,7 +106,7 @@ public class TypecheckResult {
     public String summarize() {
         if (testFailed) {
             StringJoiner summaryBuilder = new StringJoiner(System.lineSeparator());
-            summaryBuilder.add(SystemUtil.joinLines(getErrorHeaders()));
+            summaryBuilder.add(UtilPlume.joinLines(getErrorHeaders()));
 
             if (!unexpectedDiagnostics.isEmpty()) {
                 summaryBuilder.add(

--- a/framework/src/main/java/org/checkerframework/common/util/TypeVisualizer.java
+++ b/framework/src/main/java/org/checkerframework/common/util/TypeVisualizer.java
@@ -30,7 +30,7 @@ import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
 import org.checkerframework.framework.util.DefaultAnnotationFormatter;
 import org.checkerframework.framework.util.ExecUtil;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * TypeVisualizer prints AnnotatedTypeMirrors as a directed graph where each node is a type and an
@@ -603,13 +603,13 @@ public class TypeVisualizer {
                 builder.append(methodElem.getReturnType().toString());
                 builder.append(" <");
 
-                builder.append(SystemUtil.join(", ", methodElem.getTypeParameters()));
+                builder.append(UtilPlume.join(", ", methodElem.getTypeParameters()));
                 builder.append("> ");
 
                 builder.append(methodElem.getSimpleName().toString());
 
                 builder.append("(");
-                builder.append(SystemUtil.join(",", methodElem.getParameters()));
+                builder.append(UtilPlume.join(",", methodElem.getParameters()));
                 builder.append(")");
                 return builder.toString();
             }

--- a/framework/src/main/java/org/checkerframework/common/value/RangeOrListOfValues.java
+++ b/framework/src/main/java/org/checkerframework/common/value/RangeOrListOfValues.java
@@ -8,7 +8,7 @@ import org.checkerframework.common.value.qual.ArrayLenRange;
 import org.checkerframework.common.value.qual.IntVal;
 import org.checkerframework.common.value.util.Range;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * An abstraction that can be either a range or a list of values that could come from an {@link
@@ -120,7 +120,7 @@ class RangeOrListOfValues {
                 return "[]";
             }
             String res = "[";
-            res += SystemUtil.join(", ", values);
+            res += UtilPlume.join(", ", values);
             res += "]";
             return res;
         }

--- a/framework/src/main/java/org/checkerframework/common/value/ReflectiveEvaluator.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ReflectiveEvaluator.java
@@ -21,9 +21,9 @@ import org.checkerframework.checker.signature.qual.ClassGetName;
 import org.checkerframework.checker.signature.qual.DotSeparatedIdentifiers;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Evaluates expressions (such as method calls and field accesses) at compile time, to determine
@@ -117,7 +117,7 @@ public class ReflectiveEvaluator {
                     return null;
                 } catch (IllegalArgumentException e) {
                     if (reportWarnings) {
-                        String args = SystemUtil.join(", ", arguments);
+                        String args = UtilPlume.join(", ", arguments);
                         checker.reportWarning(
                                 tree,
                                 "method.evaluation.exception",
@@ -329,7 +329,7 @@ public class ReflectiveEvaluator {
                             tree,
                             "constructor.evaluation.failed",
                             typeToCreate,
-                            SystemUtil.join(", ", arguments));
+                            UtilPlume.join(", ", arguments));
                 }
                 return null;
             }

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractValue.java
@@ -21,8 +21,8 @@ import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.DefaultAnnotationFormatter;
 import org.checkerframework.javacutil.AnnotationUtils;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * An implementation of an abstract value used by the Checker Framework
@@ -80,7 +80,7 @@ public abstract class CFAbstractValue<V extends CFAbstractValue<V>> implements A
                 : "Encountered invalid type: "
                         + underlyingType
                         + " annotations: "
-                        + SystemUtil.join(", ", annotations);
+                        + UtilPlume.join(", ", annotations);
     }
 
     public static boolean validateSet(

--- a/framework/src/main/java/org/checkerframework/framework/stub/ToIndexFileConverter.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/ToIndexFileConverter.java
@@ -56,7 +56,6 @@ import org.checkerframework.checker.signature.qual.ClassGetName;
 import org.checkerframework.checker.signature.qual.DotSeparatedIdentifiers;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
 import org.plumelib.reflection.Signatures;
 import scenelib.annotations.Annotation;
 import scenelib.annotations.el.AClass;
@@ -561,7 +560,7 @@ public class ToIndexFileConverter extends GenericVisitorAdapter<Void, AElement> 
                             // could be defined in the same stub file
                             return "L" + typeName + ";";
                         }
-                        return "L" + SystemUtil.join("/", name.split("\\.")) + ";";
+                        return "L" + String.join("/", name.split("\\.")) + ";";
                     }
 
                     @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -33,9 +33,9 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcard
 import org.checkerframework.framework.type.visitor.AnnotatedTypeVisitor;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * BoundsInitializer creates AnnotatedTypeMirrors (without annotations) for the bounds of type
@@ -905,7 +905,7 @@ public class BoundsInitializer {
 
         @Override
         public String toString() {
-            return SystemUtil.join(",", this);
+            return UtilPlume.join(",", this);
         }
 
         /**
@@ -1370,7 +1370,7 @@ public class BoundsInitializer {
             List<AnnotatedTypeMirror> typeArgs = new ArrayList<>(parentAdt.getTypeArguments());
             if (argIndex >= typeArgs.size()) {
                 throw new BugInCF(
-                        SystemUtil.joinLines(
+                        UtilPlume.joinLines(
                                 "Invalid type arg index.",
                                 "parent=" + parent,
                                 "replacement=" + replacement,
@@ -1388,7 +1388,7 @@ public class BoundsInitializer {
             List<AnnotatedTypeMirror> typeArgs = parentAdt.getTypeArguments();
             if (argIndex >= typeArgs.size()) {
                 throw new BugInCF(
-                        SystemUtil.joinLines(
+                        UtilPlume.joinLines(
                                 "Invalid type arg index.",
                                 "parent=" + parent,
                                 "argIndex=" + argIndex));

--- a/framework/src/main/java/org/checkerframework/framework/type/EqualityAtmComparer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/EqualityAtmComparer.java
@@ -3,7 +3,7 @@ package org.checkerframework.framework.type;
 import org.checkerframework.checker.interning.qual.EqualsMethod;
 import org.checkerframework.framework.type.visitor.EquivalentAtmComboScanner;
 import org.checkerframework.javacutil.AnnotationUtils;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Compares two annotated type mirrors for structural equality using only the primary annotations
@@ -29,7 +29,7 @@ public class EqualityAtmComparer extends EquivalentAtmComboScanner<Boolean, Void
     protected String defaultErrorMessage(
             AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, Void v) {
         throw new UnsupportedOperationException(
-                SystemUtil.joinLines(
+                UtilPlume.joinLines(
                         "Comparing two different subclasses of AnnotatedTypeMirror.",
                         "type1=" + type1,
                         "type2=" + type2));

--- a/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityComparer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityComparer.java
@@ -18,8 +18,8 @@ import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AtmCombo;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * A visitor used to compare two type mirrors for "structural" equality. Structural equality implies
@@ -77,7 +77,7 @@ public class StructuralEqualityComparer extends AbstractAtmComboVisitor<Boolean,
     @Override
     protected String defaultErrorMessage(
             AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, Void p) {
-        return SystemUtil.joinLines(
+        return UtilPlume.joinLines(
                 "AnnotatedTypeMirrors aren't structurally equal.",
                 "  type1 = " + type1.getClass().getSimpleName() + "( " + type1 + " )",
                 "  type2 = " + type2.getClass().getSimpleName() + "( " + type2 + " )",
@@ -147,9 +147,9 @@ public class StructuralEqualityComparer extends AbstractAtmComboVisitor<Boolean,
         if (types1.size() != types2.size()) {
             throw new BugInCF(
                     "Mismatching collection sizes:%n    types 1: %s (%d)%n    types 2: %s (%d)",
-                    SystemUtil.join("; ", types1),
+                    UtilPlume.join("; ", types1),
                     types1.size(),
-                    SystemUtil.join("; ", types2),
+                    UtilPlume.join("; ", types2),
                     types2.size());
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
@@ -22,7 +22,7 @@ import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.typeannotator.DefaultForTypeAnnotator;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Adds annotations to a type based on the contents of a tree. This class applies annotations
@@ -253,7 +253,7 @@ public class LiteralTreeAnnotator extends TreeAnnotator {
                             matchesOnePerLine += System.lineSeparator() + "     " + match;
                         }
                         throw new BugInCF(
-                                SystemUtil.joinLines(
+                                UtilPlume.joinLines(
                                         "Bug in @QualifierForLiterals(stringpatterns=...) in type hierarchy definition:",
                                         " the glb of `matches` for \"" + string + "\" is " + res,
                                         " which is a subtype of " + sam,

--- a/framework/src/main/java/org/checkerframework/framework/type/typeannotator/PropagationTypeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/typeannotator/PropagationTypeAnnotator.java
@@ -14,8 +14,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclared
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * {@link PropagationTypeAnnotator} adds qualifiers to types where the qualifier to add should be
@@ -163,7 +163,7 @@ public class PropagationTypeAnnotator extends TypeAnnotator {
                 final AnnotationMirror typeParamAnno = typeParamBound.getAnnotationInHierarchy(top);
                 if (typeParamAnno == null) {
                     throw new BugInCF(
-                            SystemUtil.joinLines(
+                            UtilPlume.joinLines(
                                     "Missing annotation on type parameter",
                                     "top=" + top,
                                     "wildcardBound=" + wildcardBound,

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -49,8 +49,8 @@ import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Utility methods for operating on {@code AnnotatedTypeMirror}. This class mimics the class {@link
@@ -527,7 +527,7 @@ public class AnnotatedTypes {
         for (final AnnotatedTypeMirror typeParam : enclosingType.getTypeArguments()) {
             if (typeParam.getKind() != TypeKind.TYPEVAR) {
                 throw new BugInCF(
-                        SystemUtil.joinLines(
+                        UtilPlume.joinLines(
                                 "Type arguments of a declaration should be type variables",
                                 "enclosingClassOfElem=" + enclosingClassOfElem,
                                 "enclosingType=" + enclosingType,
@@ -539,7 +539,7 @@ public class AnnotatedTypes {
         List<AnnotatedTypeMirror> baseParams = base.getTypeArguments();
         if (ownerParams.size() != baseParams.size() && !base.wasRaw()) {
             throw new BugInCF(
-                    SystemUtil.joinLines(
+                    UtilPlume.joinLines(
                             "Unexpected number of parameters.",
                             "enclosingType=" + enclosingType,
                             "baseType=" + base));
@@ -1219,7 +1219,7 @@ public class AnnotatedTypes {
                     }
 
                     throw new BugInCF(
-                            SystemUtil.joinLines(
+                            UtilPlume.joinLines(
                                     "Unexpected AnnotatedTypeMirror with no primary annotation.",
                                     "toSearch=" + toSearch,
                                     "top=" + top,

--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -401,7 +401,7 @@ public class CheckerMain {
         args.add(java);
 
         if (SystemUtil.getJreVersion() == 8) {
-            args.add("-Xbootclasspath/p:" + SystemUtil.join(File.pathSeparator, runtimeClasspath));
+            args.add("-Xbootclasspath/p:" + String.join(File.pathSeparator, runtimeClasspath));
         } else {
             args.addAll(
                     Arrays.asList(
@@ -781,7 +781,7 @@ public class CheckerMain {
                     // Forward slash is used instead of File.separator because checker.jar uses / as
                     // the separator.
                     checkerClassNames.add(
-                            SystemUtil.join(
+                            String.join(
                                     ".",
                                     name.substring(0, name.length() - ".class".length())
                                             .split("/")));
@@ -837,7 +837,7 @@ public class CheckerMain {
             }
         }
 
-        return SystemUtil.join(",", processors);
+        return String.join(",", processors);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/DefaultSet.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/DefaultSet.java
@@ -1,7 +1,7 @@
 package org.checkerframework.framework.util.defaults;
 
 import java.util.TreeSet;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * An ordered set of Defaults (see {@link org.checkerframework.framework.util.defaults.Default}).
@@ -17,7 +17,7 @@ class DefaultSet extends TreeSet<Default> {
 
     @Override
     public String toString() {
-        return "DefaultSet( " + SystemUtil.join(", ", this) + " )";
+        return "DefaultSet( " + UtilPlume.join(", ", this) + " )";
     }
 
     public static final DefaultSet EMPTY = new DefaultSet();

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -47,9 +47,9 @@ import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.CollectionUtils;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Determines the default qualifiers on a type. Default qualifiers are specified via the {@link
@@ -186,11 +186,11 @@ public class QualifierDefaults {
     @Override
     public String toString() {
         // displays the checked and unchecked code defaults
-        return SystemUtil.joinLines(
+        return UtilPlume.joinLines(
                 "Checked code defaults: ",
-                SystemUtil.joinLines(checkedCodeDefaults),
+                UtilPlume.joinLines(checkedCodeDefaults),
                 "Unchecked code defaults: ",
-                SystemUtil.joinLines(uncheckedCodeDefaults),
+                UtilPlume.joinLines(uncheckedCodeDefaults),
                 "useConservativeDefaultsSource: " + useConservativeDefaultsSource,
                 "useConservativeDefaultsBytecode: " + useConservativeDefaultsBytecode);
     }
@@ -1168,7 +1168,7 @@ public class QualifierDefaults {
                 }
             } else {
                 throw new BugInCF(
-                        SystemUtil.joinLines(
+                        UtilPlume.joinLines(
                                 "Unexpected tree type for typeVar Element:",
                                 "typeParamElem=" + typeParamElem,
                                 typeParamDecl));

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -53,8 +53,8 @@ import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TreeUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * A class that helps checkers use qualifiers that are represented by annotations with Java
@@ -752,7 +752,7 @@ public class DependentTypesHelper {
             return;
         }
         SourceChecker checker = factory.getContext().getChecker();
-        String error = SystemUtil.joinLines(errors);
+        String error = UtilPlume.joinLines(errors);
         checker.reportError(errorTree, "flowexpr.parse.error", error);
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/ElementAnnotationUtil.java
@@ -32,8 +32,8 @@ import org.checkerframework.framework.type.ElementAnnotationApplier;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationUtils;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Utility methods for adding the annotations that are stored in an Element to the type that
@@ -61,10 +61,10 @@ public class ElementAnnotationUtil {
             throw new BugInCF(
                     "Number of types and elements don't match. "
                             + "types ( "
-                            + SystemUtil.join(", ", types)
+                            + UtilPlume.join(", ", types)
                             + " ) "
                             + "element ( "
-                            + SystemUtil.join(", ", elements)
+                            + UtilPlume.join(", ", elements)
                             + " ) ");
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/MethodApplier.java
@@ -17,7 +17,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVari
 import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Adds annotations from element to the return type, formal parameter types, type parameters, and
@@ -167,7 +167,7 @@ public class MethodApplier extends TargetedElementAnnotationApplier {
         if (!unmatched.isEmpty()) {
             throw new BugInCF(
                     "Unexpected annotations ( "
-                            + SystemUtil.join(",", unmatched)
+                            + UtilPlume.join(",", unmatched)
                             + " ) for"
                             + "type ( "
                             + type

--- a/framework/src/main/java/org/checkerframework/framework/util/element/TargetedElementAnnotationApplier.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/element/TargetedElementAnnotationApplier.java
@@ -13,7 +13,7 @@ import javax.lang.model.type.TypeKind;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.element.ElementAnnotationUtil.UnexpectedAnnotationLocationException;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * TargetedElementAnnotationApplier filters annotations for an element into 3 groups. TARGETED
@@ -141,8 +141,8 @@ abstract class TargetedElementAnnotationApplier {
                 remainingInfo.add(r.toString() + " (" + r.position + ")");
             }
             msg.add(remainingInfo.toString());
-            msg.add("Targeted annotations: " + SystemUtil.join(", ", annotatedTargets()));
-            msg.add("Valid annotations: " + SystemUtil.join(", ", validTargets()));
+            msg.add("Targeted annotations: " + UtilPlume.join(", ", annotatedTargets()));
+            msg.add("Valid annotations: " + UtilPlume.join(", ", validTargets()));
 
             throw new BugInCF(msg.toString());
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/DefaultTypeArgumentInference.java
@@ -52,10 +52,10 @@ import org.checkerframework.framework.util.typeinference.solver.SubtypesSolver;
 import org.checkerframework.framework.util.typeinference.solver.SupertypesSolver;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * An implementation of TypeArgumentInference that mostly follows the process outlined in JLS7 See
@@ -492,10 +492,10 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
 
         if (argTypes.size() != paramTypes.size()) {
             throw new BugInCF(
-                    SystemUtil.joinLines(
+                    UtilPlume.joinLines(
                             "Mismatch between formal parameter count and argument count.",
-                            "paramTypes=" + SystemUtil.join(",", paramTypes),
-                            "argTypes=" + SystemUtil.join(",", argTypes)));
+                            "paramTypes=" + UtilPlume.join(",", paramTypes),
+                            "argTypes=" + UtilPlume.join(",", argTypes)));
         }
 
         final int numberOfParams = paramTypes.size();
@@ -810,10 +810,10 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
         for (final AFConstraint afConstraint : afConstraints) {
             if (!afConstraint.isIrreducible(targets)) {
                 throw new BugInCF(
-                        SystemUtil.joinLines(
+                        UtilPlume.joinLines(
                                 "All afConstraints should be irreducible before conversion.",
-                                "afConstraints=[ " + SystemUtil.join(", ", afConstraints) + " ]",
-                                "targets=[ " + SystemUtil.join(", ", targets) + "]"));
+                                "afConstraints=[ " + UtilPlume.join(", ", afConstraints) + " ]",
+                                "targets=[ " + UtilPlume.join(", ", targets) + "]"));
             }
 
             outgoing.add(afConstraint.toTUConstraint());

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/constraint/AFReducingVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/constraint/AFReducingVisitor.java
@@ -17,8 +17,8 @@ import org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.typeinference.TypeArgInferenceUtil;
 import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.SystemUtil;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.UtilPlume;
 
 /**
  * Takes a single step in reducing a AFConstraint.
@@ -93,12 +93,12 @@ abstract class AFReducingVisitor extends AbstractAtmComboVisitor<Void, Set<AFCon
             AnnotatedTypeMirror subtype,
             AnnotatedTypeMirror supertype,
             Set<AFConstraint> constraints) {
-        return SystemUtil.joinLines(
+        return UtilPlume.joinLines(
                 "Unexpected " + reducerType.getSimpleName() + " + Combination:",
                 "subtype=" + subtype,
                 "supertype=" + supertype,
                 "constraints=[",
-                SystemUtil.join(", ", constraints),
+                UtilPlume.join(", ", constraints),
                 "]");
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/constraint/FIsAReducer.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/constraint/FIsAReducer.java
@@ -15,7 +15,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedUnionTyp
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.visitor.AbstractAtmComboVisitor;
 import org.checkerframework.framework.util.AnnotatedTypes;
-import org.checkerframework.javacutil.SystemUtil;
+import org.plumelib.util.UtilPlume;
 
 /**
  * FIsAReducer takes an FIsA constraint that is not irreducible (@see AFConstraint.isIrreducible)
@@ -76,12 +76,12 @@ public class FIsAReducer implements AFReducer {
                 AnnotatedTypeMirror argument,
                 AnnotatedTypeMirror parameter,
                 Set<AFConstraint> afConstraints) {
-            return SystemUtil.joinLines(
+            return UtilPlume.joinLines(
                     "Unexpected FIsA Combination:",
                     "argument=" + argument,
                     "parameter=" + parameter,
                     "constraints=[",
-                    SystemUtil.join(", ", afConstraints),
+                    UtilPlume.join(", ", afConstraints),
                     "]");
         }
         // ------------------------------------------------------------------------

--- a/javacutil/src/main/java/org/checkerframework/javacutil/SystemUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/SystemUtil.java
@@ -50,8 +50,10 @@ public class SystemUtil {
      * @param delimiter the delimiter that separates each element
      * @param objs the values whose string representations to join together
      * @return a new string that concatenates the string representations of the elements
+     * @deprecated use {@link UtilPlume.join}
      */
-    public static <T> String join(CharSequence delimiter, T @Nullable [] objs) {
+    @Deprecated // use UtilPlume.join
+    public static <T> String join(CharSequence delimiter, T[] objs) {
         if (objs == null) {
             return "null";
         }
@@ -65,8 +67,10 @@ public class SystemUtil {
      * @param delimiter the delimiter that separates each element
      * @param values the values whose string representations to join together
      * @return a new string that concatenates the string representations of the elements
+     * @deprecated use {@link UtilPlume.join}
      */
-    public static String join(CharSequence delimiter, @Nullable Iterable<?> values) {
+    @Deprecated // use UtilPlume.join
+    public static String join(CharSequence delimiter, Iterable<?> values) {
         if (values == null) {
             return "null";
         }
@@ -80,10 +84,12 @@ public class SystemUtil {
      * @param <T> the type of array elements
      * @param a array of values to concatenate
      * @return the concatenation of the string representations of the values, each on its own line
+     * @deprecated use {@link UtilPlume.joinLines}
      */
+    @Deprecated // use UtilPlume.joinLines
     @SafeVarargs
     @SuppressWarnings("varargs")
-    public static <T> String joinLines(T @Nullable ... a) {
+    public static <T> String joinLines(T... a) {
         return join(LINE_SEPARATOR, a);
     }
 
@@ -93,8 +99,10 @@ public class SystemUtil {
      *
      * @param v list of values to concatenate
      * @return the concatenation of the string representations of the values, each on its own line
+     * @deprecated use {@link UtilPlume.joinLines}
      */
-    public static String joinLines(@Nullable Iterable<? extends Object> v) {
+    @Deprecated // use UtilPlume.joinLines
+    public static String joinLines(Iterable<? extends Object> v) {
         return join(LINE_SEPARATOR, v);
     }
 
@@ -238,6 +246,25 @@ public class SystemUtil {
         @SuppressWarnings("nullness") // elements are not non-null yet, but will be by return stmt
         T[] result = Arrays.copyOf(array1, array1.length + array2.length);
         System.arraycopy(array2, 0, result, array1.length, array2.length);
+        return result;
+    }
+
+    /**
+     * Concatenates an element, an array, and an element.
+     *
+     * @param <T> the type of the array elements
+     * @param firstElt the first element
+     * @param array the array
+     * @param lastElt the last elemeent
+     * @return a new array containing first element, the array, and the last element, in that order
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] concatenate(T firstElt, T[] array, T lastElt) {
+        @SuppressWarnings("nullness") // elements are not non-null yet, but will be by return stmt
+        T[] result = Arrays.copyOf(array, array.length + 2);
+        result[0] = firstElt;
+        System.arraycopy(array, 0, result, 1, array.length);
+        result[result.length - 1] = lastElt;
         return result;
     }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/SystemUtil.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/SystemUtil.java
@@ -50,7 +50,7 @@ public class SystemUtil {
      * @param delimiter the delimiter that separates each element
      * @param objs the values whose string representations to join together
      * @return a new string that concatenates the string representations of the elements
-     * @deprecated use {@link UtilPlume.join}
+     * @deprecated use {@code UtilPlume.join}
      */
     @Deprecated // use UtilPlume.join
     public static <T> String join(CharSequence delimiter, T[] objs) {
@@ -67,7 +67,7 @@ public class SystemUtil {
      * @param delimiter the delimiter that separates each element
      * @param values the values whose string representations to join together
      * @return a new string that concatenates the string representations of the elements
-     * @deprecated use {@link UtilPlume.join}
+     * @deprecated use {@code UtilPlume.join}
      */
     @Deprecated // use UtilPlume.join
     public static String join(CharSequence delimiter, Iterable<?> values) {
@@ -84,7 +84,7 @@ public class SystemUtil {
      * @param <T> the type of array elements
      * @param a array of values to concatenate
      * @return the concatenation of the string representations of the values, each on its own line
-     * @deprecated use {@link UtilPlume.joinLines}
+     * @deprecated use {@code UtilPlume.joinLines}
      */
     @Deprecated // use UtilPlume.joinLines
     @SafeVarargs
@@ -99,7 +99,7 @@ public class SystemUtil {
      *
      * @param v list of values to concatenate
      * @return the concatenation of the string representations of the values, each on its own line
-     * @deprecated use {@link UtilPlume.joinLines}
+     * @deprecated use {@code UtilPlume.joinLines}
      */
     @Deprecated // use UtilPlume.joinLines
     public static String joinLines(Iterable<? extends Object> v) {


### PR DESCRIPTION
System.join's added functionality over UtilPlume.join (handling null arguments) is never used.

More generally, it is a goal to use libraries rather than re-inventing them:
JDK > Guava > plume-lib > local re-implementations

Merge with https://github.com/typetools/checker-framework-inference/pull/167