### PR TITLE
JointJavacJavaParserVisitor now handles switch expressions 

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -76,7 +76,6 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.tools.Diagnostic.Kind;
-import javax.tools.JavaFileObject;
 import org.checkerframework.checker.compilermsgs.qual.CompilerMessageKey;
 import org.checkerframework.checker.interning.qual.FindDistinct;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -360,11 +359,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     Map<Tree, com.github.javaparser.ast.Node> treePairs = new HashMap<>();
-    JavaFileObject f = root.getSourceFile();
-    if (f.toUri().getPath().contains("java17")) {
-      // Skip java17 files because they may contain switch expressions which aren't supported.
-      return;
-    }
     try (InputStream reader = root.getSourceFile().openInputStream()) {
       CompilationUnit javaParserRoot = JavaParserUtil.parseCompilationUnit(reader);
       JavaParserUtil.concatenateAddedStringLiterals(javaParserRoot);

--- a/framework/src/main/java/org/checkerframework/framework/ajava/DefaultJointVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/DefaultJointVisitor.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.modules.ModuleDeclaration;
@@ -65,6 +66,7 @@ import com.github.javaparser.ast.stmt.SynchronizedStmt;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.ast.stmt.YieldStmt;
 import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.IntersectionType;
@@ -348,6 +350,9 @@ public class DefaultJointVisitor extends JointJavacJavaParserVisitor {
   public void processSwitch(SwitchTree javacTree, SwitchStmt javaParserNode) {}
 
   @Override
+  public void processSwitchExpression(Tree javacTree, SwitchExpr javaParserNode) {}
+
+  @Override
   public void processSynchronized(SynchronizedTree javacTree, SynchronizedStmt javaParserNode) {}
 
   @Override
@@ -388,6 +393,9 @@ public class DefaultJointVisitor extends JointJavacJavaParserVisitor {
 
   @Override
   public void processWildcard(WildcardTree javacTree, WildcardType javaParserNode) {}
+
+  @Override
+  public void processYield(Tree javacTree, YieldStmt javaParserNode) {}
 
   @Override
   public void processCompoundAssignment(

--- a/framework/src/main/java/org/checkerframework/framework/ajava/ExpectedTreesVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/ExpectedTreesVisitor.java
@@ -204,6 +204,14 @@ public class ExpectedTreesVisitor extends TreeScannerWithDefaults {
   }
 
   @Override
+  public Void visitSwitchExpression17(Tree tree, Void p) {
+    super.visitSwitchExpression17(tree, p);
+    // javac surrounds switch expression in a ParenthesizedTree but JavaParser does not.
+    trees.remove(TreeUtils.switchExpressionTreeGetExpression(tree));
+    return null;
+  }
+
+  @Override
   public Void visitSynchronized(SynchronizedTree tree, Void p) {
     super.visitSynchronized(tree, p);
     // javac surrounds synchronized expressions in a ParenthesizedTree but JavaParser does not.
@@ -372,6 +380,14 @@ public class ExpectedTreesVisitor extends TreeScannerWithDefaults {
     }
 
     return super.visitVariable(tree, p);
+  }
+
+  @Override
+  public Void visitYield17(Tree tree, Void p) {
+    // JavaParser does not parse yields correctly:
+    // https://github.com/javaparser/javaparser/issues/3364
+    // So skip yields.
+    return null;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
@@ -776,9 +776,6 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
       // This occurs in a member reference like MyClass::myMember. The MyClass is wrapped in a
       // TypeExpr.
       javacTree.accept(this, ((TypeExpr) javaParserNode).getType());
-    } else if (javaParserNode instanceof VariableDeclarator) {
-      // This is a bug in yield statements.
-      processIdentifier(javacTree, ((VariableDeclarator) javaParserNode).getName());
     } else {
       throwUnexpectedNodeType(javacTree, javaParserNode);
     }

--- a/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
@@ -41,6 +41,7 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.TypeExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
@@ -74,6 +75,7 @@ import com.github.javaparser.ast.stmt.SynchronizedStmt;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.ast.stmt.YieldStmt;
 import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.IntersectionType;
@@ -140,6 +142,7 @@ import com.sun.source.tree.SwitchTree;
 import com.sun.source.tree.SynchronizedTree;
 import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TryTree;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.TypeParameterTree;
@@ -317,6 +320,7 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
       // instances. In javaParser this is one VariableDeclarationExpr with two nested
       // VariableDeclarators. Match the declarators with the VariableTrees.
       if (javaParserIter.hasNext()
+          && javacIter.peek().getKind() == Tree.Kind.VARIABLE
           && javaParserIter.peek().isExpressionStmt()
           && javaParserIter.peek().asExpressionStmt().getExpression().isVariableDeclarationExpr()) {
         for (VariableDeclarator decl :
@@ -327,7 +331,6 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
                 .asVariableDeclarationExpr()
                 .getVariables()) {
           assert javacIter.hasNext();
-          assert javacIter.peek().getKind() == Tree.Kind.VARIABLE;
           javacIter.next().accept(this, decl);
         }
 
@@ -409,8 +412,20 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
     for (int i = 0; i < treeExpressions.size(); i++) {
       treeExpressions.get(i).accept(this, labels.get(i));
     }
+    if (javacTree.getStatements() == null) {
+      Tree javacBody = TreeUtils.caseTreeGetBody(javacTree);
+      Statement nodeBody = node.getStatement(0);
+      if (javacBody.getKind() == Kind.EXPRESSION_STATEMENT) {
+        javacBody.accept(this, node.getStatement(0));
+      } else if (nodeBody.isExpressionStmt()) {
+        javacBody.accept(this, nodeBody.asExpressionStmt().getExpression());
+      } else {
+        javacBody.accept(this, nodeBody);
+      }
+    } else {
+      processStatements(javacTree.getStatements(), node.getStatements());
+    }
 
-    processStatements(javacTree.getStatements(), node.getStatements());
     return null;
   }
 
@@ -761,6 +776,9 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
       // This occurs in a member reference like MyClass::myMember. The MyClass is wrapped in a
       // TypeExpr.
       javacTree.accept(this, ((TypeExpr) javaParserNode).getType());
+    } else if (javaParserNode instanceof VariableDeclarator) {
+      // This is a bug in yield statements.
+      processIdentifier(javacTree, ((VariableDeclarator) javaParserNode).getName());
     } else {
       throwUnexpectedNodeType(javacTree, javaParserNode);
     }
@@ -1227,15 +1245,17 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
     return null;
   }
 
-  /**
-   * Visit a SwitchExpressionTree
-   *
-   * @param tree a SwitchExpressionTree, typed as Tree to be backward-compatible
-   * @param node a SwitchExpr, typed as Node to be backward-compatible
-   * @return nothing
-   */
-  public Void visitSwitchExpression17(Tree tree, Node node) {
-    // TODO
+  public Void visitSwitchExpression17(Tree javacTree, Node javaParserNode) {
+    SwitchExpr node = castNode(SwitchExpr.class, javaParserNode, javacTree);
+    processSwitchExpression(javacTree, node);
+
+    // Switch expressions are always parenthesized in javac but never in JavaParser.
+    ExpressionTree expression =
+        ((ParenthesizedTree) TreeUtils.switchExpressionTreeGetExpression(javacTree))
+            .getExpression();
+    expression.accept(this, node.getSelector());
+
+    visitLists(TreeUtils.switchExpressionTreeGetCases(javacTree), node.getEntries());
     return null;
   }
 
@@ -1452,6 +1472,16 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
    * @return nothing
    */
   public Void visitYield17(Tree tree, Node node) {
+    if (node instanceof YieldStmt) {
+      YieldStmt yieldStmt = castNode(YieldStmt.class, node, tree);
+      processYield(tree, yieldStmt);
+
+      TreeUtils.yieldTreeGetValue(tree).accept(this, yieldStmt.getExpression());
+      return null;
+    }
+    // JavaParser does not parse yields correctly:
+    // https://github.com/javaparser/javaparser/issues/3364
+    // So skip yields that aren't matched with a YieldStmt.
     return null;
   }
 
@@ -2037,6 +2067,14 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
   public abstract void processSwitch(SwitchTree javacTree, SwitchStmt javaParserNode);
 
   /**
+   * Process a {@code SwitchExpressionTree}.
+   *
+   * @param javacTree tree to process
+   * @param javaParserNode corresponding JavaParser node
+   */
+  public abstract void processSwitchExpression(Tree javacTree, SwitchExpr javaParserNode);
+
+  /**
    * Process a {@code SynchronizedTree}.
    *
    * @param javacTree tree to process
@@ -2151,6 +2189,14 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
    * @param javaParserNode corresponding JavaParser node
    */
   public abstract void processWildcard(WildcardTree javacTree, WildcardType javaParserNode);
+
+  /**
+   * Process a {@code YieldTree}.
+   *
+   * @param javacTree tree to process
+   * @param javaParserNode corresponding Javaparser node
+   */
+  public abstract void processYield(Tree javacTree, YieldStmt javaParserNode);
 
   /**
    * Process a {@code CompoundAssignmentTree}.

--- a/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/JointJavacJavaParserVisitor.java
@@ -1242,6 +1242,13 @@ public abstract class JointJavacJavaParserVisitor extends SimpleTreeVisitor<Void
     return null;
   }
 
+  /**
+   * Visit a switch expression.
+   *
+   * @param javacTree switch expression tree
+   * @param javaParserNode java parser node
+   * @return null
+   */
   public Void visitSwitchExpression17(Tree javacTree, Node javaParserNode) {
     SwitchExpr node = castNode(SwitchExpr.class, javaParserNode, javacTree);
     processSwitchExpression(javacTree, node);

--- a/framework/src/main/java/org/checkerframework/framework/ajava/JointVisitorWithDefaultAction.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/JointVisitorWithDefaultAction.java
@@ -37,6 +37,7 @@ import com.github.javaparser.ast.expr.ObjectCreationExpr;
 import com.github.javaparser.ast.expr.SimpleName;
 import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.SuperExpr;
+import com.github.javaparser.ast.expr.SwitchExpr;
 import com.github.javaparser.ast.expr.ThisExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.modules.ModuleDeclaration;
@@ -65,6 +66,7 @@ import com.github.javaparser.ast.stmt.SynchronizedStmt;
 import com.github.javaparser.ast.stmt.ThrowStmt;
 import com.github.javaparser.ast.stmt.TryStmt;
 import com.github.javaparser.ast.stmt.WhileStmt;
+import com.github.javaparser.ast.stmt.YieldStmt;
 import com.github.javaparser.ast.type.ArrayType;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.IntersectionType;
@@ -491,6 +493,11 @@ public abstract class JointVisitorWithDefaultAction extends JointJavacJavaParser
   }
 
   @Override
+  public void processSwitchExpression(Tree javacTree, SwitchExpr javaParserNode) {
+    defaultJointAction(javacTree, javaParserNode);
+  }
+
+  @Override
   public void processSynchronized(SynchronizedTree javacTree, SynchronizedStmt javaParserNode) {
     defaultJointAction(javacTree, javaParserNode);
   }
@@ -557,6 +564,11 @@ public abstract class JointVisitorWithDefaultAction extends JointJavacJavaParser
 
   @Override
   public void processWildcard(WildcardTree javacTree, WildcardType javaParserNode) {
+    defaultJointAction(javacTree, javaParserNode);
+  }
+
+  @Override
+  public void processYield(Tree javacTree, YieldStmt javaParserNode) {
     defaultJointAction(javacTree, javaParserNode);
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/ajava/TreeScannerWithDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/TreeScannerWithDefaults.java
@@ -383,6 +383,13 @@ public abstract class TreeScannerWithDefaults extends TreeScanner<Void, Void> {
     return super.visitSwitch(tree, p);
   }
 
+  /**
+   * Visit a switch expression tree.
+   *
+   * @param tree switch expression tree
+   * @param p null
+   * @return null
+   */
   public Void visitSwitchExpression17(Tree tree, Void p) {
     defaultAction(tree);
     return super.scan(tree, p);
@@ -454,6 +461,13 @@ public abstract class TreeScannerWithDefaults extends TreeScanner<Void, Void> {
     return super.visitWildcard(tree, p);
   }
 
+  /**
+   * Visit a yield tree.
+   *
+   * @param tree a yield tree
+   * @param p null
+   * @return null
+   */
   public Void visitYield17(Tree tree, Void p) {
     defaultAction(tree);
     return super.scan(tree, p);

--- a/framework/src/main/java/org/checkerframework/framework/ajava/TreeScannerWithDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/TreeScannerWithDefaults.java
@@ -76,6 +76,20 @@ public abstract class TreeScannerWithDefaults extends TreeScanner<Void, Void> {
   public abstract void defaultAction(Tree tree);
 
   @Override
+  public Void scan(Tree tree, Void unused) {
+    if (tree != null) {
+      if (tree.getKind().name().equals("SWITCH_EXPRESSION")) {
+        visitSwitchExpression17(tree, unused);
+        return null;
+      } else if (tree.getKind().name().equals("YIELD")) {
+        visitYield17(tree, unused);
+        return null;
+      }
+    }
+    return super.scan(tree, unused);
+  }
+
+  @Override
   public Void visitAnnotatedType(AnnotatedTypeTree tree, Void p) {
     defaultAction(tree);
     return super.visitAnnotatedType(tree, p);
@@ -369,6 +383,11 @@ public abstract class TreeScannerWithDefaults extends TreeScanner<Void, Void> {
     return super.visitSwitch(tree, p);
   }
 
+  public Void visitSwitchExpression17(Tree tree, Void p) {
+    defaultAction(tree);
+    return super.scan(tree, p);
+  }
+
   @Override
   public Void visitSynchronized(SynchronizedTree tree, Void p) {
     defaultAction(tree);
@@ -433,5 +452,10 @@ public abstract class TreeScannerWithDefaults extends TreeScanner<Void, Void> {
   public Void visitWildcard(WildcardTree tree, Void p) {
     defaultAction(tree);
     return super.visitWildcard(tree, p);
+  }
+
+  public Void visitYield17(Tree tree, Void p) {
+    defaultAction(tree);
+    return super.scan(tree, p);
   }
 }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1705,6 +1705,97 @@ public final class TreeUtils {
   }
 
   /**
+   * Returns the selector expression of {@code switchExpressionTree}. For example
+   *
+   * <pre>
+   *   switch ( <em>expression</em> ) { ... }
+   * </pre>
+   *
+   * @param switchExpressionTree the switch expression whose selector expression is returned
+   * @return the selector expression of {@code switchExpressionTree}
+   */
+  public static ExpressionTree switchExpressionTreeGetExpression(Tree switchExpressionTree) {
+    try {
+      Class<?> switchExpressionClass = Class.forName("com.sun.source.tree.SwitchExpressionTree");
+      Method getExpressionMethod = switchExpressionClass.getMethod("getExpression");
+      ExpressionTree expressionTree =
+          (ExpressionTree) getExpressionMethod.invoke(switchExpressionTree);
+      if (expressionTree != null) {
+        return expressionTree;
+      }
+      throw new BugInCF(
+          "TreeUtils.switchExpressionTreeGetExpression: expression is null for tree: %s",
+          switchExpressionTree);
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | InvocationTargetException
+        | IllegalAccessException e) {
+      throw new BugInCF(
+          "TreeUtils.switchExpressionTreeGetExpression: reflection failed for tree: %s",
+          switchExpressionTree, e);
+    }
+  }
+
+  /**
+   * Returns the cases of {@code switchExpressionTree}. For example
+   *
+   * <pre>
+   *   switch ( <em>expression</em> ) {
+   *     <em>cases</em>
+   *   }
+   * </pre>
+   *
+   * @param switchExpressionTree the switch expression whose cases are returned
+   * @return the cases of {@code switchExpressionTree}
+   */
+  public static List<? extends CaseTree> switchExpressionTreeGetCases(Tree switchExpressionTree) {
+    try {
+      Class<?> switchExpressionClass = Class.forName("com.sun.source.tree.SwitchExpressionTree");
+      Method getCasesMethod = switchExpressionClass.getMethod("getCases");
+      @SuppressWarnings("unchecked")
+      List<? extends CaseTree> cases =
+          (List<? extends CaseTree>) getCasesMethod.invoke(switchExpressionTree);
+      if (cases != null) {
+        return cases;
+      }
+      throw new BugInCF(
+          "TreeUtils.switchExpressionTreeGetCases: cases is null for tree: %s",
+          switchExpressionTree);
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | InvocationTargetException
+        | IllegalAccessException e) {
+      throw new BugInCF(
+          "TreeUtils.switchExpressionTreeGetCases: reflection failed for tree: %s",
+          switchExpressionTree, e);
+    }
+  }
+
+  /**
+   * Returns the value (expression) for {@code yieldTree}.
+   *
+   * @param yieldTree the yield tree
+   * @return the value (expression) for {@code yieldTree}.
+   */
+  public static ExpressionTree yieldTreeGetValue(Tree yieldTree) {
+    try {
+      Class<?> yieldTreeClass = Class.forName("com.sun.source.tree.YieldTree");
+      Method getCasesMethod = yieldTreeClass.getMethod("getValue");
+      ExpressionTree expressionTree = (ExpressionTree) getCasesMethod.invoke(yieldTree);
+      if (expressionTree != null) {
+        return expressionTree;
+      }
+      throw new BugInCF("TreeUtils.yieldTreeGetValue: expression is null for tree: %s", yieldTree);
+    } catch (ClassNotFoundException
+        | NoSuchMethodException
+        | InvocationTargetException
+        | IllegalAccessException e) {
+      throw new BugInCF(
+          "TreeUtils.yieldTreeGetValue: reflection failed for tree: %s", yieldTree, e);
+    }
+  }
+
+  /**
    * Returns true if the given method/constructor invocation is a varargs invocation.
    *
    * @param tree a method/constructor invocation


### PR DESCRIPTION
JavaParsers crashes on some yields and also parses some to objects other than YieldStmts. ( javaparser/javaparser#3364)


Fixes the last bullet point in #4977.