### PR TITLE
Use Java 11 for collecting Java files

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/JavaStubifier.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/JavaStubifier.java
@@ -1,6 +1,7 @@
 package org.checkerframework.framework.stub;
 
 import com.github.javaparser.ParseResult;
+import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ast.*;
 import com.github.javaparser.ast.body.*;
 import com.github.javaparser.ast.expr.MemberValuePair;
@@ -8,6 +9,7 @@ import com.github.javaparser.ast.expr.NormalAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.modifiers.NodeWithAccessModifiers;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.visitor.ModifierVisitor;
+import com.github.javaparser.utils.CollectionStrategy;
 import com.github.javaparser.utils.ParserCollectionStrategy;
 import com.github.javaparser.utils.ProjectRoot;
 import com.github.javaparser.utils.SourceRoot;
@@ -55,7 +57,12 @@ public class JavaStubifier {
     private static void process(String dir) {
         Path root = Paths.get(dir);
         MinimizerCallback mc = new MinimizerCallback();
-        ProjectRoot projectRoot = new ParserCollectionStrategy().collect(root);
+        CollectionStrategy strategy = new ParserCollectionStrategy();
+        // Required to include directories that contain a module-info.java, which don't parse by
+        // default.
+        strategy.getParserConfiguration()
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
+        ProjectRoot projectRoot = strategy.collect(root);
 
         projectRoot
                 .getSourceRoots()


### PR DESCRIPTION
Fixes a crash that I get when running `./gradlew jtregJdk11Tests` on my local machine.