### PR TITLE
Use dependabot v1 config instead of v2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,10 +1,11 @@
-version: 2
+version: 1
 
 # The com.amazonaws:aws-java-sdk-* dependencies are updated every day.
 # That is too many pull requests.
 
 updates:
-  - package-ecosystem: "java:gradle"
+  - package-manager: "java:gradle"
     directory: "/"
-    ignore:
-      - dependency-name: "com.amazonaws:aws-java-sdk-*"
+    ignore-updates:
+      - match:
+          dependency-name: "com.amazonaws:aws-java-sdk-*"


### PR DESCRIPTION
Fix #3730, which seems to have been caused by having the wrong version of dependabot enabled for the config script that we added. This change uses the old config script format (v1) rather than the newer v2, since we're apparently running v1.

Background: funnily enough, I wasn't able to figure out which version of dependabot we were using, so I guessed in #3724 that it was the newer version. Apparently dependabot doesn't update itself!