### PR TITLE
Use string literals instead of method calls

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterTreeUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterTreeUtil.java
@@ -50,7 +50,7 @@ public class FormatterTreeUtil {
         /*
         this.formatArgTypesElement =
                 TreeUtils.getMethod(
-                        org.checkerframework.checker.formatter.qual.Format.class.getCanonicalName(),
+                        "org.checkerframework.checker.formatter.qual.Format",
                         "value",
                         0,
                         processingEnv);

--- a/checker/src/main/java/org/checkerframework/checker/nullness/CollectionToArrayHeuristics.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/CollectionToArrayHeuristics.java
@@ -62,14 +62,8 @@ public class CollectionToArrayHeuristics {
         this.atypeFactory = factory;
 
         this.collectionToArrayE =
-                TreeUtils.getMethod(
-                        java.util.Collection.class.getCanonicalName(),
-                        "toArray",
-                        processingEnv,
-                        "T[]");
-        this.size =
-                TreeUtils.getMethod(
-                        java.util.Collection.class.getCanonicalName(), "size", 0, processingEnv);
+                TreeUtils.getMethod("java.util.Collection", "toArray", processingEnv, "T[]");
+        this.size = TreeUtils.getMethod("java.util.Collection", "size", 0, processingEnv);
         this.collectionType =
                 factory.fromElement(ElementUtils.getTypeElement(processingEnv, Collection.class));
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagationTreeAnnotator.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagationTreeAnnotator.java
@@ -53,11 +53,7 @@ public class KeyForPropagationTreeAnnotator extends TreeAnnotator {
         super(atypeFactory);
         this.keyForPropagator = propagationTreeAnnotator;
         keySetMethod =
-                TreeUtils.getMethod(
-                        java.util.Map.class.getCanonicalName(),
-                        "keySet",
-                        0,
-                        atypeFactory.getProcessingEnv());
+                TreeUtils.getMethod("java.util.Map", "keySet", 0, atypeFactory.getProcessingEnv());
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -237,11 +237,7 @@ public class NullnessAnnotatedTypeFactory
                 new SystemGetPropertyHandler(processingEnv, this, permitClearProperty);
 
         classGetCanonicalName =
-                TreeUtils.getMethod(
-                        java.lang.Class.class.getCanonicalName(),
-                        "getCanonicalName",
-                        0,
-                        processingEnv);
+                TreeUtils.getMethod("java.lang.Class", "getCanonicalName", 0, processingEnv);
 
         postInit();
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -111,17 +111,10 @@ public class NullnessVisitor
         stringType = elements.getTypeElement(String.class.getCanonicalName()).asType();
 
         ProcessingEnvironment env = checker.getProcessingEnvironment();
-        this.collectionSize =
-                TreeUtils.getMethod(java.util.Collection.class.getCanonicalName(), "size", 0, env);
-        this.collectionToArray =
-                TreeUtils.getMethod(
-                        java.util.Collection.class.getCanonicalName(), "toArray", env, "T[]");
-        systemClearProperty =
-                TreeUtils.getMethod(
-                        java.lang.System.class.getCanonicalName(), "clearProperty", 1, env);
-        systemSetProperties =
-                TreeUtils.getMethod(
-                        java.lang.System.class.getCanonicalName(), "setProperties", 1, env);
+        this.collectionSize = TreeUtils.getMethod("java.util.Collection", "size", 0, env);
+        this.collectionToArray = TreeUtils.getMethod("java.util.Collection", "toArray", env, "T[]");
+        systemClearProperty = TreeUtils.getMethod("java.lang.System", "clearProperty", 1, env);
+        systemSetProperties = TreeUtils.getMethod("java.lang.System", "setProperties", 1, env);
 
         this.permitClearProperty =
                 checker.getLintOption(

--- a/checker/src/main/java/org/checkerframework/checker/nullness/SystemGetPropertyHandler.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/SystemGetPropertyHandler.java
@@ -92,12 +92,8 @@ public class SystemGetPropertyHandler {
         this.factory = factory;
         this.permitClearProperty = permitClearProperty;
 
-        systemGetProperty =
-                TreeUtils.getMethod(
-                        java.lang.System.class.getCanonicalName(), "getProperty", 1, env);
-        systemSetProperty =
-                TreeUtils.getMethod(
-                        java.lang.System.class.getCanonicalName(), "setProperty", 2, env);
+        systemGetProperty = TreeUtils.getMethod("java.lang.System", "getProperty", 1, env);
+        systemSetProperty = TreeUtils.getMethod("java.lang.System", "setProperty", 2, env);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -117,6 +117,11 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     private final ExecutableElement patternCompile =
             TreeUtils.getMethod("java.util.regex.Pattern", "compile", 1, processingEnv);
 
+    /**
+     * Create a new RegexAnnotatedTypeFactory.
+     *
+     * @param checker the checker
+     */
     public RegexAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);
 

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -95,10 +95,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     /** The method that returns the value element of a {@code @Regex} annotation. */
     protected final ExecutableElement regexValueElement =
             TreeUtils.getMethod(
-                    org.checkerframework.checker.regex.qual.Regex.class.getCanonicalName(),
-                    "value",
-                    0,
-                    processingEnv);
+                    "org.checkerframework.checker.regex.qual.Regex", "value", 0, processingEnv);
 
     /**
      * The value method of the PartialRegex qualifier.
@@ -107,7 +104,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      */
     private final ExecutableElement partialRegexValue =
             TreeUtils.getMethod(
-                    org.checkerframework.checker.regex.qual.PartialRegex.class.getCanonicalName(),
+                    "org.checkerframework.checker.regex.qual.PartialRegex",
                     "value",
                     0,
                     processingEnv);
@@ -118,8 +115,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * @see java.util.regex.Pattern#compile(String)
      */
     private final ExecutableElement patternCompile =
-            TreeUtils.getMethod(
-                    java.util.regex.Pattern.class.getCanonicalName(), "compile", 1, processingEnv);
+            TreeUtils.getMethod("java.util.regex.Pattern", "compile", 1, processingEnv);
 
     public RegexAnnotatedTypeFactory(BaseTypeChecker checker) {
         super(checker);

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexVisitor.java
@@ -49,21 +49,11 @@ public class RegexVisitor extends BaseTypeVisitor<RegexAnnotatedTypeFactory> {
     public RegexVisitor(BaseTypeChecker checker) {
         super(checker);
         ProcessingEnvironment env = checker.getProcessingEnvironment();
-        this.matchResultEnd =
-                TreeUtils.getMethod(
-                        java.util.regex.MatchResult.class.getCanonicalName(), "end", 1, env);
-        this.matchResultGroup =
-                TreeUtils.getMethod(
-                        java.util.regex.MatchResult.class.getCanonicalName(), "group", 1, env);
-        this.matchResultStart =
-                TreeUtils.getMethod(
-                        java.util.regex.MatchResult.class.getCanonicalName(), "start", 1, env);
-        this.patternCompile =
-                TreeUtils.getMethod(
-                        java.util.regex.Pattern.class.getCanonicalName(), "compile", 2, env);
-        this.patternLiteral =
-                TreeUtils.getField(
-                        java.util.regex.Pattern.class.getCanonicalName(), "LITERAL", env);
+        this.matchResultEnd = TreeUtils.getMethod("java.util.regex.MatchResult", "end", 1, env);
+        this.matchResultGroup = TreeUtils.getMethod("java.util.regex.MatchResult", "group", 1, env);
+        this.matchResultStart = TreeUtils.getMethod("java.util.regex.MatchResult", "start", 1, env);
+        this.patternCompile = TreeUtils.getMethod("java.util.regex.Pattern", "compile", 2, env);
+        this.patternLiteral = TreeUtils.getField("java.util.regex.Pattern", "LITERAL", env);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
@@ -68,17 +68,12 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** The {@link String#replace(char, char)} method. */
     private final ExecutableElement replaceCharChar =
-            TreeUtils.getMethod(
-                    java.lang.String.class.getCanonicalName(),
-                    "replace",
-                    processingEnv,
-                    "char",
-                    "char");
+            TreeUtils.getMethod("java.lang.String", "replace", processingEnv, "char", "char");
 
     /** The {@link String#replace(CharSequence, CharSequence)} method. */
     private final ExecutableElement replaceCharSequenceCharSequence =
             TreeUtils.getMethod(
-                    java.lang.String.class.getCanonicalName(),
+                    "java.lang.String",
                     "replace",
                     processingEnv,
                     "java.lang.CharSequence",
@@ -86,7 +81,7 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** The {@link Class#getName()} method. */
     private final ExecutableElement classGetName =
-            TreeUtils.getMethod(java.lang.Class.class.getCanonicalName(), "getName", processingEnv);
+            TreeUtils.getMethod("java.lang.Class", "getName", processingEnv);
 
     /**
      * Creates a SignatureAnnotatedTypeFactory.

--- a/checker/tests/index/ListRemove.java
+++ b/checker/tests/index/ListRemove.java
@@ -3,7 +3,8 @@ import org.checkerframework.checker.index.qual.LTEqLengthOf;
 import org.checkerframework.checker.index.qual.LTLengthOf;
 
 // @skip-test until we bring list support back
-// @skip-test can't handle until TreeUtils.getMethod has a way to precisly handle method overloading
+// @skip-test can't handle until TreeUtils.getMethod has a way to precisely handle method
+// overloading
 
 public class ListRemove {
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -232,9 +232,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         this.functionApply = TreeUtils.getMethod("java.util.function.Function", "apply", 1, env);
         this.vectorType =
                 atypeFactory.fromElement(elements.getTypeElement(Vector.class.getCanonicalName()));
-        targetValueElement =
-                TreeUtils.getMethod(
-                        java.lang.annotation.Target.class.getCanonicalName(), "value", 0, env);
+        targetValueElement = TreeUtils.getMethod("java.lang.annotation.Target", "value", 0, env);
     }
 
     /**


### PR DESCRIPTION
An advantage is that the code is shorter.
A disadvantage may be that automated refactoring tools might not work as well.