### PR TITLE
Remove StubGenerator section from manual

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,9 @@
 Version 3.13.0 (May 3, 2021)
 ----------------------------
 
+Removed StubGenerator section from the manual, because changes in JDK 11 have
+broken the StubGenerator program.
+
 Method renamings:
  * `DependentTypesHelper.atReturnType` => `atMethodBody`
 

--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -684,55 +684,56 @@ find project-stubs/ -name "*.java" -type f | xargs cat > project.astub
 % That file will contain many non-unique import statements, but that shouldn't be harmful.
 
 
-\subsubsectionAndLabel{If you do not have access to the Java source code}{stub-creating-without-source}
-
-If you do not have access to the library source code, then you can create a
-stub file from the class file (Section~\ref{stub-creating}),
-and then annotate it.  The rest of this section describes this approach.
-
-
-\begin{enumerate}
-
-\item
-  Create a stub file by running the stub class generator.  (\<checker.jar> must be on your classpath.)
-
-\begin{Verbatim}
-  cd nullness-stub
-  java -cp $CHECKERFRAMEWORK/checker/dist/checker.jar \
-    org.checkerframework.framework.stub.StubGenerator java.lang.String > String.astub
-\end{Verbatim}
-
-  Supply it with the fully-qualified name of the class for which you wish to
-  generate a stub class.  The stub class generator prints the
-  stub class to standard out, so you may wish to redirect its output to a
-  file.
-
-\item
-  Add import statements for the annotations.  So you would need to
-add the following import statement at the beginning of the file:
-
-\begin{Verbatim}
-  import org.checkerframework.checker.interning.qual.*;
-\end{Verbatim}
-
-\noindent
-The stub file parser silently ignores any annotations that it cannot
-resolve to a type, so don't forget the import statement.
-Use the \<-AstubWarnIfNotFound> command-line option to see warnings
-if an entry could not be found.
-
-\item
-  Add annotations to the stub class.  For example, you might annotate
-  the \sunjavadoc{java.base/java/lang/String.html\#intern()}{String.intern()} method as follows:
-
-\begin{Verbatim}
-  @Interned String intern();
-\end{Verbatim}
-
-  You may also remove irrelevant parts of the stub file; see
-  Section~\ref{stub-format}.
-
-\end{enumerate}
+%% Changes in JDK 11 have broken StubGenerator.
+% \subsubsectionAndLabel{If you do not have access to the Java source code}{stub-creating-without-source}
+%
+% If you do not have access to the library source code, then you can create a
+% stub file from the class file (Section~\ref{stub-creating}),
+% and then annotate it.  The rest of this section describes this approach.
+%
+%
+% \begin{enumerate}
+%
+% \item
+%   Create a stub file by running the stub class generator.  (\<checker.jar> must be on your classpath.)
+%
+% \begin{Verbatim}
+%   cd nullness-stub
+%   java -cp $CHECKERFRAMEWORK/checker/dist/checker.jar \
+%     org.checkerframework.framework.stub.StubGenerator java.lang.String > String.astub
+% \end{Verbatim}
+%
+%   Supply it with the fully-qualified name of the class for which you wish to
+%   generate a stub class.  The stub class generator prints the
+%   stub class to standard out, so you may wish to redirect its output to a
+%   file.
+%
+% \item
+%   Add import statements for the annotations.  So you would need to
+% add the following import statement at the beginning of the file:
+%
+% \begin{Verbatim}
+%   import org.checkerframework.checker.interning.qual.*;
+% \end{Verbatim}
+%
+% \noindent
+% The stub file parser silently ignores any annotations that it cannot
+% resolve to a type, so don't forget the import statement.
+% Use the \<-AstubWarnIfNotFound> command-line option to see warnings
+% if an entry could not be found.
+%
+% \item
+%   Add annotations to the stub class.  For example, you might annotate
+%   the \sunjavadoc{java.base/java/lang/String.html\#intern()}{String.intern()} method as follows:
+%
+% \begin{Verbatim}
+%   @Interned String intern();
+% \end{Verbatim}
+%
+%   You may also remove irrelevant parts of the stub file; see
+%   Section~\ref{stub-format}.
+%
+% \end{enumerate}
 
 
 \subsectionAndLabel{Distributing stub files}{stub-distributing}

--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -520,7 +520,7 @@ superclass, even though the subclass inherits (does not define) the method.
 An example, \<SecureRandom.nextInt()>, is shown below.
 
 To express that method \<m> has a different type in subclass \<Sub> than
-where \<m> is defined, write a ``fake override'':  wiret the method in in
+where \<m> is defined, write a ``fake override'':  write the method in in
 class \<Sub> in a stub file.  The Checker Framework will use that type for
 \<m> at calls where the receiver's declared type is \<Sub> or lower.
 
@@ -743,7 +743,7 @@ the stub files anywhere that is convenient.  However, please consider
 providing your stub files to the checker author, so that other users can
 also benefit from the stub files you wrote.
 
-Stub files distributed with a checker appear in the same diretory as the
+Stub files distributed with a checker appear in the same directory as the
 checker implementation (the \<*Checker.java> file, see
 Section~\ref{creating-parts-of-a-checker}).  For example, in the Checker
 Framework they appear in files such as
@@ -989,10 +989,12 @@ being silently ignored.  A typo in an annotation name, or a missing
 % LocalWords: NoAnnotationFileParserWarning CHECKERFRAMEWORK AnnotatedFor regex
 % LocalWords: AuseConservativeDefaultsForUnannotatedCode buildfile qual
 % LocalWords: AprintUnannotatedMethods checkername AskipDefs bcel mkdir
-% LocalWords: AuseSafeDefaultsForUnannotatedSourceCode TypeSystem1 cd
+% LocalWords: AuseSafeDefaultsForUnannotatedSourceCode TypeSystem1 cd map1
 % LocalWords: TypeSystem2 TypeSystem3 AuseConservativeDefaultsForUncheckedCode ln
 % LocalWords: mychecker DIRS README TypeSystem un debugJSR org boolean
-% LocalWords: AstubWarnIfOverwritesBytecode Awarns AssumeAssertion
-% LocalWords: Makefile PuseLocalJdk jdkShaHash AonlyDefs
-% LocalWords: AuseConservativeDefaultsForUncheckedCodesource
-% LocalWords: AstubWarnIfNotFoundIgnoresClasses
+% LocalWords: AstubWarnIfOverwritesBytecode Awarns AssumeAssertion map2
+% LocalWords: Makefile PuseLocalJdk jdkShaHash AonlyDefs map3 SecureRandom
+% LocalWords: AuseConservativeDefaultsForUncheckedCodesource nextInt
+% LocalWords: AstubWarnIfNotFoundIgnoresClasses AmergeStubsWithSource
+% LocalWords:  AstubWarnIfRedundantWithBytecode JavaStubifier StubFiles
+% LocalWords:  BaseTypeChecker

--- a/docs/manual/annotating-libraries.tex
+++ b/docs/manual/annotating-libraries.tex
@@ -743,6 +743,15 @@ the stub files anywhere that is convenient.  However, please consider
 providing your stub files to the checker author, so that other users can
 also benefit from the stub files you wrote.
 
+Stub files distributed with a checker appear in the same diretory as the
+checker implementation (the \<*Checker.java> file, see
+Section~\ref{creating-parts-of-a-checker}).  For example, in the Checker
+Framework they appear in files such as
+\begin{Verbatim}
+checker/src/main/java/org/checkerframework/checker/regex/apache-xerces.astub
+checker/src/main/java/org/checkerframework/checker/signature/javaparser.astub
+\end{Verbatim}
+
 If you are distributing stub files with a checker implementation, you must
 configure your build system to copy the stub files into the distributed jar for
 your checker.  Here are instructions if you are using the Checker Framework

--- a/framework/src/main/java/org/checkerframework/framework/stub/StubGenerator.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/StubGenerator.java
@@ -32,8 +32,8 @@ import org.plumelib.util.StringsPlume;
 /**
  * Generates a stub file from a single class or an entire package.
  *
- * <p>A stub file can be used to add annotations to methods of classes, that are only available in
- * binary or the source of which cannot be edited.
+ * <p>TODO: StubGenerator needs to be reimplemented, because it no longer works due to changes in
+ * JDK 9.
  *
  * @checker_framework.manual #stub Using stub classes
  */


### PR DESCRIPTION
StubGenerator only works with JDK 8.
The manual section is only commented out, and the code is retained, because one day we might reimplement StubGenerator to work with Java 9+.