### PR TITLE
Add test for overloaded method in contract.

### DIFF
--- a/checker/tests/nullness/MethodOverloadingContractsKeyFor.java
+++ b/checker/tests/nullness/MethodOverloadingContractsKeyFor.java
@@ -3,6 +3,7 @@ import java.util.Map;
 import org.checkerframework.checker.nullness.qual.EnsuresKeyFor;
 import org.checkerframework.dataflow.qual.Pure;
 
+// @skip-test until bug is fixed.
 public class MethodOverloadingContractsKeyFor {
 
     static class ClassA {}

--- a/checker/tests/nullness/MethodOverloadingContractsKeyFor.java
+++ b/checker/tests/nullness/MethodOverloadingContractsKeyFor.java
@@ -1,0 +1,41 @@
+import java.util.HashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.EnsuresKeyFor;
+import org.checkerframework.dataflow.qual.Pure;
+
+public class MethodOverloadingContractsKeyFor {
+
+    static class ClassA {}
+
+    static class ClassB extends ClassA {}
+
+    @Pure
+    String name(ClassA classA) {
+        return "asClassA";
+    }
+
+    @Pure
+    Object name(ClassB classB) {
+        return "asClassB";
+    }
+
+    Map<Object, Object> map = new HashMap<>();
+
+    @EnsuresKeyFor(value = "name(#1)", map = "map")
+    void put(ClassA classA) {
+        map.put(name(classA), "");
+    }
+
+    void test(ClassA classA, ClassB classB) {
+        put(classA);
+        map.get(name(classA)).toString();
+
+        put(classB);
+        // :: error: (dereference.of.nullable)
+        map.get(name(classB)).toString();
+    }
+
+    public static void main(String[] args) {
+        new MethodOverloadingContractsKeyFor().test(new ClassA(), new ClassB());
+    }
+}

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -408,6 +408,30 @@ public final class TreeUtils {
     }
 
     /**
+     * Determine whether the given MethodInvocationTree has an underlying element.
+     *
+     * @param node the MethodInvocationTree to test
+     * @return whether the tree refers to an identifier, member select, or method invocation
+     */
+    @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
+    @Pure
+    public static boolean isUseOfElement(MethodInvocationTree node) {
+        return isUseOfElement((ExpressionTree) node);
+    }
+
+    /**
+     * Determine whether the given NewClassTree has an underlying element.
+     *
+     * @param node the NewClassTree to test
+     * @return whether the tree refers to an identifier, member select, or method invocation
+     */
+    @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
+    @Pure
+    public static boolean isUseOfElement(NewClassTree node) {
+        return isUseOfElement((ExpressionTree) node);
+    }
+
+    /**
      * Returns true if {@code tree} has a synthetic argument.
      *
      * <p>For some anonymous classes with an explicit enclosing expression, javac creates a

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -389,7 +389,7 @@ public final class TreeUtils {
      * Determine whether the given ExpressionTree has an underlying element.
      *
      * @param node the ExpressionTree to test
-     * @return true if the tree refers to an identifier, member select, or method invocation
+     * @return whether the tree refers to an identifier, member select, or method invocation
      */
     @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
     @Pure
@@ -405,30 +405,6 @@ public final class TreeUtils {
             default:
                 return false;
         }
-    }
-
-    /**
-     * Determine whether the given MethodInvocationTree has an underlying element.
-     *
-     * @param node the MethodInvocationTree to test
-     * @return true if the tree refers to an identifier, member select, or method invocation
-     */
-    @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
-    @Pure
-    public static boolean isUseOfElement(MethodInvocationTree node) {
-        return isUseOfElement((ExpressionTree) node);
-    }
-
-    /**
-     * Determine whether the given NewClassTree has an underlying element.
-     *
-     * @param node the NewClassTree to test
-     * @return true if the tree refers to an identifier, member select, or method invocation
-     */
-    @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
-    @Pure
-    public static boolean isUseOfElement(NewClassTree node) {
-        return isUseOfElement((ExpressionTree) node);
     }
 
     /**

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -389,7 +389,7 @@ public final class TreeUtils {
      * Determine whether the given ExpressionTree has an underlying element.
      *
      * @param node the ExpressionTree to test
-     * @return whether the tree refers to an identifier, member select, or method invocation
+     * @return true if the tree refers to an identifier, member select, or method invocation
      */
     @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
     @Pure
@@ -411,7 +411,7 @@ public final class TreeUtils {
      * Determine whether the given MethodInvocationTree has an underlying element.
      *
      * @param node the MethodInvocationTree to test
-     * @return whether the tree refers to an identifier, member select, or method invocation
+     * @return true if the tree refers to an identifier, member select, or method invocation
      */
     @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
     @Pure
@@ -423,7 +423,7 @@ public final class TreeUtils {
      * Determine whether the given NewClassTree has an underlying element.
      *
      * @param node the NewClassTree to test
-     * @return whether the tree refers to an identifier, member select, or method invocation
+     * @return true if the tree refers to an identifier, member select, or method invocation
      */
     @EnsuresNonNullIf(result = true, expression = "elementFromUse(#1)")
     @Pure


### PR DESCRIPTION
Here's a code snippet taken from the test.
```
    String name(ClassA classA) {...}
    String name(ClassB classB) {...}

    @EnsuresKeyFor(value = "name(#1)", map = "map")
    void put(ClassA classA) {...}
    void test(ClassB classB) {
        put(classB);
     }
```

At the call to `put`, `name(classB)` should refer to `name(ClassA classA)` not `name(ClassB classB)`

The test is currently fails and is therefore skipped, but it will be fixed once string expression are not parsed and viewpoint-adapted at the same time.  ~~I also add new methods to TreeUtils that will be needed for the Nullness Checker to type check the dataflow subproject.~~