### PR TITLE
Avoid crash in isSubtype in AccumulationChecker when supertype is polymorphic and subtype is accumulator

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
@@ -303,7 +303,7 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
      */
     public List<String> getAccumulatedValues(AnnotationMirror anno) {
         if (!isAccumulatorAnnotation(anno)) {
-            throw new BugInCF(anno + "isn't an accumulator annotation");
+            throw new BugInCF(anno + " isn't an accumulator annotation");
         }
         List<String> values = ValueCheckerUtils.getValueOfAnnotationWithStringArgument(anno);
         if (values == null) {

--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
@@ -468,6 +468,10 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
                     // checking for both predicate and non-predicate forms of top.
                     return "".equals(convertToPredicate(superAnno));
                 }
+            } else if (isPolymorphicQualifier(superAnno)) {
+                // Polymorphic annotations are only a supertype of other polymorphic annotations and
+                // the bottom type, both of which have already been checked above.
+                return false;
             }
 
             if (isPredicate(subAnno)) {

--- a/framework/tests/accumulation/SimplePolymorphic.java
+++ b/framework/tests/accumulation/SimplePolymorphic.java
@@ -12,4 +12,10 @@ class SimplePolymorphic {
     Object usePoly(@TestAccumulation("foo") Object obj) {
         return id(obj);
     }
+
+    // Check that polymorphic supertype with accumulator type doesn't cause a crash.
+    void noCrashOnPolySuper(@TestAccumulation("foo") Object obj) {
+        // :: error: assignment.type.incompatible
+        @PolyTestAccumulation Object obj2 = obj;
+    }
 }


### PR DESCRIPTION
Fixes a crash I encountered while porting a checker to use `AccumulationChecker`, because `isSubtype` assumed that `superAnno` was an accumulator when it reached the last set of checks in `isSubtype`. Also, I fixed a typo in the error message that that crash caused :)

Without this fix, you get a stacktrace like this:

```
    1 unexpected diagnostic was found:
    :-1: other: error: @org.checkerframework.framework.testchecker.testaccumulation.qual.PolyTestAccumulation isn't an accumulator annotation
      ; The Checker Framework crashed.  Please report the crash.
      Compilation unit: tests/accumulation/SimplePolymorphic.java
      Last visited tree at line 19 column 9:
              @PolyTestAccumulation Object obj2 = obj;
      Exception: java.lang.Throwable; java.lang.Throwable
        at org.checkerframework.javacutil.BugInCF.<init>(BugInCF.java:16)
        at org.checkerframework.common.accumulation.AccumulationAnnotatedTypeFactory.getAccumulatedValues(AccumulationAnnotatedTypeFactory.java:306)
        at org.checkerframework.common.accumulation.AccumulationAnnotatedTypeFactory$AccumulationQualifierHierarchy.isSubtype(AccumulationAnnotatedTypeFactory.java:485)
        at org.checkerframework.framework.type.DefaultTypeHierarchy.isAnnoSubtype(DefaultTypeHierarchy.java:254)
...
```