### PR TITLE
Keep 2 subclasses of AnnotatedTypeScanners in fields.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -98,7 +98,6 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclared
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
-import org.checkerframework.framework.type.AnnotatedTypeReplacer;
 import org.checkerframework.framework.util.element.ElementAnnotationUtil.ErrorTypeKindException;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationUtils;
@@ -1364,9 +1363,9 @@ public class AnnotationFileParser {
                 for (AnnotatedTypeVariable typePar : typeParameters) {
                     if (typeUtils.isSameType(
                             typePar.getUnderlyingType(), atype.getUnderlyingType())) {
-                        AnnotatedTypeReplacer.replace(
+                        atypeFactory.replaceAnnotations(
                                 typePar.getUpperBound(), typeVarUse.getUpperBound());
-                        AnnotatedTypeReplacer.replace(
+                        atypeFactory.replaceAnnotations(
                                 typePar.getLowerBound(), typeVarUse.getLowerBound());
                     }
                 }
@@ -2694,7 +2693,7 @@ public class AnnotationFileParser {
             // If the newType is from a JDK stub file, then keep the existing type.  This
             // way user supplied stub files override JDK stub files.
             if (!isJdkAsStub) {
-                AnnotatedTypeReplacer.replace(newType, existingType);
+                atypeFactory.replaceAnnotations(newType, existingType);
             }
             m.put(key, existingType);
         } else {

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4242,7 +4242,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
      * @param to the annotated type mirror to which the annotations will be added
      * @param top the top type of the hierarchy whose annotations will be added
      */
-    @SuppressWarnings("interning:not.interned") // assertion
     public void replaceAnnotations(
             final AnnotatedTypeMirror from,
             final AnnotatedTypeMirror to,

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1474,7 +1474,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * A scanner used to combine annotations in from two AnnotatedTypeMirrors. The scanner requires
+     * A scanner used to combine annotations from two AnnotatedTypeMirrors. The scanner requires
      * {@link #qualHierarchy}, which is set in {@link #postInit()} rather than the construtor, so
      * lazily initialize this field before use.
      */
@@ -4215,8 +4215,8 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
-     * A scanner that replaces annotations in one annotation with annotations from another. Used by
-     * {@link #replaceAnnotations(AnnotatedTypeMirror, AnnotatedTypeMirror)} and {@link
+     * A scanner that replaces annotations in one type with annotations from another. Used by {@link
+     * #replaceAnnotations(AnnotatedTypeMirror, AnnotatedTypeMirror)} and {@link
      * #replaceAnnotations(AnnotatedTypeMirror, AnnotatedTypeMirror, AnnotationMirror)}.
      */
     private final AnnotatedTypeReplacer annotatedTypeReplacer = new AnnotatedTypeReplacer();

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -65,6 +65,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.interning.qual.InternedDistinct;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
@@ -1473,6 +1474,13 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
 
     /**
+     * A scanner used to combine annotations in from two AnnotatedTypeMirrors. The scanner requires
+     * {@link #qualHierarchy}, which is set in {@link #postInit()} rather than the construtor, so
+     * lazily initialize this field before use.
+     */
+    private @MonotonicNonNull AnnotatedTypeCombiner annotatedTypeCombiner = null;
+
+    /**
      * Merges types from annotation files for {@code elt} into {@code type} by taking the greatest
      * lower bound of the annotations in both.
      *
@@ -1490,9 +1498,12 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         if (type == null) {
             return typeFromFile;
         }
+        if (annotatedTypeCombiner == null) {
+            annotatedTypeCombiner = new AnnotatedTypeCombiner(qualHierarchy);
+        }
         // Must merge (rather than only take the annotation file type if it is a subtype)
         // to support WPI.
-        AnnotatedTypeCombiner.combine(typeFromFile, type, this.getQualifierHierarchy());
+        annotatedTypeCombiner.visit(typeFromFile, type);
         return type;
     }
 
@@ -4201,6 +4212,44 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             }
         }
         return found;
+    }
+
+    /**
+     * A scanner that replaces annotations in one annotation with annotations from another. Used by
+     * {@link #replaceAnnotations(AnnotatedTypeMirror, AnnotatedTypeMirror)} and {@link
+     * #replaceAnnotations(AnnotatedTypeMirror, AnnotatedTypeMirror, AnnotationMirror)}.
+     */
+    private final AnnotatedTypeReplacer annotatedTypeReplacer = new AnnotatedTypeReplacer();
+
+    /**
+     * Replaces or adds all annotations from {@code from} to {@code to}. Annotations from {@code
+     * from} will be used everywhere they exist, but annotations in {@code to} will be kept anywhere
+     * that {@code from} is unannotated.
+     *
+     * @param from the annotated type mirror from which to take new annotations
+     * @param to the annotated type mirror to which the annotations will be added
+     */
+    public void replaceAnnotations(final AnnotatedTypeMirror from, final AnnotatedTypeMirror to) {
+        annotatedTypeReplacer.visit(from, to);
+    }
+
+    /**
+     * Replaces or adds annotations in {@code top}'s hierarchy from {@code from} to {@code to}.
+     * Annotations from {@code from} will be used everywhere they exist, but annotations in {@code
+     * to} will be kept anywhere that {@code from} is unannotated.
+     *
+     * @param from the annotated type mirror from which to take new annotations
+     * @param to the annotated type mirror to which the annotations will be added
+     * @param top the top type of the hierarchy whose annotations will be added
+     */
+    @SuppressWarnings("interning:not.interned") // assertion
+    public void replaceAnnotations(
+            final AnnotatedTypeMirror from,
+            final AnnotatedTypeMirror to,
+            final AnnotationMirror top) {
+        annotatedTypeReplacer.setTop(top);
+        annotatedTypeReplacer.visit(from, to);
+        annotatedTypeReplacer.setTop(null);
     }
 
     /** The implementation of the visitor for #containsUninferredTypeArguments. */

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -29,7 +29,10 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
      *
      * @param from the annotated type mirror from which to take new annotations
      * @param to the annotated type mirror to which the annotations will be added
+     * @deprecated use {@link AnnotatedTypeFactory#replaceAnnotations(AnnotatedTypeMirror,
+     *     AnnotatedTypeMirror)} instead.
      */
+    @Deprecated
     @SuppressWarnings("interning:not.interned") // assertion
     public static void replace(final AnnotatedTypeMirror from, final AnnotatedTypeMirror to) {
         if (from == to) {
@@ -46,7 +49,10 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
      * @param from the annotated type mirror from which to take new annotations
      * @param to the annotated type mirror to which the annotations will be added
      * @param top the top type of the hierarchy whose annotations will be added
+     * @deprecated use {@link AnnotatedTypeFactory#replaceAnnotations(AnnotatedTypeMirror,
+     *     AnnotatedTypeMirror, AnnotationMirror)} instead.
      */
+    @Deprecated
     @SuppressWarnings("interning:not.interned") // assertion
     public static void replace(
             final AnnotatedTypeMirror from,
@@ -59,7 +65,7 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     }
 
     /** If top != null we replace only the annotations in the hierarchy of top. */
-    private final AnnotationMirror top;
+    private AnnotationMirror top;
 
     /** Construct an AnnotatedTypeReplacer that will replace all annotations. */
     public AnnotatedTypeReplacer() {
@@ -73,6 +79,10 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
      * @param top if top != null, then only annotation in the hierarchy of top are affected
      */
     public AnnotatedTypeReplacer(final AnnotationMirror top) {
+        this.top = top;
+    }
+
+    public void setTop(AnnotationMirror top) {
         this.top = top;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -53,7 +53,7 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
      * @deprecated use {@link AnnotatedTypeFactory#replaceAnnotations(AnnotatedTypeMirror,
      *     AnnotatedTypeMirror, AnnotationMirror)} instead.
      */
-    @Deprecated
+    @Deprecated // 2021-03-25
     @SuppressWarnings("interning:not.interned") // assertion
     public static void replace(
             final AnnotatedTypeMirror from,
@@ -84,10 +84,10 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
     }
 
     /**
-     * If top != null, then only annotation in the hierarchy of top are affected; otherwise, all
-     * annotations are replaced.
+     * If {@code top != null}, then only annotations in the hierarchy of {@code top} are affected;
+     * otherwise, all annotations are replaced.
      *
-     * @param top if top != null, then only annotation in the hierarchy of top are replace;
+     * @param top if top != null, then only annotations in the hierarchy of top are replaced;
      *     otherwise, all annotations are replaced.
      */
     public void setTop(@Nullable AnnotationMirror top) {

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -2,6 +2,7 @@ package org.checkerframework.framework.type;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.visitor.AnnotatedTypeComparer;
@@ -82,7 +83,14 @@ public class AnnotatedTypeReplacer extends AnnotatedTypeComparer<Void> {
         this.top = top;
     }
 
-    public void setTop(AnnotationMirror top) {
+    /**
+     * If top != null, then only annotation in the hierarchy of top are affected; otherwise, all
+     * annotations are replaced.
+     *
+     * @param top if top != null, then only annotation in the hierarchy of top are replace;
+     *     otherwise, all annotations are replaced.
+     */
+    public void setTop(@Nullable AnnotationMirror top) {
         this.top = top;
     }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -349,11 +349,10 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         // to ensure that the structure of the wildcard will match that created by
         // BoundsInitializer/createType.
         if (node.getKind() == Tree.Kind.SUPER_WILDCARD) {
-            AnnotatedTypeReplacer.replace(bound, ((AnnotatedWildcardType) result).getSuperBound());
+            f.replaceAnnotations(bound, ((AnnotatedWildcardType) result).getSuperBound());
 
         } else if (node.getKind() == Tree.Kind.EXTENDS_WILDCARD) {
-            AnnotatedTypeReplacer.replace(
-                    bound, ((AnnotatedWildcardType) result).getExtendsBound());
+            f.replaceAnnotations(bound, ((AnnotatedWildcardType) result).getExtendsBound());
         }
         return result;
     }

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeCombiner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeCombiner.java
@@ -32,7 +32,7 @@ public class AnnotatedTypeCombiner extends AnnotatedTypeComparer<Void> {
     private final QualifierHierarchy hierarchy;
 
     /**
-     * Create {@link AnnotatedTypeCombiner}
+     * Create an AnnotatedTypeCombiner.
      *
      * @param hierarchy the hierarchy used to the compute the GLB
      */

--- a/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeCombiner.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/visitor/AnnotatedTypeCombiner.java
@@ -32,11 +32,11 @@ public class AnnotatedTypeCombiner extends AnnotatedTypeComparer<Void> {
     private final QualifierHierarchy hierarchy;
 
     /**
-     * Private constructor.
+     * Create {@link AnnotatedTypeCombiner}
      *
      * @param hierarchy the hierarchy used to the compute the GLB
      */
-    private AnnotatedTypeCombiner(final QualifierHierarchy hierarchy) {
+    public AnnotatedTypeCombiner(final QualifierHierarchy hierarchy) {
         this.hierarchy = hierarchy;
     }
 


### PR DESCRIPTION
See https://github.com/typetools/checker-framework/issues/4252 for why AnnotatedTypeScanners should be in fields.