### PR TITLE
Relocate asm dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -638,11 +638,11 @@ subprojects {
             }
         }
 
-        // These appear in annotation-file-utilities-all.jar:
         relocate 'org.apache', 'org.checkerframework.org.apache'
         relocate 'org.relaxng', 'org.checkerframework.org.relaxng'
         relocate 'org.plumelib', 'org.checkerframework.org.plumelib'
         relocate 'org.codehaus', 'org.checkerframework.org.codehaus'
+        relocate 'org.objectweb.asm', 'org.checkerframework.org.objectweb.asm'
         // relocate 'sun', 'org.checkerframework.sun'
         relocate 'com.google', 'org.checkerframework.com.google'
         relocate 'plume', 'org.checkerframework.plume'

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -32,7 +32,6 @@ dependencies {
         exclude group: 'com.google.errorprone', module: 'javac'
     }
     implementation project(':checker-qual')
-    implementation 'org.ow2.asm:asm:7.2'
     implementation 'org.plumelib:plume-util:1.4.1'
     implementation 'org.plumelib:reflection-util:1.0.3'
 


### PR DESCRIPTION
We rename all third party dependencies so they do not conflict with other versions on the classpath.