### PR TITLE
Don't print default annotation values.

### DIFF
--- a/checker/jtreg/sortwarnings/ErrorOrders.out
+++ b/checker/jtreg/sortwarnings/ErrorOrders.out
@@ -21,11 +21,11 @@ found   : @UpperBoundUnknown int
 required: @IndexFor("a") or @LTLengthOf("a") -- an integer less than a's length
 ErrorOrders.java:23:33: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @UpperBoundUnknown int
-required: @LTLengthOf(value="p2") int
+required: @LTLengthOf("p2") int
 ErrorOrders.java:24:47: compiler.err.proc.messager: [expression.unparsable.type.invalid] Expression invalid in dependent type annotation: [error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]
 ErrorOrders.java:24:55: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
-found   : @LTLengthOf(value="p2") int
-required: @LTLengthOf(value="[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
+found   : @LTLengthOf("p2") int
+required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
 ErrorOrders.java:29:15: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter p1 of test4.
 found   : @LowerBoundUnknown int
 required: @GTENegativeOne int
@@ -71,7 +71,7 @@ required: int
 ErrorOrders.java:33:47: compiler.err.proc.messager: [expression.unparsable.type.invalid] Expression invalid in dependent type annotation: [error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]
 ErrorOrders.java:33:55: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @UpperBoundUnknown int
-required: @LTLengthOf(value="[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
+required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
 ErrorOrders.java:36:15: compiler.err.proc.messager: [array.access.unsafe.low] Potentially unsafe array access: the index could be negative.
 found   : @LowerBoundUnknown int
 required: an integer >= 0 (@NonNegative or @Positive)
@@ -81,7 +81,7 @@ required: @IndexFor("a") or @LTLengthOf("a") -- an integer less than a's length
 ErrorOrders.java:42:43: compiler.err.proc.messager: [expression.unparsable.type.invalid] Expression invalid in dependent type annotation: [error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]
 ErrorOrders.java:42:51: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @UpperBoundUnknown int
-required: @LTLengthOf(value="[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
+required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
 ErrorOrders.java:45:11: compiler.err.proc.messager: [array.access.unsafe.low] Potentially unsafe array access: the index could be negative.
 found   : @LowerBoundUnknown int
 required: an integer >= 0 (@NonNegative or @Positive)
@@ -90,11 +90,11 @@ found   : @UpperBoundUnknown int
 required: @IndexFor("a") or @LTLengthOf("a") -- an integer less than a's length
 ErrorOrders.java:55:33: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
 found   : @UpperBoundUnknown int
-required: @LTLengthOf(value="p2") int
+required: @LTLengthOf("p2") int
 ErrorOrders.java:56:47: compiler.err.proc.messager: [expression.unparsable.type.invalid] Expression invalid in dependent type annotation: [error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]
 ErrorOrders.java:56:55: compiler.err.proc.messager: [assignment.type.incompatible] incompatible types in assignment.
-found   : @LTLengthOf(value="p2") int
-required: @LTLengthOf(value="[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
+found   : @LTLengthOf("p2") int
+required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because is an invalid expression]") int
 ErrorOrders.java:61:15: compiler.err.proc.messager: [argument.type.incompatible] incompatible argument for parameter p1 of test4.
 found   : @LowerBoundUnknown int
 required: @GTENegativeOne int

--- a/framework/src/main/java/org/checkerframework/framework/util/DefaultAnnotationFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/DefaultAnnotationFormatter.java
@@ -1,8 +1,10 @@
 package org.checkerframework.framework.util;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;
@@ -73,12 +75,12 @@ public class DefaultAnnotationFormatter implements AnnotationFormatter {
     protected void formatAnnotationMirror(AnnotationMirror am, StringBuilder sb) {
         sb.append("@");
         sb.append(am.getAnnotationType().asElement().getSimpleName());
-        Map<? extends ExecutableElement, ? extends AnnotationValue> args = am.getElementValues();
+        Map<ExecutableElement, AnnotationValue> args = removeDefaultValues(am.getElementValues());
         if (!args.isEmpty()) {
             sb.append("(");
             boolean oneValue = false;
             if (args.size() == 1) {
-                Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> first =
+                Map.Entry<ExecutableElement, AnnotationValue> first =
                         args.entrySet().iterator().next();
                 if (first.getKey().getSimpleName().contentEquals("value")) {
                     formatAnnotationMirrorArg(first.getValue(), sb);
@@ -87,8 +89,7 @@ public class DefaultAnnotationFormatter implements AnnotationFormatter {
             }
             if (!oneValue) {
                 boolean notfirst = false;
-                for (Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> arg :
-                        args.entrySet()) {
+                for (Map.Entry<ExecutableElement, AnnotationValue> arg : args.entrySet()) {
                     if (!"{}".equals(arg.getValue().toString())) {
                         if (notfirst) {
                             sb.append(", ");
@@ -101,6 +102,27 @@ public class DefaultAnnotationFormatter implements AnnotationFormatter {
             }
             sb.append(")");
         }
+    }
+
+    /**
+     * Returns a new map that only has the values in {@code elementValues} that are not the same as
+     * the default value.
+     *
+     * @param elementValues a mapping of annotation element to annotation value
+     * @return a new map with only the not default default values of {@code elementValues}
+     */
+    private Map<ExecutableElement, AnnotationValue> removeDefaultValues(
+            Map<? extends ExecutableElement, ? extends AnnotationValue> elementValues) {
+        Map<ExecutableElement, AnnotationValue> nonDefaults = new LinkedHashMap<>();
+        elementValues.forEach(
+                (element, value) -> {
+                    if (element.getDefaultValue() == null
+                            || !Objects.equals(
+                                    value.getValue(), element.getDefaultValue().getValue())) {
+                        nonDefaults.put(element, value);
+                    }
+                });
+        return nonDefaults;
     }
 
     // A helper method to print AnnotationValues (annotation arguments), without showing full


### PR DESCRIPTION
PR #2970 adds default values to all AnnotationMirrors which means the default value is printed in error messages.   For example,

```
required: @UnknownInitialization(java.lang.Object.class) @NonNull Object
```

This PR makes it so an annotation value is not printed if it is equal to the default value.

