### PR TITLE
Use one codepath for fields

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -341,19 +341,14 @@ public class JavaExpressionParseUtil {
                 return getParameterJavaExpression(s, context);
             }
 
-            // Local variable, parameter, or field.
+            // Local variable or parameter.
             if (!context.parsingMember && context.useLocalScope) {
                 // Attempt to match a local variable within the scope of the
                 // given path before attempting to match a field.
                 VariableElement varElem =
-                        resolver.findLocalVariableOrParameterOrField(s, annotatedConstruct);
+                        resolver.findLocalVariableOrParameter(s, annotatedConstruct);
                 if (varElem != null) {
-                    if (varElem.getKind() == ElementKind.FIELD) {
-                        boolean isOriginalReceiver = context.receiver instanceof ThisReference;
-                        return getFieldJavaExpression(varElem, context, isOriginalReceiver);
-                    } else {
-                        return new LocalVariable(varElem);
-                    }
+                    return new LocalVariable(varElem);
                 }
             }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -218,24 +218,23 @@ public class Resolver {
     }
 
     /**
-     * Finds the local variable with name {@code name} in the given scope.
+     * Finds the local variable (including formal parameters) with name {@code name} in the given
+     * scope.
      *
      * @param name the name of the local variable
      * @param path the tree path to the local scope
      * @return the element for the local variable, {@code null} otherwise
      */
-    public @Nullable VariableElement findLocalVariableOrParameterOrField(
-            String name, TreePath path) {
+    public @Nullable VariableElement findLocalVariableOrParameter(String name, TreePath path) {
         Log.DiagnosticHandler discardDiagnosticHandler = new Log.DiscardDiagnosticHandler(log);
         try {
             Env<AttrContext> env = getEnvForPath(path);
             Element res = wrapInvocationOnResolveInstance(FIND_VAR, env, names.fromString(name));
             if (res.getKind() == ElementKind.LOCAL_VARIABLE
-                    || res.getKind() == ElementKind.PARAMETER
-                    || res.getKind() == ElementKind.FIELD) {
+                    || res.getKind() == ElementKind.PARAMETER) {
                 return (VariableElement) res;
             } else {
-                // Most likely didn't find the variable and the Element is a SymbolNotFoundError
+                // The Element might be FIELD or a SymbolNotFoundError.
                 return null;
             }
         } finally {


### PR DESCRIPTION
Before this change, fields were treated differently depending on whether
useLocalScope was true or false.