### PR TITLE
CheckerMain: don't crash on nonexistent directories

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/CheckerMain.java
@@ -537,7 +537,11 @@ public class CheckerMain {
    */
   private List<String> jarFiles(String directory) {
     File dir = new File(directory);
-    return Arrays.asList(dir.list((d, name) -> name.endsWith(".jar") || name.endsWith(".JAR")));
+    String[] jarFiles = dir.list((d, name) -> name.endsWith(".jar") || name.endsWith(".JAR"));
+    if (jarFiles == null) {
+      return Collections.emptyList();
+    }
+    return Arrays.asList(jarFiles);
   }
 
   /** Invoke the compiler with all relevant jars on its classpath and/or bootclasspath. */


### PR DESCRIPTION
Fixes #4987