### PR TITLE
Allow for multiple method parameters to be @MustCallAlias in Resource Leak Checker; fixes #4785

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -429,8 +429,7 @@ class MustCallConsistencyAnalyzer {
     }
 
     // `mustCallAliases` is a set of the argument(s) passed in the MustCallAlias position(s), if any
-    // exists,
-    // otherwise is an empty List.
+    // exists, otherwise is an empty List.
     List<Node> mustCallAliases = getMustCallAliasArgumentNode(node);
     // If mustCallAlias is an empty List and call returns @This, add the receiver to
     // mustCallAliases.

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -521,12 +521,12 @@ class MustCallConsistencyAnalyzer {
    */
   private boolean returnTypeIsMustCallAliasWithUntrackable(MethodInvocationNode node) {
     List<Node> mustCallAliasArguments = getMustCallAliasArgumentNodes(node);
-    return !mustCallAliasArguments.isEmpty()
-        && mustCallAliasArguments.stream()
-            .allMatch(
-                mustCallAliasArgument ->
-                    mustCallAliasArgument instanceof FieldAccessNode
-                        || mustCallAliasArgument instanceof ThisNode);
+    for (Node mustCallAliasArg : mustCallAliasArguments) {
+      if (!(mustCallAliasArg instanceof FieldAccessNode || mustCallAliasArg instanceof ThisNode)) {
+        return false;
+      }
+    }
+    return !mustCallAliasArguments.isEmpty();
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -68,7 +68,14 @@ import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionParseException;
 import org.checkerframework.framework.util.StringToJavaExpression;
+import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.BugInCF;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.Pair;
+import org.checkerframework.javacutil.TreePathUtil;
+import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypeSystemError;
+import org.checkerframework.javacutil.TypesUtils;
 import org.plumelib.util.StringsPlume;
 
 /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -238,19 +238,21 @@ class MustCallConsistencyAnalyzer {
 
   /**
    * If node is an invocation of a this or super constructor that has a MustCallAlias return type
-   * and a MustCallAlias parameter, check if any variable in the current set of obligations is being
-   * passed to the other constructor. If so, remove it from the obligations.
+   * and some MustCallAlias parameter(s), check if any variable in the current set of obligations is
+   * being passed to the other constructor. If so, remove it from the obligations.
    *
    * @param obligations current obligations
    * @param node a super or this constructor invocation
    */
   private void handleThisOrSuperConstructorMustCallAlias(Set<Obligation> obligations, Node node) {
-    Node mustCallAliasArgument = getMustCallAliasArgumentNode(node);
+    List<Node> mustCallAliasArguments = getMustCallAliasArgumentNode(node);
     // If the MustCallAlias argument is also in the set of obligations, then remove it -- its
     // obligation has been fulfilled by being passed on to the MustCallAlias constructor (because a
     // this/super constructor call can only occur in the body of another constructor).
-    if (mustCallAliasArgument instanceof LocalVariableNode) {
-      removeObligationsContainingVar(obligations, (LocalVariableNode) mustCallAliasArgument);
+    for (Node mustCallAliasArgument : mustCallAliasArguments) {
+      if (mustCallAliasArgument instanceof LocalVariableNode) {
+        removeObligationsContainingVar(obligations, (LocalVariableNode) mustCallAliasArgument);
+      }
     }
   }
 
@@ -406,8 +408,8 @@ class MustCallConsistencyAnalyzer {
   /**
    * Given a node representing a method or constructor call, checks that if the result of the call
    * has a non-empty {@code @MustCall} type, then the result is pseudo-assigned to some location
-   * that can take ownership of the result. Searches for the set of same resources in {@code
-   * obligations} and adds the new resource alias to it if one exists. Otherwise creates a new set.
+   * that can take ownership of the result. Searches for the set(s) of same resources in {@code
+   * obligations} and adds the new resource alias to it if any exists. Otherwise creates a new set.
    *
    * @param obligations the currently-tracked obligations. This is always side-effected: an
    *     obligation is either modified (by removing it from the obligation set and adding a new one)
@@ -426,39 +428,45 @@ class MustCallConsistencyAnalyzer {
       return;
     }
 
-    // `mustCallAlias` is the argument passed in the MustCallAlias position, if any exists,
-    // otherwise null.
-    Node mustCallAlias = getMustCallAliasArgumentNode(node);
-    // If mustCallAlias is null and call returns @This, set mustCallAlias to the receiver.
-    if (mustCallAlias == null
+    // `mustCallAliases` is a set of the argument(s) passed in the MustCallAlias position(s), if any
+    // exists,
+    // otherwise is an empty List.
+    List<Node> mustCallAliases = getMustCallAliasArgumentNode(node);
+    // If mustCallAlias is an empty List and call returns @This, add the receiver to
+    // mustCallAliases.
+    if (mustCallAliases.isEmpty()
         && node instanceof MethodInvocationNode
         && typeFactory.returnsThis((MethodInvocationTree) tree)) {
-      mustCallAlias =
-          removeCastsAndGetTmpVarIfPresent(((MethodInvocationNode) node).getTarget().getReceiver());
+      mustCallAliases.add(
+          removeCastsAndGetTmpVarIfPresent(
+              ((MethodInvocationNode) node).getTarget().getReceiver()));
     }
 
     ResourceAlias tmpVarAsResourceAlias = new ResourceAlias(new LocalVariable(tmpVar), tree);
-    if (mustCallAlias instanceof FieldAccessNode) {
-      // Do not track the call result if the MustCallAlias argument is a field.  Handling of
-      // @Owning fields is a completely separate check, and there is never a need to track an alias
-      // of
-      // a non-@Owning field, as by definition such a field does not have obligations!
-    } else if (mustCallAlias instanceof LocalVariableNode) {
-      Obligation obligationContainingMustCallAlias =
-          getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);
-      // If mustCallAlias is a local variable already being tracked, add tmpVarAsResourceAlias
-      // to the set containing mustCallAlias.
-      if (obligationContainingMustCallAlias != null) {
-        Set<ResourceAlias> newResourceAliasSet =
-            FluentIterable.from(obligationContainingMustCallAlias.resourceAliases)
-                .append(tmpVarAsResourceAlias)
-                .toSet();
-        obligations.remove(obligationContainingMustCallAlias);
-        obligations.add(new Obligation(newResourceAliasSet));
+    for (Node mustCallAlias : mustCallAliases) {
+      if (mustCallAlias instanceof FieldAccessNode) {
+        // Do not track the call result if the MustCallAlias argument is a field.  Handling of
+        // @Owning fields is a completely separate check, and there is never a need to track an
+        // alias
+        // of
+        // a non-@Owning field, as by definition such a field does not have obligations!
+      } else if (mustCallAlias instanceof LocalVariableNode) {
+        Obligation obligationContainingMustCallAlias =
+            getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);
+        // If mustCallAlias is a local variable already being tracked, add tmpVarAsResourceAlias
+        // to the set containing mustCallAlias.
+        if (obligationContainingMustCallAlias != null) {
+          Set<ResourceAlias> newResourceAliasSet =
+              FluentIterable.from(obligationContainingMustCallAlias.resourceAliases)
+                  .append(tmpVarAsResourceAlias)
+                  .toSet();
+          obligations.remove(obligationContainingMustCallAlias);
+          obligations.add(new Obligation(newResourceAliasSet));
+        }
       }
-    } else {
-      // If mustCallAlias is neither a field nor a local already in the set of obligations,
-      // add it to a new set.
+    }
+    if (mustCallAliases.isEmpty()) {
+      // If mustCallAliases is an empty List, add tmpVarAsResourceAlias to a new set.
       obligations.add(new Obligation(ImmutableSet.of(tmpVarAsResourceAlias)));
     }
   }
@@ -513,9 +521,13 @@ class MustCallConsistencyAnalyzer {
    *     field or a definitely non-owning pointer
    */
   private boolean returnTypeIsMustCallAliasWithUntrackable(MethodInvocationNode node) {
-    Node mustCallAliasArgument = getMustCallAliasArgumentNode(node);
-    return mustCallAliasArgument instanceof FieldAccessNode
-        || mustCallAliasArgument instanceof ThisNode;
+    List<Node> mustCallAliasArguments = getMustCallAliasArgumentNode(node);
+    return !mustCallAliasArguments.isEmpty()
+        && mustCallAliasArguments.stream()
+            .allMatch(
+                mustCallAliasArgument ->
+                    mustCallAliasArgument instanceof FieldAccessNode
+                        || mustCallAliasArgument instanceof ThisNode);
   }
 
   /**
@@ -986,38 +998,38 @@ class MustCallConsistencyAnalyzer {
   }
 
   /**
-   * Finds the argument passed in the {@code @MustCallAlias} position for a call.
+   * Finds the argument(s) passed in the {@code @MustCallAlias} position(s) for a call.
    *
    * @param callNode callNode representing the call; must be {@link MethodInvocationNode} or {@link
    *     ObjectCreationNode}
    * @return if {@code callNode} invokes a method with a {@code @MustCallAlias} annotation on some
-   *     formal parameter (or the receiver), returns the result of calling {@link
-   *     #removeCastsAndGetTmpVarIfPresent(Node)} on the argument passed in that position.
-   *     Otherwise, returns {@code null}.
+   *     formal parameter(s) (or the receiver), returns the result of calling {@link
+   *     #removeCastsAndGetTmpVarIfPresent(Node)} on the argument(s) passed in corresponding
+   *     position(s). Otherwise, returns an empty List.
    */
-  private @Nullable Node getMustCallAliasArgumentNode(Node callNode) {
+  private List<Node> getMustCallAliasArgumentNode(Node callNode) {
+    List<Node> result = new ArrayList<>();
     Preconditions.checkArgument(
         callNode instanceof MethodInvocationNode || callNode instanceof ObjectCreationNode);
     if (!typeFactory.hasMustCallAlias(callNode.getTree())) {
-      return null;
+      return result;
     }
 
-    Node result = null;
     List<Node> args = getArgumentsOfInvocation(callNode);
     List<? extends VariableElement> parameters = getParametersOfInvocation(callNode);
     for (int i = 0; i < args.size(); i++) {
       if (typeFactory.hasMustCallAlias(parameters.get(i))) {
-        result = args.get(i);
-        break;
+        result.add(removeCastsAndGetTmpVarIfPresent(args.get(i)));
       }
     }
 
     // If none of the parameters were @MustCallAlias, it must be the receiver
-    if (result == null && callNode instanceof MethodInvocationNode) {
-      result = ((MethodInvocationNode) callNode).getTarget().getReceiver();
+    if (result.isEmpty() && callNode instanceof MethodInvocationNode) {
+      result.add(
+          removeCastsAndGetTmpVarIfPresent(
+              ((MethodInvocationNode) callNode).getTarget().getReceiver()));
     }
 
-    result = removeCastsAndGetTmpVarIfPresent(result);
     return result;
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -68,7 +68,7 @@ import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionParseException;
 import org.checkerframework.framework.util.StringToJavaExpression;
-import org.checkerframework.javacutil.*;
+import org.checkerframework.javacutil.TypeSystemError;
 import org.plumelib.util.StringsPlume;
 
 /**
@@ -440,7 +440,8 @@ class MustCallConsistencyAnalyzer {
         // alias of a non-@Owning field, as by definition such a field does not have obligations!
       } else {
         if (!(mustCallAlias instanceof LocalVariableNode)) {
-          throw new TypeSystemError("unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
+          throw new TypeSystemError(
+              "unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
         }
         Obligation obligationContainingMustCallAlias =
             getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -68,13 +68,7 @@ import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.util.JavaExpressionParseUtil.JavaExpressionParseException;
 import org.checkerframework.framework.util.StringToJavaExpression;
-import org.checkerframework.javacutil.AnnotationUtils;
-import org.checkerframework.javacutil.BugInCF;
-import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.Pair;
-import org.checkerframework.javacutil.TreePathUtil;
-import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.TypesUtils;
+import org.checkerframework.javacutil.*;
 import org.plumelib.util.StringsPlume;
 
 /**
@@ -446,7 +440,7 @@ class MustCallConsistencyAnalyzer {
         // alias of a non-@Owning field, as by definition such a field does not have obligations!
       } else {
         if (!(mustCallAlias instanceof LocalVariableNode)) {
-          throw new BugInCF("unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
+          throw new TypeSystemError("unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
         }
         Obligation obligationContainingMustCallAlias =
             getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -444,7 +444,10 @@ class MustCallConsistencyAnalyzer {
         // Do not track the call result if the MustCallAlias argument is a field.  Handling of
         // @Owning fields is a completely separate check, and there is never a need to track an
         // alias of a non-@Owning field, as by definition such a field does not have obligations!
-      } else if (mustCallAlias instanceof LocalVariableNode) {
+      } else {
+        if (!(mustCallAlias instanceof LocalVariableNode)) {
+          throw new BugInCF("unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
+        }
         Obligation obligationContainingMustCallAlias =
             getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);
         // If mustCallAlias is a local variable already being tracked, add tmpVarAsResourceAlias

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -439,33 +439,34 @@ class MustCallConsistencyAnalyzer {
     }
 
     ResourceAlias tmpVarAsResourceAlias = new ResourceAlias(new LocalVariable(tmpVar), tree);
-    for (Node mustCallAlias : mustCallAliases) {
-      if (mustCallAlias instanceof FieldAccessNode) {
-        // Do not track the call result if the MustCallAlias argument is a field.  Handling of
-        // @Owning fields is a completely separate check, and there is never a need to track an
-        // alias of a non-@Owning field, as by definition such a field does not have obligations!
-      } else {
-        if (!(mustCallAlias instanceof LocalVariableNode)) {
-          throw new TypeSystemError(
-              "unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
-        }
-        Obligation obligationContainingMustCallAlias =
-            getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);
-        // If mustCallAlias is a local variable already being tracked, add tmpVarAsResourceAlias
-        // to the set containing mustCallAlias.
-        if (obligationContainingMustCallAlias != null) {
-          Set<ResourceAlias> newResourceAliasSet =
-              FluentIterable.from(obligationContainingMustCallAlias.resourceAliases)
-                  .append(tmpVarAsResourceAlias)
-                  .toSet();
-          obligations.remove(obligationContainingMustCallAlias);
-          obligations.add(new Obligation(newResourceAliasSet));
-        }
-      }
-    }
     if (mustCallAliases.isEmpty()) {
       // If mustCallAliases is an empty List, add tmpVarAsResourceAlias to a new set.
       obligations.add(new Obligation(ImmutableSet.of(tmpVarAsResourceAlias)));
+    } else {
+      for (Node mustCallAlias : mustCallAliases) {
+        if (mustCallAlias instanceof FieldAccessNode) {
+          // Do not track the call result if the MustCallAlias argument is a field.  Handling of
+          // @Owning fields is a completely separate check, and there is never a need to track an
+          // alias of a non-@Owning field, as by definition such a field does not have obligations!
+        } else {
+          if (!(mustCallAlias instanceof LocalVariableNode)) {
+            throw new TypeSystemError(
+                "unexpected node type for mustCallAlias: " + mustCallAlias.getClass());
+          }
+          Obligation obligationContainingMustCallAlias =
+              getObligationForVar(obligations, (LocalVariableNode) mustCallAlias);
+          // If mustCallAlias is a local variable already being tracked, add tmpVarAsResourceAlias
+          // to the set containing mustCallAlias.
+          if (obligationContainingMustCallAlias != null) {
+            Set<ResourceAlias> newResourceAliasSet =
+                FluentIterable.from(obligationContainingMustCallAlias.resourceAliases)
+                    .append(tmpVarAsResourceAlias)
+                    .toSet();
+            obligations.remove(obligationContainingMustCallAlias);
+            obligations.add(new Obligation(newResourceAliasSet));
+          }
+        }
+      }
     }
   }
 

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -41,22 +41,22 @@ class MultipleMethodParamsMustCallAliasTest {
 
   class ReplicaInputStreams implements Closeable {
 
-    private final @Owning InputStream out1;
-    private final @Owning InputStream out2;
+    private final @Owning InputStream in1;
+    private final @Owning InputStream in2;
 
     public @MustCallAlias ReplicaInputStreams(
-        @MustCallAlias InputStream o1, @MustCallAlias InputStream o2) {
-      this.out1 = o1;
-      this.out2 = o2;
+        @MustCallAlias InputStream i1, @MustCallAlias InputStream i2) {
+      this.in1 = i1;
+      this.in2 = i2;
     }
 
     @Override
     @EnsuresCalledMethods(
-        value = {"this.out1", "this.out2"},
+        value = {"this.in1", "this.in2"},
         methods = {"close"})
     public void close() throws IOException {
-      out1.close();
-      out2.close();
+      in1.close();
+      in2.close();
     }
   }
 }

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -6,12 +6,39 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class MultipleMethodParamsMustCallAliasTest {
 
-  void testMultiMethodParamsCorrect(@Owning InputStream in1, @Owning InputStream in2)
+  void testMultiMethodParamsCorrect1(@Owning InputStream in1, @Owning InputStream in2)
       throws IOException {
 
     ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
 
     r.close();
+  }
+
+  void testMultiMethodParamsCorrect2(@Owning InputStream in1, @Owning InputStream in2)
+      throws IOException {
+
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
+
+    try {
+      in1.close();
+    } catch (IOException e) {
+    } finally {
+      in2.close();
+    }
+  }
+
+  // Is this a bug in checker framework?
+  // :: error: required.method.not.called
+  void testMultiMethodParamsCorrect3(@Owning InputStream in1, @Owning InputStream in2)
+      throws IOException {
+
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
+
+    try {
+      in1.close();
+    } finally {
+      in2.close();
+    }
   }
 
   // :: error: required.method.not.called

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -27,7 +27,7 @@ class MultipleMethodParamsMustCallAliasTest {
     }
   }
 
-  // Is this a bug in checker framework?
+  // It's a FP, see: https://github.com/typetools/checker-framework/issues/4843
   // :: error: required.method.not.called
   void testMultiMethodParamsCorrect3(@Owning InputStream in1, @Owning InputStream in2)
       throws IOException {

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.net.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.common.returnsreceiver.qual.*;
+
+class MultipleMethodParamsMustCallAliasTest {
+
+  void testMultiMethodParamsCorrect(@Owning InputStream in1, @Owning InputStream in2)
+      throws IOException {
+
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
+
+    r.close();
+  }
+
+  // :: error: required.method.not.called
+  void testMultiMethodParamsWrong1(@Owning InputStream in1, @Owning InputStream in2)
+      throws IOException {
+
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
+
+    in1.close();
+  }
+
+  // :: error: required.method.not.called
+  void testMultiMethodParamsWrong2(@Owning InputStream in1, @Owning InputStream in2)
+      throws IOException {
+
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, in2);
+
+    in2.close();
+  }
+
+  // :: error: required.method.not.called
+  void testMultiMethodParamsWrong3(@Owning InputStream in1) throws IOException {
+    // :: error: required.method.not.called
+    Socket socket = new Socket("address", 12);
+    ReplicaInputStreams r = new ReplicaInputStreams(in1, socket.getInputStream());
+  }
+
+  class ReplicaInputStreams implements Closeable {
+
+    private final @Owning InputStream out1;
+    private final @Owning InputStream out2;
+
+    public @MustCallAlias ReplicaInputStreams(
+        @MustCallAlias InputStream o1, @MustCallAlias InputStream o2) {
+      this.out1 = o1;
+      this.out2 = o2;
+    }
+
+    @Override
+    @EnsuresCalledMethods(
+        value = {"this.out1", "this.out2"},
+        methods = {"close"})
+    public void close() throws IOException {
+      out1.close();
+      out2.close();
+    }
+  }
+}


### PR DESCRIPTION
Fixes [#4785](https://github.com/typetools/checker-framework/issues/4785).

In this PR, methods and constructors are allowed to have Multiple @MustCallAlias arguments like:

`public @MustCallAlias SequenceInputStream(@MustCallAlias InputStream s1, @MustCallAlias InputStream s2) {...}`

If a call has @MustCallAlias annotation, then for each argument passed in the @MustCallAlias position, it creates a set containing the argument and it's resource aliases and add it to the set of obligations. Consider the following example:

`SequenceInputStream s3 = new SequenceInputStream(s1, s2)`

It creates two sets {s1, s3} and {s2, s3}, and then adds them to the set of obligations.