### PR TITLE
Ignore crashes caused by incorrectly inferred type arguments.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1455,38 +1455,53 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
         ExecutableElement method = invokedMethod.getElement();
         CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
-        checkTypeArguments(
-                node,
-                paramBounds,
-                typeargs,
-                node.getTypeArguments(),
-                methodName,
-                invokedMethod.getTypeVariables());
+        try {
+            checkTypeArguments(
+                    node,
+                    paramBounds,
+                    typeargs,
+                    node.getTypeArguments(),
+                    methodName,
+                    invokedMethod.getTypeVariables());
+            List<AnnotatedTypeMirror> params =
+                    AnnotatedTypes.expandVarArgs(atypeFactory, invokedMethod, node.getArguments());
+            checkArguments(params, node.getArguments(), methodName, method.getParameters());
+            checkVarargs(invokedMethod, node);
 
-        List<AnnotatedTypeMirror> params =
-                AnnotatedTypes.expandVarArgs(atypeFactory, invokedMethod, node.getArguments());
-        checkArguments(params, node.getArguments(), methodName, method.getParameters());
-        checkVarargs(invokedMethod, node);
+            if (ElementUtils.isMethod(
+                    invokedMethod.getElement(), vectorCopyInto, atypeFactory.getProcessingEnv())) {
+                typeCheckVectorCopyIntoArgument(node, params);
+            }
 
-        if (ElementUtils.isMethod(
-                invokedMethod.getElement(), vectorCopyInto, atypeFactory.getProcessingEnv())) {
-            typeCheckVectorCopyIntoArgument(node, params);
-        }
+            ExecutableElement invokedMethodElement = invokedMethod.getElement();
+            if (!ElementUtils.isStatic(invokedMethodElement)
+                    && !TreeUtils.isSuperConstructorCall(node)) {
+                checkMethodInvocability(invokedMethod, node);
+            }
 
-        ExecutableElement invokedMethodElement = invokedMethod.getElement();
-        if (!ElementUtils.isStatic(invokedMethodElement)
-                && !TreeUtils.isSuperConstructorCall(node)) {
-            checkMethodInvocability(invokedMethod, node);
-        }
+            // check precondition annotations
+            checkPreconditions(
+                    node,
+                    atypeFactory.getContractsFromMethod().getPreconditions(invokedMethodElement));
 
-        // check precondition annotations
-        checkPreconditions(
-                node, atypeFactory.getContractsFromMethod().getPreconditions(invokedMethodElement));
-
-        if (TreeUtils.isSuperConstructorCall(node)) {
-            checkSuperConstructorCall(node);
-        } else if (TreeUtils.isThisConstructorCall(node)) {
-            checkThisConstructorCall(node);
+            if (TreeUtils.isSuperConstructorCall(node)) {
+                checkSuperConstructorCall(node);
+            } else if (TreeUtils.isThisConstructorCall(node)) {
+                checkThisConstructorCall(node);
+            }
+        } catch (RuntimeException t) {
+            // Sometimes the type arguments are inferred incorrect which causes crashes. Once #979
+            // is fixed this should be removed and crashes should be reported normally.
+            if (node.getTypeArguments().size() == typeargs.size()) {
+                // They type arguments were explicitly written.
+                throw t;
+            }
+            if (!atypeFactory.ignoreUninferredTypeArguments) {
+                checker.reportError(
+                        node,
+                        "type.arguments.not.inferred",
+                        invokedMethod.getElement().getSimpleName());
+            } // else ignore the crash.
         }
 
         // Do not call super, as that would observe the arguments without

--- a/framework/tests/all-systems/Issue3826.java
+++ b/framework/tests/all-systems/Issue3826.java
@@ -1,0 +1,27 @@
+public class Issue3826 {
+    public static <B, T extends B> void getOption(Class<T> cls, B[] opts) {}
+
+    public static class ClassA {
+        public static class InnerClassA {
+            interface InnerInnerClassA {}
+        }
+    }
+
+    public static class ClassB {
+        public abstract static class InnerClassB {}
+    }
+
+    public static class ClassC {
+        interface InterfaceClassC extends ClassA.InnerClassA.InnerInnerClassA {}
+
+        private static class InnerClassC extends ClassA.InnerClassA implements InterfaceClassC {}
+
+        public ClassC(ClassA.InnerClassA.InnerInnerClassA... opts) {
+            // Does not crash
+            Issue3826.<ClassA.InnerClassA.InnerInnerClassA, InnerClassC>getOption(
+                    InnerClassC.class, opts);
+            // Crashes
+            Issue3826.getOption(InnerClassC.class, opts);
+        }
+    }
+}


### PR DESCRIPTION
(This should be reverted when #979 is fixed.
Fixes #3826.