### PR TITLE
Miscellaneous minor fixes to wpi-many.sh

### DIFF
--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -121,7 +121,7 @@ export PATH="${JAVA_HOME}/bin:${PATH}"
 mkdir -p "${OUTDIR}"
 mkdir -p "${OUTDIR}-results"
 
-pushd "${OUTDIR}" || exit 5
+cd "${OUTDIR}" || exit 5
 
 while IFS='' read -r line || [ "$line" ]
 do
@@ -139,7 +139,7 @@ do
     # TODO: consider just using hash, to skip hard forks?
     mkdir -p "${REPO_NAME_HASH}"
 
-    pushd "${REPO_NAME_HASH}" || exit 5
+    cd "${REPO_NAME_HASH}" || exit 5
 
     if [ ! -d "${REPO_NAME}" ]; then
         # The "GIT_TERMINAL_PROMPT=0" setting prevents git from prompting for
@@ -154,7 +154,7 @@ do
         rm -rf "${REPO_NAME}/dljc-out"
     fi
 
-    pushd "${REPO_NAME}" || exit 5
+    cd "${REPO_NAME}" || exit 5
 
     git checkout "${HASH}"
 
@@ -167,21 +167,22 @@ do
 
     REPO_FULLPATH=$(pwd)
 
-    popd || exit 5
+    cd "${OUTDIR}/${REPO_NAME_HASH}" || exit 5
 
     RESULT_LOG="${OUTDIR}-results/${REPO_NAME_HASH}-wpi.log"
     touch "${RESULT_LOG}"
 
-    /bin/bash -x "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -t "${TIMEOUT}" -g "${GRADLECACHEDIR}" -- "$@" &> "${RESULT_LOG}" &> "${OUTDIR}-results/tmp.log" || cat "${OUTDIR}-results/tmp.log"
+    /bin/bash -x "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -t "${TIMEOUT}" -g "${GRADLECACHEDIR}" -- "$@" &> "${RESULT_LOG}" &> "${OUTDIR}-results/wpi-out" || cat "${OUTDIR}-results/wpi-out"
+    rm -f "${OUTDIR}-result/wpi-out"
 
-    popd || exit 5
+    cd "${OUTDIR}" || exit 5
 
     # If the result is unusable (i.e. wpi cannot run),
     # we don't need it for data analysis and we can
     # delete it right away.
     if [ -f "${REPO_FULLPATH}/.cannot-run-wpi" ]; then
-        # rm -rf "${REPO_NAME_HASH}" &
-        echo "I love deleting things"
+        echo "Deleting ${REPO_NAME_HASH} because WPI could not be run."
+        rm -rf "${REPO_NAME_HASH}"
     else
         cat "${REPO_FULLPATH}/dljc-out/wpi.log" >> "${RESULT_LOG}"
     fi
@@ -190,17 +191,15 @@ do
 
 done <"${INLIST}"
 
-popd || exit 5
-
 ## This section is here rather than in wpi-summary.sh because counting lines can be moderately expensive.
 ## wpi-summary.sh is intended to be run while a human waits (unlike this script), so this script
 ## precomputes as much as it can, to make wpi-summary.sh faster.
 
-results_available=$(grep -Zvl "no build file found for" "${OUTDIR}-results/"*.log \
-    | xargs -0 grep -Zvl "dljc could not run the Checker Framework" \
-    | xargs -0 grep -Zvl "dljc could not run the build successfully" \
-    | xargs -0 grep -Zvl "dljc timed out for" \
-    | xargs -0 echo)
+results_available=$(grep -Zvl -e "no build file found for" \
+    -e "dljc could not run the Checker Framework" \
+    -e "dljc could not run the build successfully" \
+    -e "dljc timed out for" \
+    "${OUTDIR}-results/"*.log)
 
 echo "${results_available}" > "${OUTDIR}-results/results_available.txt"
 
@@ -210,10 +209,9 @@ if [ -n "${results_available}" ]; then
     # results can be inspected by hand (that is, those that WPI succeeded on).
     grep -oh "\S*\.java" "${results_available}" | sort | uniq > "${listpath}"
 
-    pushd "${SCRIPTDIR}/.do-like-javac" || exit 5
+    cd "${SCRIPTDIR}/.do-like-javac" || exit 5
     wget -nc "https://github.com/boyter/scc/releases/download/v2.13.0/scc-2.13.0-i386-unknown-linux.zip"
     unzip -o "scc-2.13.0-i386-unknown-linux.zip"
-    popd || exit 5
 
     "${SCRIPTDIR}/.do-like-javac/scc" --output "${OUTDIR}-results/loc.txt" \
         "$(< "${listpath}")"

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -213,7 +213,7 @@ echo "Finished configuring wpi.sh."
 
 rm -f "${DIR}/.cannot-run-wpi"
 
-pushd "${DIR}" || exit 5
+cd "${DIR}" || exit 5
 
 JAVA_HOME_BACKUP="${JAVA_HOME}"
 if [ "${has_java11}" = "yes" ]; then
@@ -241,8 +241,6 @@ if [ "${WPI_RESULTS_AVAILABLE}" = "no" ]; then
     echo "Check the log files in ${DIR}/dljc-out/ for diagnostics."
     touch "${DIR}/.cannot-run-wpi"
 fi
-
-popd || exit 5
 
 export JAVA_HOME="${JAVA_HOME_BACKUP}"
 


### PR DESCRIPTION
Resolves two problems with the wpi scripts' user-facing output:
1. use of `pushd` and `popd` rather than `cd` prints directory names
2. the script to compute `results-available.txt` was broken, creating garbage output about missing files and leading that file to always be empty.