### PR TITLE
Fix CFG builder loosing catch blocks in try-with-resource

### DIFF
--- a/checker/tests/nullness/TryWithResources.java
+++ b/checker/tests/nullness/TryWithResources.java
@@ -1,4 +1,6 @@
 import java.io.*;
+import java.util.zip.ZipFile;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 class TryWithResources {
     void m1(InputStream stream) {
@@ -14,5 +16,30 @@ class TryWithResources {
             in.toString();
         } catch (Exception e) {
         }
+    }
+
+    // Checking that catch blocks and code after try-catch is part of CFG (and flow-sensitive
+    // type-refinements work there)
+    boolean m3(@Nullable Object x) {
+        try (ZipFile f = openZipFile()) {
+            return true;
+        } catch (IOException e) {
+            if (x != null) {
+                // OK
+                x.toString();
+            }
+        }
+
+        if (x != null) {
+            // OK
+            return x.equals(x);
+        }
+
+        return false;
+    }
+
+    // Helper
+    private static ZipFile openZipFile() throws IOException {
+        throw new IOException("No zip-file for you!");
     }
 }

--- a/checker/tests/nullness/TryWithResources.java
+++ b/checker/tests/nullness/TryWithResources.java
@@ -18,8 +18,8 @@ class TryWithResources {
         }
     }
 
-    // Checking that catch blocks and code after try-catch is part of CFG (and flow-sensitive
-    // type-refinements work there)
+    // Check that catch blocks and code after try-catch are part of CFG (and flow-sensitive
+    // type-refinements work there).
     boolean m3(@Nullable Object x) {
         try (ZipFile f = openZipFile()) {
             return true;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3024,13 +3024,6 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
                         "start of try statement #" + TreeUtils.treeUids.get(tree),
                         env.getTypeUtils()));
 
-        // TODO: Should we handle try-with-resources blocks by also generating code
-        // for automatically closing the resources?
-        List<? extends Tree> resources = tree.getResources();
-        for (Tree resource : resources) {
-            scan(resource, p);
-        }
-
         List<Pair<TypeMirror, Label>> catchLabels = new ArrayList<>();
         for (CatchTree c : catches) {
             TypeMirror type = TreeUtils.typeOf(c.getParameter().getType());
@@ -3066,6 +3059,15 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
         Label doneLabel = new Label();
 
         tryStack.pushFrame(new TryCatchFrame(types, catchLabels));
+
+        // This needs to happen /after/ we push frame to tryStack. Otherwise we can
+        // loose catch blocks.
+        // TODO: Should we handle try-with-resources blocks by also generating code
+        // for automatically closing the resources?
+        List<? extends Tree> resources = tree.getResources();
+        for (Tree resource : resources) {
+            scan(resource, p);
+        }
 
         extendWithNode(
                 new MarkerNode(

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3060,8 +3060,8 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
 
         tryStack.pushFrame(new TryCatchFrame(types, catchLabels));
 
-        // This needs to happen /after/ we push frame to tryStack. Otherwise we can
-        // loose catch blocks.
+        // Must scan the resources *after* we push frame to tryStack. Otherwise we can
+        // lose catch blocks.
         // TODO: Should we handle try-with-resources blocks by also generating code
         // for automatically closing the resources?
         List<? extends Tree> resources = tree.getResources();


### PR DESCRIPTION
Summary:
This fix is for Phase 1 of the translation.
Consider the following block:

```
try (ZipFile f = openZipFile()) {
    return true;
} catch (IOException e) {
    // This node is missing in CFG
    log(TAG, "This `log` node is missing in CFG of the method");
}
```

where

```
private static ZipFile openZipFile() throws IOException {...}
```

This gets translated into the following CFG.
Note absence of `log(TAG, ...)`!
```
2 -> 3 EACH_TO_EACH
3 -> 4 EACH_TO_EACH
4 -> 5 EACH_TO_EACH
4 -> 1 java.io.IOException
4 -> 1 Throwable
5 -> 0 EACH_TO_EACH

2:
Process order: 1
<entry>

3:
Process order: 2
marker (start of try statement #0)   [ Marker ]
f   [ VariableDeclaration ]
Test   [ ClassName ]
Test.openZipFile   [ MethodAccess ]

4:
Process order: 3
Test.openZipFile()   [ MethodInvocation ]

5:
Process order: 4
f = Test.openZipFile()   [ Assignment ]
marker (start of try block #0)   [ Marker ]
true   [ BooleanLiteral ]
return true   [ Return ]

1:
Process order: 6
<exceptional-exit>

0:
Process order: 5
<exit>
```

The problem seems to be caused by too early translation of resources:
resources of a try block get translated **before** the new frame is pushed
onto the `tryStack`, therefore checked exceptions thrown by `openZipFile`
use toplevel `tryStack` and get attached to exceptional exit block,
instead of user-supplied `catch` block.

With this patch CFG now correctly translates try-with-resource block.

Test plan:
Added a test case for Nullness to check that flow-sensitive
type-refinements apply to code inside catch block and after try-catch.