### PR TITLE
Must Call Checker must respect the "mustcall" warning suppression prefix, even when the -AnoCreatesMustCallFor option is passed and the MustCallNoCreatesMustCallForChecker is used instead

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallNoCreatesMustCallForChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallNoCreatesMustCallForChecker.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.mustcall;
 
 import org.checkerframework.framework.qual.StubFiles;
 import org.checkerframework.framework.source.SupportedOptions;
+import org.checkerframework.framework.source.SuppressWarningsPrefix;
 
 /**
  * This copy of the Must Call Checker is identical, except that it does not load the stub files that
@@ -12,6 +13,13 @@ import org.checkerframework.framework.source.SupportedOptions;
 @StubFiles({
   "JavaEE.astub",
   "Reflection.astub",
+})
+@SuppressWarningsPrefix({
+  // Preferred checkername, so that warnings are suppressed regardless of the option passed.
+  "mustcall",
+  // Also supported, but will only suppress warnings from this checker (and not from the regular
+  // Must Call Checker).
+  "mustcallnocreatesmustcallfor"
 })
 @SupportedOptions({MustCallChecker.NO_CREATES_MUSTCALLFOR})
 public class MustCallNoCreatesMustCallForChecker extends MustCallChecker {}

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoCreatesMustCallForTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakNoCreatesMustCallForTest.java
@@ -15,7 +15,7 @@ public class ResourceLeakNoCreatesMustCallForTest extends CheckerFrameworkPerDir
         "resourceleak-nocreatesmustcallfor",
         "-Anomsgtext",
         "-AnoCreatesMustCallFor",
-        "-nowarn",
+        "-AwarnUnneededSuppressions",
         "-encoding",
         "UTF-8");
   }

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakTest.java
@@ -14,7 +14,7 @@ public class ResourceLeakTest extends CheckerFrameworkPerDirectoryTest {
         ResourceLeakChecker.class,
         "resourceleak",
         "-Anomsgtext",
-        "-nowarn",
+        "-AwarnUnneededSuppressions",
         "-encoding",
         "UTF-8");
   }

--- a/checker/tests/resourceleak-nocreatesmustcallfor/DifferentSWKeys.java
+++ b/checker/tests/resourceleak-nocreatesmustcallfor/DifferentSWKeys.java
@@ -1,0 +1,26 @@
+// A test case that the RLC's -AnoCreatesMustCallFor argument doesn't change
+// warning suppression behavior for the Must Call Checker.
+
+import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+@SuppressWarnings("required.method.not.called")
+class DifferentSWKeys {
+  void test(@Owning @MustCall("foo") Object obj) {
+    // :: warning: unneeded.suppression
+    @SuppressWarnings("mustcall")
+    @MustCall("foo") Object bar = obj;
+  }
+
+  void test2(@Owning @MustCall("foo") Object obj) {
+    // actually needed suppression
+    @SuppressWarnings("mustcall")
+    @MustCall({}) Object bar = obj;
+  }
+
+  void test3(@Owning @MustCall("foo") Object obj) {
+    // test that the option-specific suppression key works
+    @SuppressWarnings("mustcallnocreatesmustcallfor")
+    @MustCall({}) Object bar = obj;
+  }
+}

--- a/checker/tests/resourceleak/DifferentSWKeys.java
+++ b/checker/tests/resourceleak/DifferentSWKeys.java
@@ -1,0 +1,27 @@
+// A test case that the RLC's -AnoCreatesMustCallFor argument doesn't change
+// warning suppression behavior for the Must Call Checker.
+
+import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+@SuppressWarnings("required.method.not.called")
+class DifferentSWKeys {
+  void test(@Owning @MustCall("foo") Object obj) {
+    // :: warning: unneeded.suppression
+    @SuppressWarnings("mustcall")
+    @MustCall("foo") Object bar = obj;
+  }
+
+  void test2(@Owning @MustCall("foo") Object obj) {
+    // actually needed suppression
+    @SuppressWarnings("mustcall")
+    @MustCall({}) Object bar = obj;
+  }
+
+  void test3(@Owning @MustCall("foo") Object obj) {
+    // test that the option-specific suppression key doesn't work
+    @SuppressWarnings("mustcallnocreatesmustcallfor")
+    // :: error: assignment
+    @MustCall({}) Object bar = obj;
+  }
+}


### PR DESCRIPTION
fixes #4903 