### PR TITLE
Improve documentation clarity

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/dataflow/qual/SideEffectFree.java
+++ b/checker-qual/src/main/java/org/checkerframework/dataflow/qual/SideEffectFree.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * of the following Java constructs:
  *
  * <ol>
- *   <li>Assignment to any expression, except for local variables and method parameters.
+ *   <li>Assignment to any expression, except for local variables and immutable method parameters.
  *   <li>A method invocation of a method that is not {@code @SideEffectFree}.
  *   <li>Construction of a new object where the constructor is not {@code @SideEffectFree}.
  * </ol>


### PR DESCRIPTION
In a SideEfectFree method If a parameter of type int or String change value there is no problem. But if a parameter int[] change value in some element then the code won't pass the checks. For example 

public void test1(int x, String y){
         x = 34;
         y = "change";
}
It is ok.

While 

public void test2(int[] x){
         x[0] = 34;
}
It is wrong.

So i think it is better to clarify that matter.