### PR TITLE
Small fixes to wpi-many.sh

### DIFF
--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -7,7 +7,6 @@
 # https://checkerframework.org/manual/#whole-program-inference
 
 set -eo pipefail
-set -x
 # not set -u, because this script checks variables directly
 
 DEBUG=0

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -278,7 +278,8 @@ else
     # Compute lines of non-comment, non-blank Java code in the projects whose
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
-    grep -oh "\S*\.java" "$(cat "${OUTDIR}-results/results_available.txt")" | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
+    # shellcheck disable=SC2046
+    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -7,6 +7,7 @@
 # https://checkerframework.org/manual/#whole-program-inference
 
 set -eo pipefail
+set -x
 # not set -u, because this script checks variables directly
 
 DEBUG=0

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -278,8 +278,7 @@ else
     # Compute lines of non-comment, non-blank Java code in the projects whose
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
-    # shellcheck disable=SC2046
-    grep -oh "\S*\.java" "$(cat ${OUTDIR}-results/results_available.txt)" | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
+    grep -oh "\S*\.java" "$(cat "${OUTDIR}-results/results_available.txt")" | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -259,11 +259,14 @@ done < "${INLIST}"
 ## wpi-summary.sh is intended to be run while a human waits (unlike this script), so this script
 ## precomputes as much as it can, to make wpi-summary.sh faster.
 
+# this command is allowed to fail, because if no projects returned results then none
+# of these expressions will match, and we want to enter the special handling for that
+# case that appears below
 results_available=$(grep -vl -e "no build file found for" \
     -e "dljc could not run the Checker Framework" \
     -e "dljc could not run the build successfully" \
     -e "dljc timed out for" \
-    "${OUTDIR}-results/"*.log)
+    "${OUTDIR}-results/"*.log || true)
 
 echo "${results_available}" > "${OUTDIR}-results/results_available.txt"
 
@@ -291,12 +294,13 @@ else
         exit 1
     fi
 
-    cd "${SCRIPTDIR}/.do-like-javac" || exit 5
+    mkdir -p "${SCRIPTDIR}/.scc"
+    cd "${SCRIPTDIR}/.scc" || exit 5
     wget -nc "https://github.com/boyter/scc/releases/download/v2.13.0/scc-2.13.0-i386-unknown-linux.zip"
     unzip -o "scc-2.13.0-i386-unknown-linux.zip"
 
     # shellcheck disable=SC2046
-    "${SCRIPTDIR}/.do-like-javac/scc" --output "${OUTDIR}-results/loc.txt" \
+    "${SCRIPTDIR}/.scc/scc" --output "${OUTDIR}-results/loc.txt" \
         $(< "${listpath}")
 
     rm -f "${listpath}"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -283,7 +283,7 @@ else
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
     # shellcheck disable=SC2046
-    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v '^\-J' | sed "s/'//g" | sort | uniq > "${listpath}"
+    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | sed "s/'//g" | grep -v '^\-J' | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -279,7 +279,7 @@ else
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
     # shellcheck disable=SC2046
-    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
+    grep -oh "\S*\.java" "$(cat ${OUTDIR}-results/results_available.txt)" | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -282,7 +282,7 @@ else
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
     # shellcheck disable=SC2046
-    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v "^-J" | sed "s/'//g" | sort | uniq > "${listpath}"
+    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v '^-J' | sed "s/'//g" | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -259,7 +259,7 @@ done < "${INLIST}"
 ## wpi-summary.sh is intended to be run while a human waits (unlike this script), so this script
 ## precomputes as much as it can, to make wpi-summary.sh faster.
 
-results_available=$(grep -Zvl -e "no build file found for" \
+results_available=$(grep -vl -e "no build file found for" \
     -e "dljc could not run the Checker Framework" \
     -e "dljc could not run the build successfully" \
     -e "dljc timed out for" \

--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -283,7 +283,7 @@ else
     # results can be inspected by hand (that is, those that WPI succeeded on).
     # Don't match arguments like "-J--add-opens=jdk.compiler/com.sun.tools.java".
     # shellcheck disable=SC2046
-    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v '^-J' | sed "s/'//g" | sort | uniq > "${listpath}"
+    grep -oh "\S*\.java" $(cat "${OUTDIR}-results/results_available.txt") | grep -v '^\-J' | sed "s/'//g" | sort | uniq > "${listpath}"
 
     if [ ! -s "${listpath}" ] ; then
         echo "${listpath} has size zero"

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -193,12 +193,12 @@ function configure_and_exec_dljc {
   echo "JAVA_HOME: ${JAVA_HOME}" >> "$dljc_stdout"
   echo "PATH: ${PATH}" >> "$dljc_stdout"
   echo "DLJC_CMD: ${DLJC_CMD}" >> "$dljc_stdout"
-  eval "${DLJC_CMD}" < /dev/null >> "$dljc_stdout" 2>&1
-  DLJC_STATUS=$?
+  DLJC_STATUS=0
+  eval "${DLJC_CMD}" < /dev/null >> "$dljc_stdout" 2>&1 || DLJC_STATUS=$?
 
   export PATH="${PATH_BACKUP}"
 
-  echo "=== DLJC standard out/err follows: ==="
+  echo "=== DLJC standard out/err (${dljc_stdout}) follows: ==="
   cat "${dljc_stdout}"
   echo "=== End of DLJC standard out/err.  ==="
 


### PR DESCRIPTION
These minor fixes are required for do-like-javac's CI jobs to succeed: https://github.com/kelloggm/do-like-javac/pull/40. I also added a few bits of debugging info, and cleaned up the failure state when no projects succeed.