### PR TITLE
Make result of LambdaResultExpressionNode non-null

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -433,8 +433,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
         LambdaExpressionTree lambdaTree = ((UnderlyingAST.CFGLambda) underlyingAST).getLambdaTree();
         if (lambdaTree.getBodyKind() == LambdaExpressionTree.BodyKind.EXPRESSION) {
           Node resultNode =
-              new LambdaResultExpressionNode(
-                  (ExpressionTree) lambdaTree.getBody(), finalNode, env.getTypeUtils());
+              new LambdaResultExpressionNode((ExpressionTree) lambdaTree.getBody(), finalNode);
           extendWithNode(resultNode);
         }
       }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -10,14 +10,14 @@ import org.checkerframework.javacutil.TreeUtils;
 /** A node for the single expression body of a single expression lambda. */
 public class LambdaResultExpressionNode extends Node {
 
-  /** tree for the lambda expression body */
+  /** Tree for the lambda expression body. */
   protected final ExpressionTree tree;
 
-  /** final CFG node corresponding to the lambda expression body */
+  /** Final CFG node corresponding to the lambda expression body. */
   protected final Node result;
 
   /**
-   * Creates a LambdaResultExpressionNode
+   * Creates a LambdaResultExpressionNode.
    *
    * @param t tree for the lambda expression body
    * @param result final CFG node corresponding to the lambda expression body

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -12,9 +12,9 @@ import org.checkerframework.javacutil.TreeUtils;
 public class LambdaResultExpressionNode extends Node {
 
   protected final ExpressionTree tree;
-  protected final @Nullable Node result;
+  protected final Node result;
 
-  public LambdaResultExpressionNode(ExpressionTree t, @Nullable Node result, Types types) {
+  public LambdaResultExpressionNode(ExpressionTree t, Node result, Types types) {
     super(TreeUtils.typeOf(t));
     this.result = result;
     tree = t;
@@ -24,7 +24,7 @@ public class LambdaResultExpressionNode extends Node {
    * Returns the final node of the CFG corresponding to the lambda expression body (see {@link
    * #getTree()}).
    */
-  public @Nullable Node getResult() {
+  public Node getResult() {
     return result;
   }
 
@@ -44,10 +44,7 @@ public class LambdaResultExpressionNode extends Node {
 
   @Override
   public String toString() {
-    if (result != null) {
-      return "-> " + result;
-    }
-    return "-> ()";
+    return "-> " + result;
   }
 
   @Override
@@ -70,10 +67,6 @@ public class LambdaResultExpressionNode extends Node {
 
   @Override
   public Collection<Node> getOperands() {
-    if (result == null) {
-      return Collections.emptyList();
-    } else {
-      return Collections.singletonList(result);
-    }
+    return Collections.singletonList(result);
   }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -4,17 +4,25 @@ import com.sun.source.tree.ExpressionTree;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
-import javax.lang.model.util.Types;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.javacutil.TreeUtils;
 
 /** A node for the single expression body of a single expression lambda. */
 public class LambdaResultExpressionNode extends Node {
 
+  /** tree for the lambda expression body */
   protected final ExpressionTree tree;
+
+  /** final CFG node corresponding to the lambda expression body */
   protected final Node result;
 
-  public LambdaResultExpressionNode(ExpressionTree t, Node result, Types types) {
+  /**
+   * Creates a LambdaResultExpressionNode
+   *
+   * @param t tree for the lambda expression body
+   * @param result final CFG node corresponding to the lambda expression body
+   */
+  public LambdaResultExpressionNode(ExpressionTree t, Node result) {
     super(TreeUtils.typeOf(t));
     this.result = result;
     tree = t;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/LambdaResultExpressionNode.java
@@ -31,6 +31,8 @@ public class LambdaResultExpressionNode extends Node {
   /**
    * Returns the final node of the CFG corresponding to the lambda expression body (see {@link
    * #getTree()}).
+   *
+   * @return the final node of the CFG corresponding to the lambda expression body
    */
   public Node getResult() {
     return result;
@@ -39,6 +41,9 @@ public class LambdaResultExpressionNode extends Node {
   /**
    * Returns the {@link ExpressionTree} corresponding to the body of a lambda expression with an
    * expression body (e.g. X for ({@code o -> X}) where X is an expression and not a {...} block).
+   *
+   * @return the {@link ExpressionTree} corresponding to the body of a lambda expression with an
+   *     expression body
    */
   @Override
   public ExpressionTree getTree() {


### PR DESCRIPTION
I think this code was modeled on that in `ReturnNode`, where the result can be `null` (for a statement `return;` with no value).  But if a lambda has an expression body, it cannot be empty; so here the result should be `@NonNull`.