### PR TITLE
Fix dependencies and `.gitignore` for dataflow tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,8 @@ checker/tests/nullness/generics/*.class
 checker/tests/nullness-temp/*.java
 checker/tests/nullness-temp/*.class
 
+dataflow/tests/issue3447/Out.txt
+dataflow/tests/issue3447/*.class
 dataflow/tests/live-variable/Out.txt
 dataflow/tests/live-variable/*.class
 

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,22 @@ dataflow/manual/dataflow.log
 dataflow/manual/dataflow.out
 dataflow/manual/dataflow.pdf
 
+docs/tutorial/src/personalblog-demo/bin/net/eyde/personalblog/service/PersonalBlogService.class
+docs/tutorial/src/personalblog-demo/bin/net/eyde/personalblog/struts/action/ReadAction.class
+docs/tutorial/sourcefiles.zip
+
+# release tmps
+tmp
+
+# Maven files
+target/
+*.ipr
+*.iws
+*.iml
+/.gradle/
+
+## Tests
+
 checker/tests/command-line/issue618/TwoCheckers.class
 checker/tests/command-line/issue618/out.txt
 checker/tests/nullness-extra/*.class
@@ -125,6 +141,9 @@ checker/tests/nullness/generics/*.class
 checker/tests/nullness-temp/*.java
 checker/tests/nullness-temp/*.class
 
+dataflow/tests/live-variable/Out.txt
+dataflow/tests/live-variable/*.class
+
 checker/jtreg/multipleexecutions/Main.class
 
 # Source is copied from elsewhere.
@@ -136,17 +155,3 @@ checker/tests/wpi-testchecker/inference-output/
 checker/tests/wpi-nullness/annotated/
 checker/tests/wpi-nullness/inference-output/
 framework/tests/returnsreceiverdelomboked/
-
-docs/tutorial/src/personalblog-demo/bin/net/eyde/personalblog/service/PersonalBlogService.class
-docs/tutorial/src/personalblog-demo/bin/net/eyde/personalblog/struts/action/ReadAction.class
-docs/tutorial/sourcefiles.zip
-
-# release tmps
-tmp
-
-# Maven files
-target/
-*.ipr
-*.iws
-*.iml
-/.gradle/

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -54,7 +54,7 @@ createDataflowShaded('shaded')
 createDataflowShaded('nullaway')
 createDataflowShaded('errorprone')
 
-task liveVariableTest(dependsOn: ':checker:assemble', group: 'Verification') {
+task liveVariableTest(dependsOn: [':checker:assemble', compileTestJava], group: 'Verification') {
     description 'Test the live variable analysis test for dataflow framework.'
     inputs.file('tests/live-variable/Expected.txt')
     inputs.file('tests/live-variable/Test.java')
@@ -82,7 +82,7 @@ task liveVariableTest(dependsOn: ':checker:assemble', group: 'Verification') {
     }
 }
 
-task issue3447Test(dependsOn: ':checker:assemble', group: 'Verification') {
+task issue3447Test(dependsOn: [':checker:assemble', compileTestJava], group: 'Verification') {
     description 'Test issue 3447 test case for backward analysis.'
     inputs.file('tests/issue3447/Test.java')
     delete('tests/issue3447/Out.txt')

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -54,7 +54,7 @@ createDataflowShaded('shaded')
 createDataflowShaded('nullaway')
 createDataflowShaded('errorprone')
 
-task liveVariableTest(dependsOn: compileTestJava, group: 'Verification') {
+task liveVariableTest(dependsOn: ':checker:assemble', group: 'Verification') {
     description 'Test the live variable analysis test for dataflow framework.'
     inputs.file('tests/live-variable/Expected.txt')
     inputs.file('tests/live-variable/Test.java')
@@ -82,7 +82,7 @@ task liveVariableTest(dependsOn: compileTestJava, group: 'Verification') {
     }
 }
 
-task issue3447Test(dependsOn: compileTestJava, group: 'Verification') {
+task issue3447Test(dependsOn: ':checker:assemble', group: 'Verification') {
     description 'Test issue 3447 test case for backward analysis.'
     inputs.file('tests/issue3447/Test.java')
     delete('tests/issue3447/Out.txt')

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -54,7 +54,7 @@ createDataflowShaded('shaded')
 createDataflowShaded('nullaway')
 createDataflowShaded('errorprone')
 
-task liveVariableTest(dependsOn: [':checker:assemble', compileTestJava], group: 'Verification') {
+task liveVariableTest(dependsOn: [assemble, compileTestJava], group: 'Verification') {
     description 'Test the live variable analysis test for dataflow framework.'
     inputs.file('tests/live-variable/Expected.txt')
     inputs.file('tests/live-variable/Test.java')
@@ -82,7 +82,7 @@ task liveVariableTest(dependsOn: [':checker:assemble', compileTestJava], group: 
     }
 }
 
-task issue3447Test(dependsOn: [':checker:assemble', compileTestJava], group: 'Verification') {
+task issue3447Test(dependsOn: [assemble, compileTestJava], group: 'Verification') {
     description 'Test issue 3447 test case for backward analysis.'
     inputs.file('tests/issue3447/Test.java')
     delete('tests/issue3447/Out.txt')


### PR DESCRIPTION
Running `./gradlew :dataflow:liveVariableTest` from a clean checkout does not work; this pull request fixes that.