### PR TITLE
Initializes all fields of newly created ATM before substituting type vars.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -327,6 +327,20 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
   /** Map keys are canonical names of aliased annotations. */
   private final Map<@FullyQualifiedName String, Alias> aliases = new HashMap<>();
+  /**
+   * Scans all parts of the {@link AnnotatedTypeMirror} so that all of its fields are initialized.
+   */
+  private SimpleAnnotatedTypeScanner<Void, Void> atmInitializer =
+      new SimpleAnnotatedTypeScanner<>((type1, q) -> null);
+
+  /**
+   * Initializes all fields of {@code type}.
+   *
+   * @param type annotated type mirror
+   */
+  public void initializeAtm(AnnotatedTypeMirror type) {
+    atmInitializer.visit(type);
+  }
 
   /**
    * Information about one annotation alias.

--- a/framework/src/main/java/org/checkerframework/framework/type/SupertypeFinder.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/SupertypeFinder.java
@@ -210,7 +210,7 @@ class SupertypeFinder {
 
       List<AnnotatedDeclaredType> superTypesNew = new ArrayList<>();
       for (AnnotatedDeclaredType dt : supertypes) {
-        dt.getTypeArguments(); // Initialize the type arguments.
+        type.atypeFactory.initializeAtm(dt);
         superTypesNew.add(
             (AnnotatedDeclaredType) atypeFactory.getTypeVarSubstitutor().substitute(mapping, dt));
       }

--- a/framework/tests/all-systems/Issue4849.java
+++ b/framework/tests/all-systems/Issue4849.java
@@ -1,0 +1,21 @@
+// The error is reproducable only if the classes are not inner classes.
+final class Issue4849F<T> {}
+
+abstract class C<F1> extends Issue4849G<C<F1>> {}
+
+abstract class Issue4849G<M extends Issue4849G<M>> {
+  abstract M e();
+}
+
+@SuppressWarnings("all") // Just check for crashes.
+abstract class Issue4849 {
+  enum MyEnum {}
+
+  abstract <F1> C<F1> n(Issue4849F<F1> field1);
+
+  abstract <E extends Enum<E>> Issue4849F<E> of(Class<E> e);
+
+  void method() {
+    C<MyEnum> c = this.n(this.of(MyEnum.class)).e();
+  }
+}

--- a/framework/tests/all-systems/Issue4849.java
+++ b/framework/tests/all-systems/Issue4849.java
@@ -11,11 +11,11 @@ abstract class Issue4849G<M extends Issue4849G<M>> {
 abstract class Issue4849 {
   enum MyEnum {}
 
-  abstract <F1> C<F1> n(Issue4849F<F1> field1);
+  abstract <F1> Issue4849C<F1> n(Issue4849F<F1> field1);
 
   abstract <E extends Enum<E>> Issue4849F<E> of(Class<E> e);
 
   void method() {
-    C<MyEnum> c = this.n(this.of(MyEnum.class)).e();
+    Issue4849C<MyEnum> c = this.n(this.of(MyEnum.class)).e();
   }
 }

--- a/framework/tests/all-systems/Issue4849.java
+++ b/framework/tests/all-systems/Issue4849.java
@@ -1,4 +1,4 @@
-// The error is reproducable only if the classes are not inner classes.
+// The error is reproducable none of the classes are not inner classes.
 final class Issue4849F<T> {}
 
 abstract class Issue4849C<F1> extends Issue4849G<Issue4849C<F1>> {}

--- a/framework/tests/all-systems/Issue4849.java
+++ b/framework/tests/all-systems/Issue4849.java
@@ -1,7 +1,7 @@
 // The error is reproducable only if the classes are not inner classes.
 final class Issue4849F<T> {}
 
-abstract class C<F1> extends Issue4849G<C<F1>> {}
+abstract class Issue4849C<F1> extends Issue4849G<Issue4849C<F1>> {}
 
 abstract class Issue4849G<M extends Issue4849G<M>> {
   abstract M e();


### PR DESCRIPTION
Fixes #4849.