### PR TITLE
Resource Leak Checker should not crash when checking the obligations of type variables

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1488,7 +1488,7 @@ class MustCallConsistencyAnalyzer {
         cmAnno =
             typeFactory
                 .getAnnotatedType(alias.reference.getElement())
-                .getAnnotationInHierarchy(typeFactory.top);
+                .getEffectiveAnnotationInHierarchy(typeFactory.top);
       }
 
       if (calledMethodsSatisfyMustCall(mustCallValue, cmAnno)) {

--- a/checker/tests/resourceleak/Issue4815.java
+++ b/checker/tests/resourceleak/Issue4815.java
@@ -1,5 +1,4 @@
 // Test case for https://tinyurl.com/cfissue/4815
-// @skip-test until the bug is fixed.
 
 import java.util.List;
 import org.checkerframework.checker.mustcall.qual.MustCall;
@@ -7,6 +6,8 @@ import org.checkerframework.checker.mustcall.qual.Owning;
 
 public class Issue4815 {
   public <T extends Component> void initialize(
+      // This error is a false positive, so if the checker stops finding it that would be fine.
+      // :: error: (required.method.not.called)
       List<T> list, @Owning @MustCall("initialize") T object) {
     object.initialize();
     list.add(object);


### PR DESCRIPTION
This fixes the crash reported in #4815. I think it would be best not to report an error at all, but the Called Methods store doesn't have any information about `object` when it goes out of scope. I think that's a separate problem.