### PR TITLE
Prevent duplicate annotations in .class files; fixes #3956

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
@@ -94,7 +94,7 @@ public class TypeAnnotationUtils {
      * lenient than {@code List.equals}, which uses {@code Object.equals} on list elements.
      *
      * @param values1 the first {@code values} field
-     * @param values1 the second {@code values} field
+     * @param values2 the second {@code values} field
      * @return true if the two {@code values} fields represent the same name-to-value mapping, in
      *     the same order
      */

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypeAnnotationUtils.java
@@ -98,6 +98,7 @@ public class TypeAnnotationUtils {
      * @return true if the two {@code values} fields represent the same name-to-value mapping, in
      *     the same order
      */
+    @SuppressWarnings("InvalidParam") // Error Prone tries to be clever, but it is not
     private static boolean typeCompoundValuesEquals(
             List<Pair<MethodSymbol, Attribute>> values1,
             List<Pair<MethodSymbol, Attribute>> values2) {


### PR DESCRIPTION
Fixes #3956.

To resolve the error report, it is necessary to release plume-util version 1.3.0 and make the Checker Framework use it.