### PR TITLE
wpiManyTest should require that the expected number of *-typecheck.out files are produced

### DIFF
--- a/checker/bin/wpi-many.sh
+++ b/checker/bin/wpi-many.sh
@@ -203,7 +203,8 @@ do
       fi
       # the repo will be deleted later if SKIP_OR_DELETE_UNUSABLE is "delete"
     else
-      /bin/bash -x "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -t "${TIMEOUT}" -g "${GRADLECACHEDIR}" -- "$@" &> "${OUTDIR}-results/wpi-out"
+      # it's important that </dev/null is on this line, or wpi.sh might consume stdin, which would stop the larger wpi-many loop early
+      /bin/bash -x "${SCRIPTDIR}/wpi.sh" -d "${REPO_FULLPATH}" -t "${TIMEOUT}" -g "${GRADLECACHEDIR}" -- "$@" &> "${OUTDIR}-results/wpi-out" </dev/null
     fi
 
     cd "${OUTDIR}" || exit 5

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -713,7 +713,8 @@ task wpiManyTest(group: "Verification") {
         def expectedTypecheckFileCount = file("${project.projectDir}/tests/wpi-many/testin.txt").text.readLines().size()
         def actualTypecheckFileCount = typecheckFiles.size()
         if (actualTypecheckFileCount != expectedTypecheckFileCount) {
-            println("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
+            println("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: " +
+                    "found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
             println("========= Output from last run of wpi.sh (${typecheckFilesDir}/wpi-out): ========")
             exec {
                 commandLine 'cat', "${typecheckFilesDir}/wpi-out"
@@ -728,7 +729,8 @@ task wpiManyTest(group: "Verification") {
                 details.getFile().eachLine { line -> println(line) }
                 println("======== end of contents of ${filename} ========")
             }
-            throw new GradleException("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
+            throw new GradleException("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: " +
+                    "found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
         }
 
         // check that WPI causes the expected builds to succeed

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -710,8 +710,10 @@ task wpiManyTest(group: "Verification") {
         def typecheckFiles = fileTree(typecheckFilesDir).matching {
             include "**/*-typecheck.out"
         }
-        if (typecheckFiles.size() == 0) {
-            println("Failure: No *-typecheck.out files in ${typecheckFilesDir}")
+        def expectedTypecheckFileCount = file("${project.projectDir}/tests/wpi-many/testin.txt").text.readLines().size()
+        def actualTypecheckFileCount = typecheckFiles.size()
+        if (actualTypecheckFileCount != expectedTypecheckFileCount) {
+            println("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
             println("========= Output from last run of wpi.sh (${typecheckFilesDir}/wpi-out): ========")
             exec {
                 commandLine 'cat', "${typecheckFilesDir}/wpi-out"
@@ -726,7 +728,7 @@ task wpiManyTest(group: "Verification") {
                 details.getFile().eachLine { line -> println(line) }
                 println("======== end of contents of ${filename} ========")
             }
-            throw new GradleException("Failure: No *-typecheck.out files in ${project.projectDir}/build/wpi-many-tests-results/")
+            throw new GradleException("Failure: Too few *-typecheck.out files in ${typecheckFilesDir}: found ${actualTypecheckFileCount} but expected ${expectedTypecheckFileCount}.")
         }
 
         // check that WPI causes the expected builds to succeed


### PR DESCRIPTION
Before, all that was checked was:
* one or more `*-typecheck.out` files are produced, and
* each such file contains no unexpected errors.

This test is incomplete, because if the first test runs and succeeds then the others might or might not run at all. In fact, such an error was introduced: at some point, `wpi.sh` started consuming `stdin` unexpectedly, and we didn't notice. This PR:
* corrects the test, so that it checks that the number of `*-typecheck.out` files matches the number of lines in the input file, and
* fixes the bug in `wpi-many.sh` that permitted `wpi.sh` to consume the input file