### PR TITLE
Add AssignmentContexts for parameters of constructor calls

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import javax.lang.model.element.ExecutableElement;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.javacutil.TreeUtils;
 import org.plumelib.util.UtilPlume;
@@ -35,6 +36,14 @@ public class ObjectCreationNode extends Node {
         this.constructor = constructor;
         this.arguments = arguments;
         this.classbody = classbody;
+
+        // set assignment contexts for parameters
+        int i = 0;
+        ExecutableElement elem = TreeUtils.elementFromUse(tree);
+        for (Node arg : arguments) {
+            AssignmentContext ctx = new AssignmentContext.MethodParameterContext(elem, i++);
+            arg.setAssignmentContext(ctx);
+        }
     }
 
     public Node getConstructor() {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ObjectCreationNode.java
@@ -40,9 +40,11 @@ public class ObjectCreationNode extends Node {
         // set assignment contexts for parameters
         int i = 0;
         ExecutableElement elem = TreeUtils.elementFromUse(tree);
-        for (Node arg : arguments) {
-            AssignmentContext ctx = new AssignmentContext.MethodParameterContext(elem, i++);
-            arg.setAssignmentContext(ctx);
+        if (elem != null) {
+            for (Node arg : arguments) {
+                AssignmentContext ctx = new AssignmentContext.MethodParameterContext(elem, i++);
+                arg.setAssignmentContext(ctx);
+            }
         }
     }
 


### PR DESCRIPTION
It seems these contexts should also be present when expressions are passed as a parameter to a constructor call (in addition to normal method invocations).  They would be useful for a checker we are working on.

@smillst I'm not sure how to write a test for this.  Maybe these additional contexts could be relevant to type inference?