### PR TITLE
the absence of -AmergeStubsWithSource should not impact the results of parsing Ajava files, even when parsing them AS stub files

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -729,7 +729,9 @@ public class AnnotationFileParser {
     // Must include protected JDK methods.  For example, Object.clone is protected, but it contains
     // annotations that apply to calls like `super.clone()` and `myArray.clone()`.
     return (fileType == AnnotationFileType.BUILTIN_STUB
-            || (fileType.isStub() && !mergeStubsWithSource))
+            || (fileType.isStub()
+                && fileType != AnnotationFileType.AJAVA_AS_STUB
+                && !mergeStubsWithSource))
         && node.getModifiers().contains(Modifier.privateModifier());
   }
 


### PR DESCRIPTION
This problem was discovered when DLJC's CI failed in [this PR](https://github.com/kelloggm/do-like-javac/pull/49), when we tried to remove the `-AmergeStubsWithSource` option from WPI after switching WPI to use `.ajava` files exclusively. This PR must be merged before that one, and only if that one's tests are passing.