### PR TITLE
Put dependencies in canonical order

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -18,11 +18,11 @@ sourceSets {
 }
 
 dependencies {
-    implementation project(':framework')
-    implementation project(':dataflow')
     implementation project(':javacutil')
+    implementation project(':dataflow')
+    implementation project(':framework')
     implementation project(':checker-qual')
-    // As of 2019/12/16, the version of reflection-util in the Annotation
+    // As of 2019-12-16, the version of reflection-util in the Annotation
     // File Utilities takes priority over this version, in the fat jar
     // file. :-( So update it and re-build it locally when updating this.
     implementation 'org.plumelib:reflection-util:1.0.2'

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -18,8 +18,8 @@ def versions = [
 
 
 dependencies {
-    implementation project(':dataflow')
     implementation project(':javacutil')
+    implementation project(':dataflow')
     implementation files("${stubparserJar}")
     // AFU is an "includedBuild" imported in checker-framework/settings.gradle, so the version number doesn't matter.
     // https://docs.gradle.org/current/userguide/composite_builds.html#settings_defined_composite


### PR DESCRIPTION
Also use standard (ISO 8601) formatting for date.