### PR TITLE
In `updateFromReturn`, remove Java expressions that contain local variables

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
@@ -3,6 +3,7 @@ package org.checkerframework.checker.index;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.checker.index.upperbound.OffsetEquation;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.Receiver;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -25,11 +26,12 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
     }
 
     @Override
-    protected String standardizeString(
+    protected @Nullable String standardizeString(
             final String expression,
             FlowExpressionContext context,
             TreePath localScope,
-            boolean useLocalScope) {
+            boolean useLocalScope,
+            boolean removeErroneousExpressions) {
         if (DependentTypesError.isExpressionError(expression)) {
             return expression;
         }
@@ -44,7 +46,11 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
                 return new DependentTypesError(expression, e).toString();
             }
             if (result == null) {
-                return new DependentTypesError(expression, " ").toString();
+                if (removeErroneousExpressions) {
+                    return null;
+                } else {
+                    return new DependentTypesError(expression, " ").toString();
+                }
             }
             if (result instanceof FieldAccess && ((FieldAccess) result).isFinal()) {
                 Object constant = ((FieldAccess) result).getField().getConstantValue();

--- a/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/OffsetDependentTypesHelper.java
@@ -3,7 +3,6 @@ package org.checkerframework.checker.index;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.util.TreePath;
 import org.checkerframework.checker.index.upperbound.OffsetEquation;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.Receiver;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -26,12 +25,11 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
     }
 
     @Override
-    protected @Nullable String standardizeString(
+    protected String standardizeString(
             final String expression,
             FlowExpressionContext context,
             TreePath localScope,
-            boolean useLocalScope,
-            boolean removeErroneousExpressions) {
+            boolean useLocalScope) {
         if (DependentTypesError.isExpressionError(expression)) {
             return expression;
         }
@@ -46,11 +44,7 @@ public class OffsetDependentTypesHelper extends DependentTypesHelper {
                 return new DependentTypesError(expression, e).toString();
             }
             if (result == null) {
-                if (removeErroneousExpressions) {
-                    return null;
-                } else {
-                    return new DependentTypesError(expression, " ").toString();
-                }
+                return new DependentTypesError(expression, " ").toString();
             }
             if (result instanceof FieldAccess && ((FieldAccess) result).isFinal()) {
                 Object constant = ((FieldAccess) result).getField().getConstantValue();

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -170,9 +170,10 @@ public class LockAnnotatedTypeFactory
                     String expression,
                     FlowExpressionContext context,
                     TreePath localScope,
-                    boolean useLocalScope) {
+                    boolean useLocalScope,
+                    boolean removeErroneousExpressions) {
                 if (DependentTypesError.isExpressionError(expression)) {
-                    return expression;
+                    return null;
                 }
 
                 // Adds logic to parse <self> expression, which only the Lock Checker uses.
@@ -185,17 +186,29 @@ public class LockAnnotatedTypeFactory
                             FlowExpressionParseUtil.parse(
                                     expression, context, localScope, useLocalScope);
                     if (result == null) {
-                        return new DependentTypesError(expression, " ").toString();
+                        if (removeErroneousExpressions) {
+                            return null;
+                        } else {
+                            return new DependentTypesError(expression, " ").toString();
+                        }
                     }
                     if (!isExpressionEffectivelyFinal(result)) {
                         // If the expression isn't effectively final, then return the
                         // NOT_EFFECTIVELY_FINAL error string.
-                        return new DependentTypesError(expression, NOT_EFFECTIVELY_FINAL)
-                                .toString();
+                        if (removeErroneousExpressions) {
+                            return null;
+                        } else {
+                            return new DependentTypesError(expression, NOT_EFFECTIVELY_FINAL)
+                                    .toString();
+                        }
                     }
                     return result.toString();
                 } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
-                    return new DependentTypesError(expression, e).toString();
+                    if (removeErroneousExpressions) {
+                        return null;
+                    } else {
+                        return new DependentTypesError(expression, e).toString();
+                    }
                 }
             }
         };

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -170,10 +170,9 @@ public class LockAnnotatedTypeFactory
                     String expression,
                     FlowExpressionContext context,
                     TreePath localScope,
-                    boolean useLocalScope,
-                    boolean removeErroneousExpressions) {
+                    boolean useLocalScope) {
                 if (DependentTypesError.isExpressionError(expression)) {
-                    return null;
+                    return expression;
                 }
 
                 // Adds logic to parse <self> expression, which only the Lock Checker uses.
@@ -186,29 +185,17 @@ public class LockAnnotatedTypeFactory
                             FlowExpressionParseUtil.parse(
                                     expression, context, localScope, useLocalScope);
                     if (result == null) {
-                        if (removeErroneousExpressions) {
-                            return null;
-                        } else {
-                            return new DependentTypesError(expression, " ").toString();
-                        }
+                        return new DependentTypesError(expression, " ").toString();
                     }
                     if (!isExpressionEffectivelyFinal(result)) {
                         // If the expression isn't effectively final, then return the
                         // NOT_EFFECTIVELY_FINAL error string.
-                        if (removeErroneousExpressions) {
-                            return null;
-                        } else {
-                            return new DependentTypesError(expression, NOT_EFFECTIVELY_FINAL)
-                                    .toString();
-                        }
+                        return new DependentTypesError(expression, NOT_EFFECTIVELY_FINAL)
+                                .toString();
                     }
                     return result.toString();
                 } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
-                    if (removeErroneousExpressions) {
-                        return null;
-                    } else {
-                        return new DependentTypesError(expression, e).toString();
-                    }
+                    return new DependentTypesError(expression, e).toString();
                 }
             }
         };

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -986,7 +986,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         if (dependentTypesHelper != null) {
             AnnotationMirror anno =
                     dependentTypesHelper.standardizeAnnotation(
-                            flowExprContext, path, annoFromContract, false);
+                            flowExprContext, path, annoFromContract, false, false);
             dependentTypesHelper.checkAnnotation(anno, path.getLeaf());
             return anno;
         } else {

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -362,7 +362,7 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
             return;
         }
 
-        // See Issue 682
+        // Whole-program inference ignores some locations.  See Issue 682:
         // https://github.com/typetools/checker-framework/issues/682
         if (classSymbol == null) { // TODO: Handle anonymous classes.
             return;

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -27,7 +27,9 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.framework.util.dependenttypes.DependentTypesHelper;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
@@ -379,6 +381,12 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
 
         // Type of the expression returned
         AnnotatedTypeMirror rhsATM = atf.getAnnotatedType(retNode.getTree().getExpression());
+        DependentTypesHelper dependentTypesHelper =
+                ((GenericAnnotatedTypeFactory) atf).getDependentTypesHelper();
+        if (dependentTypesHelper != null) {
+            dependentTypesHelper.standardizeReturnType(
+                    methodTree, rhsATM, /*removeErroneousExpressions=*/ true);
+        }
         storage.updateAnnotationSetInScene(
                 method.returnType, atf, jaifPath, rhsATM, lhsATM, TypeUseLocation.RETURN);
 

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -583,7 +583,7 @@ public abstract class CFAbstractTransfer<
         // TODO: common implementation with BaseTypeVisitor.standardizeAnnotationFromContract
         if (analysis.dependentTypesHelper != null) {
             return analysis.dependentTypesHelper.standardizeAnnotation(
-                    flowExprContext, path, annoFromContract, false);
+                    flowExprContext, path, annoFromContract, false, false);
             // BaseTypeVisitor checks the validity of the annotaiton. Errors are reported there
             // when called from BaseTypeVisitor.checkContractsAtMethodDeclaration().
         } else {

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -308,7 +308,7 @@ public class DependentTypesHelper {
      * @param m the method to be standardized
      * @param atm the method return type
      */
-    public void standardizeReturnType(MethodTree m, AnnotatedTypeMirror atm) {
+    public final void standardizeReturnType(MethodTree m, AnnotatedTypeMirror atm) {
         standardizeReturnType(m, atm, false);
     }
 
@@ -565,7 +565,7 @@ public class DependentTypesHelper {
     }
 
     @SuppressWarnings("nullness") // removeErroneousExpressions==false => return value is non-null
-    protected String standardizeString(
+    protected final String standardizeString(
             String expression,
             FlowExpressionContext context,
             TreePath localScope,
@@ -586,11 +586,11 @@ public class DependentTypesHelper {
             boolean useLocalScope,
             boolean removeErroneousExpressions) {
         if (DependentTypesError.isExpressionError(expression)) {
-            return expression;
-        }
-        if (expression.equals("<self>")) {
-            // Hack for Lock Checker
-            return expression;
+            if (removeErroneousExpressions) {
+                return null;
+            } else {
+                return expression;
+            }
         }
         try {
             Receiver result =

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -32,7 +32,6 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.expression.ArrayCreation;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.FlowExpressions;
@@ -564,51 +563,23 @@ public class DependentTypesHelper {
         }
     }
 
-    @SuppressWarnings("nullness") // removeErroneousExpressions==false => return value is non-null
-    protected final String standardizeString(
+    protected String standardizeString(
             String expression,
             FlowExpressionContext context,
             TreePath localScope,
             boolean useLocalScope) {
-        return standardizeString(expression, context, localScope, useLocalScope, false);
-    }
-
-    /**
-     * Standardize the Java expression.
-     *
-     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
-     *     converting them into an explanation of why they are illegal
-     */
-    protected @Nullable String standardizeString(
-            String expression,
-            FlowExpressionContext context,
-            TreePath localScope,
-            boolean useLocalScope,
-            boolean removeErroneousExpressions) {
         if (DependentTypesError.isExpressionError(expression)) {
-            if (removeErroneousExpressions) {
-                return null;
-            } else {
-                return expression;
-            }
+            return expression;
         }
         try {
             Receiver result =
                     FlowExpressionParseUtil.parse(expression, context, localScope, useLocalScope);
             if (result == null) {
-                if (removeErroneousExpressions) {
-                    return null;
-                } else {
-                    return new DependentTypesError(expression, " ").toString();
-                }
+                return new DependentTypesError(expression, " ").toString();
             }
             return result.toString();
         } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
-            if (removeErroneousExpressions) {
-                return null;
-            } else {
-                return new DependentTypesError(expression, e).toString();
-            }
+            return new DependentTypesError(expression, e).toString();
         }
     }
 
@@ -685,14 +656,10 @@ public class DependentTypesHelper {
             List<String> standardizedStrings = new ArrayList<>();
             for (String expression : expressionStrings) {
                 String standardized =
-                        standardizeString(
-                                expression,
-                                context,
-                                localScope,
-                                useLocalScope,
-                                removeErroneousExpressions);
-                if (standardized == null) {
-                    assert removeErroneousExpressions;
+                        standardizeString(expression, context, localScope, useLocalScope);
+                if (removeErroneousExpressions
+                        && DependentTypesError.isExpressionError(standardized)) {
+                    // nothing to do
                 } else {
                     standardizedStrings.add(standardized);
                 }

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -588,8 +588,9 @@ public class DependentTypesHelper {
         } catch (FlowExpressionParseUtil.FlowExpressionParseException e) {
             if (removeErroneousExpressions) {
                 return null;
+            } else {
+                return new DependentTypesError(expression, e).toString();
             }
-            return new DependentTypesError(expression, e).toString();
         }
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -588,6 +588,10 @@ public class DependentTypesHelper {
         if (DependentTypesError.isExpressionError(expression)) {
             return expression;
         }
+        if (expression.equals("<self>")) {
+            // Hack for Lock Checker
+            return expression;
+        }
         try {
             Receiver result =
                     FlowExpressionParseUtil.parse(expression, context, localScope, useLocalScope);

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -526,6 +526,10 @@ public class DependentTypesHelper {
         standardizeDoNotUseLocals(context, localScope, type, false);
     }
 
+    /**
+     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+     *     converting them into an explanation of why they are illegal
+     */
     private void standardizeDoNotUseLocals(
             FlowExpressionContext context,
             TreePath localScope,
@@ -542,6 +546,10 @@ public class DependentTypesHelper {
         standardizeAtm(context, localScope, type, useLocalScope, false);
     }
 
+    /**
+     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+     *     converting them into an explanation of why they are illegal
+     */
     private void standardizeAtm(
             FlowExpressionContext context,
             TreePath localScope,
@@ -565,6 +573,12 @@ public class DependentTypesHelper {
         return standardizeString(expression, context, localScope, useLocalScope, false);
     }
 
+    /**
+     * Standardize the Java expression.
+     *
+     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+     *     converting them into an explanation of why they are illegal
+     */
     protected @Nullable String standardizeString(
             String expression,
             FlowExpressionContext context,
@@ -626,7 +640,12 @@ public class DependentTypesHelper {
                 context, localScope, anno, useLocalScope, removeErroneousExpressions);
     }
 
-    /** Standardizes an annotation. If it is not a dependent type annotation, returns null. */
+    /**
+     * Standardizes an annotation. If it is not a dependent type annotation, returns null.
+     *
+     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+     *     converting them into an explanation of why they are illegal
+     */
     private AnnotationMirror standardizeAnnotationIfDependentType(
             FlowExpressionContext context,
             TreePath localScope,
@@ -640,7 +659,12 @@ public class DependentTypesHelper {
                 context, localScope, anno, useLocalScope, removeErroneousExpressions);
     }
 
-    /** Standardizes a dependent type annotation. */
+    /**
+     * Standardizes a dependent type annotation.
+     *
+     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+     *     converting them into an explanation of why they are illegal
+     */
     private AnnotationMirror standardizeDependentTypeAnnotation(
             FlowExpressionContext context,
             TreePath localScope,
@@ -685,6 +709,10 @@ public class DependentTypesHelper {
          */
         private final boolean removeErroneousExpressions;
 
+        /**
+         * @param removeErroneousExpressions if true, remove erroneous expressions rather than
+         *     converting them into an explanation of why they are illegal
+         */
         private StandardizeTypeAnnotator(
                 FlowExpressionContext context,
                 TreePath localScope,


### PR DESCRIPTION
`updateFromReturn` transfers a type from a return expression to a method return type.  References to local variables make sense within the method body but not in the method signature.

Similar standardization might be necessary elsewhere.

Reinstate Javadoc checking after merging.