### PR TITLE
Rename debugToString to toStringDebug

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/FlowExpressions.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/FlowExpressions.java
@@ -549,7 +549,7 @@ public class FlowExpressions {
          *
          * @return a verbose printed representation of this
          */
-        public String debugToString() {
+        public String toStringDebug() {
             return String.format(
                     "Receiver (%s) %s type=%s", getClass().getSimpleName(), toString(), type);
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -1006,8 +1006,8 @@ public class FlowExpressionParseUtil {
          *
          * @return a verbose printed representation of this
          */
-        public String debugToString() {
-            return debugToString(4);
+        public String toStringDebug() {
+            return toStringDebug(4);
         }
 
         /**
@@ -1016,12 +1016,12 @@ public class FlowExpressionParseUtil {
          *
          * @return a verbose printed representation of this
          */
-        public String debugToString(int indent) {
+        public String toStringDebug(int indent) {
             String indentString = String.join("", Collections.nCopies(indent, " "));
             StringJoiner sj = new StringJoiner(indentString, indentString, "");
-            sj.add(String.format("receiver=%s%n", receiver.debugToString()));
+            sj.add(String.format("receiver=%s%n", receiver.toStringDebug()));
             sj.add(String.format("arguments=%s%n", arguments));
-            sj.add(String.format("outerReceiver=%s%n", outerReceiver.debugToString()));
+            sj.add(String.format("outerReceiver=%s%n", outerReceiver.toStringDebug()));
             sj.add(String.format("checkerContext=%s%n", "..."));
             // sj.add(String.format("checkerContext=%s%n", checkerContext));
             sj.add(String.format("parsingMember=%s%n", parsingMember));

--- a/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/FlowExpressionParseUtil.java
@@ -1014,7 +1014,8 @@ public class FlowExpressionParseUtil {
          * Format this object verbosely, with each line indented by the given number of spaces but
          * without a trailing newline.
          *
-         * @return a verbose printed representation of this
+         * @param indent the number of spaces to indent the string representation of this
+         * @return a verbose string representation of this
          */
         public String toStringDebug(int indent) {
             String indentString = String.join("", Collections.nCopies(indent, " "));


### PR DESCRIPTION
"debugToString" makes it sound (to me, at least) like a conversion is being performed between a "debug" and a "String".  Another benefit of the renaming is that "toStringDebug" puts the most important information -- "toString" -- first.