### PR TITLE
AnnotatedIntersectionTypes can have TypeVariable bounds

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -2080,7 +2080,9 @@ public abstract class AnnotatedTypeMirror {
                 Set<AnnotationMirror> newAnnos = this.getAnnotationsField();
                 if (bounds != null) {
                     for (AnnotatedTypeMirror bound : bounds) {
-                        bound.replaceAnnotations(newAnnos);
+                        if (bound.getKind() != TypeKind.TYPEVAR) {
+                            bound.replaceAnnotations(newAnnos);
+                        }
                     }
                 }
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/BoundsInitializer.java
@@ -1253,9 +1253,10 @@ public class BoundsInitializer {
         @Override
         protected void replaceTypeInternal(
                 AnnotatedTypeMirror parent, AnnotatedTypeVariable replacement) {
-            throw new BugInCF(
-                    "Type variables cannot be intersection bounds.%nparent=%s%nreplacement=%s",
-                    parent, replacement);
+            AnnotatedIntersectionType intersection = (AnnotatedIntersectionType) parent;
+            List<AnnotatedTypeMirror> bounds = new ArrayList<>(intersection.bounds);
+            bounds.set(boundIndex, replacement);
+            intersection.setBounds(bounds);
         }
 
         @Override
@@ -1265,7 +1266,7 @@ public class BoundsInitializer {
                 throw new BugInCF("Invalid superIndex %d: parent=%s", boundIndex, parent);
             }
 
-            return isect.directSuperTypes().get(boundIndex);
+            return isect.getBounds().get(boundIndex);
         }
 
         @Override


### PR DESCRIPTION
These changes should have been in https://github.com/typetools/checker-framework/pull/3790.