### PR TITLE
Stub files with no package and an annotation on a class fails to parse

### DIFF
--- a/checker/jtreg/stubs/general/Driver2.java
+++ b/checker/jtreg/stubs/general/Driver2.java
@@ -1,0 +1,9 @@
+/*
+ * @test
+ * @summary Test that a stub file can have no package, but have an annotation on the class.
+ * @compile -XDrawDiagnostics -processor org.checkerframework.checker.nullness.NullnessChecker -Astubs=NoPackage.astub Driver2.java  -Werror
+ */
+
+class Driver2 {
+    void test() {}
+}

--- a/checker/jtreg/stubs/general/NoPackage.astub
+++ b/checker/jtreg/stubs/general/NoPackage.astub
@@ -1,0 +1,3 @@
+// No package statement.
+@SuppressWarnings("") // Any annotation.
+class Test {}


### PR DESCRIPTION
This adds a failing test case, so it shouldn't be merged.