### PR TITLE
Don't format ajava files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -378,21 +378,21 @@ List<String> getJavaFilesToFormat(projectName) {
         if (!details.path.contains("nullness-javac-errors")
                 && !details.path.contains("returnsreceiverdelomboked")
                 && !details.path.contains("build")
-                && details.name.endsWith('java')) {
+                && details.name.endsWith('.java')) {
             javaFiles.add(details.file)
         }
     }
 
     // Collect all java files in jtreg directory
     fileTree("${project(projectName).projectDir}/jtreg").visit { details ->
-        if (!details.path.contains("nullness-javac-errors") && details.name.endsWith('java')) {
+        if (!details.path.contains("nullness-javac-errors") && details.name.endsWith('.java')) {
             javaFiles.add(details.file)
         }
     }
 
     // Collect all java files in jtregJdk11 directory
     fileTree("${project(projectName).projectDir}/jtregJdk11").visit { details ->
-        if (!details.path.contains("nullness-javac-errors") && details.name.endsWith('java')) {
+        if (!details.path.contains("nullness-javac-errors") && details.name.endsWith('.java')) {
             javaFiles.add(details.file)
         }
     }


### PR DESCRIPTION
When I run `./gradlew wholeProgramInferenceTestCheckerAjavaTests` and then `./gradlew reformat`, it attempts to format the generated ajava files, filling the terminal with messages about attempting to format a non-Java file. This is because it attempts to format all files ending in `java`, which includes ajava files. It should instead collect files ending with `.java`.