### PR TITLE
Add a delocalize method to DependentTypesHelper.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenes.java
@@ -652,8 +652,7 @@ public class WholeProgramInferenceScenes implements WholeProgramInference {
         atypeFactory.wpiAdjustForUpdateNonField(rhsATM);
         DependentTypesHelper dependentTypesHelper =
                 ((GenericAnnotatedTypeFactory) atypeFactory).getDependentTypesHelper();
-        dependentTypesHelper.standardizeReturnType(
-                methodDeclTree, rhsATM, /*removeErroneousExpressions=*/ true);
+        dependentTypesHelper.delocalize(methodDeclTree, rhsATM);
         ATypeElement returnTypeAnnos = getReturnType(methodElt, lhsATM, atypeFactory);
         updateAnnotationSet(returnTypeAnnos, TypeUseLocation.RETURN, rhsATM, lhsATM, file);
 

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -420,10 +420,11 @@ public class DependentTypesHelper {
 
     /**
      * Viewpoint-adapt all dependent type annotations to the method declaration, {@code
-     * methodDeclTree}.
+     * methodDeclTree}. This changes occurrences of formal parameter names to "#2" syntax, and it
+     * removes expressions that contain other local variables.
      *
      * @param methodDeclTree the method declaration to which the annotations are viewpoint-adapted
-     * @param atm type to viewpoint-adapt
+     * @param atm type to viewpoint-adapt; is side-effected by this method
      */
     public void delocalize(MethodTree methodDeclTree, AnnotatedTypeMirror atm) {
         if (!hasDependentType(atm)) {
@@ -434,10 +435,10 @@ public class DependentTypesHelper {
         if (pathToMethodDecl == null) {
             return;
         }
-        // TODO: 1.) parameter names need to be covert to the # index syntax.
+        // TODO: 1.) parameter names need to be coverted to the # index syntax.
         // TODO: 2.) If an annotation only has expressions that cannot be delocalized, then that
-        // annotation needs to be changed to top, rather an the dependent type annotation with no an
-        // empty array as a value element.
+        // annotation needs to be changed to top, rather than the dependent type annotation with
+        // an empty array as a value element.
 
         JavaExpressionContext context =
                 JavaExpressionContext.buildContextForMethodDeclaration(

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -402,24 +402,7 @@ public class DependentTypesHelper {
      * @param methodDeclTree a method declaration
      * @param atm the method return type; is side-effected by this method
      */
-    public final void standardizeReturnType(MethodTree methodDeclTree, AnnotatedTypeMirror atm) {
-        standardizeReturnType(methodDeclTree, atm, /*removeErroneousExpressions=*/ false);
-    }
-
-    /**
-     * Standardizes the Java expressions in annotations for a method return type. {@code atm} might
-     * come from the method declaration or from the type of the expression in a {@code return}
-     * statement.
-     *
-     * @param methodDeclTree a method declaration
-     * @param atm the method return type; is side-effected by this method
-     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
-     *     converting them into an explanation of why they are illegal
-     */
-    public void standardizeReturnType(
-            MethodTree methodDeclTree,
-            AnnotatedTypeMirror atm,
-            boolean removeErroneousExpressions) {
+    public void standardizeReturnType(MethodTree methodDeclTree, AnnotatedTypeMirror atm) {
         if (!hasDependentType(atm)) {
             return;
         }
@@ -429,44 +412,37 @@ public class DependentTypesHelper {
             return;
         }
 
-        ExecutableElement methodElt = TreeUtils.elementFromDeclaration(methodDeclTree);
-
-        standardizeForMethodSignature(
-                methodDeclTree, pathToMethodDecl, methodElt, atm, removeErroneousExpressions);
+        JavaExpressionContext context =
+                JavaExpressionContext.buildContextForMethodDeclaration(
+                        methodDeclTree, pathToMethodDecl, factory.getChecker());
+        standardizeDoNotUseLocalScope(context, pathToMethodDecl, atm);
     }
 
     /**
-     * Standardizes the Java expressions in annotations for a method signature location, including:
+     * Viewpoint-adapt all dependent type annotations to the method declaration, {@code
+     * methodDeclTree}.
      *
-     * <ul>
-     *   <li>type annotations on a return type, formal parameter type, or exception type, and
-     *   <li>declaration annotations on a method (such as a pre- or post-condition contract
-     *       annotation) or formal parameter.
-     * </ul>
-     *
-     * @param methodDeclTree a method declaration
-     * @param pathToMethodDecl the path to the method declaration
-     * @param elt the element for the method or a formal parameter; used for obtaining the enclosing
-     *     class
-     * @param atm a type that has a dependent type annotation; is side-effected by this method
-     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
-     *     converting them into an explanation of why they are illegal
+     * @param methodDeclTree the method declaration to which the annotations are viewpoint-adapted
+     * @param atm type to viewpoint-adapt
      */
-    public void standardizeForMethodSignature(
-            MethodTree methodDeclTree,
-            TreePath pathToMethodDecl,
-            Element elt,
-            AnnotatedTypeMirror atm,
-            boolean removeErroneousExpressions) {
-        if (!hasDependentAnnotations()) {
+    public void delocalize(MethodTree methodDeclTree, AnnotatedTypeMirror atm) {
+        if (!hasDependentType(atm)) {
             return;
         }
 
-        TypeMirror enclosingType = ElementUtils.enclosingTypeElement(elt).asType();
+        TreePath pathToMethodDecl = factory.getPath(methodDeclTree);
+        if (pathToMethodDecl == null) {
+            return;
+        }
+        // TODO: 1.) parameter names need to be covert to the # index syntax.
+        // TODO: 2.) If an annotation only has expressions that cannot be delocalized, then that
+        // annotation needs to be changed to top, rather an the dependent type annotation with no an
+        // empty array as a value element.
+
         JavaExpressionContext context =
                 JavaExpressionContext.buildContextForMethodDeclaration(
-                        methodDeclTree, enclosingType, factory.getChecker());
-        standardizeDoNotUseLocalScope(context, pathToMethodDecl, atm, removeErroneousExpressions);
+                        methodDeclTree, pathToMethodDecl, factory.getChecker());
+        standardizeAtm(context, pathToMethodDecl, atm, false, true);
     }
 
     /** A set containing {@link Tree.Kind#METHOD} and {@link Tree.Kind#LAMBDA_EXPRESSION}. */
@@ -501,12 +477,10 @@ public class DependentTypesHelper {
 
                 if (enclTree.getKind() == Kind.METHOD) {
                     MethodTree methodDeclTree = (MethodTree) enclTree;
-                    standardizeForMethodSignature(
-                            methodDeclTree,
-                            pathTillEnclTree,
-                            variableElt,
-                            type,
-                            /*removeErroneousExpressions=*/ false);
+                    JavaExpressionContext context =
+                            JavaExpressionContext.buildContextForMethodDeclaration(
+                                    methodDeclTree, pathTillEnclTree, factory.getChecker());
+                    standardizeDoNotUseLocalScope(context, pathTillEnclTree, type);
                 } else {
                     LambdaExpressionTree lambdaTree = (LambdaExpressionTree) enclTree;
                     JavaExpressionContext parameterContext =
@@ -673,27 +647,7 @@ public class DependentTypesHelper {
      */
     private void standardizeDoNotUseLocalScope(
             JavaExpressionContext context, TreePath localScope, AnnotatedTypeMirror type) {
-        standardizeDoNotUseLocalScope(
-                context, localScope, type, /*removeErroneousExpressions=*/ false);
-    }
-
-    // TODO: Eliminate all uses of this.
-    /**
-     * Standardize a type, setting useLocalScope to false.
-     *
-     * @param context the context
-     * @param localScope the local scope
-     * @param type the type to standardize; is side-effected by this method
-     * @param removeErroneousExpressions if true, remove erroneous expressions rather than
-     *     converting them into an explanation of why they are illegal
-     */
-    private void standardizeDoNotUseLocalScope(
-            JavaExpressionContext context,
-            TreePath localScope,
-            AnnotatedTypeMirror type,
-            boolean removeErroneousExpressions) {
-        standardizeAtm(
-                context, localScope, type, /*useLocalScope=*/ false, removeErroneousExpressions);
+        standardizeAtm(context, localScope, type, false, /*removeErroneousExpressions=*/ false);
     }
 
     private void standardizeAtm(

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -442,7 +442,12 @@ public class DependentTypesHelper {
         JavaExpressionContext context =
                 JavaExpressionContext.buildContextForMethodDeclaration(
                         methodDeclTree, pathToMethodDecl, factory.getChecker());
-        standardizeAtm(context, pathToMethodDecl, atm, false, true);
+        standardizeAtm(
+                context,
+                pathToMethodDecl,
+                atm,
+                /*useLocalScope=*/ false, /*removeErroneousExpressions*/
+                true);
     }
 
     /** A set containing {@link Tree.Kind#METHOD} and {@link Tree.Kind#LAMBDA_EXPRESSION}. */
@@ -647,7 +652,12 @@ public class DependentTypesHelper {
      */
     private void standardizeDoNotUseLocalScope(
             JavaExpressionContext context, TreePath localScope, AnnotatedTypeMirror type) {
-        standardizeAtm(context, localScope, type, false, /*removeErroneousExpressions=*/ false);
+        standardizeAtm(
+                context,
+                localScope,
+                type,
+                /*useLocalScope=*/ false,
+                /*removeErroneousExpressions=*/ false);
     }
 
     private void standardizeAtm(


### PR DESCRIPTION
Removed methods that were only called once or called with `removeErroneousExpressions` = `false`.

I also removed `standardizeForMethodSignature`.  We might want this method again in the future, but currently it's only called in two places and doesn't reduce code duplication.  (It's javadoc was also wrong; it wasn't called for contracts.)