### PR TITLE
extendWithNode is called for side effect, so don't return a value

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGBuilder.java
@@ -1967,12 +1967,10 @@ public class CFGBuilder {
          * Extend the list of extended nodes with a node.
          *
          * @param node the node to add
-         * @return the same node (for convenience)
          */
-        protected <T extends Node> T extendWithNode(T node) {
+        protected void extendWithNode(Node node) {
             addToLookupMap(node);
             extendWithExtendedNode(new NodeHolder(node));
-            return node;
         }
 
         /**
@@ -3512,7 +3510,8 @@ public class CFGBuilder {
                     throw new Error("unexpected binary tree: " + kind);
             }
             assert r != null : "unexpected binary tree";
-            return extendWithNode(r);
+            extendWithNode(r);
+            return r;
         }
 
         @Override
@@ -3962,7 +3961,8 @@ public class CFGBuilder {
                         new VariableDeclarationNode(indexVariable);
                 indexVariableNode.setInSource(false);
                 extendWithNode(indexVariableNode);
-                IntegerLiteralNode zeroNode = extendWithNode(new IntegerLiteralNode(zero));
+                IntegerLiteralNode zeroNode = new IntegerLiteralNode(zero);
+                extendWithNode(zeroNode);
 
                 translateAssignment(indexVariable, new LocalVariableNode(indexVariable), zeroNode);
 
@@ -3976,7 +3976,8 @@ public class CFGBuilder {
 
                 IdentifierTree arrayUse1 = treeBuilder.buildVariableUse(arrayVariable);
                 handleArtificialTree(arrayUse1);
-                LocalVariableNode arrayNode1 = extendWithNode(new LocalVariableNode(arrayUse1));
+                LocalVariableNode arrayNode1 = new LocalVariableNode(arrayUse1);
+                extendWithNode(arrayNode1);
 
                 MemberSelectTree lengthSelect = treeBuilder.buildArrayLengthAccess(arrayUse1);
                 handleArtificialTree(lengthSelect);
@@ -4228,7 +4229,8 @@ public class CFGBuilder {
         public Node visitArrayAccess(ArrayAccessTree tree, Void p) {
             Node array = scan(tree.getExpression(), p);
             Node index = unaryNumericPromotion(scan(tree.getIndex(), p));
-            Node arrayAccess = extendWithNode(new ArrayAccessNode(tree, array, index));
+            Node arrayAccess = new ArrayAccessNode(tree, array, index);
+            extendWithNode(arrayAccess);
             Element aioobeElement = getTypeElement(ArrayIndexOutOfBoundsException.class);
             extendWithNodeWithException(arrayAccess, aioobeElement.asType());
             Element npeElement = getTypeElement(NullPointerException.class);
@@ -4292,8 +4294,8 @@ public class CFGBuilder {
                     throw new Error("unexpected literal tree");
             }
             assert r != null : "unexpected literal tree";
-            Node result = extendWithNode(r);
-            return result;
+            extendWithNode(r);
+            return r;
         }
 
         @Override
@@ -4330,7 +4332,8 @@ public class CFGBuilder {
             }
 
             Node node = new ArrayCreationNode(tree, type, dimensionNodes, initializerNodes);
-            return extendWithNode(node);
+            extendWithNode(node);
+            return node;
         }
 
         @Override
@@ -4435,9 +4438,13 @@ public class CFGBuilder {
                 // Could be a selector of a class or package
                 Element element = TreeUtils.elementFromUse(tree);
                 if (ElementUtils.isClassElement(element)) {
-                    return extendWithNode(new ClassNameNode(tree, expr));
+                    Node result = new ClassNameNode(tree, expr);
+                    extendWithNode(result);
+                    return result;
                 } else if (element.getKind() == ElementKind.PACKAGE) {
-                    return extendWithNode(new PackageNameNode(tree, (PackageNameNode) expr));
+                    Node result = new PackageNameNode(tree, (PackageNameNode) expr);
+                    extendWithNode(result);
+                    return result;
                 } else {
                     throw new Error("Unexpected element kind: " + element.getKind());
                 }
@@ -4787,7 +4794,9 @@ public class CFGBuilder {
 
         @Override
         public Node visitParameterizedType(ParameterizedTypeTree tree, Void p) {
-            return extendWithNode(new ParameterizedTypeNode(tree));
+            Node result = new ParameterizedTypeNode(tree);
+            extendWithNode(result);
+            return result;
         }
 
         @Override
@@ -4797,7 +4806,9 @@ public class CFGBuilder {
 
         @Override
         public Node visitArrayType(ArrayTypeTree tree, Void p) {
-            return extendWithNode(new ArrayTypeNode(tree, types));
+            Node result = new ArrayTypeNode(tree, types);
+            extendWithNode(new ArrayTypeNode(tree, types));
+            return result;
         }
 
         @Override
@@ -4813,7 +4824,9 @@ public class CFGBuilder {
 
         @Override
         public Node visitPrimitiveType(PrimitiveTypeTree tree, Void p) {
-            return extendWithNode(new PrimitiveTypeNode(tree, types));
+            Node result = new PrimitiveTypeNode(tree, types);
+            extendWithNode(result);
+            return result;
         }
 
         @Override
@@ -4847,17 +4860,18 @@ public class CFGBuilder {
 
                         switch (kind) {
                             case BITWISE_COMPLEMENT:
-                                result = extendWithNode(new BitwiseComplementNode(tree, expr));
+                                result = new BitwiseComplementNode(tree, expr);
                                 break;
                             case UNARY_MINUS:
-                                result = extendWithNode(new NumericalMinusNode(tree, expr));
+                                result = new NumericalMinusNode(tree, expr);
                                 break;
                             case UNARY_PLUS:
-                                result = extendWithNode(new NumericalPlusNode(tree, expr));
+                                result = new NumericalPlusNode(tree, expr);
                                 break;
                             default:
                                 throw new Error("Unexpected kind");
                         }
+                        extendWithNode(result);
                         break;
                     }
 
@@ -4865,7 +4879,8 @@ public class CFGBuilder {
                     {
                         // see JLS 15.15.6
                         Node expr = scan(tree.getExpression(), p);
-                        result = extendWithNode(new ConditionalNotNode(tree, unbox(expr)));
+                        result = new ConditionalNotNode(tree, unbox(expr));
+                        extendWithNode(result);
                         break;
                     }
 
@@ -4929,7 +4944,8 @@ public class CFGBuilder {
                     // special node NLLCHK
                     if (tree.toString().startsWith("<*nullchk*>")) {
                         Node expr = scan(tree.getExpression(), p);
-                        result = extendWithNode(new NullChkNode(tree, expr));
+                        result = new NullChkNode(tree, expr);
+                        extendWithNode(result);
                         break;
                     }
 
@@ -4990,7 +5006,8 @@ public class CFGBuilder {
 
             AssignmentNode assignNode = new AssignmentNode(target, expr, narrowed);
             assignNode.setInSource(false);
-            return extendWithNode(assignNode);
+            extendWithNode(assignNode);
+            return assignNode;
         }
 
         @Override


### PR DESCRIPTION
The trick of returning the argument makes some code more concise, but it is
confusing since the method is primarily called for side effect, and it is
used inconsistently throughout the codebase.  Removing the return type
makes clients more uniform and explicit, if a bit more verbose.