### PR TITLE
If a declared type is not a uses, then its type arguments must be type variables.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -969,12 +969,12 @@ public abstract class AnnotatedTypeMirror {
             for (AnnotatedTypeMirror typeArg : ts) {
               if (typeArg.getKind() != TypeKind.TYPEVAR) {
                 throw new BugInCF(
-                    "Type declaration must have type variables as type arguments. Found: %s.",
+                    "Type declaration must have type variables as type arguments. Found %s",
                     typeArg);
               }
               if (!typeArg.isDeclaration()) {
                 throw new BugInCF(
-                    "Type declarations must have type varaibles that are declarations. Found %s",
+                    "Type declarations must have type variables that are declarations. Found %s",
                     typeArg);
               }
             }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -965,7 +965,20 @@ public abstract class AnnotatedTypeMirror {
         typeArgs = Collections.emptyList();
       } else {
         if (isDeclaration()) {
-          // TODO: check that all args are really declarations
+          if (isDeclaration()) {
+            for (AnnotatedTypeMirror typeArg : ts) {
+              if (typeArg.getKind() != TypeKind.TYPEVAR) {
+                throw new BugInCF(
+                    "Type declaration must have type variables as type arguments. Found: %s.",
+                    typeArg);
+              }
+              if (!typeArg.isDeclaration()) {
+                throw new BugInCF(
+                    "Type declarations must have type varaibles that are declarations. Found %s",
+                    typeArg);
+              }
+            }
+          }
           typeArgs = Collections.unmodifiableList(ts);
         } else {
           List<AnnotatedTypeMirror> uses = CollectionsPlume.mapList(AnnotatedTypeMirror::asUse, ts);


### PR DESCRIPTION
This pull request checks for this.