### PR TITLE
Refactor the JavaExpression parse method to clarify `localScope`

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -141,8 +141,8 @@ public class JavaExpressionParseUtil {
             String expression, JavaExpressionContext context, @Nullable TreePath localPath)
             throws JavaExpressionParseException {
         // The underlying javac API used to convert from Strings to Elements requires a tree path
-        // even when the information could be deduced from elements alone.  So use the
-        // path to the current CompilationUnit.
+        // even when the information could be deduced from elements alone.  So use the path to the
+        // current CompilationUnit.
         TreePath pathToCompilationUnit = context.checker.getPathToCompilationUnit();
         Expression expr;
         try {

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -123,29 +123,27 @@ public class JavaExpressionParseUtil {
      * Return its representation as a {@link JavaExpression}, or throw a {@link
      * JavaExpressionParseException}.
      *
-     * <p>A {@link TreePath}, {@code somePath}, is required to use the underlying javac API to
-     * convert from Strings to {@link Element}s even when the information could be deduced from
-     * elements alone.
-     *
-     * <p>If {@code localPath} is nonnull, then identifiers may be parsed to local variables in
-     * scope at {@code localPath}. In this case, it is as if the identifier was written at the
-     * location of {@code localPath}. If {@code localPath} is null, then no identifier can be parsed
-     * to a local variable.
+     * <p>If {@code localPath} is nonnull, then identifiers are parsed as if the identifier was
+     * written at the location of {@code localPath}. This means identifiers will be parsed to local
+     * variables in scope at {@code localPath} when possible. If {@code localPath} is null, then no
+     * identifier can be parsed to a local variable. In either case, the parameter syntax, e.g. #1,
+     * is always parsed to the arguments in {@code context}. This is because a parameter of a lambda
+     * can refer both to local variables in scope at its declaration and to a parameter of the
+     * lambda.
      *
      * @param expression a Java expression to parse
      * @param context information about any receiver and arguments
-     * @param somePath path to use javac API
      * @param localPath if non-null, the location at which to parse identifiers to local variables
      * @return the JavaExpression for the given string
      * @throws JavaExpressionParseException if the string cannot be parsed
      */
     public static JavaExpression parse(
-            String expression,
-            JavaExpressionContext context,
-            TreePath somePath,
-            @Nullable TreePath localPath)
+            String expression, JavaExpressionContext context, @Nullable TreePath localPath)
             throws JavaExpressionParseException {
-
+        // A TreePath is required to use the underlying javac API to convert from Strings to
+        // Elements even when the information could be deduced from elements alone.  So use the the
+        // path to the current CompilationUnit.
+        TreePath pathToCompilationUnit = context.checker.getPathToCompilationUnit();
         Expression expr;
         try {
             expr = StaticJavaParser.parseExpression(replaceParameterSyntax(expression));

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -119,22 +119,31 @@ public class JavaExpressionParseUtil {
     private static final int PARAMETER_REPLACEMENT_LENGTH = PARAMETER_REPLACEMENT.length();
 
     /**
-     * Parse a string and return its representation as a {@link JavaExpression}, or throw a {@link
+     * Parse a string and view-point adapt it to the given {@code context} and {@code localPath}.
+     * Return its representation as a {@link JavaExpression}, or throw a {@link
      * JavaExpressionParseException}.
+     *
+     * <p>A {@link TreePath}, {@code somePath}, is required to use the underlying javac API to
+     * convert from Strings to {@link Element}s even when the information could be deduced from
+     * elements alone.
+     *
+     * <p>If {@code localPath} is nonnull, then identifiers may be parsed to local variables in
+     * scope at {@code localPath}. In this case, it is as if the identifier was written at the
+     * location of {@code localPath}. If {@code localPath} is null, then no identifier can be parsed
+     * to a local variable.
      *
      * @param expression a Java expression to parse
      * @param context information about any receiver and arguments
-     * @param localScope a program element annotated with an annotation that contains {@code
-     *     expression}
-     * @param useLocalScope whether {@code annotatedConstruct} should be used to resolve identifiers
+     * @param somePath path to use javac API
+     * @param localPath if non-null, the location at which to parse identifiers to local variables
      * @return the JavaExpression for the given string
      * @throws JavaExpressionParseException if the string cannot be parsed
      */
     public static JavaExpression parse(
             String expression,
             JavaExpressionContext context,
-            TreePath localScope,
-            boolean useLocalScope)
+            TreePath somePath,
+            @Nullable TreePath localPath)
             throws JavaExpressionParseException {
 
         Expression expr;

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -119,11 +119,11 @@ public class JavaExpressionParseUtil {
     private static final int PARAMETER_REPLACEMENT_LENGTH = PARAMETER_REPLACEMENT.length();
 
     /**
-     * Parse a string and view-point adapt it to the given {@code context} and {@code localPath}.
+     * Parse a string and viewpoint-adapt it to the given {@code context} and {@code localPath}.
      * Return its representation as a {@link JavaExpression}, or throw a {@link
      * JavaExpressionParseException}.
      *
-     * <p>If {@code localPath} is nonnull, then identifiers are parsed as if the identifier was
+     * <p>If {@code localPath} is non-null, then identifiers are parsed as if the identifier was
      * written at the location of {@code localPath}. This means identifiers will be parsed to local
      * variables in scope at {@code localPath} when possible. If {@code localPath} is null, then no
      * identifier can be parsed to a local variable. In either case, the parameter syntax, e.g. #1,
@@ -133,15 +133,15 @@ public class JavaExpressionParseUtil {
      *
      * @param expression a Java expression to parse
      * @param context information about any receiver and arguments
-     * @param localPath if non-null, the location at which to parse identifiers to local variables
+     * @param localPath if non-null, the expression is parsed as if it were written at this location
      * @return the JavaExpression for the given string
      * @throws JavaExpressionParseException if the string cannot be parsed
      */
     public static JavaExpression parse(
             String expression, JavaExpressionContext context, @Nullable TreePath localPath)
             throws JavaExpressionParseException {
-        // A TreePath is required to use the underlying javac API to convert from Strings to
-        // Elements even when the information could be deduced from elements alone.  So use the the
+        // The underlying javac API used to convert from Strings to Elements requires a tree path
+        // even when the information could be deduced from elements alone.  So use the
         // path to the current CompilationUnit.
         TreePath pathToCompilationUnit = context.checker.getPathToCompilationUnit();
         Expression expr;


### PR DESCRIPTION
Currently `localScope` is used both 
1. when parsing identifiers to local variables (if `useLocalScope` is true) and 
2. when parsing to things that are from elements and only need a TreePath because of the javac API the framework uses.  

I propose we split the two uses into two different variables named
1. `localPath` 
2. `somePath`
(I'm open to suggestions on other names, too)

In this pull request (that shall not be merged), I've made changes to `JavaExpressionParseUtil#parse` to show what the Javadoc will be.  @mernst, I wanted your feedback on this design before making similar changes at every use of `localScope` and `useLocalScope`. 