### PR TITLE
Make dependabot ignore AWS SDK updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "java:gradle"
+    directory: "/"
+    ignore:
+      - dependency-name: "com.amazonaws:aws-java-sdk-*"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,4 +3,5 @@ updates:
   - package-ecosystem: "java:gradle"
     directory: "/"
     ignore:
+      # This dependency is updated every day.  That is too many pull requests.
       - dependency-name: "com.amazonaws:aws-java-sdk-*"

--- a/docs/developer/release/README-release-process.html
+++ b/docs/developer/release/README-release-process.html
@@ -118,6 +118,12 @@ miss a step if you only read the paragraph asking you to say 'yes'.
         any customizations are necessary.
       </li>
       <li>
+        <b>Update the AWS Java SDK BOM dependency</b>.  Edit
+        the <code>com.amazonaws:aws-java-sdk-bom</code> dependency in
+        file <code>checker/build.gradle</code> to be the latest version number at
+        <a href="https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk">https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk</a>.
+      </li>
+      <li>
         <b>Update AFU and Checker Framework change logs</b> by following the instructions
         at <a href="#content_guidelines">content guidelines</a>.
       </li>

--- a/docs/developer/release/README-release-process.html
+++ b/docs/developer/release/README-release-process.html
@@ -118,9 +118,9 @@ miss a step if you only read the paragraph asking you to say 'yes'.
         any customizations are necessary.
       </li>
       <li>
-        <b>Update the AWS Java SDK BOM dependency</b>.  Edit
-        the <code>com.amazonaws:aws-java-sdk-bom</code> dependency in
-        file <code>checker/build.gradle</code> to be the latest version number at
+        <b>Update the AWS Java SDK BOM dependency.</b> In file <code>checker/build.gradle</code>,
+        edit the <code>com.amazonaws:aws-java-sdk-bom</code> dependency to be the latest version
+        number at
         <a href="https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk">https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk</a>.
       </li>
       <li>


### PR DESCRIPTION
See discussion on https://github.com/typetools/checker-framework/pull/3723.