### PR TITLE
Remove undocumented feature of lowercasing user-written SuppressWarnings strings

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessTransfer.java
@@ -256,6 +256,7 @@ public class NullnessTransfer
      * A scanner that returns true if there is an occurrence of @PolyNull that is not at the top
      * level.
      */
+    // Not static so it can access field POLYNULL.
     private class ContainsPolyNullNotAtTopLevelScanner
             extends SimpleAnnotatedTypeScanner<Boolean, Void> {
         /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -895,7 +895,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      */
     private void reportPurityError(String msgKeyPrefix, Pair<Tree, String> r) {
         String reason = r.second;
-        @SuppressWarnings("CompilerMessages")
+        @SuppressWarnings("compilermessages")
         @CompilerMessageKey String msgKey = msgKeyPrefix + reason;
         if (reason.equals("call") || reason.equals("call.method")) {
             MethodInvocationTree mitree = (MethodInvocationTree) r.first;
@@ -961,7 +961,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             }
 
             if (formalParamNames != null && formalParamNames.contains(expression)) {
-                @SuppressWarnings("CompilerMessages")
+                @SuppressWarnings("compilermessages")
                 @CompilerMessageKey String key = "contracts." + contract.kind.errorKey + ".expression.parameter.name";
                 checker.reportWarning(
                         node,
@@ -3643,7 +3643,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             Set<Pair<Receiver, AnnotationMirror>> superPost2 =
                     resolveContracts(superPost, overridden);
             Set<Pair<Receiver, AnnotationMirror>> subPost2 = resolveContracts(subPost, overrider);
-            @SuppressWarnings("CompilerMessages")
+            @SuppressWarnings("compilermessages")
             @CompilerMessageKey String postmsg = "contracts.postcondition." + msgKey + ".invalid";
             checkContractsSubset(
                     overriderMeth,
@@ -3660,7 +3660,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             Set<Pair<Receiver, AnnotationMirror>> superPre2 =
                     resolveContracts(superPre, overridden);
             Set<Pair<Receiver, AnnotationMirror>> subPre2 = resolveContracts(subPre, overrider);
-            @SuppressWarnings("CompilerMessages")
+            @SuppressWarnings("compilermessages")
             @CompilerMessageKey String premsg = "contracts.precondition." + msgKey + ".invalid";
             checkContractsSubset(
                     overriderMeth,
@@ -3683,7 +3683,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     resolveContracts(superCPostTrue, overridden);
             Set<Pair<Receiver, AnnotationMirror>> subCPostTrue2 =
                     resolveContracts(subCPostTrue, overrider);
-            @SuppressWarnings("CompilerMessages")
+            @SuppressWarnings("compilermessages")
             @CompilerMessageKey String posttruemsg = "contracts.conditional.postcondition.true." + msgKey + ".invalid";
             checkContractsSubset(
                     overriderMeth,
@@ -3701,7 +3701,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
                     resolveContracts(superCPostFalse, overridden);
             Set<Pair<Receiver, AnnotationMirror>> subCPostFalse2 =
                     resolveContracts(subCPostFalse, overrider);
-            @SuppressWarnings("CompilerMessages")
+            @SuppressWarnings("compilermessages")
             @CompilerMessageKey String postfalsemsg =
                     "contracts.conditional.postcondition.false." + msgKey + ".invalid";
             checkContractsSubset(

--- a/framework/src/main/java/org/checkerframework/common/util/report/ReportVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/util/report/ReportVisitor.java
@@ -71,7 +71,7 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
         }
     }
 
-    @SuppressWarnings("CompilerMessages") // These warnings are not translated.
+    @SuppressWarnings("compilermessages") // These warnings are not translated.
     @Override
     public Void scan(Tree tree, Void p) {
         if ((tree != null) && (treeKinds != null) && treeKinds.contains(tree.getKind())) {
@@ -280,7 +280,7 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
         return super.visitInstanceOf(node, p);
     }
 
-    @SuppressWarnings("CompilerMessages") // These warnings are not translated.
+    @SuppressWarnings("compilermessages") // These warnings are not translated.
     @Override
     public Void visitModifiers(ModifiersTree node, Void p) {
         if (node != null && modifiers != null) {

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -1797,9 +1797,6 @@ public abstract class SourceChecker extends AbstractTypeProcessor
                 return null;
             }
             this.suppressWarningsStringsFromOption = swStrings.split(",");
-            Arrays.setAll(
-                    suppressWarningsStringsFromOption,
-                    i -> suppressWarningsStringsFromOption[i].toLowerCase());
         }
 
         return this.suppressWarningsStringsFromOption;
@@ -1846,7 +1843,6 @@ public abstract class SourceChecker extends AbstractTypeProcessor
             // tree has a @SuppressWarnings annotation that didn't suppress any warnings.
             SuppressWarnings suppressAnno = elt.getAnnotation(SuppressWarnings.class);
             String[] suppressWarningsStrings = suppressAnno.value();
-            Arrays.setAll(suppressWarningsStrings, i -> suppressWarningsStrings[i].toLowerCase());
             for (String suppressWarningsString : suppressWarningsStrings) {
                 for (String errorKey : allErrorKeys) {
                     if (shouldSuppress(prefixes, new String[] {suppressWarningsString}, errorKey)) {
@@ -2065,8 +2061,6 @@ public abstract class SourceChecker extends AbstractTypeProcessor
             SuppressWarnings suppressWarningsAnno = elt.getAnnotation(SuppressWarnings.class);
             if (suppressWarningsAnno != null) {
                 String[] suppressWarningsStrings = suppressWarningsAnno.value();
-                Arrays.setAll(
-                        suppressWarningsStrings, i -> suppressWarningsStrings[i].toLowerCase());
                 if (shouldSuppress(suppressWarningsStrings, errKey)) {
                     if (hasOption("warnUnneededSuppressions")) {
                         elementsWithSuppressedWarnings.add(elt);

--- a/framework/tests/all-systems/EqualityTests.java
+++ b/framework/tests/all-systems/EqualityTests.java
@@ -1,7 +1,7 @@
 public class EqualityTests {
     // the Interning checker correctly issues an error below, but we would like to keep this test in
     // all-systems.
-    @SuppressWarnings("Interning")
+    @SuppressWarnings("interning")
     public boolean compareLongs(Long v1, Long v2) {
         // This expression used to cause an assertion
         // failure in GLB computation.

--- a/framework/tests/all-systems/StateMatch.java
+++ b/framework/tests/all-systems/StateMatch.java
@@ -5,7 +5,7 @@ public class StateMatch {
     private double[][] elts = null;
 
     @SuppressWarnings({
-        "Interning",
+        "interning",
         "index"
     }) // This code is inherently unsafe for the index checker, but adding index annotations
     // produces warnings for other checkers (fenum).


### PR DESCRIPTION
An alternative to this change is to document the feature, use mixed-case throughout the examples, and encourage it for users.