### PR TITLE
Improve documentation about processorpath

### DIFF
--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -199,7 +199,7 @@ not throw exceptions (e.g., \<+>, \<->, \code{<}\code{<}, \<!=>).
 \subsectionAndLabel{\<@StaticallyExecutable> methods and the classpath}{constant-value-staticallyexecutable-annotation}
 
 The Constant Value Checker statically executes (at compile time) methods annotated with
-\refqualclass{common/value/qual}{StaticallyExecutable}..
+\refqualclass{common/value/qual}{StaticallyExecutable}.
 
 \begin{figure}
 \begin{Verbatim}
@@ -238,14 +238,15 @@ The static execution feature has some requirements:
 
 \item
   The \<@StaticallyExecutable> method and any method it calls must be on
-the classpath (or the processorpath, if you use it) for the compiler.  This
-is because the Constant Value Checker reflectively calls these methods at
-compile time.
+  the same path (the classpath or the processorpath) as the Checker
+  Framework.  This is because the Constant Value Checker reflectively calls
+  these methods at compile time.
 
 To use \<@StaticallyExecutable> on methods in your own code, you should
 first compile the code without the Constant Value Checker and then add
 the location of the resulting \code{.class} files to the
-classpath or processorpath. For example, the command-line arguments to the Checker Framework
+classpath or processorpath, whichever is appropriate. For example, the
+command-line arguments to the Checker Framework
 might include:
 \begin{Verbatim}
   -processor org.checkerframework.common.value.ValueChecker
@@ -275,7 +276,8 @@ Some examples of these:
 
   The checker could not find the class
   specified for resolving a \<@StaticallyExecutable> method. Typically
-  this means that the classpath (or the processorpath, if you use it) lacks the given classfile.
+  this means that the path that contains the Checker Framework (the
+  classpath or the processorpath) lacks the given classfile.
 
 \item \code{[method.find.failed] Failed to find a method named foo with argument types [@IntVal(3) int].}
 
@@ -372,8 +374,9 @@ concatenation are null.
 With the command-line argument, the type of ``\<x + "c">'' is
 \<@StringVal("ac", "bc") String>.
 
-%%  LocalWords:  UnknownVal StringValue BottomVal astub Astubs IntRange
+%%  LocalWords:  UnknownVal StringValue BottomVal astub Astubs IntRange bc
 %%  LocalWords:  StaticallyExecutable BoolVal IntVal DoubleVal StringVal
 %%  LocalWords:  classpath AreportEvalWarns ArrayLen ArrayLenRange casted
 %%  LocalWords:  qual AignoreRangeOverflow MinLen PolyValue GTENegativeOne
 %%  LocalWords:  staticallyexecutable concats AnonNullStringsConcatenation
+%%  LocalWords:  ClassVal MethodVal processorpath nullc

--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -192,21 +192,19 @@ Checker attempts to execute the expression.  This is independent of any
 optimizations performed by the compiler and does not affect the code that
 is generated.
 
-The Constant Value Checker statically executes operators that do
+The Constant Value Checker statically executes (at compile time) operators that do
 not throw exceptions (e.g., \<+>, \<->, \code{<}\code{<}, \<!=>).
 
 
 \subsectionAndLabel{\<@StaticallyExecutable> methods and the classpath}{constant-value-staticallyexecutable-annotation}
 
-The Constant Value Checker statically executes methods annotated with
-\refqualclass{common/value/qual}{StaticallyExecutable}, \emph{if the
-method has already been compiled and is on the classpath (or on the
-processorpath, if you use it)}.
+The Constant Value Checker statically executes (at compile time) methods annotated with
+\refqualclass{common/value/qual}{StaticallyExecutable}..
 
 \begin{figure}
 \begin{Verbatim}
 @StaticallyExecutable @Pure
-public int myAdd(int a, int b) {
+public static int myAdd(int a, int b) {
     return a + b;
 }
 
@@ -222,14 +220,28 @@ public void bar() {
 \label{fig-staticallyexecutable}
 \end{figure}
 
-A \<@StaticallyExecutable> method must
-be \refqualclass{dataflow/qual}{Pure} (side-effect-free and
-deterministic).
+The static execution feature has some requirements:
 
-Additionally, a \<@StaticallyExecutable> method and any method it calls must be on
+\begin{itemize}
+\item
+  A \<@StaticallyExecutable> method must be
+  \refqualclass{dataflow/qual}{Pure} (side-effect-free and deterministic).
+
+\item
+  The Constant Value Checker must have an estimate for all the arguments at
+  a call site.
+
+  This means that \<@StaticallyExecutable> is not applicable
+  to user-written instance methods.  It is only applicable to instance
+  methods whose receiver is a compile-time constant, such as a primitive
+  wrapper or an array.
+
+\item
+  The \<@StaticallyExecutable> method and any method it calls must be on
 the classpath (or the processorpath, if you use it) for the compiler.  This
 is because the Constant Value Checker reflectively calls these methods at
 compile time.
+
 To use \<@StaticallyExecutable> on methods in your own code, you should
 first compile the code without the Constant Value Checker and then add
 the location of the resulting \code{.class} files to the
@@ -244,6 +256,8 @@ or
   -processor org.checkerframework.common.value.ValueChecker
   -processorpath ${CHECKERFRAMEWORK}/checker/build/libs/checker-3.6.1-SNAPSHOT.jar:MY_PROJECT/build/
 \end{Verbatim}
+
+\end{itemize}
 
 
 \sectionAndLabel{Warnings}{value-checker-warnings}
@@ -273,7 +287,7 @@ Some examples of these:
 
 \item \code{[method.evaluation.exception] Failed to evaluate method public static int Test.foo(int) because it threw an exception: java.lang.ArithmeticException: / by zero.}
 
-  An exception was thrown when trying to statically execute the
+  An exception was thrown when trying to statically execute (at compile time) the
   method. In this case it was a divide-by-zero exception. If the
   arguments to the method each only had one value in their annotations
   then this exception will always occur when the program is actually

--- a/docs/manual/constant-value-checker.tex
+++ b/docs/manual/constant-value-checker.tex
@@ -200,7 +200,8 @@ not throw exceptions (e.g., \<+>, \<->, \code{<}\code{<}, \<!=>).
 
 The Constant Value Checker statically executes methods annotated with
 \refqualclass{common/value/qual}{StaticallyExecutable}, \emph{if the
-method has already been compiled and is on the classpath}.
+method has already been compiled and is on the classpath (or on the
+processorpath, if you use it)}.
 
 \begin{figure}
 \begin{Verbatim}
@@ -226,16 +227,22 @@ be \refqualclass{dataflow/qual}{Pure} (side-effect-free and
 deterministic).
 
 Additionally, a \<@StaticallyExecutable> method and any method it calls must be on
-the classpath for the compiler, because they are reflectively called at
-compile-time to perform the constant value analysis.
+the classpath (or the processorpath, if you use it) for the compiler.  This
+is because the Constant Value Checker reflectively calls these methods at
+compile time.
 To use \<@StaticallyExecutable> on methods in your own code, you should
 first compile the code without the Constant Value Checker and then add
 the location of the resulting \code{.class} files to the
-classpath. For example, the command-line arguments to the Checker Framework
+classpath or processorpath. For example, the command-line arguments to the Checker Framework
 might include:
 \begin{Verbatim}
   -processor org.checkerframework.common.value.ValueChecker
   -classpath $CLASSPATH:MY_PROJECT/build/
+\end{Verbatim}
+or
+\begin{Verbatim}
+  -processor org.checkerframework.common.value.ValueChecker
+  -processorpath ${CHECKERFRAMEWORK}/checker/build/libs/checker-3.6.1-SNAPSHOT.jar:MY_PROJECT/build/
 \end{Verbatim}
 
 
@@ -254,15 +261,14 @@ Some examples of these:
 
   The checker could not find the class
   specified for resolving a \<@StaticallyExecutable> method. Typically
-  this is caused by not providing the path of a class-file needed to
-  the classpath.
+  this means that the classpath (or the processorpath, if you use it) lacks the given classfile.
 
 \item \code{[method.find.failed] Failed to find a method named foo with argument types [@IntVal(3) int].}
 
   The checker could not find the method \code{foo(int)} specified for
   resolving a \<@StaticallyExecutable> method, but could find the
   class. This is usually due to providing an outdated version of the
-  class-file that does not contain the
+  classfile that does not contain the
   method that was annotated as \<@StaticallyExecutable>.
 
 \item \code{[method.evaluation.exception] Failed to evaluate method public static int Test.foo(int) because it threw an exception: java.lang.ArithmeticException: / by zero.}

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -224,7 +224,8 @@ subclass to the \<-processor> command-line option:
   javac -processor \textit{mypackage.MyPropChecker} SourceFile.java
 \end{alltt}
 Note that your custom checker's
-\<.class> files must be on the Java classpath or processorpath.
+\<.class> files must be on the same path (the classpath or processorpath)
+as the Checker Framework.
 Invoking a custom checker that builds on
 the Subtyping Checker is slightly different (Section~\ref{subtyping-using}).
 
@@ -2375,7 +2376,7 @@ without warnings or errors.
 % LocalWords:  QualifierHierarchy QualifierRoot createQualifierHierarchy util
 % LocalWords:  createTypeHierarchy ImplicitFor treeClasses TypeMirror Anno
 % LocalWords:  LiteralTree ExpressionTree typeClasses addComputedTypeAnnotations nullable
-% LocalWords:  createSupportedTypeQualifiers FooChecker nullness
+% LocalWords:  createSupportedTypeQualifiers FooChecker nullness KeyFor
 % LocalWords:  FooVisitor FooAnnotatedTypeFactory basicstyle InterningVisitor
 % LocalWords:  InterningAnnotatedTypeFactory QualifierDefaults TypeKind getKind
 % LocalWords:  setAbsoluteDefaults PolymorphicQualifier TreeVisitor subnodes
@@ -2411,7 +2412,7 @@ without warnings or errors.
 %%  LocalWords:  CheckerFrameworkTest GenericAnnotatedTypeFactory MyClass
 %%  LocalWords:  addCheckedCodeDefaults RelevantJavaTypes TargetLocations
 %%  LocalWords:  TypeUseLocation createExpressionAnnoHelper internalReprOf
-%%  LocalWords:  ExpressionAnnotationHelper FlowExpressions CFTransfer
+%%  LocalWords:  ExpressionAnnotationHelper FlowExpressions CFTransfer LSP
 %%  LocalWords:  AnnotationProvider FooTransfer createFlowTransferFunction
 %%  LocalWords:  SupportedLintOptions myoption StubFiles scriptfile outdir
 %%  LocalWords:  somedir Acfgviz Averbosecfg cfgviz MyVisualizer init apis
@@ -2425,3 +2426,5 @@ without warnings or errors.
 %%  LocalWords:  TypeAnnotationUtils reimplementing typesystem TreeType
 %%  LocalWords:  getTypeFactoryOfSubchecker someDirectory checkername
 %%  LocalWords:  AnnotationMirror AnnotationMirrorMap AnnotationMirrorSet
+%%  LocalWords:  processorpath CheckerName EnsuresNonNullIf reportError
+%%  LocalWords:  reportWarning AnnotatedFor AdumpOnErrors AparseAllJdk

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -224,7 +224,7 @@ subclass to the \<-processor> command-line option:
   javac -processor \textit{mypackage.MyPropChecker} SourceFile.java
 \end{alltt}
 Note that your custom checker's
-\<.class> files must be on the Java classpath.
+\<.class> files must be on the Java classpath or processorpath.
 Invoking a custom checker that builds on
 the Subtyping Checker is slightly different (Section~\ref{subtyping-using}).
 

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -562,7 +562,8 @@ must be on the compilation classpath.
 
 \item \<-processorpath \$CHECKERFRAMEWORK/checker/dist/checker.jar>:
 \<checker.jar> must be on the processor path. Using this option means that the processor path, not
-the classpath, will be searched for annotation processors.
+the classpath, will be searched for annotation processors and for classes
+that they load.
 
 \item \<-processor org.checkerframework.checker.nullness.NullnessChecker>:
 Choose which checker to run by passing its fully qualified name as a processor.

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -562,8 +562,8 @@ must be on the compilation classpath.
 
 \item \<-processorpath \$CHECKERFRAMEWORK/checker/dist/checker.jar>:
 \<checker.jar> must be on the processor path. Using this option means that the processor path, not
-the classpath, will be searched for annotation processors and for classes
-that they load.
+the classpath, will be searched for annotation processors
+and for classes that they load.
 
 \item \<-processor org.checkerframework.checker.nullness.NullnessChecker>:
 Choose which checker to run by passing its fully qualified name as a processor.
@@ -1268,8 +1268,9 @@ Advantages of the latter two-step approach include:
 % LocalWords:  annotationProcessors annotationProcessor JavaCompile Ctrl
 % LocalWords:  targetJavaVersion GradleExamples gradle JavaVersion lombok
 % LocalWords:  systemPath artifactID MacOS eclipsec getter getRole setRole
-% LocalWords:  config copyableAnnotations COPYABLE localRepository init
-% LocalWords:  compilerArguments Xmaxerrs Xmaxwarns netbeans macrodef
+% LocalWords:  config copyableAnnotations COPYABLE localRepository init FQ
+% LocalWords:  compilerArguments Xmaxerrs Xmaxwarns netbeans macrodef LSP
 % LocalWords:  annotationProcessorPaths checkTypes OracleJDK java8 java11
 % LocalWords:  bootclasspath processorpath intellij typechecking postpass
-% LocalWords:  Delombok r4173
+% LocalWords:  Delombok r4173 pathnames HandlerUtil errorProneJavac
+%%  LocalWords:  uncomment

--- a/docs/manual/fenum-checker.tex
+++ b/docs/manual/fenum-checker.tex
@@ -138,14 +138,15 @@ through the \code{-Aquals} option, using a comma-no-space-separated notation:
 \end{alltt}
 
 The annotations listed in \code{-Aquals} must be accessible to
-the compiler during compilation in the classpath or processorpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath or processorpath)
-before you run the Fenum Checker with \code{javac}.  It
+the compiler during compilation.  Before you run the Fenum Checker with
+\code{javac}, they must be compiled and on the same path (the classpath or
+processorpath) as the Checker Framework.  It
 is not sufficient to supply their source files on the command line.
 
 You can also provide the fully-qualified paths to a set of directories
 that contain the annotations through the \code{-AqualDirs} option,
-using a colon-no-space-separated notation. For example:
+using a colon-no-space-separated notation. For example,
+if the Checker Framework is on the classpath rather than the processorpath:
 
 \begin{alltt}
   javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
@@ -164,8 +165,6 @@ the class file will work with the above commands:
 
 The two options can be used at the same time to provide groups of annotations
 from directories, and individually named annotations.
-
-You can use the processorpath instead of the classpath, if you prefer.
 
 \item
 If your code uses the \refqualclass{checker/fenum/qual}{Fenum} annotation, you do
@@ -298,4 +297,4 @@ primitive types as well as for reference types.
 % LocalWords:  SubtypeOf FenumTop MyFile Enum enum AWT java jls qual
 %  LocalWords:  FenumUnqualified FenumBottom ElementType classpath typedef
 %%  LocalWords:  bootclasspath AqualDirs myProject myLibrary RUNTIME
-%  LocalWords:  setNavigationMode NavigationMode checkers''
+%  LocalWords:  setNavigationMode NavigationMode checkers'' processorpath

--- a/docs/manual/fenum-checker.tex
+++ b/docs/manual/fenum-checker.tex
@@ -138,8 +138,8 @@ through the \code{-Aquals} option, using a comma-no-space-separated notation:
 \end{alltt}
 
 The annotations listed in \code{-Aquals} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath)
+the compiler during compilation in the classpath or processorpath.  In other words, they must
+already be compiled (and, typically, be on the javac classpath or processorpath)
 before you run the Fenum Checker with \code{javac}.  It
 is not sufficient to supply their source files on the command line.
 
@@ -164,6 +164,8 @@ the class file will work with the above commands:
 
 The two options can be used at the same time to provide groups of annotations
 from directories, and individually named annotations.
+
+You can use the processorpath instead of the classpath, if you prefer.
 
 \item
 If your code uses the \refqualclass{checker/fenum/qual}{Fenum} annotation, you do

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -826,9 +826,10 @@ checker is an ``annotation processor''.
   providing multiple checkers, if one checker detects any error, subsequent
   checkers may not run.
 \item \<-processorpath> Indicates where to search for the
-  checker.  This should also contain any qualifiers used by type-checkers
-  such as the Subtyping Checker (see Section~\ref{subtyping-example}) and
-  the Constant Value Checker (see
+  checker.  This should also contain any classes used by type-checkers,
+  such as qualifiers used by the Subtyping Checker (see
+  Section~\ref{subtyping-example}) and classes that define
+  statically-executable methods used by the Constant Value Checker (see
   Section~\ref{constant-value-staticallyexecutable-annotation}).
 \item \<-proc:>\{\<none>,\<only>\} Controls whether checking
   happens; \<-proc:none>
@@ -1516,7 +1517,7 @@ same methodology in different words.
 % LocalWords:  int XDTA newdir Awarns signedness urgin bytecodes gradle
 % LocalWords:  subpackages bak tIDE Multiset NullPointerException AskipUses
 % LocalWords:  html JCIP MultiSet Astubs Afilenames Anomsgtext Ashowchecks tex
-% LocalWords:  Aquals processorpath regex RegEx Xmaxwarns com
+% LocalWords:  Aquals processorpath regex RegEx Xmaxwarns com astub jaifs
 % LocalWords:  IntelliJ assertNotNull checkNotNull Goetz antipattern subclassed
 % LocalWords:  callees Xmx unconfuse fenum propkey forName jsr308 Djsr308
 % LocalWords:  bootclasspath AonlyUses AskipDefs AonlyDefs AcheckPurityAnnotations
@@ -1530,7 +1531,7 @@ same methodology in different words.
 % LocalWords:  typedef guieffect Gradle jdk8 javadoc MyFile argfiles tz1
 % LocalWords:  AshowSuppressWarningsStrings AoutputArgsToFile RegexChecker
 % LocalWords:  NullnessChecker commandlineargfile AnnotatedFor Xmx2500m
-% LocalWords:  AsafeDefaultsForUnannotatedBytecode Signedness Werror
+% LocalWords:  AsafeDefaultsForUnannotatedBytecode Signedness Werror jaif
 % LocalWords:  AuseSafeDefaultsForUnannotatedSourceCode beingConstructed
 % LocalWords:  AuseConservativeDefaultsForUncheckedCode AresolveReflection Ainfer
 % LocalWords:  AconservativeUninferredTypeArguments Averbosecfg Acfgviz
@@ -1542,4 +1543,5 @@ same methodology in different words.
 % LocalWords:  ArequirePrefixInWarningSuppressions MaybePresent checker''
 % LocalWords:  AignoreInvalidAnnotationLocations AprintGitProperties
 % LocalWords:  AstubWarnIfRedundantWithBytecode annotation'' AassumePure
-% LocalWords:  AassumeDeterministic
+% LocalWords:  AassumeDeterministic stubfilename outputformat AparseAllJdk
+%%  LocalWords:  AmergeStubsWithSource MyBatis

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -826,8 +826,10 @@ checker is an ``annotation processor''.
   providing multiple checkers, if one checker detects any error, subsequent
   checkers may not run.
 \item \<-processorpath> Indicates where to search for the
-  checker; should also contain any qualifiers used by the Subtyping
-  Checker; see Section~\ref{subtyping-example}
+  checker.  This should also contain any qualifiers used by type-checkers
+  such as the Subtyping Checker (see Section~\ref{subtyping-example}) and
+  the Constant Value Checker (see
+  Section~\ref{constant-value-staticallyexecutable-annotation}).
 \item \<-proc:>\{\<none>,\<only>\} Controls whether checking
   happens; \<-proc:none>
   means to skip checking; \<-proc:only> means to do only

--- a/docs/manual/subtyping-checker.tex
+++ b/docs/manual/subtyping-checker.tex
@@ -54,7 +54,8 @@ notation:
 \item
 Provide the fully-qualified paths to a set of directories that contain the
 annotations in the custom type system through the \code{-AqualDirs} option,
-using a colon-no-space-separated notation. For example:
+using a colon-no-space-separated notation. For example,
+if the Checker Framework is on the classpath rather than the processorpath:
 
 \begin{alltt}
   javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
@@ -64,16 +65,16 @@ using a colon-no-space-separated notation. For example:
 
 \end{itemize}
 
-If you use the processorpath, place the annotations on it itstead of on the
-classpath.
+If the Checker Framework is on the processorpath, place the annotations on
+the processorpath instead of on the classpath.
 
 
 \subsectionAndLabel{Compiling your qualifiers and your project}{subtyping-compiling}
 
 The annotations listed in \code{-Aquals} or \code{-AqualDirs} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath or processorpath)
-before you run the Subtyping Checker with \code{javac}.  It
+the compiler during compilation.  Before you run the Subtyping Checker with
+\code{javac}, they must be compiled and on the same path (the classpath or
+processorpath) as the Checker Framework.  It
 is not sufficient to supply their source files on the command line.
 
 
@@ -148,8 +149,8 @@ Don't forget to compile these classes:
 $ javac myPackage/qual/Encrypted.java myPackage/qual/PossiblyUnencrypted.java
 \end{Verbatim}
 
-The resulting \<.class> files should either be on your classpath, or on the
-processor path if you use it (it is set via the \<-processorpath> command-line option to javac).
+The resulting \<.class> files should either be on the same path (the classpath or
+processor path) as the Checker Framework.
 
 \item
   Write \code{@Encrypted} annotations in your program (say, in file

--- a/docs/manual/subtyping-checker.tex
+++ b/docs/manual/subtyping-checker.tex
@@ -64,12 +64,15 @@ using a colon-no-space-separated notation. For example:
 
 \end{itemize}
 
+If you use the processorpath, place the annotations on it itstead of on the
+classpath.
+
 
 \subsectionAndLabel{Compiling your qualifiers and your project}{subtyping-compiling}
 
 The annotations listed in \code{-Aquals} or \code{-AqualDirs} must be accessible to
 the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath)
+already be compiled (and, typically, be on the javac classpath or processorpath)
 before you run the Subtyping Checker with \code{javac}.  It
 is not sufficient to supply their source files on the command line.
 
@@ -146,7 +149,7 @@ $ javac myPackage/qual/Encrypted.java myPackage/qual/PossiblyUnencrypted.java
 \end{Verbatim}
 
 The resulting \<.class> files should either be on your classpath, or on the
-processor path (set via the \<-processorpath> command-line option to javac).
+processor path if you use it (it is set via the \<-processorpath> command-line option to javac).
 
 \item
   Write \code{@Encrypted} annotations in your program (say, in file

--- a/docs/manual/units-checker.tex
+++ b/docs/manual/units-checker.tex
@@ -261,15 +261,16 @@ notation:
 \end{alltt}
 
 The annotations listed in \code{-Aunits} must be accessible to
-the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath or processorpath)
-before you run the Units Checker with \code{javac}.  It
+the compiler during compilation.  Before you run the Units Checker with
+\code{javac}, they must be compiled and on the same path (the classpath or
+processorpath) as the Checker Framework.  It
 is not sufficient to supply their source files on the command line.
 
 \item
 You can also provide the fully-qualified paths to a set of directories
 that contain units qualifiers through the \code{-AunitsDirs} option,
-using a colon-no-space-separated notation. For example:
+using a colon-no-space-separated notation. For example,
+if the Checker Framework is on the classpath rather than the processorpath:
 
 \begin{alltt}
   javac -classpath \textit{/full/path/to/myProject/bin}:\textit{/full/path/to/myLibrary/bin} \ttbs
@@ -290,8 +291,6 @@ will work with the above commands:
 
 The two options can be used at the same time to provide groups of annotations
 from directories, and individually named annotations.
-
-You can use the processorpath instead of the classpath, if you prefer.
 
 \end{itemize}
 
@@ -325,4 +324,4 @@ For examples, see class \code{UnitsTools}.
 % LocalWords:  milli RetentionPolicy SubtypeOf UnitsMultiple hz PolyUnit
 % LocalWords:  UnitsRelations Aunits MyFile mm2 m2 km2 enum ElementType
 %  LocalWords:  MixedUnits java mPERs2 api classpath bootclasspath
-%%  LocalWords:  AunitsDirs myProject myLibrary
+%%  LocalWords:  AunitsDirs myProject myLibrary Luminance processorpath

--- a/docs/manual/units-checker.tex
+++ b/docs/manual/units-checker.tex
@@ -262,7 +262,7 @@ notation:
 
 The annotations listed in \code{-Aunits} must be accessible to
 the compiler during compilation in the classpath.  In other words, they must
-already be compiled (and, typically, be on the javac classpath)
+already be compiled (and, typically, be on the javac classpath or processorpath)
 before you run the Units Checker with \code{javac}.  It
 is not sufficient to supply their source files on the command line.
 
@@ -290,6 +290,8 @@ will work with the above commands:
 
 The two options can be used at the same time to provide groups of annotations
 from directories, and individually named annotations.
+
+You can use the processorpath instead of the classpath, if you prefer.
 
 \end{itemize}
 


### PR DESCRIPTION
Fixes https://github.com/typetools/checker-framework/issues/3630.

I wonder whether we should merge this pull request, or replace it by a pull request that recommends *not* using classpath and using processorpath instead.