### PR TITLE
Ignore control flow due to NullPointerExceptions in Called Methods Checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
@@ -11,12 +11,16 @@ import org.checkerframework.framework.flow.CFAnalysis;
  */
 public class CalledMethodsAnalysis extends CFAnalysis {
 
+  /**
+   * Creates a new {@code CalledMethodsAnalysis}.
+   *
+   * @param checker the checker
+   * @param factory the factory
+   */
   protected CalledMethodsAnalysis(
       BaseTypeChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
     super(checker, factory);
   }
-
-  private static final String NPE_NAME = NullPointerException.class.getCanonicalName();
 
   /**
    * Ignore exceptional control flow due to {@code NullPointerException}s, as this checker assumes
@@ -28,6 +32,9 @@ public class CalledMethodsAnalysis extends CFAnalysis {
    */
   @Override
   protected boolean isIgnoredExceptionType(TypeMirror exceptionType) {
-    return ((Type) exceptionType).tsym.getQualifiedName().contentEquals(NPE_NAME);
+    return ((Type) exceptionType)
+        .tsym
+        .getQualifiedName()
+        .contentEquals("java.lang.NullPointerException");
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
@@ -1,0 +1,21 @@
+package org.checkerframework.checker.calledmethods;
+
+import com.sun.tools.javac.code.Type;
+import javax.lang.model.type.TypeMirror;
+import org.checkerframework.common.basetype.BaseTypeChecker;
+import org.checkerframework.framework.flow.CFAnalysis;
+
+public class CalledMethodsAnalysis extends CFAnalysis {
+
+  protected CalledMethodsAnalysis(
+      BaseTypeChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
+    super(checker, factory);
+  }
+
+  private static final String NPE_NAME = NullPointerException.class.getCanonicalName();
+
+  @Override
+  protected boolean isIgnoredExceptionType(TypeMirror typeMirror) {
+    return ((Type) typeMirror).tsym.getQualifiedName().contentEquals(NPE_NAME);
+  }
+}

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
@@ -5,6 +5,10 @@ import javax.lang.model.type.TypeMirror;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.framework.flow.CFAnalysis;
 
+/**
+ * The analysis for the Called Methods Checker. The analysis is specialized to ignore certain
+ * exception types; see {@link #isIgnoredExceptionType(TypeMirror)}.
+ */
 public class CalledMethodsAnalysis extends CFAnalysis {
 
   protected CalledMethodsAnalysis(
@@ -14,8 +18,16 @@ public class CalledMethodsAnalysis extends CFAnalysis {
 
   private static final String NPE_NAME = NullPointerException.class.getCanonicalName();
 
+  /**
+   * Ignore exceptional control flow due to {@code NullPointerException}s, as this checker assumes
+   * the Nullness Checker will be used to prevent such exceptions.
+   *
+   * @param exceptionType exception type
+   * @return {@code true} if {@code exceptionType} is {@code NullPointerException}, {@code false}
+   *     otherwise
+   */
   @Override
-  protected boolean isIgnoredExceptionType(TypeMirror typeMirror) {
-    return ((Type) typeMirror).tsym.getQualifiedName().contentEquals(NPE_NAME);
+  protected boolean isIgnoredExceptionType(TypeMirror exceptionType) {
+    return ((Type) exceptionType).tsym.getQualifiedName().contentEquals(NPE_NAME);
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -354,6 +354,11 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
     }
   }
 
+  @Override
+  protected CalledMethodsAnalysis createFlowAnalysis() {
+    return new CalledMethodsAnalysis(checker, this);
+  }
+
   /**
    * Returns the annotation type mirror for the type of {@code expressionTree} with default
    * annotations applied. As types relevant to Called Methods checking are rarely used inside

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -22,7 +22,6 @@ import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.framework.flow.CFAbstractStore;
-import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -56,7 +55,7 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
    *
    * @param analysis the analysis
    */
-  public CalledMethodsTransfer(final CFAnalysis analysis) {
+  public CalledMethodsTransfer(final CalledMethodsAnalysis analysis) {
     super(analysis);
     calledMethodsValueElement =
         ((CalledMethodsAnnotatedTypeFactory) atypeFactory).calledMethodsValueElement;

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakTransfer.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.resourceleak;
 
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
+import org.checkerframework.checker.calledmethods.CalledMethodsAnalysis;
 import org.checkerframework.checker.calledmethods.CalledMethodsTransfer;
 import org.checkerframework.checker.mustcall.CreatesMustCallForElementSupplier;
 import org.checkerframework.checker.mustcall.MustCallAnnotatedTypeFactory;
@@ -14,7 +15,6 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.dataflow.cfg.node.TernaryExpressionNode;
 import org.checkerframework.dataflow.expression.JavaExpression;
-import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFValue;
 import org.checkerframework.javacutil.TypesUtils;
@@ -34,7 +34,7 @@ public class ResourceLeakTransfer extends CalledMethodsTransfer {
    * @param analysis the analysis. Its type factory must be a {@link
    *     ResourceLeakAnnotatedTypeFactory}.
    */
-  public ResourceLeakTransfer(final CFAnalysis analysis) {
+  public ResourceLeakTransfer(final CalledMethodsAnalysis analysis) {
     super(analysis);
     this.rlTypeFactory = (ResourceLeakAnnotatedTypeFactory) analysis.getTypeFactory();
   }

--- a/checker/tests/calledmethods/EnsuresCalledMethodsIfTest.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsIfTest.java
@@ -7,14 +7,11 @@ import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsIf;
 class EnsuresCalledMethodsIfTest {
 
   @EnsuresCalledMethods(value = "#1", methods = "close")
-  // The contract is not satisfied.  Suppose `sock` is null.  Then `sock.close()` throws a
-  // NullPointerException before `sock.close()` has a chance to be called.  The exception is caught
-  // and control exits the method without `close()` being called.
-  // :: error: (contracts.postcondition)
+  // If `sock` is null, `sock.close()` will not be called, and the method will exit normally, as the
+  // NullPointerException is caught.  But, the Called Methods Checker
+  // assumes the program is free of NullPointerExceptions, delegating verification of that
+  // property to the Nullness Checker.  So, the postcondition is verified.
   public static void closeSock(EnsuresCalledMethodsIfTest sock) throws Exception {
-    if (!sock.isOpen()) {
-      return;
-    }
     try {
       sock.close();
     } catch (Exception e) {

--- a/checker/tests/calledmethods/EnsuresCalledMethodsIfTest.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsIfTest.java
@@ -12,6 +12,9 @@ class EnsuresCalledMethodsIfTest {
   // assumes the program is free of NullPointerExceptions, delegating verification of that
   // property to the Nullness Checker.  So, the postcondition is verified.
   public static void closeSock(EnsuresCalledMethodsIfTest sock) throws Exception {
+    if (!sock.isOpen()) {
+      return;
+    }
     try {
       sock.close();
     } catch (Exception e) {

--- a/checker/tests/calledmethods/Postconditions.java
+++ b/checker/tests/calledmethods/Postconditions.java
@@ -96,4 +96,35 @@ public class Postconditions {
     } catch (java.io.IOException e) {
     }
   }
+
+  @EnsuresCalledMethods(
+      value = {"#1", "#2"},
+      methods = "a")
+  static void callAOnBoth(Postconditions p1, Postconditions p2) {
+    p1.a();
+    p2.a();
+  }
+
+  @EnsuresCalledMethods(
+      value = {"#1", "#2"},
+      methods = "a")
+  static void callAOnBothTryCatch(Postconditions p1, Postconditions p2) {
+    try {
+      p1.a();
+    } catch (NullPointerException e) {
+    }
+    p2.a();
+  }
+
+  @EnsuresCalledMethods(
+      value = {"#1", "#2"},
+      methods = "a")
+  static int callAOnBothTryFinally(Postconditions p1, Postconditions p2) {
+    try {
+      p1.a();
+    } finally {
+      p2.a();
+      return 0;
+    }
+  }
 }

--- a/checker/tests/calledmethods/Postconditions.java
+++ b/checker/tests/calledmethods/Postconditions.java
@@ -108,7 +108,8 @@ public class Postconditions {
   @EnsuresCalledMethods(
       value = {"#1", "#2"},
       methods = "a")
-  static void callAOnBothTryCatch(Postconditions p1, Postconditions p2) {
+  static void callAOnBothCatchNPE(Postconditions p1, Postconditions p2) {
+    // postcondition is verified because the checker assumes NullPointerExceptions cannot occur
     try {
       p1.a();
     } catch (NullPointerException e) {
@@ -119,7 +120,8 @@ public class Postconditions {
   @EnsuresCalledMethods(
       value = {"#1", "#2"},
       methods = "a")
-  static int callAOnBothTryFinally(Postconditions p1, Postconditions p2) {
+  static int callAOnBothFinallyNPE(Postconditions p1, Postconditions p2) {
+    // postcondition is verified because the checker assumes NullPointerExceptions cannot occur
     try {
       p1.a();
     } finally {

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -27,8 +27,6 @@ class MultipleMethodParamsMustCallAliasTest {
     }
   }
 
-  // It's a FP, see: https://github.com/typetools/checker-framework/issues/4843
-  // :: error: required.method.not.called
   void testMultiMethodParamsCorrect3(@Owning InputStream in1, @Owning InputStream in2)
       throws IOException {
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -361,7 +361,17 @@ public abstract class AbstractAnalysis<
     initInitialInputs();
   }
 
-  protected boolean isIgnoredExceptionType(TypeMirror typeMirror) {
+  /**
+   * Should exceptional control flow for a particular exception type be ignored?
+   *
+   * <p>The default implementation always returns {@code false}. Subclasses should override the
+   * method to implement a different policy.
+   *
+   * @param exceptionType the exception type
+   * @return {@code true} if exceptional control flow due to {@code exceptionType} should be
+   *     ignored, {@code false} otherwise
+   */
+  protected boolean isIgnoredExceptionType(TypeMirror exceptionType) {
     return false;
   }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.PriorityQueue;
 import java.util.Set;
 import javax.lang.model.element.Element;
+import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.interning.qual.InternedDistinct;
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
@@ -358,6 +359,10 @@ public abstract class AbstractAnalysis<
   protected final void init(ControlFlowGraph cfg) {
     initFields(cfg);
     initInitialInputs();
+  }
+
+  protected boolean isIgnoredExceptionType(TypeMirror typeMirror) {
+    return false;
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
@@ -159,6 +159,9 @@ public class ForwardAnalysisImpl<
           // Propagate store to exceptional successors
           for (Map.Entry<TypeMirror, Set<Block>> e : eb.getExceptionalSuccessors().entrySet()) {
             TypeMirror cause = e.getKey();
+            if (isIgnoredExceptionType(cause)) {
+              continue;
+            }
             S exceptionalStore = transferResult.getExceptionalStore(cause);
             if (exceptionalStore != null) {
               for (Block exceptionSucc : e.getValue()) {


### PR DESCRIPTION
Fixes #4843

The Called Methods Checker assumes that the checked code is free of NullPointerExceptions (this property should be verified by the Nullness Checker).  This PR enhances the Called Methods Checker's type inference to ignore control flow due to NullPointerExceptions, enabling it to verify more code.  See https://github.com/typetools/checker-framework/issues/4843#issuecomment-889263475 for more context.

The change is implemented by enhancing the dataflow framework to allow for ignoring exceptional control flow for particular exception types.

We may want to ignore more exception types in the future; we can add that in a follow-up PR.