### PR TITLE
Remove test for null tree

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -204,19 +204,6 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
     for (int i = 0; i < arguments.size(); i++) {
       Node arg = arguments.get(i);
       Tree argTree = arg.getTree();
-      if (argTree == null) {
-        String msg =
-            String.format(
-                "updateInferredExecutableParameterTypes(%s, %s)%n  i=%d, arg=%s [%s], argTree=null",
-                methodElt, arguments, i, arg, arg.getClass());
-        System.out.println(msg);
-        throw new BugInCF(msg);
-        // TODO: Handle variable-length list as parameter.
-        // An ArrayCreationNode with a null tree is created when the
-        // parameter is a variable-length list. We are ignoring it for now.
-        // See Issue 682: https://github.com/typetools/checker-framework/issues/682
-        // continue;
-      }
 
       VariableElement ve = methodElt.getParameters().get(i);
       AnnotatedTypeMirror paramATM = atypeFactory.getAnnotatedType(ve);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -205,11 +205,17 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       Node arg = arguments.get(i);
       Tree argTree = arg.getTree();
       if (argTree == null) {
+        String msg =
+            String.format(
+                "updateInferredExecutableParameterTypes(%s, %s)%n  i=%d, arg=%s [%s], argTree=null",
+                methodElt, arguments, i, arg, arg.getClass());
+        System.out.println(msg);
+        throw new BugInCF(msg);
         // TODO: Handle variable-length list as parameter.
         // An ArrayCreationNode with a null tree is created when the
         // parameter is a variable-length list. We are ignoring it for now.
         // See Issue 682: https://github.com/typetools/checker-framework/issues/682
-        continue;
+        // continue;
       }
 
       VariableElement ve = methodElt.getParameters().get(i);


### PR DESCRIPTION
I can't find a test case for which the tree is null, but removing the code will help us find one.