### PR TITLE
Re-enable WPI-many tests on JDK 8, and strengthen oracle for WPI-many tests generally

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -853,13 +853,9 @@ subprojects {
             if (project.name.is('checker')) {
                 if (!isJava8) {
                     dependsOn('jtregJdk11Tests')
-                    // TODO: Remove this line, when wpiManyTests doesn't ignore wpi failures.
-                    dependsOn('wpiManyTests', 'wpiPlumeLibTests')
                 }
                 dependsOn('nullnessExtraTests', 'commandLineTests', 'tutorialTests',
-                          // TODO: Reinstate this line, when wpiManyTests doesn't ignore wpi failures.
-                          // 'wholeProgramInferenceTests', 'wpiManyTests', 'wpiPlumeLibTests')
-                          'wholeProgramInferenceTests')
+                          'wholeProgramInferenceTests', 'wpiManyTests', 'wpiPlumeLibTests')
             }
 
             if (project.name.is('dataflow')) {

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -147,8 +147,14 @@ function configure_and_exec_dljc {
       return
   fi
 
+  if [ "${JAVA_HOME}" = "${JAVA8_HOME}" ]; then
+    JDK_VERSION_ARG="--jdkVersion 8"
+  else
+    JDK_VERSION_ARG="--jdkVersion 11"
+  fi
+
   # This command also includes "clean"; I'm not sure why it is necessary.
-  DLJC_CMD="${DLJC} -t wpi $* -- ${BUILD_CMD}"
+  DLJC_CMD="${DLJC} -t wpi ${JDK_VERSION_ARG} $* -- ${BUILD_CMD}"
 
   if [ ! "x${TIMEOUT}" = "x" ]; then
       TMP="${DLJC_CMD}"

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -605,12 +605,12 @@ task wpiManyTests(group: "Verification") {
                 throw new GradleException("Failure: WPI produced empty typecheck file " + filename)
             }
             file.eachLine { line ->
-                if (line.startsWith("Running ")) {
+                if (line.startsWith("Running ") || line.startsWith("warning: [path]")
+                        || line.endsWith("warnings")) {
                   return;
                 }
-                if (line.toLowerCase().contains("error")
-                    || line.startsWith("Usage: javac")) {
-                    throw new GradleException("Failure: WPI scripts produced an error in " + filename + ". " +
+                if (!line.trim().equals("")) {
+                    throw new GradleException("Failure: WPI scripts produced an unexpected output in " + filename + ". " +
                             "Failing line is the following: " + line)
                 }
             }


### PR DESCRIPTION
Also fixes a minor bug in `wpi.sh`, which should have been providing the JDK version to DLJC directly via an argument. DLJC already had this functionality, but `wpi.sh` wasn't using it for some reason.

Related, I fixed how DLJC handles `-source`, `-target`, and `--release` flags; it now has different behavior depending on the value of its `--jdkVersion` argument:
* on Java 8, it uses `-source` and `-target`
* on Java 11, it always uses `--release`, even when the code is Java 8 (i.e. it uses `--release 8`).

The proximate cause of the failing WPI many tests on Java 8 JDKs was that DLJC was trying to use `--release 8` whenever the source/target level was 8, even on non-Java 11 JVMs. See https://github.com/kelloggm/do-like-javac/commit/8873d6f2987fab12723dc6ddce4b1e86d4460057.