### PR TITLE
Report contracts.precondition.not.satisfied when JavaExpression is unknown

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -182,6 +182,9 @@ public class InitializationVisitor<
                 || !(expr instanceof FieldAccess)) {
             return super.checkContract(expr, necessaryAnnotation, inferredAnnotation, store);
         }
+        if (expr.containsUnknown()) {
+            return false;
+        }
 
         FieldAccess fa = (FieldAccess) expr;
         if (fa.getReceiver() instanceof ThisReference || fa.getReceiver() instanceof ClassName) {

--- a/checker/tests/nullness/Issue3631.java
+++ b/checker/tests/nullness/Issue3631.java
@@ -1,0 +1,18 @@
+import org.checkerframework.checker.nullness.qual.RequiresNonNull;
+
+public class Issue3631 {
+
+    void f(Object otherArg) {
+        // Cast's aren't a supported JavaExpression.
+        // :: error: (contracts.precondition.not.satisfied)
+        ((Issue3631Helper) otherArg).m();
+    }
+}
+
+class Issue3631Helper {
+
+    String type = "foo";
+
+    @RequiresNonNull("type")
+    void m() {}
+}

--- a/checker/tests/nullness/Issue3631.java
+++ b/checker/tests/nullness/Issue3631.java
@@ -3,7 +3,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 public class Issue3631 {
 
     void f(Object otherArg) {
-        // Cast's aren't a supported JavaExpression.
+        // Casts aren't a supported JavaExpression.
         // :: error: (contracts.precondition.not.satisfied)
         ((Issue3631Helper) otherArg).m();
     }


### PR DESCRIPTION
Fixes #3632.