### PR TITLE
Define glb more precisely for the Nullness Checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -946,7 +946,7 @@ public abstract class InitializationAnnotatedTypeFactory<
          * Returns the greatest lower bound of two types.
          *
          * @param a the first argument
-         * @param a the second argument
+         * @param b the second argument
          * @return the glb of the two arguments
          */
         protected TypeMirror glbTypeFrame(TypeMirror a, TypeMirror b) {

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -888,5 +888,75 @@ public abstract class InitializationAnnotatedTypeFactory<
 
             return TypesUtils.leastUpperBound(a, b, processingEnv);
         }
+
+        /**
+         * Compute the greatest lower bound of two initialization qualifiers. Returns null if one of
+         * the qualifiers is not in the initialization hierarachy. Subclasses should override
+         * greatestLowerBound and call this method for initialization qualifiers.
+         *
+         * @param anno1 an initialization qualifier
+         * @param qual1 a qualifier kind
+         * @param anno2 an initialization qualifier
+         * @param qual2 a qualifier kind
+         * @return the glb of anno1 and anno2
+         */
+        protected AnnotationMirror greatestLowerBoundInitialization(
+                AnnotationMirror anno1,
+                QualifierKind qual1,
+                AnnotationMirror anno2,
+                QualifierKind qual2) {
+            if (!isInitializationAnnotation(anno1) || !isInitializationAnnotation(anno2)) {
+                return null;
+            }
+
+            // Handle the case where one is a subtype of the other.
+            if (isSubtypeInitialization(anno1, qual1, anno2, qual2)) {
+                return anno1;
+            } else if (isSubtypeInitialization(anno2, qual2, anno1, qual1)) {
+                return anno2;
+            }
+            boolean unknowninit1 = isUnknownInitialization(anno1);
+            boolean unknowninit2 = isUnknownInitialization(anno2);
+            boolean underinit1 = isUnderInitialization(anno1);
+            boolean underinit2 = isUnderInitialization(anno2);
+
+            // Handle @Initialized.
+            if (isInitialized(anno1)) {
+                assert underinit2;
+                return FBCBOTTOM;
+            } else if (isInitialized(anno2)) {
+                assert underinit1;
+                return FBCBOTTOM;
+            }
+
+            if (underinit1 && underinit2) {
+                return createUnderInitializationAnnotation(
+                        glbTypeFrame(
+                                getTypeFrameFromAnnotation(anno1),
+                                getTypeFrameFromAnnotation(anno2)));
+            }
+
+            assert (unknowninit1 || underinit1) && (unknowninit2 || underinit2);
+            return createUnderInitializationAnnotation(
+                    glbTypeFrame(
+                            getTypeFrameFromAnnotation(anno1), getTypeFrameFromAnnotation(anno2)));
+        }
+
+        /**
+         * Returns the greatest lower bound of two types.
+         *
+         * @param a the first argument
+         * @param a the second argument
+         * @return the glb of the two arguments
+         */
+        protected TypeMirror glbTypeFrame(TypeMirror a, TypeMirror b) {
+            if (types.isSubtype(a, b)) {
+                return a;
+            } else if (types.isSubtype(b, a)) {
+                return b;
+            }
+
+            return TypesUtils.greatestLowerBound(a, b, processingEnv);
+        }
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
 import org.checkerframework.checker.initialization.qual.FBCBottom;
@@ -929,34 +930,22 @@ public abstract class InitializationAnnotatedTypeFactory<
                 return FBCBOTTOM;
             }
 
+            TypeMirror typeFrame =
+                    TypesUtils.greatestLowerBound(
+                            getTypeFrameFromAnnotation(anno1),
+                            getTypeFrameFromAnnotation(anno2),
+                            processingEnv);
+            if (typeFrame.getKind() == TypeKind.ERROR
+                    || typeFrame.getKind() == TypeKind.INTERSECTION) {
+                return FBCBOTTOM;
+            }
+
             if (underinit1 && underinit2) {
-                return createUnderInitializationAnnotation(
-                        glbTypeFrame(
-                                getTypeFrameFromAnnotation(anno1),
-                                getTypeFrameFromAnnotation(anno2)));
+                return createUnderInitializationAnnotation(typeFrame);
             }
 
             assert (unknowninit1 || underinit1) && (unknowninit2 || underinit2);
-            return createUnderInitializationAnnotation(
-                    glbTypeFrame(
-                            getTypeFrameFromAnnotation(anno1), getTypeFrameFromAnnotation(anno2)));
-        }
-
-        /**
-         * Returns the greatest lower bound of two types.
-         *
-         * @param a the first argument
-         * @param b the second argument
-         * @return the glb of the two arguments
-         */
-        protected TypeMirror glbTypeFrame(TypeMirror a, TypeMirror b) {
-            if (types.isSubtype(a, b)) {
-                return a;
-            } else if (types.isSubtype(b, a)) {
-                return b;
-            }
-
-            return TypesUtils.greatestLowerBound(a, b, processingEnv);
+            return createUnderInitializationAnnotation(typeFrame);
         }
     }
 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -647,7 +647,8 @@ public class NullnessAnnotatedTypeFactory
                 QualifierKind glbKind) {
             if (!qualifierKind1.isInSameHierarchyAs(NULLABLE)
                     || !qualifierKind2.isInSameHierarchyAs(NULLABLE)) {
-                return FBCBOTTOM;
+                return this.greatestLowerBoundInitialization(
+                        a1, qualifierKind1, a2, qualifierKind2);
             }
             throw new BugInCF(
                     "Unexpected annotations greatestLowerBoundWithElements(%s, %s)", a1, a2);


### PR DESCRIPTION
This is important for whole-program inference, which uses GLB to combine stubs and source code.

The code for new method `greatestLowerBoundInitialization` is very similar to that for existing method `leastUpperBoundInitialization`.