### PR TITLE
remove the -u option from wpi-many.sh

### DIFF
--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -19,8 +19,6 @@ while getopts "o:i:u:t:g:s" opt; do
        ;;
     i) INLIST="$OPTARG"
        ;;
-    u) GITHUB_USER="$OPTARG"
-       ;;
     t) TIMEOUT="$OPTARG"
        ;;
     g) GRADLECACHEDIR="$OPTARG"
@@ -116,10 +114,6 @@ if [ "x${INLIST}" = "x" ]; then
     exit 4
 fi
 
-if [ "x${GITHUB_USER}" = "x" ]; then
-    GITHUB_USER="${USER}"
-fi
-
 if [ "x${GRADLECACHEDIR}" = "x" ]; then
   GRADLECACHEDIR=".gradle"
 fi
@@ -195,17 +189,6 @@ do
     cd "./${REPO_NAME}" || (echo "command failed in $(pwd): cd ./${REPO_NAME}" && exit 5)
 
     git checkout "${HASH}"
-
-    OWNER=$(echo "${REPO}" | cut -d / -f 4)
-
-    if [ "${OWNER}" = "${GITHUB_USER}" ]; then
-        ORIGIN=$(echo "${REPOHASH}" | awk '{print $3}')
-        # The `unannotated` remote is just a convenience for data analysis.
-        # Running this script twice in a row on projects whose owner
-        # is the github user always causes a harmless error on this
-        # line, because the `unannotated` remote is already set.
-        git remote add unannotated "${ORIGIN}" &> /dev/null || true
-    fi
 
     REPO_FULLPATH=$(pwd)
 

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -13,7 +13,7 @@ DEBUG=0
 # To enable debugging, uncomment the following line.
 # DEBUG=1
 
-while getopts "o:i:u:t:g:s" opt; do
+while getopts "o:i:t:g:s" opt; do
   case $opt in
     o) OUTDIR="$OPTARG"
        ;;

--- a/docs/manual/inference.tex
+++ b/docs/manual/inference.tex
@@ -306,26 +306,17 @@ An invocation should also include \<-- [\emph{DLJC-ARGS}]> at the end;
   % The need to be an absolute pathname is a bug in wpi-many.sh that should be fixed.
   The file must be specified as an absolute, not relative, path.
   Each line
-  should have 2 or 3 elements, separated by whitespace:
+  should have 2 elements, separated by whitespace:
   \begin{enumerate}
   \item
     The URL of the git repository on GitHub. The URL must be of the form
     https://github.com/username/repository .  The script is reliant on the
     number of slashes, so excluding ``https://'' is an error.
   \item The commit hash to use.
-  \item
-    If the repository's owner is the user specified by the -u flag, the
-    original (upstream) GitHub repository.  Its only use is to be made an
-    upstream named "unannotated".
   \end{enumerate}
 
 \item[-t timeout]
   The timeout for running the checker on each project, in seconds.
-
-\item[-u user]
-  The GitHub owner for repositories that have been forked and
-  modified. These repositories must have a third entry in the infile
-  indicating their origin. Default is "\$USER".
 
 \item[-g GRADLECACHEDIR]
   The directory to use for the `-g` option to Gradle (the Gradle home


### PR DESCRIPTION
We didn't test it, it adds complexity, its implementation was buggy, and as far as we're aware no-one is using it.

See also the comment chain here: https://github.com/typetools/checker-framework/pull/4662#discussion_r632745038