### PR TITLE
Handle null Strings in comparison

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -607,7 +607,10 @@ public final class SceneToStubWriter {
                     @Override
                     public int compare(@BinaryName String o1, @BinaryName String o2) {
                         return ComparisonChain.start()
-                                .compare(packagePart(o1), packagePart(o2))
+                                .compare(
+                                        packagePart(o1),
+                                        packagePart(o2),
+                                        Comparator.nullsFirst(Comparator.naturalOrder()))
                                 .compare(basenamePart(o1), basenamePart(o2))
                                 .result();
                     }


### PR DESCRIPTION
The expressions `packagePart(o1)` and `packagePart(o2)` in the modified code can be `null`, which causes a `NullPointerException` when the list being sorted has multiple elements. As far as I can tell, everywhere this code is called in the test suite, the list has at most one element, so the comparison function is never called and no `NullPointerException` is thrown. I'm not sure if constructing such an example is possible, but I did encounter when working with a buggy version of the framework. This code didn't end up being the problem, but it should probably be fixed regardless.