### PR TITLE
Make CFTreeBuilder easier to read.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/flow/CFTreeBuilder.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFTreeBuilder.java
@@ -3,10 +3,14 @@ package org.checkerframework.framework.flow;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.BoundKind;
-import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCAnnotatedType;
+import com.sun.tools.javac.tree.JCTree.JCAnnotation;
+import com.sun.tools.javac.tree.JCTree.JCExpression;
+import com.sun.tools.javac.tree.JCTree.JCTypeApply;
 import com.sun.tools.javac.util.List;
 import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -14,6 +18,11 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedIntersectionType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.trees.TreeBuilder;
 
@@ -44,15 +53,15 @@ public class CFTreeBuilder extends TreeBuilder {
         // Convert the annotations from a set of AnnotationMirrors
         // to a list of AnnotationTrees.
         Set<AnnotationMirror> annotations = annotatedType.getAnnotations();
-        List<JCTree.JCAnnotation> annotationTrees = List.nil();
+        List<JCAnnotation> annotationTrees = List.nil();
 
         for (AnnotationMirror am : annotations) {
             // TODO: what TypeAnnotationPosition should be used?
             Attribute.TypeCompound typeCompound =
                     TypeAnnotationUtils.createTypeCompoundFromAnnotationMirror(
                             am, TypeAnnotationUtils.unknownTAPosition(), env);
-            JCTree.JCAnnotation annotationTree = maker.Annotation(typeCompound);
-            JCTree.JCAnnotation typeAnnotationTree =
+            JCAnnotation annotationTree = maker.Annotation(typeCompound);
+            JCAnnotation typeAnnotationTree =
                     maker.TypeAnnotation(
                             annotationTree.getAnnotationType(), annotationTree.getArguments());
 
@@ -64,7 +73,7 @@ public class CFTreeBuilder extends TreeBuilder {
         // Convert the underlying type from a TypeMirror to an
         // ExpressionTree and combine with the AnnotationTrees
         // to form a ClassTree of kind ANNOTATION_TYPE.
-        Tree underlyingTypeTree;
+        JCExpression underlyingTypeTree;
         switch (annotatedType.getKind()) {
             case BYTE:
                 underlyingTypeTree = maker.TypeIdent(TypeTag.BYTE);
@@ -94,84 +103,64 @@ public class CFTreeBuilder extends TreeBuilder {
                 underlyingTypeTree = maker.TypeIdent(TypeTag.VOID);
                 break;
             case TYPEVAR:
-                {
-                    // No recursive annotations.
-                    AnnotatedTypeMirror.AnnotatedTypeVariable variable =
-                            (AnnotatedTypeMirror.AnnotatedTypeVariable) annotatedType;
-                    TypeVariable underlyingTypeVar = variable.getUnderlyingType();
-                    underlyingTypeTree =
-                            maker.Ident((Symbol.TypeSymbol) underlyingTypeVar.asElement());
-                    break;
-                }
+                // No recursive annotations.
+                AnnotatedTypeVariable variable = (AnnotatedTypeVariable) annotatedType;
+                TypeVariable underlyingTypeVar = variable.getUnderlyingType();
+                underlyingTypeTree = maker.Ident((TypeSymbol) underlyingTypeVar.asElement());
+                break;
             case WILDCARD:
-                {
-                    AnnotatedTypeMirror.AnnotatedWildcardType wildcard =
-                            (AnnotatedTypeMirror.AnnotatedWildcardType) annotatedType;
-                    WildcardType wildcardType = wildcard.getUnderlyingType();
-                    if (wildcardType.getExtendsBound() != null) {
-                        Tree annotatedExtendsBound =
-                                createAnnotatedType(wildcard.getExtendsBound());
-                        underlyingTypeTree =
-                                maker.Wildcard(
-                                        maker.TypeBoundKind(BoundKind.EXTENDS),
-                                        (JCTree) annotatedExtendsBound);
-                    } else if (wildcardType.getSuperBound() != null) {
-                        Tree annotatedSuperBound = createAnnotatedType(wildcard.getSuperBound());
-                        underlyingTypeTree =
-                                maker.Wildcard(
-                                        maker.TypeBoundKind(BoundKind.SUPER),
-                                        (JCTree) annotatedSuperBound);
-                    } else {
-                        underlyingTypeTree =
-                                maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
-                    }
-                    break;
+                AnnotatedWildcardType wildcard = (AnnotatedWildcardType) annotatedType;
+                WildcardType wildcardType = wildcard.getUnderlyingType();
+                if (wildcardType.getExtendsBound() != null) {
+                    Tree annotatedExtendsBound = createAnnotatedType(wildcard.getExtendsBound());
+                    underlyingTypeTree =
+                            maker.Wildcard(
+                                    maker.TypeBoundKind(BoundKind.EXTENDS),
+                                    (JCTree) annotatedExtendsBound);
+                } else if (wildcardType.getSuperBound() != null) {
+                    Tree annotatedSuperBound = createAnnotatedType(wildcard.getSuperBound());
+                    underlyingTypeTree =
+                            maker.Wildcard(
+                                    maker.TypeBoundKind(BoundKind.SUPER),
+                                    (JCTree) annotatedSuperBound);
+                } else {
+                    underlyingTypeTree =
+                            maker.Wildcard(maker.TypeBoundKind(BoundKind.UNBOUND), null);
                 }
+                break;
             case INTERSECTION:
-                {
-                    AnnotatedTypeMirror.AnnotatedIntersectionType intersectionType =
-                            (AnnotatedTypeMirror.AnnotatedIntersectionType) annotatedType;
-                    List<JCTree.JCExpression> components = List.nil();
-                    for (AnnotatedTypeMirror.AnnotatedDeclaredType adt :
-                            intersectionType.directSuperTypes()) {
-                        components =
-                                components.append((JCTree.JCExpression) createAnnotatedType(adt));
-                    }
-                    underlyingTypeTree = maker.TypeIntersection(components);
-                    break;
+                AnnotatedIntersectionType intersectionType =
+                        (AnnotatedIntersectionType) annotatedType;
+                List<JCExpression> components = List.nil();
+                for (AnnotatedDeclaredType adt : intersectionType.directSuperTypes()) {
+                    components = components.append((JCExpression) createAnnotatedType(adt));
                 }
+                underlyingTypeTree = maker.TypeIntersection(components);
+                break;
+                // case UNION:
                 // TODO: case UNION similar to INTERSECTION, but write test first.
             case DECLARED:
-                {
-                    underlyingTypeTree = maker.Type((Type) annotatedType.getUnderlyingType());
+                underlyingTypeTree = maker.Type((Type) annotatedType.getUnderlyingType());
 
-                    if (underlyingTypeTree instanceof JCTree.JCTypeApply) {
-                        // Replace the type parameters with annotated versions.
-                        AnnotatedTypeMirror.AnnotatedDeclaredType annotatedDeclaredType =
-                                (AnnotatedTypeMirror.AnnotatedDeclaredType) annotatedType;
-                        List<JCTree.JCExpression> typeArgTrees = List.nil();
-                        for (AnnotatedTypeMirror arg : annotatedDeclaredType.getTypeArguments()) {
-                            typeArgTrees =
-                                    typeArgTrees.append(
-                                            (JCTree.JCExpression) createAnnotatedType(arg));
-                        }
-                        JCTree.JCExpression clazz =
-                                (JCTree.JCExpression)
-                                        ((JCTree.JCTypeApply) underlyingTypeTree).getType();
-                        underlyingTypeTree = maker.TypeApply(clazz, typeArgTrees);
+                if (underlyingTypeTree instanceof JCTypeApply) {
+                    // Replace the type parameters with annotated versions.
+                    AnnotatedDeclaredType annotatedDeclaredType =
+                            (AnnotatedDeclaredType) annotatedType;
+                    List<JCExpression> typeArgTrees = List.nil();
+                    for (AnnotatedTypeMirror arg : annotatedDeclaredType.getTypeArguments()) {
+                        typeArgTrees = typeArgTrees.append((JCExpression) createAnnotatedType(arg));
                     }
-                    break;
+                    JCExpression clazz =
+                            (JCExpression) ((JCTypeApply) underlyingTypeTree).getType();
+                    underlyingTypeTree = maker.TypeApply(clazz, typeArgTrees);
                 }
+                break;
             case ARRAY:
-                {
-                    AnnotatedTypeMirror.AnnotatedArrayType annotatedArrayType =
-                            (AnnotatedTypeMirror.AnnotatedArrayType) annotatedType;
-                    Tree annotatedComponentTree =
-                            createAnnotatedType(annotatedArrayType.getComponentType());
-                    underlyingTypeTree =
-                            maker.TypeArray((JCTree.JCExpression) annotatedComponentTree);
-                    break;
-                }
+                AnnotatedArrayType annotatedArrayType = (AnnotatedArrayType) annotatedType;
+                Tree annotatedComponentTree =
+                        createAnnotatedType(annotatedArrayType.getComponentType());
+                underlyingTypeTree = maker.TypeArray((JCExpression) annotatedComponentTree);
+                break;
             case ERROR:
                 underlyingTypeTree = maker.TypeIdent(TypeTag.ERROR);
                 break;
@@ -181,14 +170,14 @@ public class CFTreeBuilder extends TreeBuilder {
                 break;
         }
 
-        ((JCTree) underlyingTypeTree).setType((Type) annotatedType.getUnderlyingType());
+        underlyingTypeTree.setType((Type) annotatedType.getUnderlyingType());
 
         if (annotationTrees.isEmpty()) {
             return underlyingTypeTree;
         }
 
-        JCTree.JCAnnotatedType annotatedTypeTree =
-                maker.AnnotatedType(annotationTrees, (JCTree.JCExpression) underlyingTypeTree);
+        JCAnnotatedType annotatedTypeTree =
+                maker.AnnotatedType(annotationTrees, underlyingTypeTree);
         annotatedTypeTree.setType((Type) annotatedType.getUnderlyingType());
 
         return annotatedTypeTree;


### PR DESCRIPTION
There are no code changes.  I just removed unnecessary  `{}` and add imports for inner class such as `AnnotatedTypeMirror.AnnotatedWildcardType`.