### PR TITLE
Add argument to MostlyNoElementQualifierHierarchy operations

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/FenumAnnotatedTypeFactory.java
@@ -138,7 +138,8 @@ public class FenumAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == FENUM_KIND && qualifierKind2 == FENUM_KIND) {
                 if (AnnotationUtils.areSame(a1, a2)) {
                     return a1;
@@ -157,7 +158,8 @@ public class FenumAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == FENUM_KIND && qualifierKind2 == FENUM_KIND) {
                 return FENUM_BOTTOM;
             } else if (qualifierKind1 == FENUM_KIND) {

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterAnnotatedTypeFactory.java
@@ -145,7 +145,8 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror anno1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror anno2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1.isBottom()) {
                 return anno2;
             } else if (qualifierKind2.isBottom()) {
@@ -203,7 +204,8 @@ public class FormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror anno1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror anno2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1.isTop()) {
                 return anno2;
             } else if (qualifierKind2.isTop()) {

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterAnnotatedTypeFactory.java
@@ -270,7 +270,8 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                 AnnotationMirror anno1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror anno2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1.isBottom()) {
                 return anno2;
             } else if (qualifierKind2.isBottom()) {
@@ -331,7 +332,8 @@ public class I18nFormatterAnnotatedTypeFactory extends BaseAnnotatedTypeFactory 
                 AnnotationMirror anno1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror anno2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1.isTop()) {
                 return anno2;
             } else if (qualifierKind2.isTop()) {

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -324,7 +324,8 @@ public class LockAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == GUARDEDBY_KIND && qualifierKind2 == GUARDEDBY_KIND) {
                 List<String> locks1 =
                         AnnotationUtils.getElementValueArray(a1, "value", String.class, true);
@@ -355,7 +356,8 @@ public class LockAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == GUARDEDBY_KIND && qualifierKind2 == GUARDEDBY_KIND) {
                 List<String> locks1 =
                         AnnotationUtils.getElementValueArray(a1, "value", String.class, true);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -211,7 +211,6 @@ public class KeyForAnnotatedTypeFactory
         return new KeyForQualifierHierarchy(getSupportedTypeQualifiers(), elements);
     }
 
-    /// TODO: eliminate
     /** KeyForQualifierHierarchy */
     private final class KeyForQualifierHierarchy extends MostlyNoElementQualifierHierarchy {
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForAnnotatedTypeFactory.java
@@ -211,6 +211,7 @@ public class KeyForAnnotatedTypeFactory
         return new KeyForQualifierHierarchy(getSupportedTypeQualifiers(), elements);
     }
 
+    /// TODO: eliminate
     /** KeyForQualifierHierarchy */
     private final class KeyForQualifierHierarchy extends MostlyNoElementQualifierHierarchy {
 
@@ -261,7 +262,8 @@ public class KeyForAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == KEYFOR_KIND && qualifierKind2 == KEYFOR_KIND) {
                 List<String> a1Values = extractValues(a1);
                 List<String> a2Values = extractValues(a2);
@@ -281,7 +283,8 @@ public class KeyForAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == KEYFOR_KIND && qualifierKind2 == KEYFOR_KIND) {
 
                 List<String> a1Values = extractValues(a1);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -629,7 +629,8 @@ public class NullnessAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (!qualifierKind1.isInSameHierarchyAs(NULLABLE)
                     || !qualifierKind2.isInSameHierarchyAs(NULLABLE)) {
                 return this.leastUpperBoundInitialization(a1, qualifierKind1, a2, qualifierKind2);
@@ -642,7 +643,8 @@ public class NullnessAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (!qualifierKind1.isInSameHierarchyAs(NULLABLE)
                     || !qualifierKind2.isInSameHierarchyAs(NULLABLE)) {
                 return FBCBOTTOM;

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
@@ -256,6 +256,7 @@ public class NullnessTransfer
      * A scanner that returns true if there is an occurrence of @PolyNull that is not at the top
      * level.
      */
+    // Not static so it can access field POLYNULL.
     private class ContainsPolyNullNotAtTopLevelScanner
             extends SimpleAnnotatedTypeScanner<Boolean, Void> {
         /**

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -199,7 +199,8 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == REGEX_KIND && qualifierKind2 == REGEX_KIND) {
                 int value1 = getRegexValue(a1);
                 int value2 = getRegexValue(a2);
@@ -227,7 +228,8 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == REGEX_KIND && qualifierKind2 == REGEX_KIND) {
                 int value1 = getRegexValue(a1);
                 int value2 = getRegexValue(a2);

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -583,7 +583,8 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1.isBottom()) {
                 return a2;
             } else if (qualifierKind2.isBottom()) {
@@ -610,7 +611,8 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             return UnitsAnnotatedTypeFactory.this.BOTTOM;
         }
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/MostlyNoElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/MostlyNoElementQualifierHierarchy.java
@@ -25,9 +25,9 @@ import org.checkerframework.framework.util.QualifierKindHierarchy;
  *   <li>{@link #isSubtypeWithElements(AnnotationMirror, QualifierKind, AnnotationMirror,
  *       QualifierKind)}
  *   <li>{@link #leastUpperBoundWithElements(AnnotationMirror, QualifierKind, AnnotationMirror,
- *       QualifierKind)}
+ *       QualifierKind,QualifierKind)}
  *   <li>{@link #greatestLowerBoundWithElements(AnnotationMirror, QualifierKind, AnnotationMirror,
- *       QualifierKind)}
+ *       QualifierKind,QualifierKind)}
  * </ul>
  *
  * <p>MostlyNoElementQualifierHierarchy uses a {@link QualifierKindHierarchy} to model the
@@ -90,7 +90,7 @@ public abstract class MostlyNoElementQualifierHierarchy extends ElementQualifier
             return null;
         }
         if (lub.hasElements()) {
-            return leastUpperBoundWithElements(a1, qual1, a2, qual2);
+            return leastUpperBoundWithElements(a1, qual1, a2, qual2, lub);
         }
         return kindToElementlessQualifier.get(lub);
     }
@@ -106,13 +106,15 @@ public abstract class MostlyNoElementQualifierHierarchy extends ElementQualifier
      * @param qualifierKind1 QualifierKind for {@code a1}
      * @param a2 second annotation
      * @param qualifierKind2 QualifierKind for {@code a2}
+     * @param lubKind the kind of the lub of {@code qualifierKind1} and {@code qualifierKind2}
      * @return the least upper bound of {@code a1} and {@code a2}
      */
     protected abstract AnnotationMirror leastUpperBoundWithElements(
             AnnotationMirror a1,
             QualifierKind qualifierKind1,
             AnnotationMirror a2,
-            QualifierKind qualifierKind2);
+            QualifierKind qualifierKind2,
+            QualifierKind lubKind);
 
     @Override
     public final @Nullable AnnotationMirror greatestLowerBound(
@@ -125,7 +127,7 @@ public abstract class MostlyNoElementQualifierHierarchy extends ElementQualifier
             return null;
         }
         if (glb.hasElements()) {
-            return greatestLowerBoundWithElements(a1, qual1, a2, qual2);
+            return greatestLowerBoundWithElements(a1, qual1, a2, qual2, glb);
         }
         return kindToElementlessQualifier.get(glb);
     }
@@ -147,5 +149,6 @@ public abstract class MostlyNoElementQualifierHierarchy extends ElementQualifier
             AnnotationMirror a1,
             QualifierKind qualifierKind1,
             AnnotationMirror a2,
-            QualifierKind qualifierKind2);
+            QualifierKind qualifierKind2,
+            QualifierKind glbKind);
 }

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/flowexpression/FlowExpressionAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/flowexpression/FlowExpressionAnnotatedTypeFactory.java
@@ -67,7 +67,8 @@ public class FlowExpressionAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1.getName() == FEBottom.class.getCanonicalName()) {
                 return a2;
             } else if (qualifierKind2.getName() == FEBottom.class.getCanonicalName()) {
@@ -89,7 +90,8 @@ public class FlowExpressionAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1.getName() == FETop.class.getCanonicalName()) {
                 return a2;
             } else if (qualifierKind2.getName() == FETop.class.getCanonicalName()) {

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
@@ -131,7 +131,8 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == qualifierKind2) {
                 // Both are Value
                 if (AnnotationUtils.areSame(a1, a2)) {
@@ -153,7 +154,8 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == qualifierKind2) {
                 // Both are Value
                 if (AnnotationUtils.areSame(a1, a2)) {

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/wholeprograminference/WholeProgramInferenceTestAnnotatedTypeFactory.java
@@ -115,7 +115,8 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind glbKind) {
             if (qualifierKind1 == qualifierKind2 && qualifierKind1 == SIBLING_WITH_FIELDS_KIND) {
                 if (isSubtypeWithElements(a1, qualifierKind1, a2, qualifierKind2)) {
                     return a1;
@@ -135,7 +136,8 @@ public class WholeProgramInferenceTestAnnotatedTypeFactory extends BaseAnnotated
                 AnnotationMirror a1,
                 QualifierKind qualifierKind1,
                 AnnotationMirror a2,
-                QualifierKind qualifierKind2) {
+                QualifierKind qualifierKind2,
+                QualifierKind lubKind) {
             if (qualifierKind1 == qualifierKind2 && qualifierKind1 == SIBLING_WITH_FIELDS_KIND) {
                 if (isSubtypeWithElements(a1, qualifierKind1, a2, qualifierKind2)) {
                     return a1;


### PR DESCRIPTION
This prevents clients from having to recompute it, but passes it redundantly to clients who don't care.
It is moitvated by #3847.
