### PR TITLE
Removed `AnnotatedTypeFactory#postTypeVarSubstitution`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@ Version 3.1?.? (November 1, 2021)
 **Implementation details:**
 
 Removed `org.checkerframework.framework.type.VisitorState`
+Removed `AnnotatedTypeFactory#postTypeVarSubstitution`
 
 Deprecated methods in AnnotatedTypeFactory:
 * `getCurrentClassTree`

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1825,22 +1825,6 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
   }
 
   /**
-   * A callback method for the AnnotatedTypeFactory subtypes to customize
-   * AnnotatedTypeMirror.substitute().
-   *
-   * @param varDecl a declaration of a type variable
-   * @param varUse a use of the same type variable
-   * @param value the new type to substitute in for the type variable
-   */
-  public void postTypeVarSubstitution(
-      AnnotatedTypeVariable varDecl, AnnotatedTypeVariable varUse, AnnotatedTypeMirror value) {
-    if (!varUse.getAnnotationsField().isEmpty()
-        && !AnnotationUtils.areSame(varUse.getAnnotationsField(), varDecl.getAnnotationsField())) {
-      value.replaceAnnotations(varUse.getAnnotationsField());
-    }
-  }
-
-  /**
    * Adapt the upper bounds of the type variables of a class relative to the type instantiation. In
    * some type systems, the upper bounds depend on the instantiation of the class. For example, in
    * the Generic Universe Type system, consider a class declaration


### PR DESCRIPTION
This method was only used by the Quals Framework and should have been removed then.