### PR TITLE
Make NodeWithExceptionsHolder deterministic

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1924,7 +1924,7 @@ public class CFGBuilder {
         protected NodeWithExceptionsHolder extendWithNodeWithExceptions(
                 Node node, Set<TypeMirror> causes) {
             addToLookupMap(node);
-            Map<TypeMirror, Set<Label>> exceptions = new HashMap<>();
+            Map<TypeMirror, Set<Label>> exceptions = new LinkedHashMap<>();
             for (TypeMirror cause : causes) {
                 exceptions.put(cause, tryStack.possibleLabels(cause));
             }
@@ -1960,7 +1960,7 @@ public class CFGBuilder {
         protected NodeWithExceptionsHolder insertNodeWithExceptionsAfter(
                 Node node, Set<TypeMirror> causes, Node pred) {
             addToLookupMap(node);
-            Map<TypeMirror, Set<Label>> exceptions = new HashMap<>();
+            Map<TypeMirror, Set<Label>> exceptions = new LinkedHashMap<>();
             for (TypeMirror cause : causes) {
                 exceptions.put(cause, tryStack.possibleLabels(cause));
             }


### PR DESCRIPTION
On [this](https://github.com/typetools/checker-framework/blob/3057728a41b1dc1d53eaa2ffeb1bb1e9ec303e57/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java#L1418) line, the `exceptions` field of the `NodeWithExceptionsHolder` class is iterated over to modify the `missingExceptionalEdges` variable, which should be deterministic.

This makes the collections used to initialize that field deterministic.