### PR TITLE
Fix missing Javadoc CI errors

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/lock/LockTreeAnnotator.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockTreeAnnotator.java
@@ -36,7 +36,12 @@ public class LockTreeAnnotator extends TreeAnnotator {
     return super.visitBinary(node, type);
   }
 
-  /** Indicates that the result of the operation is a boolean value. */
+  /**
+   * Indicates that the result of the operation is a boolean value.
+   *
+   * @param opKind the operation to check
+   * @return whether the result is boolean
+   */
   private static boolean isBinaryComparisonOrInstanceOfOperator(Tree.Kind opKind) {
     switch (opKind) {
       case EQUAL_TO:

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
@@ -76,6 +76,11 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
   protected static final Pattern SELF_RECEIVER_PATTERN = Pattern.compile("^<self>(\\.(.*))?$");
 
+  /**
+   * Constructs a {@link LockVisitor}
+   *
+   * @param checker the type checker to use.
+   */
   public LockVisitor(BaseTypeChecker checker) {
     super(checker);
     for (String checkerName : atypeFactory.getCheckerNames()) {

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
@@ -80,7 +80,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
   protected static final Pattern SELF_RECEIVER_PATTERN = Pattern.compile("^<self>(\\.(.*))?$");
 
   /**
-   * Constructs a {@link LockVisitor}
+   * Constructs a {@link LockVisitor}.
    *
    * @param checker the type checker to use.
    */

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
@@ -71,9 +71,12 @@ import org.plumelib.util.CollectionsPlume;
  * @checker_framework.manual #lock-checker Lock Checker
  */
 public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
+  /** The class of GuardedBy */
   private final Class<? extends Annotation> checkerGuardedByClass = GuardedBy.class;
+  /** The class of GuardSatisfied */
   private final Class<? extends Annotation> checkerGuardSatisfiedClass = GuardSatisfied.class;
 
+  /** A pattern for spotting self receiver */
   protected static final Pattern SELF_RECEIVER_PATTERN = Pattern.compile("^<self>(\\.(.*))?$");
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class BitwiseAndNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link BitwiseAndNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public BitwiseAndNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.AND;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
@@ -17,9 +17,9 @@ public class BitwiseAndNode extends BinaryOperationNode {
   /**
    * Constructs a {@link BitwiseAndNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public BitwiseAndNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseAndNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class BitwiseAndNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link BitwiseAndNode}
+   * Constructs a {@link BitwiseAndNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class BitwiseComplementNode extends UnaryOperationNode {
 
   /**
-   * Constructs a {@link BitwiseComplementNode}
+   * Constructs a {@link BitwiseComplementNode}.
    *
    * @param tree the tree of the bitwise complement
    * @param operand the operand of the bitwise complement

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
@@ -17,8 +17,8 @@ public class BitwiseComplementNode extends UnaryOperationNode {
   /**
    * Constructs a {@link BitwiseComplementNode}
    *
-   * @param tree The tree of the whole operation
-   * @param operand The operand of the operation
+   * @param tree the tree of the bitwise complement
+   * @param operand the operand of the bitwise complement
    */
   public BitwiseComplementNode(UnaryTree tree, Node operand) {
     super(tree, operand);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseComplementNode.java
@@ -14,6 +14,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class BitwiseComplementNode extends UnaryOperationNode {
 
+  /**
+   * Constructs a {@link BitwiseComplementNode}
+   *
+   * @param tree The tree of the whole operation
+   * @param operand The operand of the operation
+   */
   public BitwiseComplementNode(UnaryTree tree, Node operand) {
     super(tree, operand);
     assert tree.getKind() == Tree.Kind.BITWISE_COMPLEMENT;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class BitwiseOrNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link BitwiseOrNode}
+   * Constructs a {@link BitwiseOrNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
@@ -17,9 +17,9 @@ public class BitwiseOrNode extends BinaryOperationNode {
   /**
    * Constructs a {@link BitwiseOrNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public BitwiseOrNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseOrNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class BitwiseOrNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link BitwiseOrNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public BitwiseOrNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.OR;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class BitwiseXorNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link BitwiseXorNode}
+   * Constructs a {@link BitwiseXorNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
@@ -17,9 +17,9 @@ public class BitwiseXorNode extends BinaryOperationNode {
   /**
    * Constructs a {@link BitwiseXorNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public BitwiseXorNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/BitwiseXorNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class BitwiseXorNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link BitwiseXorNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public BitwiseXorNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.XOR;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class FloatingDivisionNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link FloatingDivisionNode}
+   * Constructs a {@link FloatingDivisionNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class FloatingDivisionNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link FloatingDivisionNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public FloatingDivisionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.DIVIDE;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingDivisionNode.java
@@ -17,9 +17,9 @@ public class FloatingDivisionNode extends BinaryOperationNode {
   /**
    * Constructs a {@link FloatingDivisionNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public FloatingDivisionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
@@ -17,9 +17,9 @@ public class FloatingRemainderNode extends BinaryOperationNode {
   /**
    * Constructs a {@link FloatingRemainderNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public FloatingRemainderNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class FloatingRemainderNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link FloatingRemainderNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public FloatingRemainderNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.REMAINDER;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/FloatingRemainderNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class FloatingRemainderNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link FloatingRemainderNode}
+   * Constructs a {@link FloatingRemainderNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class GreaterThanNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link GreaterThanNode}
+   * Constructs a {@link GreaterThanNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
@@ -17,9 +17,9 @@ public class GreaterThanNode extends BinaryOperationNode {
   /**
    * Constructs a {@link GreaterThanNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public GreaterThanNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class GreaterThanNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link GreaterThanNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public GreaterThanNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.GREATER_THAN;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class GreaterThanOrEqualNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link GreaterThanOrEqualNode}
+   * Constructs a {@link GreaterThanOrEqualNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class GreaterThanOrEqualNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link GreaterThanOrEqualNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public GreaterThanOrEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.GREATER_THAN_EQUAL;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/GreaterThanOrEqualNode.java
@@ -17,9 +17,9 @@ public class GreaterThanOrEqualNode extends BinaryOperationNode {
   /**
    * Constructs a {@link GreaterThanOrEqualNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public GreaterThanOrEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
@@ -17,9 +17,9 @@ public class IntegerDivisionNode extends BinaryOperationNode {
   /**
    * Constructs an {@link IntegerDivisionNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public IntegerDivisionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class IntegerDivisionNode extends BinaryOperationNode {
 
   /**
-   * Constructs an {@link IntegerDivisionNode}
+   * Constructs an {@link IntegerDivisionNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerDivisionNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class IntegerDivisionNode extends BinaryOperationNode {
 
+  /**
+   * Constructs an {@link IntegerDivisionNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public IntegerDivisionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.DIVIDE;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class IntegerRemainderNode extends BinaryOperationNode {
 
   /**
-   * Constructs an {@link IntegerRemainderNode}
+   * Constructs an {@link IntegerRemainderNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class IntegerRemainderNode extends BinaryOperationNode {
 
+  /**
+   * Constructs an {@link IntegerRemainderNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public IntegerRemainderNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.REMAINDER;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/IntegerRemainderNode.java
@@ -17,9 +17,9 @@ public class IntegerRemainderNode extends BinaryOperationNode {
   /**
    * Constructs an {@link IntegerRemainderNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public IntegerRemainderNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
@@ -17,9 +17,9 @@ public class LeftShiftNode extends BinaryOperationNode {
   /**
    * Constructs a {@link LeftShiftNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public LeftShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class LeftShiftNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link LeftShiftNode}
+   * Constructs a {@link LeftShiftNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LeftShiftNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class LeftShiftNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link LeftShiftNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public LeftShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.LEFT_SHIFT;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -19,9 +19,9 @@ public class LessThanNode extends BinaryOperationNode {
   /**
    * Constructs a {@link LessThanNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public LessThanNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -16,6 +16,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class LessThanNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link LessThanNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public LessThanNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.LESS_THAN;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanNode.java
@@ -17,7 +17,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class LessThanNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link LessThanNode}
+   * Constructs a {@link LessThanNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class LessThanOrEqualNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link LessThanOrEqualNode}
+   * Constructs a {@link LessThanOrEqualNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
@@ -17,9 +17,9 @@ public class LessThanOrEqualNode extends BinaryOperationNode {
   /**
    * Constructs a {@link LessThanOrEqualNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public LessThanOrEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LessThanOrEqualNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class LessThanOrEqualNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link LessThanOrEqualNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public LessThanOrEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.LESS_THAN_EQUAL;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NotEqualNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link NotEqualNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public NotEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.NOT_EQUAL_TO;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
@@ -17,9 +17,9 @@ public class NotEqualNode extends BinaryOperationNode {
   /**
    * Constructs a {@link NotEqualNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public NotEqualNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NotEqualNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NotEqualNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link NotEqualNode}
+   * Constructs a {@link NotEqualNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
@@ -19,6 +19,12 @@ public class NullChkNode extends Node {
   protected final Tree tree;
   protected final Node operand;
 
+  /**
+   * Constructs a {@link NullChkNode}
+   *
+   * @param tree The tree of the whole operation
+   * @param operand The operand of the operation
+   */
   public NullChkNode(Tree tree, Node operand) {
     super(TreeUtils.typeOf(tree));
     assert tree.getKind() == Tree.Kind.OTHER;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
@@ -15,8 +15,9 @@ import org.checkerframework.javacutil.TreeUtils;
  * </pre>
  */
 public class NullChkNode extends Node {
-
+  /** The entire tree of the null check */
   protected final Tree tree;
+  /** The operand of the null check */
   protected final Node operand;
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NullChkNode.java
@@ -21,10 +21,10 @@ public class NullChkNode extends Node {
   protected final Node operand;
 
   /**
-   * Constructs a {@link NullChkNode}
+   * Constructs a {@link NullChkNode}.
    *
-   * @param tree The tree of the whole operation
-   * @param operand The operand of the operation
+   * @param tree the nullchk tree
+   * @param operand the operand of the null check
    */
   public NullChkNode(Tree tree, Node operand) {
     super(TreeUtils.typeOf(tree));

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NumericalAdditionNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link NumericalAdditionNode}
+   * Constructs a {@link NumericalAdditionNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NumericalAdditionNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link NumericalAdditionNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public NumericalAdditionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.PLUS || tree.getKind() == Tree.Kind.PLUS_ASSIGNMENT;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalAdditionNode.java
@@ -17,9 +17,9 @@ public class NumericalAdditionNode extends BinaryOperationNode {
   /**
    * Constructs a {@link NumericalAdditionNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public NumericalAdditionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
@@ -14,6 +14,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NumericalMinusNode extends UnaryOperationNode {
 
+  /**
+   * Constructs a {@link NumericalMinusNode}
+   *
+   * @param tree The tree of the whole operation
+   * @param operand The operand of the operation
+   */
   public NumericalMinusNode(UnaryTree tree, Node operand) {
     super(tree, operand);
     assert tree.getKind() == Tree.Kind.UNARY_MINUS;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMinusNode.java
@@ -15,10 +15,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NumericalMinusNode extends UnaryOperationNode {
 
   /**
-   * Constructs a {@link NumericalMinusNode}
+   * Constructs a {@link NumericalMinusNode}.
    *
-   * @param tree The tree of the whole operation
-   * @param operand The operand of the operation
+   * @param tree the unary tree
+   * @param operand the operand of the unary minus
    */
   public NumericalMinusNode(UnaryTree tree, Node operand) {
     super(tree, operand);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NumericalMultiplicationNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link NumericalMultiplicationNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public NumericalMultiplicationNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.MULTIPLY;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
@@ -17,9 +17,9 @@ public class NumericalMultiplicationNode extends BinaryOperationNode {
   /**
    * Constructs a {@link NumericalMultiplicationNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public NumericalMultiplicationNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalMultiplicationNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NumericalMultiplicationNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link NumericalMultiplicationNode}
+   * Constructs a {@link NumericalMultiplicationNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
@@ -14,6 +14,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NumericalPlusNode extends UnaryOperationNode {
 
+  /**
+   * Constructs a {@link NumericalPlusNode}
+   *
+   * @param tree The tree of the whole operation
+   * @param operand The operand of the operation
+   */
   public NumericalPlusNode(UnaryTree tree, Node operand) {
     super(tree, operand);
     assert tree.getKind() == Tree.Kind.UNARY_PLUS;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalPlusNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NumericalPlusNode extends UnaryOperationNode {
 
   /**
-   * Constructs a {@link NumericalPlusNode}
+   * Constructs a {@link NumericalPlusNode}.
    *
    * @param tree The tree of the whole operation
    * @param operand The operand of the operation

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class NumericalSubtractionNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link NumericalSubtractionNode}
+   * Constructs a {@link NumericalSubtractionNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
@@ -17,9 +17,9 @@ public class NumericalSubtractionNode extends BinaryOperationNode {
   /**
    * Constructs a {@link NumericalSubtractionNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public NumericalSubtractionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/NumericalSubtractionNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class NumericalSubtractionNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link NumericalSubtractionNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public NumericalSubtractionNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.MINUS;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class SignedRightShiftNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link SignedRightShiftNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public SignedRightShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.RIGHT_SHIFT;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
@@ -17,9 +17,9 @@ public class SignedRightShiftNode extends BinaryOperationNode {
   /**
    * Constructs a {@link SignedRightShiftNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public SignedRightShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/SignedRightShiftNode.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class SignedRightShiftNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link SignedRightShiftNode}
+   * Constructs a {@link SignedRightShiftNode}.
    *
    * @param tree the binary tree
    * @param left the left operand

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
@@ -15,8 +15,11 @@ import org.checkerframework.javacutil.TreeUtils;
  * </pre>
  */
 public class StringConcatenateAssignmentNode extends Node {
+  /** The entire tree of the assignment */
   protected final Tree tree;
+  /** The left-hand side of the assignment */
   protected final Node left;
+  /** The right-hand side of the assignment */
   protected final Node right;
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
@@ -25,9 +25,9 @@ public class StringConcatenateAssignmentNode extends Node {
   /**
    * Constructs an {@link StringConcatenateAssignmentNode}
    *
-   * @param tree The binary tree of the assignment
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree of the assignment
+   * @param left the left-hand side
+   * @param right the right-hand side
    */
   public StringConcatenateAssignmentNode(Tree tree, Node left, Node right) {
     super(TreeUtils.typeOf(tree));

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
@@ -19,6 +19,13 @@ public class StringConcatenateAssignmentNode extends Node {
   protected final Node left;
   protected final Node right;
 
+  /**
+   * Constructs an {@link StringConcatenateAssignmentNode}
+   *
+   * @param tree The binary tree of the assignment
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public StringConcatenateAssignmentNode(Tree tree, Node left, Node right) {
     super(TreeUtils.typeOf(tree));
     assert tree.getKind() == Tree.Kind.PLUS_ASSIGNMENT;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateAssignmentNode.java
@@ -23,7 +23,7 @@ public class StringConcatenateAssignmentNode extends Node {
   protected final Node right;
 
   /**
-   * Constructs an {@link StringConcatenateAssignmentNode}
+   * Constructs an {@link StringConcatenateAssignmentNode}.
    *
    * @param tree the binary tree of the assignment
    * @param left the left-hand side

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class StringConcatenateNode extends BinaryOperationNode {
 
+  /**
+   * Constructs a {@link StringConcatenateNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public StringConcatenateNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.PLUS;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/StringConcatenateNode.java
@@ -15,11 +15,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class StringConcatenateNode extends BinaryOperationNode {
 
   /**
-   * Constructs a {@link StringConcatenateNode}
+   * Constructs a {@link StringConcatenateNode}.
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public StringConcatenateNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
@@ -17,9 +17,9 @@ public class UnsignedRightShiftNode extends BinaryOperationNode {
   /**
    * Constructs an {@link UnsignedRightShiftNode}
    *
-   * @param tree The binary tree
-   * @param left The left-hand side
-   * @param right The right-hand side
+   * @param tree the binary tree
+   * @param left the left operand
+   * @param right the right operand
    */
   public UnsignedRightShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/UnsignedRightShiftNode.java
@@ -14,6 +14,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 public class UnsignedRightShiftNode extends BinaryOperationNode {
 
+  /**
+   * Constructs an {@link UnsignedRightShiftNode}
+   *
+   * @param tree The binary tree
+   * @param left The left-hand side
+   * @param right The right-hand side
+   */
   public UnsignedRightShiftNode(BinaryTree tree, Node left, Node right) {
     super(tree, left, right);
     assert tree.getKind() == Tree.Kind.UNSIGNED_RIGHT_SHIFT;

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -269,6 +269,8 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
    * {@code @Unique}
    *
    * @param exp the Tree to check
+   * @return true if {@code exp} has type {@code @Unique} and is not a method invocation nor a new
+   *     class expression
    */
   private boolean canBeLeaked(Tree exp) {
     AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(exp);

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -457,6 +457,12 @@ public abstract class CFAbstractTransfer<
     }
   }
 
+  /**
+   * Adds information about effectively final variables (from outer scopes)
+   *
+   * @param store the store to add to
+   * @param enclosingElement the enclosing element of the code we are analyzing
+   */
   private void addFinalLocalValues(S store, Element enclosingElement) {
     // add information about effectively final variables (from outer scopes)
     for (Map.Entry<Element, V> e : analysis.atypeFactory.getFinalLocalValues().entrySet()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -44,12 +44,19 @@ import org.checkerframework.javacutil.TypesUtils;
  */
 public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     implements TypeHierarchy {
-  // used for processingEnvironment when needed
+  /**
+   * The type-checker that is associated with this.
+   *
+   * <p>Used for processingEnvironment when needed.
+   */
   protected final BaseTypeChecker checker;
 
+  /** The qualifier hierarchy that is associated with this */
   protected final QualifierHierarchy qualifierHierarchy;
+  /** The equality comparer */
   protected final StructuralEqualityComparer equalityComparer;
 
+  /** Whether to ignore raw types */
   protected final boolean ignoreRawTypes;
   /** Whether to make array subtyping invariant with respect to array component types */
   protected final boolean invariantArrayComponents;
@@ -74,7 +81,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
    * Creates a DefaultTypeHierarchy.
    *
    * @param checker the type-checker that is associated with this
-   * @param qualifierHierarchy the qualiifer hierarchy that is associated with this
+   * @param qualifierHierarchy the qualifier hierarchy that is associated with this
    * @param ignoreRawTypes whether to ignore raw types
    * @param invariantArrayComponents whether to make array subtyping invariant with respect to array
    *     component types

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -1081,7 +1081,13 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     return type;
   }
 
-  /** A union type is a subtype if ALL of its alternatives are subtypes of supertype. */
+  /**
+   * A union type is a subtype if ALL of its alternatives are subtypes of supertype.
+   *
+   * @param subtype the potential subtype to check
+   * @param supertype the supertype to check
+   * @return whether all the alternatives of subtype are subtypes of supertype
+   */
   protected boolean visitUnion_Type(AnnotatedUnionType subtype, AnnotatedTypeMirror supertype) {
     return areAllSubtypes(subtype.getAlternatives(), supertype);
   }

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -51,6 +51,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   protected final StructuralEqualityComparer equalityComparer;
 
   protected final boolean ignoreRawTypes;
+  /** Whether to make array subtyping invariant with respect to array component types */
   protected final boolean invariantArrayComponents;
 
   /** The top annotation of the hierarchy currently being checked. */
@@ -1092,6 +1093,13 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     return areAllSubtypes(subtype.getAlternatives(), supertype);
   }
 
+  /**
+   * Check a wildcard type's relation against a subtype
+   *
+   * @param subtype the potential subtype to check
+   * @param supertype the wildcard supertype to check
+   * @return whether the subtype is a subtype of the supertype's super bound
+   */
   protected boolean visitType_Wildcard(
       AnnotatedTypeMirror subtype, AnnotatedWildcardType supertype) {
     if (supertype.isUninferredTypeArgument()) { // TODO: REMOVE WHEN WE FIX TYPE ARG INFERENCE
@@ -1101,6 +1109,13 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     return isSubtype(subtype, supertype.getSuperBound(), currentTop);
   }
 
+  /**
+   * Check a wildcard type's relation against a supertype
+   *
+   * @param subtype the potential wildcard subtype to check
+   * @param supertype the supertype to check
+   * @return whether the subtype's extends bound is a subtype of the supertype
+   */
   protected boolean visitWildcard_Type(
       AnnotatedWildcardType subtype, AnnotatedTypeMirror supertype) {
     if (subtype.isUninferredTypeArgument()) {

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -51,14 +51,14 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
    */
   protected final BaseTypeChecker checker;
 
-  /** The qualifier hierarchy that is associated with this */
+  /** The qualifier hierarchy that is associated with this. */
   protected final QualifierHierarchy qualifierHierarchy;
-  /** The equality comparer */
+  /** The equality comparer. */
   protected final StructuralEqualityComparer equalityComparer;
 
-  /** Whether to ignore raw types */
+  /** Whether to ignore raw types. */
   protected final boolean ignoreRawTypes;
-  /** Whether to make array subtyping invariant with respect to array component types */
+  /** Whether to make array subtyping invariant with respect to array component types. */
   protected final boolean invariantArrayComponents;
 
   /** The top annotation of the hierarchy currently being checked. */
@@ -1101,7 +1101,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   }
 
   /**
-   * Check a wildcard type's relation against a subtype
+   * Check a wildcard type's relation against a subtype.
    *
    * @param subtype the potential subtype to check
    * @param supertype the wildcard supertype to check
@@ -1117,7 +1117,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   }
 
   /**
-   * Check a wildcard type's relation against a supertype
+   * Check a wildcard type's relation against a supertype.
    *
    * @param subtype the potential wildcard subtype to check
    * @param supertype the supertype to check

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
@@ -9,13 +9,25 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
 /** A ListTreeAnnotator implementation that additionally outputs debugging information. */
 public class DebugListTreeAnnotator extends ListTreeAnnotator {
+  /** The tree kinds to debug */
   private final Set<Tree.Kind> kinds;
 
+  /**
+   * Constructs a DebugListTreeAnnotator that does not output any debug information
+   *
+   * @param annotators the annotators for ListTreeAnnotator
+   */
   public DebugListTreeAnnotator(TreeAnnotator... annotators) {
     super(annotators);
     kinds = Collections.emptySet();
   }
 
+  /**
+   * Constructs a DebugListTreeAnnotator that outputs debug for the given tree kinds
+   *
+   * @param kinds the tree kinds to output debug info for
+   * @param annotators the annotators for ListTreeAnnotator
+   */
   public DebugListTreeAnnotator(Tree.Kind[] kinds, TreeAnnotator... annotators) {
     super(annotators);
     this.kinds = new HashSet<>(Arrays.asList(kinds));

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
@@ -9,11 +9,11 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
 /** A ListTreeAnnotator implementation that additionally outputs debugging information. */
 public class DebugListTreeAnnotator extends ListTreeAnnotator {
-  /** The tree kinds to debug */
+  /** The tree kinds to debug. */
   private final Set<Tree.Kind> kinds;
 
   /**
-   * Constructs a DebugListTreeAnnotator that does not output any debug information
+   * Constructs a DebugListTreeAnnotator that does not output any debug information.
    *
    * @param annotators the annotators for ListTreeAnnotator
    */
@@ -23,7 +23,7 @@ public class DebugListTreeAnnotator extends ListTreeAnnotator {
   }
 
   /**
-   * Constructs a DebugListTreeAnnotator that outputs debug for the given tree kinds
+   * Constructs a DebugListTreeAnnotator that outputs debug for the given tree kinds.
    *
    * @param kinds the tree kinds to output debug info for
    * @param annotators the annotators for ListTreeAnnotator

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
@@ -42,11 +42,11 @@ public class LiteralTreeAnnotator extends TreeAnnotator {
    * For type systems with single top qualifiers, the sets will always contain
    * at most one element.
    */
-  /** Maps AST kind to the set of AnnotationMirrors that should be defaulted */
+  /** Maps AST kind to the set of AnnotationMirrors that should be defaulted. */
   private final Map<Tree.Kind, Set<AnnotationMirror>> treeKinds;
-  /** Maps AST class to the set of AnnotationMirrors that should be defaulted */
+  /** Maps AST class to the set of AnnotationMirrors that should be defaulted. */
   private final Map<Class<?>, Set<AnnotationMirror>> treeClasses;
-  /** Maps String literal pattern to the set of AnnotationMirrors that should be defaulted */
+  /** Maps String literal pattern to the set of AnnotationMirrors that should be defaulted. */
   private final IdentityHashMap<Pattern, Set<AnnotationMirror>> stringPatterns;
 
   protected final QualifierHierarchy qualHierarchy;

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
@@ -42,8 +42,11 @@ public class LiteralTreeAnnotator extends TreeAnnotator {
    * For type systems with single top qualifiers, the sets will always contain
    * at most one element.
    */
+  /** Maps AST kind to the set of AnnotationMirrors that should be defaulted */
   private final Map<Tree.Kind, Set<AnnotationMirror>> treeKinds;
+  /** Maps AST class to the set of AnnotationMirrors that should be defaulted */
   private final Map<Class<?>, Set<AnnotationMirror>> treeClasses;
+  /** Maps String literal pattern to the set of AnnotationMirrors that should be defaulted */
   private final IdentityHashMap<Pattern, Set<AnnotationMirror>> stringPatterns;
 
   protected final QualifierHierarchy qualHierarchy;

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/LiteralTreeAnnotator.java
@@ -67,7 +67,11 @@ public class LiteralTreeAnnotator extends TreeAnnotator {
     literalKindToTreeKind.put(LiteralKind.STRING, Tree.Kind.STRING_LITERAL);
   }
 
-  /** Creates a {@link LiteralTreeAnnotator} for the given {@code atypeFactory}. */
+  /**
+   * Creates a {@link LiteralTreeAnnotator} for the given {@code atypeFactory}.
+   *
+   * @param atypeFactory the type factory to make an annotator for
+   */
   public LiteralTreeAnnotator(AnnotatedTypeFactory atypeFactory) {
     super(atypeFactory);
     this.treeKinds = new EnumMap<>(Tree.Kind.class);

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -902,6 +902,7 @@ public class AnnotatedTypes {
    * <p>Otherwise, it would return the list of parameters as if the vararg is expanded to match the
    * size of the passed arguments.
    *
+   * @param atypeFactory the type factory to use for fetching annotated types
    * @param method the method's type
    * @param args the arguments to the method invocation
    * @return the types that the method invocation arguments need to be subtype of

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1317,6 +1317,7 @@ public final class TreeUtils {
   /**
    * Returns true if the tree is the declaration or use of a local variable.
    *
+   * @param tree the tree to check
    * @return true if the tree is the declaration or use of a local variable
    */
   public static boolean isLocalVariable(Tree tree) {


### PR DESCRIPTION
This adds Javadoc to several areas that cause the CI to complain about missing Javadoc in new branches that haven't touched this code.  The new documentation is fairly perfunctory in places, but it satisfies the checker.