### PR TITLE
Make @RequiresNonNull repeatable

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/RequiresNonNull.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/RequiresNonNull.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.nullness.qual;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -61,6 +62,7 @@ import org.checkerframework.framework.qual.PreconditionAnnotation;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Repeatable(RequiresNonNull.List.class)
 @PreconditionAnnotation(qualifier = NonNull.class)
 public @interface RequiresNonNull {
   /**
@@ -70,4 +72,23 @@ public @interface RequiresNonNull {
    * @checker_framework.manual #java-expressions-as-arguments Syntax of Java expressions
    */
   String[] value();
+
+  /**
+   * A wrapper annotation that makes the {@link RequiresNonNull} annotation repeatable.
+   *
+   * <p>Programmers generally do not need to write this. It is created by Java when a programmer
+   * writes more than one {@link RequiresNonNull} annotation at the same location.
+   */
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+  @PreconditionAnnotation(qualifier = NonNull.class)
+  @interface List {
+    /**
+     * Returns the repeatable annotations.
+     *
+     * @return the repeatable annotations
+     */
+    RequiresNonNull[] value();
+  }
 }

--- a/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/RequiresNonNull.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/RequiresNonNull.java
@@ -69,6 +69,8 @@ public @interface RequiresNonNull {
    * The Java expressions that need to be {@link
    * org.checkerframework.checker.nullness.qual.NonNull}.
    *
+   * @return the Java expressions that need to be {@link
+   *     org.checkerframework.checker.nullness.qual.NonNull}
    * @checker_framework.manual #java-expressions-as-arguments Syntax of Java expressions
    */
   String[] value();

--- a/checker/tests/nullness/RepeatedRequiresNonNull.java
+++ b/checker/tests/nullness/RepeatedRequiresNonNull.java
@@ -1,0 +1,78 @@
+// A test that multiple @RequiresNonNull annotations can be written on the same
+// method and work correctly.
+
+import org.checkerframework.checker.nullness.qual.*;
+import org.checkerframework.framework.qual.RequiresQualifier;
+
+class RepeatedRequiresNonNull {
+  @Nullable Object f1;
+  @Nullable Object f2;
+
+  @RequiresNonNull("this.f1")
+  @RequiresNonNull("this.f2")
+  void test() {
+    f1.toString();
+    f2.toString();
+  }
+
+  void use1() {
+    // :: error: (contracts.precondition)
+    test();
+  }
+
+  void use2() {
+    if (this.f1 != null) {
+      // :: error: (contracts.precondition)
+      test();
+    }
+  }
+
+  void use3() {
+    if (this.f2 != null) {
+      // :: error: (contracts.precondition)
+      test();
+    }
+  }
+
+  void use4() {
+    if (this.f1 != null && this.f2 != null) {
+      test();
+    }
+  }
+
+  // This part of the test is to ensure that @RequiresNonNull and @RequiresQualifier behave
+  // the same way. It is identical, but uses @RequiresQualifier on the test2() method instead
+  // of the @RequiresNonNull on the test() method.
+
+  @RequiresQualifier(expression = "this.f1", qualifier = NonNull.class)
+  @RequiresQualifier(expression = "this.f2", qualifier = NonNull.class)
+  void test2() {
+    f1.toString();
+    f2.toString();
+  }
+
+  void use21() {
+    // :: error: (contracts.precondition)
+    test2();
+  }
+
+  void use22() {
+    if (this.f1 != null) {
+      // :: error: (contracts.precondition)
+      test2();
+    }
+  }
+
+  void use23() {
+    if (this.f2 != null) {
+      // :: error: (contracts.precondition)
+      test2();
+    }
+  }
+
+  void use24() {
+    if (this.f1 != null && this.f2 != null) {
+      test2();
+    }
+  }
+}


### PR DESCRIPTION
This isn't strictly necessary (since `@RequiresNonNull` can already take multiple arguments), but it makes the annotation more consistent with `@RequiresQualifier`, which does permit both multiple arguments and multiple annotations per declaration.

This PR will be useful if we start using `-Ainfer` with the Nullness Checker, because right now it emits each precondition as its own annotation (which works with `@RequiresQualifier`, but would not work with `@RequiresNonNull` without this PR).

I considered adding a special test case for `-Ainfer`'s interaction with this PR, but decided that was probably not necessary. If you think it is, I can write one (or you can).