### PR TITLE
Make parameter and return node lists for initial stores non-null

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardTransferFunction.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/BackwardTransferFunction.java
@@ -1,7 +1,6 @@
 package org.checkerframework.dataflow.analysis;
 
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
 
@@ -23,11 +22,11 @@ public interface BackwardTransferFunction<V extends AbstractValue<V>, S extends 
    * Returns the initial store that should be used at the normal exit block.
    *
    * @param underlyingAST the underlying AST of the given control flow graph
-   * @param returnNodes the return nodes of the given control flow graph if the underlying AST of
-   *     this graph is a method. Otherwise will be set to {@code null}
+   * @param returnNodes the return nodes of the given control flow graph (an empty list if the
+   *     underlying AST is not a method)
    * @return the initial store that should be used at the normal exit block
    */
-  S initialNormalExitStore(UnderlyingAST underlyingAST, @Nullable List<ReturnNode> returnNodes);
+  S initialNormalExitStore(UnderlyingAST underlyingAST, List<ReturnNode> returnNodes);
 
   /**
    * Returns the initial store that should be used at the exceptional exit block or given the

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardTransferFunction.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardTransferFunction.java
@@ -1,7 +1,6 @@
 package org.checkerframework.dataflow.analysis;
 
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.UnderlyingAST;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 
@@ -20,12 +19,11 @@ public interface ForwardTransferFunction<V extends AbstractValue<V>, S extends S
     extends TransferFunction<V, S> {
 
   /**
-   * Returns the initial store to be used by the org.checkerframework.dataflow analysis. {@code
-   * parameters} is non-null if the underlying AST is a method.
+   * Returns the initial store to be used by the org.checkerframework.dataflow analysis.
    *
    * @param underlyingAST an abstract syntax tree
-   * @param parameters a list of local variable nodes
+   * @param parameters a list of local variable nodes representing formal parameters (if any)
    * @return the initial store
    */
-  S initialStore(UnderlyingAST underlyingAST, @Nullable List<LocalVariableNode> parameters);
+  S initialStore(UnderlyingAST underlyingAST, List<LocalVariableNode> parameters);
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationTransfer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationTransfer.java
@@ -1,7 +1,6 @@
 package org.checkerframework.dataflow.constantpropagation;
 
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.ConditionalTransferResult;
 import org.checkerframework.dataflow.analysis.ForwardTransferFunction;
 import org.checkerframework.dataflow.analysis.RegularTransferResult;
@@ -23,7 +22,7 @@ public class ConstantPropagationTransfer
 
   @Override
   public ConstantPropagationStore initialStore(
-      UnderlyingAST underlyingAST, @Nullable List<LocalVariableNode> parameters) {
+      UnderlyingAST underlyingAST, List<LocalVariableNode> parameters) {
     ConstantPropagationStore store = new ConstantPropagationStore();
     return store;
   }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/livevariable/LiveVarTransfer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/livevariable/LiveVarTransfer.java
@@ -1,7 +1,6 @@
 package org.checkerframework.dataflow.livevariable;
 
 import java.util.List;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.BackwardTransferFunction;
 import org.checkerframework.dataflow.analysis.RegularTransferResult;
 import org.checkerframework.dataflow.analysis.TransferInput;
@@ -23,7 +22,7 @@ public class LiveVarTransfer
 
   @Override
   public LiveVarStore initialNormalExitStore(
-      UnderlyingAST underlyingAST, @Nullable List<ReturnNode> returnNodes) {
+      UnderlyingAST underlyingAST, List<ReturnNode> returnNodes) {
     return new LiveVarStore();
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -216,7 +216,7 @@ public abstract class CFAbstractTransfer<
 
   /** The initial store maps method formal parameters to their currently most refined type. */
   @Override
-  public S initialStore(UnderlyingAST underlyingAST, @Nullable List<LocalVariableNode> parameters) {
+  public S initialStore(UnderlyingAST underlyingAST, List<LocalVariableNode> parameters) {
     if (underlyingAST.getKind() != UnderlyingAST.Kind.LAMBDA
         && underlyingAST.getKind() != UnderlyingAST.Kind.METHOD) {
       if (fixedInitialStore != null) {


### PR DESCRIPTION
The dataflow code always initializes these lists with a non-null value; in cases where there are no parameters or return nodes (like a CFG for a field initializer), an empty list is used.  Declaring the corresponding parameters as `@NonNull` lets interface implementors avoid unnecessary null checks.