### PR TITLE
update WPI docs to note that DLJC now requires python3

### DIFF
--- a/docs/manual/inference.tex
+++ b/docs/manual/inference.tex
@@ -224,7 +224,7 @@ set, the WPI scripts will download this dependency automatically.)
   git,
   gradle,
   mvn,
-  python2.7 (for dljc),
+  python3 (for dljc),
   wget.
 
   Python2.7 modules:
@@ -572,5 +572,5 @@ some benefits:
 %%  LocalWords:  Ainfer java jaif plugin classpath m2 m1 multi javax CFI
 %%  LocalWords:  AsuggestPureMethods CHECKERFRAMEWORK GuardedByBottom dljc
 %%  LocalWords:  IgnoreInWholeProgramInference typechecking Inference'' m3
-% LocalWords:  PROJECTDIR awk gradle mvn python2 wget subprocess32 github
+% LocalWords:  PROJECTDIR awk gradle mvn python3 wget subprocess32 github
 % LocalWords:  securerandom astub typecheck


### PR DESCRIPTION
…thon 2.7, thanks to https://github.com/kelloggm/do-like-javac/pull/22