### PR TITLE
Widening from an integral type to an integral type

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -199,20 +199,7 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
       result.add(UNSIGNED);
       return result;
     }
-    AnnotationMirror anno = annos.iterator().next();
-    if (AnnotationUtils.areSame(anno, POLY_SIGNED)) {
-      return annos;
-    } else if (getQualifierHierarchy().isSubtype(anno, UNSIGNED)) {
-      // TODO: A future enhancement will make the widened type indicate the unsigned basetype
-      // from which it was widened.
-      result.add(SIGNED_POSITIVE_FROM_UNSIGNED);
-      return result;
-    } else {
-      // TODO: A future enhancement will make the widened type indicate the signed basetype
-      // from which it was widened.
-      result.add(SIGNEDNESS_GLB);
-      return result;
-    }
+    return annos;
   }
 
   @Override


### PR DESCRIPTION
should not change the annotation.

From the [JLS](https://docs.oracle.com/javase/specs/jls/se17/html/jls-5.html#jls-5.1.2)

> A widening conversion of a signed integer value to an integral type T simply sign-extends the two's-complement representation of the integer value to fill the wider format.

```
@Unsigned short s = -2;
@Signed int i = s; // this should be an error.
```

@mernst  is this the right or am I misunderstanding something?