### PR TITLE
Don't crash with an NPE if an accumulator doesn't have a default value

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
@@ -97,7 +97,8 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
         if (!accValue.getReturnType().isInstance(new String[0])) {
             rejectMalformedAccumulator("have an element of type String[]");
         }
-        if (((String[]) accValue.getDefaultValue()).length != 0) {
+        if (accValue.getDefaultValue() == null
+                || ((String[]) accValue.getDefaultValue()).length != 0) {
             rejectMalformedAccumulator("have the empty String array {} as its default value");
         }
 


### PR DESCRIPTION
Encountered while porting an existing checker to use `AccumulationChecker`, was a big pain to diagnose.