### PR TITLE
Don't err if directory is concurrently created by a different thread

### DIFF
--- a/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TestUtilities.java
@@ -8,6 +8,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -420,11 +423,18 @@ public class TestUtilities {
         }
     }
 
-    public static void ensureDirectoryExists(File path) {
-        if (!path.exists()) {
-            if (!path.mkdirs()) {
-                throw new RuntimeException("Could not make directory: " + path.getAbsolutePath());
-            }
+    /**
+     * Create the directory (and its parents) if it does not exist.
+     *
+     * @param dir the directory to create
+     */
+    public static void ensureDirectoryExists(String dir) {
+        try {
+            Files.createDirectories(Paths.get(dir));
+        } catch (FileAlreadyExistsException e) {
+            // directory already exists
+        } catch (IOException e) {
+            throw new RuntimeException("Could not make directory: " + dir + ": " + e.getMessage());
         }
     }
 

--- a/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/TypecheckExecutor.java
@@ -34,7 +34,7 @@ public class TypecheckExecutor {
         if (dOption == null) {
             throw new Error("-d not supplied");
         }
-        TestUtilities.ensureDirectoryExists(new File(dOption));
+        TestUtilities.ensureDirectoryExists(dOption);
 
         final StringWriter javacOutput = new StringWriter();
         DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();


### PR DESCRIPTION
This change may fix the following test failure: https://dev.azure.com/mernst22/checker-framework/_build/results?buildId=4940&view=logs&j=11811b1c-d14b-5529-93a4-5f2e1e50e37a&t=c6036049-c59d-531d-b0de-bbcb93026718&l=782