### PR TITLE
Don't clear type parameters in StubParser

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/test/junit/StubParserTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/StubParserTest.java
@@ -1,0 +1,31 @@
+package org.checkerframework.checker.test.junit;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.tainting.TaintingChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/** JUnit tests for stub parsing. */
+public class StubParserTest extends CheckerFrameworkPerDirectoryTest {
+
+    /**
+     * Create a StubParserTest.
+     *
+     * @param testFiles the files containing test code, which will be type-checked
+     */
+    public StubParserTest(List<File> testFiles) {
+        super(
+                testFiles,
+                TaintingChecker.class,
+                "stubparser",
+                "-Anomsgtext",
+                "-AmergeStubsWithSource",
+                "-Astubs=tests/stubparser/TypeParamWithInner.astub");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"stubparser", "all-systems"};
+    }
+}

--- a/checker/tests/stubparser/TypeParamWithInner.astub
+++ b/checker/tests/stubparser/TypeParamWithInner.astub
@@ -1,0 +1,12 @@
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+// T extends @Untainted String in stub file. Tests bug where the presence of an inner class causes
+// annotations on type variables to be forgotten.
+public class TypeParamWithInner<T extends @Untainted String> {
+    public class Inner {
+    }
+
+    public void requiresUntainted(T param) {
+        @Untainated String s = param;
+    }
+}

--- a/checker/tests/stubparser/TypeParamWithInner.java
+++ b/checker/tests/stubparser/TypeParamWithInner.java
@@ -3,8 +3,7 @@ import org.checkerframework.checker.tainting.qual.Untainted;
 // T extends @Untainted String in stub file. Tests bug where the presence of an inner class causes
 // annotations on type variables to be forgotten.
 public class TypeParamWithInner<T extends String> {
-    public class Inner {
-    }
+    public class Inner {}
 
     public void requiresUntainted(T param) {
         @Untainted String s = param;

--- a/checker/tests/stubparser/TypeParamWithInner.java
+++ b/checker/tests/stubparser/TypeParamWithInner.java
@@ -1,0 +1,12 @@
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+// T extends @Untainted String in stub file. Tests bug where the presence of an inner class causes
+// annotations on type variables to be forgotten.
+public class TypeParamWithInner<T extends String> {
+    public class Inner {
+    }
+
+    public void requiresUntainted(T param) {
+        @Untainted String s = param;
+    }
+}

--- a/framework/src/main/java/org/checkerframework/framework/stub/StubParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/StubParser.java
@@ -620,6 +620,7 @@ public class StubParser {
             return;
         }
 
+        List<AnnotatedTypeVariable> typeDeclTypeParameters = null;
         if (typeElt.getKind() == ElementKind.ENUM) {
             if (!(typeDecl instanceof EnumDeclaration)) {
                 stubWarn(
@@ -629,7 +630,8 @@ public class StubParser {
                                 + "...");
                 return;
             }
-            typeParameters.addAll(processEnum((EnumDeclaration) typeDecl, typeElt));
+            typeDeclTypeParameters = processEnum((EnumDeclaration) typeDecl, typeElt);
+            typeParameters.addAll(typeDeclTypeParameters);
         } else if (typeElt.getKind() == ElementKind.ANNOTATION_TYPE) {
             if (!(typeDecl instanceof AnnotationDeclaration)) {
                 stubWarn(
@@ -649,7 +651,8 @@ public class StubParser {
                                 + "...");
                 return;
             }
-            typeParameters.addAll(processType((ClassOrInterfaceDeclaration) typeDecl, typeElt));
+            typeDeclTypeParameters = processType((ClassOrInterfaceDeclaration) typeDecl, typeElt);
+            typeParameters.addAll(typeDeclTypeParameters);
         } // else it's an EmptyTypeDeclaration.  TODO:  An EmptyTypeDeclaration can have
         // annotations, right?
 
@@ -682,7 +685,9 @@ public class StubParser {
                     break;
             }
         }
-        typeParameters.clear();
+        if (typeDeclTypeParameters != null) {
+            typeParameters.removeAll(typeDeclTypeParameters);
+        }
     }
 
     /** True if the argument contains {@code @NoStubParserWarning}. */


### PR DESCRIPTION
The `StubParser` class keeps track of the type variables in scope for the elements it's processing. When processing a class, it should add the class's type parameters on entry and remove them when leaving. The current implementation clears *all* type parameters when it finishes processing a class. This means after processing an inner class, all type parameters are cleared, including those of the enclosing class.