### PR TITLE
Update expected inference output for bcel-util

### DIFF
--- a/checker/bin-devel/wpi-plumelib/bcel-util.expected
+++ b/checker/bin-devel/wpi-plumelib/bcel-util.expected
@@ -3,7 +3,7 @@ warning: No processor claimed any of these annotations: org.checkerframework.che
 #
 # This is in method fqBinaryNameToType, but there are no calls to it, so WPI didn't infer a type for its formal parameter.
 #
-src/main/java/org/plumelib/bcelutil/BcelUtil.java:779: error: [argument] incompatible argument for parameter typename of parseFqBinaryName.
+src/main/java/org/plumelib/bcelutil/BcelUtil.java:786: error: [argument] incompatible argument for parameter typename of parseFqBinaryName.
         Signatures.ClassnameAndDimensions.parseFqBinaryName(classname);
                                                             ^
   found   : @SignatureUnknown String


### PR DESCRIPTION
Required to make inference tests pass,  due to https://github.com/plume-lib/bcel-util/commit/1fefa60c329236486f74891e0b44567d622c7c7c