### PR TITLE
Update to StubParser 3.22.1 (2nd attempt)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,7 @@ task maybeCloneAndBuildDependencies() {
     doLast {
         if (!file(stubparserJar).exists()) {
             exec {
-                workingDir ${stubparser}/javaparser-core/target
+                workingDir "${stubparser}/javaparser-core/target"
                 executable 'ls'
                 ignoreExitValue = true
             }

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
     afu = "${annotationTools}/annotation-file-utilities"
 
     stubparser = "${parentDir}/stubparser"
-    stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.20.2.1.jar"
+    stubparserJar = "${stubparser}/javaparser-core/target/stubparser-3.22.1.jar"
 
     jtregHome = "${parentDir}/jtreg"
     formatScriptsHome = "${project(':checker').projectDir}/bin-devel/.run-google-java-format"

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -49,7 +49,7 @@ echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 
 ## Build stubparser
-"$PLUME_SCRIPTS/git-clone-related" --debug typetools stubparser
+"$PLUME_SCRIPTS/git-clone-related" typetools stubparser
 echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
 (cd ../stubparser/ && ./.build-without-test.sh)
 echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -49,7 +49,7 @@ echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 
 ## Build stubparser
-"$PLUME_SCRIPTS/git-clone-related" typetools stubparser
+"$PLUME_SCRIPTS/git-clone-related" --debug typetools stubparser
 echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
 (cd ../stubparser/ && ./.build-without-test.sh)
 echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"


### PR DESCRIPTION
This is a replacement for https://github.com/typetools/checker-framework/pull/4735 with a renamed branch to match the branch in stubparser, as requested -- apologies for getting it wrong first time round.