### PR TITLE
Add calledmethods and mustcall entries to appropriate lists in manual

### DIFF
--- a/docs/manual/advanced-features.tex
+++ b/docs/manual/advanced-features.tex
@@ -966,6 +966,9 @@ Type systems that cannot support a run-time test are:
   fields are set in the constructor (see
   \chapterpageref{initialization-checker})
 \item
+  \ahrefloc{called-methods-checker}{Called Methods Checker} for
+  the builder pattern (see \chapterpageref{called-methods-checker})
+\item
   \ahrefloc{fenum-checker}{Fake Enum Checker} to allow type-safe fake enum
   patterns and type aliases or typedefs (see \chapterpageref{fenum-checker})
 \item
@@ -993,6 +996,9 @@ Type systems that cannot support a run-time test are:
 \item
   \ahrefloc{aliasing-checker}{Aliasing Checker} to identify whether
   expressions have aliases (see \chapterpageref{aliasing-checker})
+\item
+  \ahrefloc{must-call-checker}{Must Call Checker} to over-approximate the
+  methods that should be called on an object before it is de-allocated (see \chapterpageref{must-call-checker})
 \item
   \ahrefloc{subtyping-checker}{Subtyping Checker} for customized checking without
   writing any code (see \chapterpageref{subtyping-checker})

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -37,6 +37,9 @@ The Checker Framework comes with checkers for specific types of errors:
   \ahrefloc{index-checker}{Index Checker} for array accesses
   (see \chapterpageref{index-checker})
 \item
+  \ahrefloc{called-methods-checker}{Called Methods Checker} for
+  the builder pattern (see \chapterpageref{called-methods-checker})
+\item
   \ahrefloc{fenum-checker}{Fake Enum Checker} to allow type-safe fake enum
   patterns and type aliases or typedefs (see \chapterpageref{fenum-checker})
 \item


### PR DESCRIPTION
The Must Call Checker was already referenced in `introduction.tex`, but wasn't mentioned in the corresponding list in `advanced-features.tex`. Both lists were missing the Called Methods Checker.