### PR TITLE
JavaExpressionParseUtil: Parse unqualified class names correctly.

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1277,6 +1277,12 @@ systems) \code{<self>}.
 \item a binary expression, e.g., \<x + y> or <\#1 - 1>.  These are used by
   the Index Checker, for example.
 
+\item a class name expression within another expression, e.g., \<String.class> or \<pkg.MyClass.staticField>.
+At a method signature, a class can only be referenced by its simple name if it can be referenced in
+normal Java code by its simple name at the location of the method signature without an import. For example,
+a class in the same package as the class in which the method is declared does not need to be referenced
+by its fully qualified name.
+
 \end{itemize}
 
 % We want this in the future:

--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1282,7 +1282,7 @@ systems) \code{<self>}.
   class name must be fully-qualified unless it can be referenced by its
   simple name without an \<import> statement at the location where the
   annotation appears.  For example, an annotation in class \<C> can use the
-  simple name of a class in \<java.lang> or in the name package as \<C>.
+  simple name of a class in \<java.lang> or in the same package as \<C>.
 
 \end{itemize}
 

--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -1277,11 +1277,12 @@ systems) \code{<self>}.
 \item a binary expression, e.g., \<x + y> or <\#1 - 1>.  These are used by
   the Index Checker, for example.
 
-\item a class name expression within another expression, e.g., \<String.class> or \<pkg.MyClass.staticField>.
-At a method signature, a class can only be referenced by its simple name if it can be referenced in
-normal Java code by its simple name at the location of the method signature without an import. For example,
-a class in the same package as the class in which the method is declared does not need to be referenced
-by its fully qualified name.
+\item a class name expression within another expression, e.g., ``String''
+  in \<String.class> or ``pkg.MyClass'' in \<pkg.MyClass.staticField>.  The
+  class name must be fully-qualified unless it can be referenced by its
+  simple name without an \<import> statement at the location where the
+  annotation appears.  For example, an annotation in class \<C> can use the
+  simple name of a class in \<java.lang> or in the name package as \<C>.
 
 \end{itemize}
 

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -402,8 +402,7 @@ public class JavaExpressionParseUtil {
          *
          * @param context JavaExpressionContext
          * @param identifier possible class name
-         * @return the {@code ClassName} for {@code identifier} or null if if it is not a class
-         *     name.
+         * @return the {@code ClassName} for {@code identifier} or null if it is not a class name.
          */
         protected @Nullable ClassName getIdentifierAsClassName(
                 JavaExpressionContext context, String identifier) {
@@ -467,6 +466,7 @@ public class JavaExpressionParseUtil {
                     }
                 }
             }
+
             return null;
         }
 
@@ -477,7 +477,7 @@ public class JavaExpressionParseUtil {
          *
          * @param context {@link JavaExpressionContext}
          * @param identifier possibly a field name
-         * @return a field access or null if {@code identifier} is not a field
+         * @return a field access, or null if {@code identifier} is not a field
          */
         protected @Nullable FieldAccess getIdentifierAsField(
                 JavaExpressionContext context, String identifier) {
@@ -514,6 +514,7 @@ public class JavaExpressionParseUtil {
                 }
                 return fieldAccess;
             }
+
             return null;
         }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -49,6 +49,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
@@ -395,6 +396,7 @@ public class JavaExpressionParseUtil {
          *   <li>the type of "this" in this context
          *   <li>a type declared in "this" or in an enclosing type of "this"
          *   <li>a type in the java.lang package
+         *   <li>a type in the unnamed package
          * </ol>
          *
          * @param context JavaExpressionContext
@@ -438,6 +440,16 @@ public class JavaExpressionParseUtil {
                         resolver.findClassInPackage(identifier, packageSymbol, annotatedConstruct);
                 if (classSymbol != null) {
                     return new ClassName(classSymbol.asType());
+                }
+            }
+
+            // Is identifier a class in the unnamed package?
+            Element classElem = resolver.findClass(identifier, annotatedConstruct);
+            if (classElem.getEnclosingElement().getKind() == ElementKind.PACKAGE
+                    && ((PackageElement) classElem.getEnclosingElement()).isUnnamed()) {
+                TypeMirror classType = ElementUtils.getType(classElem);
+                if (classType != null) {
+                    return new ClassName(classType);
                 }
             }
             return null;

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -35,6 +35,7 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
 import com.sun.tools.javac.code.Symbol.MethodSymbol;
+import com.sun.tools.javac.code.Symbol.PackageSymbol;
 import com.sun.tools.javac.code.Type.ArrayType;
 import com.sun.tools.javac.code.Type.ClassType;
 import java.util.ArrayList;
@@ -431,6 +432,18 @@ public class JavaExpressionParseUtil {
                     return new ClassName(classType);
                 }
                 searchType = getTypeOfEnclosingClass((DeclaredType) searchType);
+            }
+            if (context.receiver.getType().getKind() == TypeKind.DECLARED) {
+                // Is identifier in the same package as this?
+                PackageSymbol packageSymbol =
+                        (PackageSymbol)
+                                ElementUtils.enclosingPackage(
+                                        ((DeclaredType) context.receiver.getType()).asElement());
+                ClassSymbol classSymbol =
+                        resolver.findClassInPackage(identifier, packageSymbol, annotatedConstruct);
+                if (classSymbol != null) {
+                    return new ClassName(classSymbol.asType());
+                }
             }
             // Is identifier a simple name for a class in java.lang?
             Symbol.PackageSymbol packageSymbol =

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -458,11 +458,13 @@ public class JavaExpressionParseUtil {
 
             // Is identifier a class in the unnamed package?
             Element classElem = resolver.findClass(identifier, annotatedConstruct);
-            if (classElem.getEnclosingElement().getKind() == ElementKind.PACKAGE
-                    && ((PackageElement) classElem.getEnclosingElement()).isUnnamed()) {
-                TypeMirror classType = ElementUtils.getType(classElem);
-                if (classType != null) {
-                    return new ClassName(classType);
+            if (classElem != null) {
+                PackageElement pkg = ElementUtils.enclosingPackage(classElem);
+                if (pkg != null && pkg.isUnnamed()) {
+                    TypeMirror classType = ElementUtils.getType(classElem);
+                    if (classType != null) {
+                        return new ClassName(classType);
+                    }
                 }
             }
             return null;

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -353,45 +353,14 @@ public class JavaExpressionParseUtil {
             }
 
             // Field access
-            TypeMirror receiverType = context.receiver.getType();
-            // isOriginalReceiver is true if receiverType has not been reassigned.
-            boolean isOriginalReceiver = true;
-            VariableElement fieldElem = null;
-            if (s.equals("length") && receiverType.getKind() == TypeKind.ARRAY) {
-                fieldElem = resolver.findField(s, receiverType, annotatedConstruct);
-            }
-            if (fieldElem == null) {
-                // Search for field in each enclosing class.
-                while (receiverType.getKind() == TypeKind.DECLARED) {
-                    fieldElem = resolver.findField(s, receiverType, annotatedConstruct);
-                    if (fieldElem != null) {
-                        break;
-                    }
-                    receiverType = getTypeOfEnclosingClass((DeclaredType) receiverType);
-                    isOriginalReceiver = false;
-                }
-            }
-            if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
-                FieldAccess fieldAccess =
-                        getFieldJavaExpression(fieldElem, context, isOriginalReceiver);
-                TypeElement scopeClassElement =
-                        TypesUtils.getTypeElement(fieldAccess.getReceiver().getType());
-                if (!isOriginalReceiver
-                        && !ElementUtils.isStatic(fieldElem)
-                        && ElementUtils.isStatic(scopeClassElement)) {
-                    throw new ParseRuntimeException(
-                            constructJavaExpressionParseError(
-                                    s,
-                                    "a non-static field can't be referenced from a static inner class or enum"));
-                }
+            FieldAccess fieldAccess = getIdentifierAsField(context, s);
+            if (fieldAccess != null) {
                 return fieldAccess;
             }
 
-            // Class name
-            Element classElem = resolver.findClass(s, annotatedConstruct);
-            TypeMirror classType = ElementUtils.getType(classElem);
+            ClassName classType = getIdentifierAsClassName(context, s);
             if (classType != null) {
-                return new ClassName(classType);
+                return classType;
             }
 
             // Err if a formal parameter name is used, instead of the "#2" syntax.
@@ -413,6 +382,115 @@ public class JavaExpressionParseUtil {
 
             throw new ParseRuntimeException(
                     constructJavaExpressionParseError(s, "identifier not found"));
+        }
+
+        /**
+         * If {@code identifier} is a unqualified class name, return the {@link ClassName}. If not,
+         * return null.
+         *
+         * <p>If {@code context.useLocalScope} is false, then the only classes that may be used
+         * without qualification are:
+         *
+         * <ol>
+         *   <li>the type of "this" in this context
+         *   <li>a type declared in "this" or in an enclosing type of "this"
+         *   <li>a type in the java.lang package
+         * </ol>
+         *
+         * @param context JavaExpressionContext
+         * @param identifier possible class name
+         * @return the {@code ClassName} for {@code identifier} or null if if it is not a class
+         *     name.
+         */
+        protected @Nullable ClassName getIdentifierAsClassName(
+                JavaExpressionContext context, String identifier) {
+            if (!context.parsingMember && context.useLocalScope) {
+                Element classElem = resolver.findClass(identifier, annotatedConstruct);
+                TypeMirror classType = ElementUtils.getType(classElem);
+                if (classType != null) {
+                    return new ClassName(classType);
+                }
+            }
+            TypeMirror typeOfThis = context.receiver.getType();
+            // Is identifier the simple name of this?
+            if (typeOfThis.getKind() == TypeKind.DECLARED) {
+                if (((DeclaredType) typeOfThis)
+                        .asElement()
+                        .getSimpleName()
+                        .contentEquals(identifier)) {
+                    return new ClassName(typeOfThis);
+                }
+            }
+
+            // Is identifier an inner class of this or of any enclosing class of this?
+            TypeMirror searchType = context.receiver.getType();
+            while (searchType.getKind() == TypeKind.DECLARED) {
+                Element classElem =
+                        resolver.findClassInType(identifier, searchType, annotatedConstruct);
+                if (classElem != null) {
+                    TypeMirror classType = ElementUtils.getType(classElem);
+                    return new ClassName(classType);
+                }
+                searchType = getTypeOfEnclosingClass((DeclaredType) searchType);
+            }
+            // Is identifier a simple name for a class in java.lang?
+            Symbol.PackageSymbol packageSymbol =
+                    resolver.findPackage("java.lang", annotatedConstruct);
+            if (packageSymbol != null) {
+                ClassSymbol classSymbol =
+                        resolver.findClassInPackage(identifier, packageSymbol, annotatedConstruct);
+                if (classSymbol != null) {
+                    return new ClassName(classSymbol.asType());
+                }
+            }
+            return null;
+        }
+
+        /**
+         * If {@code identifier} is a field name, then return the {@link FieldAccess} corresponding
+         * to using that field at the given {@code context}. If {@code identifier} is not a field
+         * name, this method returns null.
+         *
+         * @param context {@link JavaExpressionContext}
+         * @param identifier possibly a field name
+         * @return a field access or null if {@code identifier} is not a field
+         */
+        protected @Nullable FieldAccess getIdentifierAsField(
+                JavaExpressionContext context, String identifier) {
+            TypeMirror receiverType = context.receiver.getType();
+            // isOriginalReceiver is true if receiverType has not been reassigned.
+            boolean isOriginalReceiver = true;
+            VariableElement fieldElem = null;
+            if (identifier.equals("length") && receiverType.getKind() == TypeKind.ARRAY) {
+                fieldElem = resolver.findField(identifier, receiverType, annotatedConstruct);
+            }
+            if (fieldElem == null) {
+                // Search for field in each enclosing class.
+                while (receiverType.getKind() == TypeKind.DECLARED) {
+                    fieldElem = resolver.findField(identifier, receiverType, annotatedConstruct);
+                    if (fieldElem != null) {
+                        break;
+                    }
+                    receiverType = getTypeOfEnclosingClass((DeclaredType) receiverType);
+                    isOriginalReceiver = false;
+                }
+            }
+            if (fieldElem != null && fieldElem.getKind() == ElementKind.FIELD) {
+                FieldAccess fieldAccess =
+                        getFieldJavaExpression(fieldElem, context, isOriginalReceiver);
+                TypeElement scopeClassElement =
+                        TypesUtils.getTypeElement(fieldAccess.getReceiver().getType());
+                if (!isOriginalReceiver
+                        && !ElementUtils.isStatic(fieldElem)
+                        && ElementUtils.isStatic(scopeClassElement)) {
+                    throw new ParseRuntimeException(
+                            constructJavaExpressionParseError(
+                                    identifier,
+                                    "a non-static field can't be referenced from a static inner class or enum"));
+                }
+                return fieldAccess;
+            }
+            return null;
         }
 
         @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -411,20 +411,17 @@ public class JavaExpressionParseUtil {
                     return new ClassName(classType);
                 }
             }
-            TypeMirror typeOfThis = context.receiver.getType();
-            // Is identifier the simple name of this?
-            if (typeOfThis.getKind() == TypeKind.DECLARED) {
-                if (((DeclaredType) typeOfThis)
-                        .asElement()
-                        .getSimpleName()
-                        .contentEquals(identifier)) {
-                    return new ClassName(typeOfThis);
-                }
-            }
 
             // Is identifier an inner class of this or of any enclosing class of this?
             TypeMirror searchType = context.receiver.getType();
             while (searchType.getKind() == TypeKind.DECLARED) {
+                // Is identifier the simple name of this?
+                if (((DeclaredType) searchType)
+                        .asElement()
+                        .getSimpleName()
+                        .contentEquals(identifier)) {
+                    return new ClassName(searchType);
+                }
                 Element classElem =
                         resolver.findClassInType(identifier, searchType, annotatedConstruct);
                 if (classElem != null) {

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaExpressionParseUtil.java
@@ -425,7 +425,7 @@ public class JavaExpressionParseUtil {
                     return new ClassName(searchType);
                 }
                 Element classElem =
-                        resolver.findClassInType(identifier, searchType, annotatedConstruct);
+                        resolver.findNestedClassInType(identifier, searchType, annotatedConstruct);
                 if (classElem != null) {
                     TypeMirror classType = ElementUtils.getType(classElem);
                     return new ClassName(classType);

--- a/framework/tests/flow2/flowexpression-scope/Class2.java
+++ b/framework/tests/flow2/flowexpression-scope/Class2.java
@@ -7,11 +7,25 @@ import pkg1.Class1;
 
 public class Class2 {
     @RequiresOdd("Class1.field")
+    // :: error: (flowexpr.parse.error)
+    public void requiresOddParseError() {
+        // :: error: (assignment.type.incompatible)
+        @Odd Object odd = Class1.field;
+    }
+
+    @RequiresOdd("pkg1.Class1.field")
     public void requiresOdd() {
         @Odd Object odd = Class1.field;
     }
 
     @EnsuresOdd("Class1.field")
+    // :: error: (flowexpr.parse.error)
+    public void ensuresOddParseError() {
+        // :: warning: (cast.unsafe.constructor.invocation)
+        Class1.field = new @Odd Object();
+    }
+
+    @EnsuresOdd("pkg1.Class1.field")
     public void ensuresOdd() {
         // :: warning: (cast.unsafe.constructor.invocation)
         Class1.field = new @Odd Object();

--- a/framework/tests/flow2/flowexpression-scope/Issue862.java
+++ b/framework/tests/flow2/flowexpression-scope/Issue862.java
@@ -1,4 +1,3 @@
-// @skip-test
 // Test case for Issue 862
 // https://github.com/typetools/checker-framework/issues/862
 
@@ -6,7 +5,6 @@ package pkg3;
 
 import pkg2.Class2;
 
-// @skip-test
 public class Issue862 {
     void illegalUse(Class2 class2) {
         // :: error: (contracts.precondition.not.satisfied)

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -263,6 +263,37 @@ public class Resolver {
     }
 
     /**
+     * Finds the class with {@code name} in a given type.
+     *
+     * @param name the name of the class
+     * @param type the type
+     * @param path the tree path
+     * @return the {@code ClassSymbol} for the class if it is found, {@code null} otherwise
+     */
+    public @Nullable ClassSymbol findClassInType(String name, TypeMirror type, TreePath path) {
+        Log.DiagnosticHandler discardDiagnosticHandler = new Log.DiscardDiagnosticHandler(log);
+        try {
+            Env<AttrContext> env = getEnvForPath(path);
+            Element res =
+                    wrapInvocationOnResolveInstance(
+                            FIND_IDENT_IN_TYPE,
+                            env,
+                            type,
+                            names.fromString(name),
+                            Kinds.KindSelector.TYP);
+
+            if (ElementUtils.isTypeElement(res)) {
+                return (ClassSymbol) res;
+            } else {
+                // Most likely didn't find the field and the Element is a SymbolNotFoundError
+                return null;
+            }
+        } finally {
+            log.popDiagnosticHandler(discardDiagnosticHandler);
+        }
+    }
+
+    /**
      * Finds the class with name {@code name} in a given package.
      *
      * @param name the name of the class

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -263,14 +263,15 @@ public class Resolver {
     }
 
     /**
-     * Finds the class with {@code name} in a given type.
+     * Finds the nested class with {@code name} in a given type.
      *
      * @param name the name of the class
      * @param type the type
      * @param path the tree path
      * @return the {@code ClassSymbol} for the class if it is found, {@code null} otherwise
      */
-    public @Nullable ClassSymbol findClassInType(String name, TypeMirror type, TreePath path) {
+    public @Nullable ClassSymbol findNestedClassInType(
+            String name, TypeMirror type, TreePath path) {
         Log.DiagnosticHandler discardDiagnosticHandler = new Log.DiscardDiagnosticHandler(log);
         try {
             Env<AttrContext> env = getEnvForPath(path);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -285,7 +285,6 @@ public class Resolver {
             if (ElementUtils.isTypeElement(res)) {
                 return (ClassSymbol) res;
             } else {
-                // Most likely didn't find the field and the Element is a SymbolNotFoundError
                 return null;
             }
         } finally {


### PR DESCRIPTION
See manual change for explantation. I also moved the code that parses identifiers to fields to a new method, so you'll see those changes, too.
Fixes #862. 

Merge with https://github.com/codespecs/daikon/pull/316

