### PR TITLE
Fix false positive in Resource Leak Checker related to try-with-resources

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -161,7 +161,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
    *     identical to anno
    */
   // Package private to permit usage from the visitor in the common assignment check.
-  /* package-private */ AnnotationMirror withoutClose(@Nullable AnnotationMirror anno) {
+  public AnnotationMirror withoutClose(@Nullable AnnotationMirror anno) {
     if (anno == null || AnnotationUtils.areSame(anno, BOTTOM)) {
       return BOTTOM;
     } else if (!AnnotationUtils.areSameByName(

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -160,7 +160,6 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
    * @return a MustCall annotation that does not have "close" as one of its values, but is otherwise
    *     identical to anno
    */
-  // Package private to permit usage from the visitor in the common assignment check.
   public AnnotationMirror withoutClose(@Nullable AnnotationMirror anno) {
     if (anno == null || AnnotationUtils.areSame(anno, BOTTOM)) {
       return BOTTOM;

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -999,8 +999,8 @@ class MustCallConsistencyAnalyzer {
   /**
    * Returns true if must-call type of node only contains close.
    *
-   * @param node the node
-   * @return
+   * @param node the node.
+   * @return true if must-call type of node only contains close.
    */
   boolean isJustCloseable(Node node) {
     MustCallAnnotatedTypeFactory mcAtf =

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -988,7 +988,7 @@ class MustCallConsistencyAnalyzer {
           && (typeFactory.canCreateObligations() || ElementUtils.isFinal(lhsElement))) {
         removeObligationsContainingVar(obligations, (LocalVariableNode) rhs);
       }
-    } else if (lhsElement.getKind() == ElementKind.RESOURCE_VARIABLE && isJustCloseable(rhs)) {
+    } else if (lhsElement.getKind() == ElementKind.RESOURCE_VARIABLE && isMustCallClose(rhs)) {
       removeObligationsContainingVar(obligations, (LocalVariableNode) rhs);
     } else if (lhs instanceof LocalVariableNode) {
       LocalVariableNode lhsVar = (LocalVariableNode) lhs;
@@ -997,12 +997,13 @@ class MustCallConsistencyAnalyzer {
   }
 
   /**
-   * Returns true if must-call type of node only contains close.
+   * Returns true if must-call type of node only contains close. This is a helper method for
+   * handling try-with-resources statements.
    *
    * @param node the node.
    * @return true if must-call type of node only contains close.
    */
-  boolean isJustCloseable(Node node) {
+  boolean isMustCallClose(Node node) {
     MustCallAnnotatedTypeFactory mcAtf =
         typeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
     AnnotatedTypeMirror mustCallAnnotatedType = mcAtf.getAnnotatedType(node.getTree());

--- a/checker/tests/resourceleak/BibtexCleanReport.java
+++ b/checker/tests/resourceleak/BibtexCleanReport.java
@@ -1,0 +1,25 @@
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import org.plumelib.util.EntryReader;
+import org.plumelib.util.UtilPlume;
+
+@SuppressWarnings("deprecation")
+public final class BibtexCleanReport {
+  public static void main(String[] args) {
+    for (String filename : args) {
+      File inFile = new File(filename);
+      File outFile = new File(inFile.getName()); // in current directory
+      // Delete the file to work around a bug.  Files.newBufferedWriter (which is called by
+      // UtilPlume.bufferedFileWriter) seems to have a bug where it does not correctly truncate the
+      // file first.  If the target file already exists, then characters beyond what is written
+      // remain in the file.
+      outFile.delete();
+      try (PrintWriter out = new PrintWriter(UtilPlume.bufferedFileWriter(outFile.toString()));
+          EntryReader er = new EntryReader(filename)) {
+      } catch (IOException e) {
+
+      }
+    }
+  }
+}

--- a/checker/tests/resourceleak/TryWithResourcesFP.java
+++ b/checker/tests/resourceleak/TryWithResourcesFP.java
@@ -1,3 +1,5 @@
+// Based on a false positive reported on the BibTeX project
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -5,7 +7,7 @@ import org.plumelib.util.EntryReader;
 import org.plumelib.util.UtilPlume;
 
 @SuppressWarnings("deprecation")
-public final class BibtexCleanReport {
+public final class TryWithResourcesFP {
   public static void main(String[] args) {
     for (String filename : args) {
       File inFile = new File(filename);

--- a/checker/tests/resourceleak/TryWithResourcesMultiResources.java
+++ b/checker/tests/resourceleak/TryWithResourcesMultiResources.java
@@ -1,0 +1,41 @@
+import java.io.IOException;
+import java.net.Socket;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class TryWithResourcesMultiResources {
+
+  class OuterResource implements java.io.Closeable {
+    private final @Owning Socket socket;
+
+    public @MustCallAlias OuterResource(@MustCallAlias Socket sock) throws IOException {
+      this.socket = sock;
+    }
+
+    @Override
+    @EnsuresCalledMethods(
+        value = {"this.socket"},
+        methods = {"close"})
+    public void close() throws IOException {
+      this.socket.close();
+    }
+  }
+
+  public void multiResourcesWrong(String address, int port) {
+    // :: error: required.method.not.called
+    try (OuterResource outer = new OuterResource(new Socket(address, port))) {
+
+    } catch (Exception e) {
+
+    }
+  }
+
+  public void multiResourcesCorrect(String address, int port) {
+    try (Socket s = new Socket(address, port);
+        OuterResource outer = new OuterResource(s)) {
+
+    } catch (Exception e) {
+
+    }
+  }
+}

--- a/checker/tests/resourceleak/TryWithResourcesMultiResources.java
+++ b/checker/tests/resourceleak/TryWithResourcesMultiResources.java
@@ -21,6 +21,7 @@ public class TryWithResourcesMultiResources {
     }
   }
 
+  // If "new OuterResource" throws an exception, then the socket won't be released.
   public void multiResourcesWrong(String address, int port) {
     // :: error: required.method.not.called
     try (OuterResource outer = new OuterResource(new Socket(address, port))) {


### PR DESCRIPTION
RLC reported a false positive for this [line](https://github.com/kelloggm/wpi-many-tests-bibtex-clean/blob/703c0190ab7d7436a5be6e160667f194da44fdee/src/main/java/org/plumelib/bibtex/BibtexClean.java#L60-L61). That was because assignments to resource variables are handled in Must Call Checker which doesn't have any information about resource aliases. This PR removes the set of rhs obligations if lhs is a resource variable and must call type of rhs only contains `close()` method.

Reported error:
`try (PrintWriter out = new PrintWriter(UtilPlume.bufferedFileWriter(outFile.toString()));                                                                       
The type of object is: java.io.BufferedWriter.
Reason for going out of scope: possible exceptional exit due to new EntryReader(filename) with exception type java.io.IOException`