### PR TITLE
In dataflow-shaded artifact,  Shade all org.checkerframework packages.

### DIFF
--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -14,8 +14,10 @@ shadowJar {
     // Without this line, the Maven artifact will have the classifier "all".
     archiveClassifier = ''
 
-    relocate 'org.checkerframework.dataflow', "org.checkerframework.shaded.dataflow"
-    relocate 'org.checkerframework.javacutil', "org.checkerframework.shaded.javacutil"
+    relocate ('org.checkerframework', 'org.checkerframework.shaded') {
+        // Shade all Checker Framework packages, except for the dataflow qualifiers.
+        exclude 'org.checkerframework.dataflow.qual.*'
+    }
 
     // Relocate external dependencies
     relocate 'org.plume', "org.checkerframework.shaded.org.plume"

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -13,15 +13,12 @@ shadowJar {
     archiveFileName = "dataflow-shaded.jar"
     // Without this line, the Maven artifact will have the classifier "all".
     archiveClassifier = ''
-    archiveName('dataflow-shaded')
-    // The version number includes both "." and possibly "-SNAPSHOT", so convert it to a legal
-    // package name.
-    String shadedPkg = "shaded_${project.version}".replace('-', '_').replace('.','_')
-    relocate 'org.checkerframework.dataflow', "org.checkerframework.${shadedPkg}.dataflow"
-    relocate 'org.checkerframework.javacutil', "org.checkerframework.${shadedPkg}.javacutil"
+
+    relocate 'org.checkerframework.dataflow', "org.checkerframework.shaded.dataflow"
+    relocate 'org.checkerframework.javacutil', "org.checkerframework.shaded.javacutil"
 
     // Relocate external dependencies
-    relocate 'org.plume', "org.checkerframework.${shadedPkg}.org.plume"
+    relocate 'org.plume', "org.checkerframework.shaded.org.plume"
 }
 
 artifacts {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,9 +13,6 @@ files provided on the command line.
 
 **Implementation details:**
 
-The package names in the dataflow-shaded artifact include the version number of
-the artifact using `_` in place of `.`.
-
 **Closed issues:**
 
 


### PR DESCRIPTION
Except for org.checkerframework.dataflow.qual.  Those classes are compared to qualifiers written in source code that may not have been shaded.

This includes changes from #4642, merge that one first.