### PR TITLE
add additional debug logging in wpi.sh

### DIFF
--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -207,7 +207,7 @@ function configure_and_exec_dljc {
   # Framework crashed, so output the log file for easier debugging.
   wpi_no_output_message="No WPI outputs were discovered; it is likely that WPI failed or the Checker Framework crashed"
   if [[ $(cat "${dljc_stdout}") == *"${wpi_no_output_message}"* ]]; then
-    wpi_log_path="${DIR}"/dljc_out/wpi.log
+    wpi_log_path="${DIR}"/dljc-out/wpi.log
     echo "=== ${wpi_no_output_message}: printing ${wpi_log_path} ==="
     cat "${wpi_log_path}"
     echo "=== end of ${wpi_log_path} ==="

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -202,6 +202,17 @@ function configure_and_exec_dljc {
   cat "${dljc_stdout}"
   echo "=== End of DLJC standard out/err.  ==="
 
+  # the wpi.py script in do-like-javac outputs the following text if no build/whole-program-inference directory
+  # exists, which means that WPI produced no output. When that happens, the reason is usually that the Checker
+  # Framework crashed, so output the log file for easier debugging.
+  wpi_no_output_message="No WPI outputs were discovered; it is likely that WPI failed or the Checker Framework crashed"
+  if [[ $(cat "${dljc_stdout}") == *"${wpi_no_output_message}"* ]]; then
+    wpi_log_path="${DIR}"/dljc_out/wpi.log
+    echo "=== ${wpi_no_output_message}: printing ${wpi_log_path} ==="
+    cat "${wpi_log_path}"
+    echo "=== end of ${wpi_log_path} ==="
+  fi
+
   if [[ $DLJC_STATUS -eq 124 ]]; then
       echo "dljc timed out for ${DIR}"
       WPI_RESULTS_AVAILABLE="dljc timed out for ${DIR}"


### PR DESCRIPTION
Should be merged after https://github.com/kelloggm/do-like-javac/pull/44 on which it depends.

Mike, I mentioned to you earlier that I had a lead on the failures in do-like-javac's CI. This PR and https://github.com/kelloggm/do-like-javac/pull/44 are what came of that lead; in the end, the file that this PR prints in that case contained a crash from the GUI Effect Checker, which isn't WPI related.