### PR TITLE
Use getCurrentPath in BaseTypeVisitor subclasses.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -229,7 +229,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
     // involving it.
     if (atypeFactory.isDirectlyMarkedUIThroughInference(node)) {
       // Backtrack path to the lambda expression itself
-      TreePath path = visitorState.getPath();
+      TreePath path = getCurrentPath();
       while (path.getLeaf() != node) {
         assert path.getLeaf().getKind() != Tree.Kind.COMPILATION_UNIT;
         path = path.getParentPath();
@@ -448,12 +448,12 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
     // assignments involving it.
     if (atypeFactory.isDirectlyMarkedUIThroughInference(node)) {
       // Backtrack path to the new class expression itself
-      TreePath path = visitorState.getPath();
+      TreePath path = getCurrentPath();
       while (path.getLeaf() != node) {
         assert path.getLeaf().getKind() != Tree.Kind.COMPILATION_UNIT;
         path = path.getParentPath();
       }
-      scanUp(visitorState.getPath().getParentPath());
+      scanUp(getCurrentPath().getParentPath());
     }
     return v;
   }

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -173,7 +173,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
 
     // If we are visiting a pseudo-assignment, visitorLeafKind is either
     // Tree.Kind.NEW_CLASS or Tree.Kind.METHOD_INVOCATION.
-    TreePath path = visitorState.getPath();
+    TreePath path = getCurrentPath();
     if (path == null) {
       return;
     }
@@ -182,7 +182,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
     if (visitorLeafKind == Tree.Kind.NEW_CLASS || visitorLeafKind == Tree.Kind.METHOD_INVOCATION) {
       // Handling pseudo-assignments
       if (canBeLeaked(valueTree)) {
-        Tree.Kind parentKind = visitorState.getPath().getParentPath().getLeaf().getKind();
+        Tree.Kind parentKind = getCurrentPath().getParentPath().getLeaf().getKind();
 
         if (!varType.hasAnnotation(NonLeaked.class)
             && !(varType.hasAnnotation(LeakedToResult.class)


### PR DESCRIPTION
(`visitorState.getPath()` will be removed in another pull request.)