### PR TITLE
Disable Error Prone on JDK 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ allprojects {
                 // Error Prone must be available in the annotation processor path
                 options.annotationProcessorPath = configurations.errorprone
                 // Enable Error Prone
-                options.errorprone.enabled = true
+                options.errorprone.enabled = !isJava8
                 options.errorprone.disableWarningsInGeneratedCode = true
                 options.errorprone.errorproneArgs = [
                         // Many compiler classes are interned.
@@ -694,7 +694,7 @@ subprojects {
         //  * Temporarily comment out "-Werror" elsewhere in this file
         //  * Repeatedly run `./gradlew clean compileJava` and fix all errors
         //  * Uncomment "-Werror"
-      ext.errorproneVersion = '2.10.0'
+      ext.errorproneVersion = '2.11.0'
       errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: errorproneVersion
 
       // TODO: it's a bug that annotatedlib:guava requires the error_prone_annotations dependency.


### PR DESCRIPTION
An alternative to #5022.  If the latest version of ErrorProne starts behaving differently than version 2.10.0, we will want to just disable it.  This pull request show how to disable ErrorProne on JDK 8.