### PR TITLE
Ignore declaration annotations when issuing nullness.on.primitive warning.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -653,6 +653,9 @@ public class NullnessAnnotatedTypeFactory
      * Returns true if some annotation in the given list is a nullness annotation such
      * as @NonNull, @Nullable, @MonotonicNonNull, etc.
      *
+     * <p>This method ignores aliases of nullness annotations that are declaration annotations,
+     * because they may apply to inner types.
+     *
      * @param annoTrees a list of annotations on a variable/method declaration; null if this type is
      *     not from such a location
      * @param typeTree the type whose annotations to test
@@ -665,7 +668,7 @@ public class NullnessAnnotatedTypeFactory
 
         for (AnnotationTree annoTree : annos) {
             AnnotationMirror am = TreeUtils.annotationFromAnnotationTree(annoTree);
-            if (isNullnessAnnotation(am)) {
+            if (isNullnessAnnotation(am) && !AnnotationUtils.isDeclarationAnnotation(am)) {
                 return true;
             }
         }

--- a/checker/tests/nullness/Issue3935.java
+++ b/checker/tests/nullness/Issue3935.java
@@ -1,5 +1,10 @@
 import android.annotation.Nullable;
 
 public class Issue3935 {
+    // Note: Nullable is a declaration annotation and applies to the array, not the array element.
     private @Nullable byte[] data;
+
+    // Declaration annotations on primitives are ignored, but this should issue
+    // a nullness.on.primitive error.
+    @Nullable byte b;
 }

--- a/checker/tests/nullness/Issue3935.java
+++ b/checker/tests/nullness/Issue3935.java
@@ -1,0 +1,5 @@
+import android.annotation.Nullable;
+
+public class Issue3935 {
+    private @Nullable byte[] data;
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2405,13 +2405,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
      * Returns a new list containing only the supported annotations from its argument -- that is,
      * those that are part of the current type system.
      *
+     * <p>This method ignores aliases of supported annotations that are declaration annotations,
+     * because they may apply to inner types.
+     *
      * @param annoTrees annotation trees
      * @return a new list containing only the supported annotations from its argument
      */
     private List<AnnotationTree> supportedAnnoTrees(List<? extends AnnotationTree> annoTrees) {
         List<AnnotationTree> result = new ArrayList<>(1);
         for (AnnotationTree at : annoTrees) {
-            if (atypeFactory.isSupportedQualifier(TreeUtils.annotationFromAnnotationTree(at))) {
+            AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(at);
+            if (!AnnotationUtils.isDeclarationAnnotation(anno)
+                    && atypeFactory.isSupportedQualifier(anno)) {
                 result.add(at);
             }
         }


### PR DESCRIPTION
Fixes #3935.