### PR TITLE
Change order of arguments to createCheckTypeTask

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -680,19 +680,19 @@ subprojects {
         // Add tasks to run various checkers on all the main source sets.
         // These pass and are run by nonJunitTests.
         createCheckTypeTask(project.name, 'Interning',
-	    'org.checkerframework.checker.interning.InterningChecker',
-	    ['-Astubs=javax-lang-model-element-name.astub'])
+            'org.checkerframework.checker.interning.InterningChecker',
+            ['-Astubs=javax-lang-model-element-name.astub'])
         createCheckTypeTask(project.name, 'NullnessOnlyAnnotatedFor',
-	    'org.checkerframework.checker.nullness.NullnessChecker',
-	    ['-AskipUses=com.sun.*', '-AuseConservativeDefaultsForUncheckedCode=source'])
+            'org.checkerframework.checker.nullness.NullnessChecker',
+            ['-AskipUses=com.sun.*', '-AuseConservativeDefaultsForUncheckedCode=source'])
         createCheckTypeTask(project.name, 'Purity',
-	    'org.checkerframework.framework.util.PurityChecker')
+            'org.checkerframework.framework.util.PurityChecker')
         createCheckTypeTask(project.name, 'Signature',
-	    'org.checkerframework.checker.signature.SignatureChecker')
+            'org.checkerframework.checker.signature.SignatureChecker')
         // These pass on some subprojects, which nonJunitTests runs.  TODO: Incrementally add @AnnotatedFor on classes.
         createCheckTypeTask(project.name, 'Nullness',
-	    'org.checkerframework.checker.nullness.NullnessChecker',
-	    ['-AskipUses=com.sun.*'])
+            'org.checkerframework.checker.nullness.NullnessChecker',
+            ['-AskipUses=com.sun.*'])
 
 
         // Add jtregTests to framework and checker modules

--- a/build.gradle
+++ b/build.gradle
@@ -691,7 +691,8 @@ subprojects {
 	    'org.checkerframework.checker.signature.SignatureChecker')
         // These pass on some subprojects, which nonJunitTests runs.  TODO: Incrementally add @AnnotatedFor on classes.
         createCheckTypeTask(project.name, 'Nullness',
-	    'org.checkerframework.checker.nullness.NullnessChecker', ['-AskipUses=com.sun.*'])
+	    'org.checkerframework.checker.nullness.NullnessChecker',
+	    ['-AskipUses=com.sun.*'])
 
 
         // Add jtregTests to framework and checker modules

--- a/build.gradle
+++ b/build.gradle
@@ -284,15 +284,16 @@ task version() {
 
 /**
  * Creates a task that runs the checker on the main source set of each subproject. The task is named
- * "check${shortName}", for example "checkPurity" or "checkNullness".
+ * "check${taskName}", for example "checkPurity" or "checkNullness".
+ *
  * @param projectName name of the project
- * @param checker full qualified name of the checker to run
- * @param shortName shorter version of the checker to use to name the task.
+ * @param taskName short name (often the checker name) to use as part of the task name
+ * @param checker fully qualified name of the checker to run
  * @param args list of arguments to pass to the checker
  */
-def createCheckTypeTask(projectName, checker, shortName, args = []) {
-    project("${projectName}").tasks.create(name: "check${shortName}", type: JavaCompile, dependsOn: ':checker:shadowJar') {
-        description "Run the ${shortName} Checker on the main sources."
+def createCheckTypeTask(projectName, taskName, checker, args = []) {
+    project("${projectName}").tasks.create(name: "check${taskName}", type: JavaCompile, dependsOn: ':checker:shadowJar') {
+        description "Run the ${taskName} Checker on the main sources."
         group 'Verification'
         // Always run the task.
         outputs.upToDateWhen { false }
@@ -678,12 +679,19 @@ subprojects {
 
         // Add tasks to run various checkers on all the main source sets.
         // These pass and are run by nonJunitTests.
-        createCheckTypeTask(project.name, 'org.checkerframework.checker.interning.InterningChecker', 'Interning', ['-Astubs=javax-lang-model-element-name.astub'])
-        createCheckTypeTask(project.name, 'org.checkerframework.checker.nullness.NullnessChecker', 'NullnessOnlyAnnotatedFor', ['-AskipUses=com.sun.*', '-AuseConservativeDefaultsForUncheckedCode=source'])
-        createCheckTypeTask(project.name, 'org.checkerframework.framework.util.PurityChecker', 'Purity')
-        createCheckTypeTask(project.name, 'org.checkerframework.checker.signature.SignatureChecker', 'Signature')
+        createCheckTypeTask(project.name, 'Interning',
+	    'org.checkerframework.checker.interning.InterningChecker',
+	    ['-Astubs=javax-lang-model-element-name.astub'])
+        createCheckTypeTask(project.name, 'NullnessOnlyAnnotatedFor',
+	    'org.checkerframework.checker.nullness.NullnessChecker',
+	    ['-AskipUses=com.sun.*', '-AuseConservativeDefaultsForUncheckedCode=source'])
+        createCheckTypeTask(project.name, 'Purity',
+	    'org.checkerframework.framework.util.PurityChecker')
+        createCheckTypeTask(project.name, 'Signature',
+	    'org.checkerframework.checker.signature.SignatureChecker')
         // These pass on some subprojects, which nonJunitTests runs.  TODO: Incrementally add @AnnotatedFor on classes.
-        createCheckTypeTask(project.name, 'org.checkerframework.checker.nullness.NullnessChecker', 'Nullness', ['-AskipUses=com.sun.*'])
+        createCheckTypeTask(project.name, 'Nullness',
+	    'org.checkerframework.checker.nullness.NullnessChecker', ['-AskipUses=com.sun.*'])
 
 
         // Add jtregTests to framework and checker modules

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -105,7 +105,8 @@ clean {
 }
 
 // Add non-junit tests
-createCheckTypeTask(project.name, 'org.checkerframework.checker.compilermsgs.CompilerMessagesChecker', "CompilerMessages")
+createCheckTypeTask(project.name,, "CompilerMessages",
+    'org.checkerframework.checker.compilermsgs.CompilerMessagesChecker')
 checkCompilerMessages {
     doFirst {
         options.compilerArgs += [

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -165,7 +165,8 @@ shadowJar {
     }
 }
 
-createCheckTypeTask(project.name, 'org.checkerframework.checker.compilermsgs.CompilerMessagesChecker', "CompilerMessages")
+createCheckTypeTask(project.name, "CompilerMessages",
+    'org.checkerframework.checker.compilermsgs.CompilerMessagesChecker')
 checkCompilerMessages {
     options.compilerArgs += [
             '-Apropfiles=' + sourceSets.main.resources.filter { file -> file.name.equals('messages.properties') }.asPath


### PR DESCRIPTION
This puts the easier-to-read short name first, and permits better line breaks at call sites.