### PR TITLE
Use the  term "selector expression".

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundTransfer.java
@@ -825,7 +825,7 @@ public class UpperBoundTransfer extends IndexAbstractTransfer {
     // TODO: This cannot be done in strengthenAnnotationOfEqualTo, because that does not provide
     // transfer input.
     List<Node> caseNodes = n.getCaseOperands();
-    AssignmentNode assign = (AssignmentNode) n.getSwitchOperand();
+    AssignmentNode assign = n.getSwitchOperand();
     Node switchNode = assign.getExpression();
     for (Node caseNode : caseNodes) {
       refineSubtrahendWithOffset(switchNode, caseNode, false, in, result.getThenStore());

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -2228,6 +2228,12 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
       extendWithNode(selectorExprAssignment);
     }
 
+    /**
+     * Build the CGF for the case tree, {@code tree}.
+     *
+     * @param tree a case tree whose CFG is built
+     * @param index the index of the case tree in {@link #caseBodyLabels}
+     */
     private void buildCase(CaseTree tree, int index) {
       final Label thisBodyL = caseBodyLabels[index];
       final Label nextBodyL = caseBodyLabels[index + 1];

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -2159,9 +2159,9 @@ public class CFGTranslationPhaseOne extends TreePathScanner<Node, Void> {
       caseBodyLabels[cases] = breakTargetL.peekLabel();
 
       // Create a synthetic variable to which the switch selector expression will be assigned
-      TypeMirror selectorExprTree = TreeUtils.typeOf(switchTree.getExpression());
+      TypeMirror selectorExprType = TreeUtils.typeOf(switchTree.getExpression());
       VariableTree selectorVarTree =
-          treeBuilder.buildVariableDecl(selectorExprTree, uniqueName("switch"), findOwner(), null);
+          treeBuilder.buildVariableDecl(selectorExprType, uniqueName("switch"), findOwner(), null);
       handleArtificialTree(selectorVarTree);
 
       VariableDeclarationNode selectorVarNode = new VariableDeclarationNode(selectorVarTree);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/CaseNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/CaseNode.java
@@ -23,8 +23,10 @@ public class CaseNode extends Node {
 
   /** The tree for this node. */
   protected final CaseTree tree;
-  /** The switch expression that contains this node. */
-  protected final Node switchExpr;
+  /**
+   * The Node for the assignment of the switch selector expression to a synthetic local variable.
+   */
+  protected final AssignmentNode selectorExprAssignment;
   /**
    * The case expressions to match the switch expression against: the operands of (possibly
    * multiple) case labels.
@@ -35,20 +37,27 @@ public class CaseNode extends Node {
    * Create a new CaseNode.
    *
    * @param tree the tree for this node
-   * @param switchExpr the switch expression
+   * @param selectorExprAssignment the switch expression
    * @param caseExprs the case expression(s) to match the switch expression against
    * @param types a factory of utility methods for operating on types
    */
-  public CaseNode(CaseTree tree, Node switchExpr, List<Node> caseExprs, Types types) {
+  public CaseNode(
+      CaseTree tree, AssignmentNode selectorExprAssignment, List<Node> caseExprs, Types types) {
     super(types.getNoType(TypeKind.NONE));
     assert tree.getKind() == Tree.Kind.CASE;
     this.tree = tree;
-    this.switchExpr = switchExpr;
+    this.selectorExprAssignment = selectorExprAssignment;
     this.caseExprs = caseExprs;
   }
 
-  public Node getSwitchOperand() {
-    return switchExpr;
+  /**
+   * The Node for the assignment of the switch selector expression to a synthetic local variable.
+   * This is used to refine the type of the switch selector expression in a case block.
+   *
+   * @return the assignment of the switch selector expression to a synthetic local variable
+   */
+  public AssignmentNode getSwitchOperand() {
+    return selectorExprAssignment;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -1131,7 +1131,7 @@ public abstract class CFAbstractTransfer<
 
     for (Node caseOperand : n.getCaseOperands()) {
       V caseValue = in.getValueOfSubNode(caseOperand);
-      AssignmentNode assign = (AssignmentNode) n.getSwitchOperand();
+      AssignmentNode assign = n.getSwitchOperand();
       V switchValue = store.getValue(JavaExpression.fromNode(assign.getTarget()));
       result =
           strengthenAnnotationOfEqualTo(


### PR DESCRIPTION
Previously, this expression was referred to as the "switch expression", but now "switch expression" are expressions that are switches.  So, use the newer term from [the JLS "selector expression"](https://docs.oracle.com/javase/specs/jls/se17/html/jls-14.html#jls-14.11).

For example:
```
switch (selectorExpression) { ... }
```

I also moved the code that builds the selector expression node(s) to its own method and added documentation.