### PR TITLE
When releasing, make Randoop use the latest version of the Checker Framework

### DIFF
--- a/docs/developer/release/README-release-process.html
+++ b/docs/developer/release/README-release-process.html
@@ -213,6 +213,12 @@ TreeAnnotator
     If the release did not add, remove, or rename any type qualifiers, no changes are required.
     Those instructions do not work on macOS, so you may need to use buffalo to make the changes.
   </li>
+  <li> <strong>Make Randoop use the latest Checker Framework version.</strong>
+    Make a <a href="https://github.com/randoop/randoop/pulls">pull request</a> to <a href="https://github.com/randoop/randoop">Randoop</a>, changing this line In Randoop's <code>build.gradle</code> file:
+<pre>
+def checkerFrameworkVersion = "..." // Checker Framework version
+</pre>
+  </li>
 </ol>
 
   <h2 id="continuous-integration">Continuous integration tests</h2>


### PR DESCRIPTION
An alternative to this pull request is to change Randoop's `build.gradle` file so that it always uses the latest version of the Checker Framework.  Although this means that a Randoop build might suddenly start failing due to a change in the Checker Framework, I consider that acceptable.