### PR TITLE
add support to WPI for enum constants with class bodies

### DIFF
--- a/checker/tests/ainfer-testchecker/non-annotated/CrazyEnum.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/CrazyEnum.java
@@ -1,0 +1,20 @@
+@SuppressWarnings("all") // Check for crashes.
+public class CrazyEnum {
+  private enum MyEnum {
+    ENUM_CONST1 {
+      private final String s = method();
+
+      private String method() {
+        return "hello";
+      }
+    },
+
+    ENUM_CONST2 {
+      private final String s = this.method();
+
+      private String method() {
+        return "hello";
+      }
+    }
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -494,6 +494,15 @@ public class WholeProgramInferenceJavaParserStorage
             ClassOrInterfaceAnnos enclosingClass = classToAnnos.get(enclosingClassName);
             String fieldName = javacTree.getName().toString();
             enclosingClass.enumConstants.add(fieldName);
+
+            // Ensure that if an enum constant defines a class, that class gets registered properly.
+            // See e.g. https://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.9.1 for
+            // the specification of an enum constant, which does permit it to define an anonymous
+            // class.
+            NewClassTree constructor = (NewClassTree) javacTree.getInitializer();
+            if (constructor.getClassBody() != null) {
+              addClass(constructor.getClassBody());
+            }
           }
 
           @Override


### PR DESCRIPTION
the test case `CrazyEnums.java` is copied from the all-systems tests. There are still other crashes elsewhere in the all-systems tests; if we manage to fix all of those, we can consider removing `CrazyEnums.java` from this test suite (should I add a TODO item?)