### PR TITLE
Correct GenericAnnotatedTypeFactory#getStoreAfter(Node)

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1019,6 +1019,9 @@ public abstract class GenericAnnotatedTypeFactory<
      * @return the store immediately after a given {@link Node}
      */
     public Store getStoreAfter(Node node) {
+        if (!analysis.isRunning()) {
+            return flowResult.getStoreAfter(node);
+        }
         Store res =
                 AnalysisResult.runAnalysisFor(
                         node,

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1016,6 +1016,7 @@ public abstract class GenericAnnotatedTypeFactory<
     /**
      * Returns the store immediately after a given {@link Node}.
      *
+     * @param node node after which the store is returned
      * @return the store immediately after a given {@link Node}
      */
     public Store getStoreAfter(Node node) {


### PR DESCRIPTION
Make the implementation of `GenericAnnotatedTypeFactory#getStoreAfter(Node)` match the implementations of `#getStoreAfter(Tree)`, `#getStoreBefore(Node)`, and `#getStoreBefore(Tree)`.

The Checker Framework doesn't have any calls to `#getStoreAfter(Node)`, so there isn't an easy way to add a test case for this.

@msridhar I think this fixes #3566.  (Or at least with this fix, the RuntimeException in  "repro-store-bug" is not hit...). Can you confirm that this fixes the whole issue?  

