### PR TITLE
Capture bounds of intersection types in `asMemberOf`

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -448,8 +448,17 @@ public class AnnotatedTypes {
             memberType);
       case INTERSECTION:
         AnnotatedTypeMirror result = memberType;
+        TypeMirror enclosingElementType = member.getEnclosingElement().asType();
         for (AnnotatedTypeMirror bound : ((AnnotatedIntersectionType) receiverType).getBounds()) {
-          result = substituteTypeVariables(types, atypeFactory, bound, member, result);
+          if (TypesUtils.isErasedSubtype(bound.getUnderlyingType(), enclosingElementType, types)) {
+            result =
+                substituteTypeVariables(
+                    types,
+                    atypeFactory,
+                    atypeFactory.applyCaptureConversion(bound),
+                    member,
+                    result);
+          }
         }
         return result;
       case UNION:


### PR DESCRIPTION
With out this change code crashes in my type inference branch. I couldn't reproduce on master because that bounds that cause a crash only arise during type inference.