### PR TITLE
allow users to run the Called Methods Checker without the Returns Receiver Checker, if desired

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,7 @@
 Version 3.9.0
 
+The Called Methods Checker supports the -AdisableReturnsReceiver command-line option.
+
 Implementation details:
 
 Renamed StubParser to AnnotationFileParser

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.calledmethods;
 
 import java.util.LinkedHashSet;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.common.accumulation.AccumulationChecker;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.returnsreceiver.ReturnsReceiverChecker;
@@ -51,19 +52,54 @@ public class CalledMethodsChecker extends AccumulationChecker {
     public static final String USE_VALUE_CHECKER = "useValueChecker";
 
     /**
+     * Some use cases for the Called Methods Checker do not involve checking fluent APIs, and in
+     * those cases disabling the Returns Receiver Checker using this flag will make the Called
+     * Methods Checker run much faster.
+     */
+    public static final String DISABLE_RETURNS_RECEIVER_CHECKER = "disableReturnsReceiver";
+
+    /**
      * The number of calls to build frameworks supported by this invocation. Incremented only if the
      * {@link #COUNT_FRAMEWORK_BUILD_CALLS} option was supplied.
      */
     int numBuildCalls = 0;
 
+    /** Never access this boolean directly. Call {@link #isRRDisabled()} instead. */
+    private @MonotonicNonNull Boolean rrDisabled = null;
+
+    /**
+     * Was the returns receiver checker disabled on the command line?
+     *
+     * @return whether the -AdisableReturnsReceiver option was specified on the command line.
+     */
+    private boolean isRRDisabled() {
+        if (rrDisabled == null) {
+            // BaseTypeChecker#hasOption calls this getImmediateSubcheckerClasses (so that all
+            // subcheckers' options are
+            // considered), so the processingEnvironment must be checked for options directly,
+            // because this method
+            // is called from there.
+            rrDisabled =
+                    this.processingEnv.getOptions().containsKey(DISABLE_RETURNS_RECEIVER_CHECKER)
+                            || this.processingEnv
+                                    .getOptions()
+                                    .containsKey(
+                                            this.getClass().getSimpleName()
+                                                    + "_"
+                                                    + DISABLE_RETURNS_RECEIVER_CHECKER);
+        }
+        return rrDisabled;
+    }
+
     @Override
     protected LinkedHashSet<Class<? extends BaseTypeChecker>> getImmediateSubcheckerClasses() {
         LinkedHashSet<Class<? extends BaseTypeChecker>> checkers =
                 super.getImmediateSubcheckerClasses();
-        checkers.add(ReturnsReceiverChecker.class);
-
+        if (!isRRDisabled()) {
+            checkers.add(ReturnsReceiverChecker.class);
+        }
         // BaseTypeChecker#hasOption calls this method (so that all subcheckers' options are
-        // considered), so the processingEnvironment must be checked for the option directly.
+        // considered), so the processingEnvironment must be checked for options directly.
         if (this.processingEnv.getOptions().containsKey(USE_VALUE_CHECKER)
                 || this.processingEnv
                         .getOptions()
@@ -71,6 +107,20 @@ public class CalledMethodsChecker extends AccumulationChecker {
             checkers.add(ValueChecker.class);
         }
         return checkers;
+    }
+
+    /**
+     * Check whether the given alias analysis is enabled by this particular accumulation checker.
+     *
+     * @param aliasAnalysis the analysis to check
+     * @return true iff the analysis is enabled
+     */
+    @Override
+    public boolean isEnabled(AliasAnalysis aliasAnalysis) {
+        if (aliasAnalysis == AliasAnalysis.RETURNS_RECEIVER) {
+            return !isRRDisabled();
+        }
+        return super.isEnabled(aliasAnalysis);
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -68,17 +68,15 @@ public class CalledMethodsChecker extends AccumulationChecker {
     private @MonotonicNonNull Boolean returnsReceiverDisabled = null;
 
     /**
-     * Was the returns receiver checker disabled on the command line?
+     * Was the Returns Receiver Checker disabled on the command line?
      *
-     * @return whether the -AdisableReturnsReceiver option was specified on the command line.
+     * @return whether the -AdisableReturnsReceiver option was specified on the command line
      */
     private boolean isReturnsReceiverDisabled() {
         if (returnsReceiverDisabled == null) {
             // BaseTypeChecker#hasOption calls getImmediateSubcheckerClasses (so that all
-            // subcheckers' options are
-            // considered), so the processingEnvironment must be checked for options directly,
-            // because this method
-            // is called from there.
+            // subcheckers' options are considered), so the processingEnvironment must be checked
+            // for options directly, because this method is called from there.
             returnsReceiverDisabled =
                     this.processingEnv.getOptions().containsKey(DISABLE_RETURNS_RECEIVER)
                             || this.processingEnv

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -64,22 +64,22 @@ public class CalledMethodsChecker extends AccumulationChecker {
      */
     int numBuildCalls = 0;
 
-    /** Never access this boolean directly. Call {@link #isRRDisabled()} instead. */
-    private @MonotonicNonNull Boolean rrDisabled = null;
+    /** Never access this boolean directly. Call {@link #isReturnsReceiverDisabled()} instead. */
+    private @MonotonicNonNull Boolean returnsReceiverDisabled = null;
 
     /**
      * Was the returns receiver checker disabled on the command line?
      *
      * @return whether the -AdisableReturnsReceiver option was specified on the command line.
      */
-    private boolean isRRDisabled() {
-        if (rrDisabled == null) {
+    private boolean isReturnsReceiverDisabled() {
+        if (returnsReceiverDisabled == null) {
             // BaseTypeChecker#hasOption calls getImmediateSubcheckerClasses (so that all
             // subcheckers' options are
             // considered), so the processingEnvironment must be checked for options directly,
             // because this method
             // is called from there.
-            rrDisabled =
+            returnsReceiverDisabled =
                     this.processingEnv.getOptions().containsKey(DISABLE_RETURNS_RECEIVER)
                             || this.processingEnv
                                     .getOptions()
@@ -88,14 +88,14 @@ public class CalledMethodsChecker extends AccumulationChecker {
                                                     + "_"
                                                     + DISABLE_RETURNS_RECEIVER);
         }
-        return rrDisabled;
+        return returnsReceiverDisabled;
     }
 
     @Override
     protected LinkedHashSet<Class<? extends BaseTypeChecker>> getImmediateSubcheckerClasses() {
         LinkedHashSet<Class<? extends BaseTypeChecker>> checkers =
                 super.getImmediateSubcheckerClasses();
-        if (!isRRDisabled()) {
+        if (!isReturnsReceiverDisabled()) {
             checkers.add(ReturnsReceiverChecker.class);
         }
         // BaseTypeChecker#hasOption calls this method (so that all subcheckers' options are
@@ -118,7 +118,7 @@ public class CalledMethodsChecker extends AccumulationChecker {
     @Override
     public boolean isEnabled(AliasAnalysis aliasAnalysis) {
         if (aliasAnalysis == AliasAnalysis.RETURNS_RECEIVER) {
-            return !isRRDisabled();
+            return !isReturnsReceiverDisabled();
         }
         return super.isEnabled(aliasAnalysis);
     }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -74,7 +74,7 @@ public class CalledMethodsChecker extends AccumulationChecker {
      */
     private boolean isRRDisabled() {
         if (rrDisabled == null) {
-            // BaseTypeChecker#hasOption calls this getImmediateSubcheckerClasses (so that all
+            // BaseTypeChecker#hasOption calls getImmediateSubcheckerClasses (so that all
             // subcheckers' options are
             // considered), so the processingEnvironment must be checked for options directly,
             // because this method

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -56,7 +56,7 @@ public class CalledMethodsChecker extends AccumulationChecker {
      * those cases disabling the Returns Receiver Checker using this flag will make the Called
      * Methods Checker run much faster.
      */
-    public static final String DISABLE_RETURNS_RECEIVER_CHECKER = "disableReturnsReceiver";
+    public static final String DISABLE_RETURNS_RECEIVER = "disableReturnsReceiver";
 
     /**
      * The number of calls to build frameworks supported by this invocation. Incremented only if the
@@ -80,13 +80,13 @@ public class CalledMethodsChecker extends AccumulationChecker {
             // because this method
             // is called from there.
             rrDisabled =
-                    this.processingEnv.getOptions().containsKey(DISABLE_RETURNS_RECEIVER_CHECKER)
+                    this.processingEnv.getOptions().containsKey(DISABLE_RETURNS_RECEIVER)
                             || this.processingEnv
                                     .getOptions()
                                     .containsKey(
                                             this.getClass().getSimpleName()
                                                     + "_"
-                                                    + DISABLE_RETURNS_RECEIVER_CHECKER);
+                                                    + DISABLE_RETURNS_RECEIVER);
         }
         return rrDisabled;
     }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableReturnsReceiverTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/CalledMethodsDisableReturnsReceiverTest.java
@@ -1,0 +1,27 @@
+package org.checkerframework.checker.test.junit;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.calledmethods.CalledMethodsChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Basic tests for the Called Methods Checker. */
+public class CalledMethodsDisableReturnsReceiverTest extends CheckerFrameworkPerDirectoryTest {
+    public CalledMethodsDisableReturnsReceiverTest(List<File> testFiles) {
+        super(
+                testFiles,
+                CalledMethodsChecker.class,
+                "calledmethods-disablereturnsreceiver",
+                "-Anomsgtext",
+                "-AdisableReturnsReceiver",
+                "-nowarn",
+                "-encoding",
+                "UTF-8");
+    }
+
+    @Parameters
+    public static String[] getTestDirs() {
+        return new String[] {"calledmethods-disablereturnsreceiver"};
+    }
+}

--- a/checker/tests/calledmethods-disablereturnsreceiver/SimpleFluentInference.java
+++ b/checker/tests/calledmethods-disablereturnsreceiver/SimpleFluentInference.java
@@ -1,0 +1,76 @@
+// This is a copy of SimpleFluentInference.java in the main calledmethods
+// test directory. The only difference is that the expected errors have been
+// modified to account for the Returns Receiver checker having been disabled.
+
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.common.returnsreceiver.qual.*;
+
+/* Simple inference of a fluent builder */
+class SimpleFluentInference {
+    SimpleFluentInference build(@CalledMethods({"a", "b"}) SimpleFluentInference this) {
+        return this;
+    }
+
+    SimpleFluentInference weakbuild(@CalledMethods({"a"}) SimpleFluentInference this) {
+        return this;
+    }
+
+    @This SimpleFluentInference a() {
+        return this;
+    }
+
+    @This SimpleFluentInference b() {
+        return this;
+    }
+
+    // intentionally does not have an @This annotation
+    SimpleFluentInference c() {
+        return new SimpleFluentInference();
+    }
+
+    static void doStuffCorrect() {
+        SimpleFluentInference s =
+                new SimpleFluentInference()
+                        .a()
+                        .b()
+                        // :: error: finalizer.invocation.invalid
+                        .build();
+    }
+
+    static void doStuffWrong() {
+        SimpleFluentInference s =
+                new SimpleFluentInference()
+                        .a()
+                        // :: error: finalizer.invocation.invalid
+                        .build();
+    }
+
+    static void doStuffRightWeak() {
+        SimpleFluentInference s =
+                new SimpleFluentInference()
+                        .a()
+                        // :: error: finalizer.invocation.invalid
+                        .weakbuild();
+    }
+
+    static void noReturnsReceiverAnno() {
+        SimpleFluentInference s =
+                new SimpleFluentInference()
+                        .a()
+                        .b()
+                        .c()
+                        // :: error: finalizer.invocation.invalid
+                        .build();
+    }
+
+    static void fluentLoop() {
+        SimpleFluentInference s = new SimpleFluentInference().a();
+        int i = 10;
+        while (i > 0) {
+            // :: error: finalizer.invocation.invalid
+            s.b().build();
+            i--;
+            s = new SimpleFluentInference();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3971 