### PR TITLE
use areSameByName instead of areSameByClass in AccumulationAnnotatedTypeFactory

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
@@ -83,7 +83,7 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
      * The name of the predicate annotation, if one exists, to avoid recomputing it from {@link
      * #predicate} every time the checker needs to check if an arbitrary annotation is a predicate.
      */
-    private final @MonotonicNonNull @CanonicalName String predicateName;
+    private final @Nullable @CanonicalName String predicateName;
 
     /**
      * Create an annotated type factory for an accumulation checker.
@@ -110,6 +110,9 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
         }
         this.accumulationChecker = (AccumulationChecker) checker;
 
+        this.top = createAccumulatorAnnotation(Collections.emptyList());
+        this.bottom = AnnotationBuilder.fromClass(elements, bottom);
+
         this.accumulator = accumulator;
         // Check that the requirements of the accumulator are met.
         Method[] accDeclaredMethods = accumulator.getDeclaredMethods();
@@ -128,7 +131,7 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
                 || ((String[]) accValue.getDefaultValue()).length != 0) {
             rejectMalformedAccumulator("have the empty String array {} as its default value");
         }
-        this.top = createAccumulatorAnnotation(Collections.emptyList());
+
         this.accumulatorName = AnnotationUtils.annotationName(top);
 
         this.predicate = predicate;
@@ -149,8 +152,6 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
         } else {
             this.predicateName = null;
         }
-
-        this.bottom = AnnotationBuilder.fromClass(elements, bottom);
 
         // Every subclass must call postInit!  This does not do so.
     }

--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationAnnotatedTypeFactory.java
@@ -53,19 +53,16 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
     public final AccumulationChecker accumulationChecker;
 
     /**
-     * The canonical top annotation for this accumulation checker: an instance of the accumulator
-     * annotation with no arguments.
-     */
-    public final AnnotationMirror top;
-
-    /** The canonical bottom annotation for this accumulation checker. */
-    public final AnnotationMirror bottom;
-
-    /**
      * The annotation that accumulates things in this accumulation checker. Must be an annotation
      * with exactly one field named "value" whose type is a String array.
      */
     private final Class<? extends Annotation> accumulator;
+
+    /**
+     * The canonical top annotation for this accumulation checker: an instance of the accumulator
+     * annotation with no arguments.
+     */
+    public final AnnotationMirror top;
 
     /**
      * The name of the accumulator annotation, to avoid recomputing it from {@link #accumulator}
@@ -84,6 +81,9 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
      * #predicate} every time the checker needs to check if an arbitrary annotation is a predicate.
      */
     private final @Nullable @CanonicalName String predicateName;
+
+    /** The canonical bottom annotation for this accumulation checker. */
+    public final AnnotationMirror bottom;
 
     /**
      * Create an annotated type factory for an accumulation checker.
@@ -110,9 +110,6 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
         }
         this.accumulationChecker = (AccumulationChecker) checker;
 
-        this.top = createAccumulatorAnnotation(Collections.emptyList());
-        this.bottom = AnnotationBuilder.fromClass(elements, bottom);
-
         this.accumulator = accumulator;
         // Check that the requirements of the accumulator are met.
         Method[] accDeclaredMethods = accumulator.getDeclaredMethods();
@@ -131,6 +128,8 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
                 || ((String[]) accValue.getDefaultValue()).length != 0) {
             rejectMalformedAccumulator("have the empty String array {} as its default value");
         }
+
+        this.top = createAccumulatorAnnotation(Collections.emptyList());
 
         this.accumulatorName = AnnotationUtils.annotationName(top);
 
@@ -152,6 +151,8 @@ public abstract class AccumulationAnnotatedTypeFactory extends BaseAnnotatedType
         } else {
             this.predicateName = null;
         }
+
+        this.bottom = AnnotationBuilder.fromClass(elements, bottom);
 
         // Every subclass must call postInit!  This does not do so.
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -161,6 +161,9 @@ public class AnnotationUtils {
     /**
      * Checks that the annotation {@code am} has the name of {@code annoClass}. Values are ignored.
      *
+     * <p>This method is not very efficient. It is more efficient to use {@link #areSameByName} or
+     * {@link AnnotatedTypFactory#areSameByClass}.
+     *
      * @param am the AnnotationMirror whose class to compare
      * @param annoClass the class to compare
      * @return true if annoclass is the class of am

--- a/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/AnnotationUtils.java
@@ -162,7 +162,7 @@ public class AnnotationUtils {
      * Checks that the annotation {@code am} has the name of {@code annoClass}. Values are ignored.
      *
      * <p>This method is not very efficient. It is more efficient to use {@link #areSameByName} or
-     * {@link AnnotatedTypFactory#areSameByClass}.
+     * {@code AnnotatedTypeFactory#areSameByClass}.
      *
      * @param am the AnnotationMirror whose class to compare
      * @param annoClass the class to compare


### PR DESCRIPTION
@msridhar noticed that the calls to `areSameByClass` were taking an inordinate amount of wall clock time when running the CalledMethods Checker, because `areSameByClass` calls `getCanonicalName` under the hood. This semantics-preserving change modifies the checker to use `areSameByName` instead, which directly compares strings instead (and should therefore be faster).