### PR TITLE
Make ElementUtils#getQualifiedName unique for method parameters

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -176,14 +176,14 @@ public class ElementUtils {
      * @return the qualified name of the given element
      */
     public static String getQualifiedName(Element elt) {
-        Name n = getQualifiedClassName(elt);
-        if (n == null) {
-            return "Unexpected element: " + elt;
-        }
         if (elt.getKind() == ElementKind.PACKAGE || isClassElement(elt)) {
+            Name n = getQualifiedClassName(elt);
+            if (n == null) {
+                return "Unexpected element: " + elt;
+            }
             return n.toString();
         } else {
-            return n + "." + elt;
+            return getQualifiedName(elt.getEnclosingElement()) + "." + elt;
         }
     }
 


### PR DESCRIPTION
This change is motivated by the `StubTypes#declAnnosFromStubFiles`, which is a map of type `Map<String, Set<AnnotationMirror>>`. The keys are values computed by `ElementUitls#getQualifiedName`. When a stub file contains a declaration annotation on a method parameter, and also another (unannotated) method with a parameter of the same name, this map would confuse the two and return the declaration annotation if either parameter was queried. This change fixes that problem.

I'm not sure how to test this within the CF itself, because I don't know of any checkers that use declaration annotations in stub files other than the MustCall Checker. The problem came up in the context described below, and I've confirmed that this change fixes it.

Consider the following stub file, which is reduced form of the one used by the MustCall Checker for `java.io.PrintStream`:

```
package java.io;
class PrintStream {
    @PolyMustCall PrintStream(@PolyMustCall @Owning OutputStream arg0);
    @NotOwning PrintStream printf(String arg0, Object[] arg1);
}
```

`@Owning` and `@NotOwning` are declaration annotations that indicate ownership transfer (their semantics are irrelevant). Because there was an `@Owning` annotation on `arg0` of the constructor, calling `AnnotatedTypeFactory#getDeclAnnotation` to check if the element representing the first parameter of `printf` has an `@Owning` annotation actually found an `@Owning` annotation, which is clearly erroneous.

After the change in this PR, that no longer happens.