### PR TITLE
Avoid NPE when reading stub/ajava files in GenericAnnotatedTypeFactory#getInferredValue

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1816,8 +1816,13 @@ public abstract class GenericAnnotatedTypeFactory<
 
   /**
    * Returns the inferred value (by the org.checkerframework.dataflow analysis) for a given tree.
+   *
+   * @param tree the tree
+   * @return the value for the tree, if one has been computed by dataflow. If no value has been
+   *     computed, null is returned (this does not mean that no value will ever be computed for the
+   *     given tree).
    */
-  public Value getInferredValueFor(Tree tree) {
+  public @Nullable Value getInferredValueFor(Tree tree) {
     if (tree == null) {
       throw new BugInCF("GenericAnnotatedTypeFactory.getInferredValueFor called with null tree");
     }
@@ -1825,7 +1830,9 @@ public abstract class GenericAnnotatedTypeFactory<
     if (analysis.isRunning()) {
       as = analysis.getValue(tree);
     }
-    if (as == null) {
+    // flowResult is null if the analysis has not yet started running, such as when parsing stub
+    // or ajava files.
+    if (as == null && flowResult != null) {
       as = flowResult.getValue(tree);
     }
     return as;

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1826,13 +1826,19 @@ public abstract class GenericAnnotatedTypeFactory<
     if (tree == null) {
       throw new BugInCF("GenericAnnotatedTypeFactory.getInferredValueFor called with null tree");
     }
+    if (stubTypes.isParsing()
+        || ajavaTypes.isParsing()
+        || (currentFileAjavaTypes != null && currentFileAjavaTypes.isParsing())) {
+      // When parsing stub or ajava files, the analysis is not running (it has not yet started),
+      // and flowResult is null (no analysis has occurred). Instead of attempting to find a
+      // non-existent inferred type, return null.
+      return null;
+    }
     Value as = null;
     if (analysis.isRunning()) {
       as = analysis.getValue(tree);
     }
-    // flowResult is null if the analysis has not yet started running, such as when parsing stub
-    // or ajava files.
-    if (as == null && flowResult != null) {
+    if (as == null) {
       as = flowResult.getValue(tree);
     }
     return as;


### PR DESCRIPTION
Also updates the documentation. At all call-sites, this method was already treated as if it returned `@Nullable Value` rather than `Value`, because flow might not have actually computed a value. 

The NPE that this change avoids is that `flowResult` is `null` even if `analysis.isRunning()` returns false, in the case where the analysis has not yet started. Previously, this code appears to have assumed that the analysis has already started (so the only reason that `isRunning()` could return false would be because the analysis had finished). That assumption wasn't documented.

I believe that the change that I made here is consistent with the way the method is documented and used, but I'm not 100% sure. An alternative solution would be to change this method's documentation to indicate that it cannot be used before the analysis starts, and then to chase down the caller for the particular bug I was trying to fix.

The particular bug that I made this change to fix is the cause of the CI failure on this PR: https://github.com/kelloggm/do-like-javac/pull/25, which updates do-like-javac to use ajava files rather than stub files during WPI. I tested that this change does eliminate that crash locally. In particular, the chain that leads to the crash starts [here](https://github.com/typetools/checker-framework/blob/9ffddcd842be6ee3b1d5385c7ecf13d078719793/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java#L1006) when `type.directSupertypes()` is called. I am still confused about why this hasn't come up before, since that code has been present for a long time (as long as the stub parser has existed) in some form.