### PR TITLE
Update to StubParser 3.22.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,7 @@ task maybeCloneAndBuildDependencies() {
     doLast {
         if (!file(stubparserJar).exists()) {
             exec {
-                workingDir ${stubparser}/javaparser-core/target
+                workingDir "${stubparser}/javaparser-core/target"
                 executable 'ls'
                 ignoreExitValue = true
             }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     afu = "${annotationTools}/annotation-file-utilities"
 
     stubparser = "${parentDir}/stubparser"
-    stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.20.2.1.jar"
+    stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.22.1.jar"
 
     jtregHome = "${parentDir}/jtreg"
     formatScriptsHome = "${project(':checker').projectDir}/bin-devel/.run-google-java-format"


### PR DESCRIPTION
This is the partner commit of https://github.com/typetools/stubparser/pull/69 which updates the stubparser to be based on javaparser-3.22.1.