### PR TITLE
Issue expression.unparsable.type.invalid rather than flowexpr.parse

### DIFF
--- a/checker/tests/nullness/ParameterExpression.java
+++ b/checker/tests/nullness/ParameterExpression.java
@@ -45,32 +45,32 @@ public class ParameterExpression {
     }
 
     @EnsuresNonNull("param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m6a(Object param) {
         param = new Object();
     }
 
     @EnsuresNonNull("param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m6b(Object param) {
         // :: error: (assignment.type.incompatible)
         param = null;
     }
 
     @EnsuresNonNull("param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m6c(@Nullable Object param) {
         param = new Object();
     }
 
     @EnsuresNonNull("param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m6d(@Nullable Object param) {
         param = null;
     }
 
     @EnsuresNonNull("param.toString()")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m6e(@Nullable Object param) {
         param = null;
     }
@@ -109,7 +109,7 @@ public class ParameterExpression {
     public void m8() {}
 
     @RequiresNonNull("param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public void m9(Object param) {}
 
     // Warning issued. 'field' is a field, but in this case what matters is that it is the name of a
@@ -126,7 +126,7 @@ public class ParameterExpression {
     }
 
     @EnsuresNonNullIf(result = true, expression = "param")
-    // :: error: (expression.parameter.name.invalid)
+    // :: error: (flowexpr.parse.error)
     public boolean m12(Object param) {
         param = new Object();
         return true;

--- a/checker/tests/nullness/ParameterExpression.java
+++ b/checker/tests/nullness/ParameterExpression.java
@@ -45,31 +45,33 @@ public class ParameterExpression {
     }
 
     @EnsuresNonNull("param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public void m6a(Object param) {
         param = new Object();
     }
 
     @EnsuresNonNull("param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public void m6b(Object param) {
         // :: error: (assignment.type.incompatible)
         param = null;
     }
 
     @EnsuresNonNull("param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public void m6c(@Nullable Object param) {
         param = new Object();
     }
 
     @EnsuresNonNull("param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public void m6d(@Nullable Object param) {
+        param = null;
+    }
+
+    @EnsuresNonNull("param.toString()")
+    // :: error: (expression.parameter.name.invalid)
+    public void m6e(@Nullable Object param) {
         param = null;
     }
 
@@ -107,8 +109,7 @@ public class ParameterExpression {
     public void m8() {}
 
     @RequiresNonNull("param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public void m9(Object param) {}
 
     // Warning issued. 'field' is a field, but in this case what matters is that it is the name of a
@@ -125,8 +126,7 @@ public class ParameterExpression {
     }
 
     @EnsuresNonNullIf(result = true, expression = "param")
-    // :: error: (flowexpr.parse.error)
-    // :: warning: (expression.parameter.name.invalid)
+    // :: error: (expression.parameter.name.invalid)
     public boolean m12(Object param) {
         param = new Object();
         return true;

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -977,7 +977,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     /** Matches warnings about use of formal parameter name. */
-    public static final Pattern FORMAL_PARAM_NAME_PATTERN =
+    public static final Pattern FORMAL_PARAM_NAME_WARNING_PATTERN =
             Pattern.compile(
                     "^.*'([a-zA-Z_$][a-zA-Z0-9_$]*)' because Use \"#(\\d+)\" rather than \"\\1\"$");
     /**
@@ -1018,7 +1018,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             } catch (JavaExpressionParseException e) {
 
                 Matcher m =
-                        FORMAL_PARAM_NAME_PATTERN.matcher(
+                        FORMAL_PARAM_NAME_WARNING_PATTERN.matcher(
                                 e.getDiagMessage().getArgs()[0].toString());
                 if (m.matches()) {
                     String locationOfExpression =

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -42,7 +42,7 @@ lambda.param.type.incompatible=incompatible parameter types for parameter %s in 
 
 # The first argument is a string like "annotation @KeyFor on parameter 'param1'"
 # or "postcondition @EnsuresKeyFor on the declaration".
-expression.parameter.name.invalid=The %s of method '%s' contains invalid identifier '%s'. Use "#%d" for the formal parameter.
+expression.parameter.name.invalid=The %s of method '%s' contains invalid identifier '%s'. Use "#%s" for the formal parameter.
 expression.parameter.name.shadows.field=The %s of method '%s' contains ambiguous identifier '%s'. Use "this.%s" for the field, or "#%d" for the formal parameter.
 
 inconsistent.constructor.type=Constructor type (%s) is a subtype of the top type (%s), therefore it cannot be statically verified.

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -42,7 +42,7 @@ lambda.param.type.incompatible=incompatible parameter types for parameter %s in 
 
 # The first argument is a string like "annotation @KeyFor on parameter 'param1'"
 # or "postcondition @EnsuresKeyFor on the declaration".
-expression.parameter.name.invalid=The %s of method '%s' contains invalid identifier '%s'. Use "#%s" for the formal parameter.
+expression.parameter.name.invalid=The %s of method '%s' contains invalid identifier '%s'. Use "#%d" for the formal parameter.
 expression.parameter.name.shadows.field=The %s of method '%s' contains ambiguous identifier '%s'. Use "this.%s" for the field, or "#%d" for the formal parameter.
 
 inconsistent.constructor.type=Constructor type (%s) is a subtype of the top type (%s), therefore it cannot be statically verified.


### PR DESCRIPTION
When a parameter is referenced anywhere in a contract expression.