### PR TITLE
Optimize LocalVariable#hashCode/equals

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -7,7 +7,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.ElementUtils;
-import org.checkerframework.javacutil.TypeAnnotationUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -64,9 +63,7 @@ public class LocalVariable extends JavaExpression {
     // different between subcheckers.  The owner of a lambda parameter is the enclosing
     // method, so a local variable and a lambda parameter might have the same name and the
     // same owner.  pos is used to differentiate this case.
-    return vs1.pos == vs2.pos
-        && vs1.name.contentEquals(vs2.name)
-        && vs1.owner.toString().equals(vs2.owner.toString());
+    return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);
   }
 
   /**
@@ -81,10 +78,7 @@ public class LocalVariable extends JavaExpression {
   @Override
   public int hashCode() {
     VarSymbol vs = (VarSymbol) element;
-    return Objects.hash(
-        vs.name.toString(),
-        TypeAnnotationUtils.unannotatedType(vs.type).toString(),
-        vs.owner.toString());
+    return Objects.hash(vs.pos, vs.name, vs.owner);
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -56,7 +56,7 @@ public class LocalVariable extends JavaExpression {
    * @return true if the two elements are the same
    */
   protected static boolean sameElement(Element element1, Element element2) {
-    return element1.equals(element2);
+    return vs1.equals(vs2);
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -59,10 +59,8 @@ public class LocalVariable extends JavaExpression {
   protected static boolean sameElement(Element element1, Element element2) {
     VarSymbol vs1 = (VarSymbol) element1;
     VarSymbol vs2 = (VarSymbol) element2;
-    // The code below isn't just return vs1.equals(vs2) because an element might be
-    // different between subcheckers.  The owner of a lambda parameter is the enclosing
-    // method, so a local variable and a lambda parameter might have the same name and the
-    // same owner.  pos is used to differentiate this case.
+    // The owner of a lambda parameter is the enclosing method, so a local variable and a lambda
+    // parameter might have the same name and the same owner. Use pos to differentiate this case.
     return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);
   }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -60,8 +60,7 @@ public class LocalVariable extends JavaExpression {
     VarSymbol vs1 = (VarSymbol) element1;
     VarSymbol vs2 = (VarSymbol) element2;
     // If a LocalVariable is created via JavaExpressionParseUtil#parse, then `vs1.equals(vs2)` will
-    // not return true when the LocalVariables even if the elements represent the same local
-    // variable.
+    // not return true even if the elements represent the same local variable.
     // The owner of a lambda parameter is the enclosing method, so a local variable and a lambda
     // parameter might have the same name and the same owner. Use pos to differentiate this case.
     return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -59,6 +59,9 @@ public class LocalVariable extends JavaExpression {
   protected static boolean sameElement(Element element1, Element element2) {
     VarSymbol vs1 = (VarSymbol) element1;
     VarSymbol vs2 = (VarSymbol) element2;
+    // If a LocalVariable is created via JavaExpressionParseUtil#parse, then `vs1.equals(vs2)` will
+    // not return true when the LocalVariables even if the elements represent the same local
+    // variable.
     // The owner of a lambda parameter is the enclosing method, so a local variable and a lambda
     // parameter might have the same name and the same owner. Use pos to differentiate this case.
     return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -70,7 +70,7 @@ public class LocalVariable extends JavaExpression {
 
   @Override
   public int hashCode() {
-    return vs.hashCode();
+    return element.hashCode();
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -70,7 +70,7 @@ public class LocalVariable extends JavaExpression {
 
   @Override
   public int hashCode() {
-    return element.hashCode();
+    return vs.hashCode();
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -1,6 +1,7 @@
 package org.checkerframework.dataflow.expression;
 
 import com.sun.tools.javac.code.Symbol.VarSymbol;
+import java.util.Objects;
 import javax.lang.model.element.Element;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
@@ -56,7 +57,11 @@ public class LocalVariable extends JavaExpression {
    * @return true if the two elements are the same
    */
   protected static boolean sameElement(Element element1, Element element2) {
-    return vs1.equals(vs2);
+    VarSymbol vs1 = (VarSymbol) element1;
+    VarSymbol vs2 = (VarSymbol) element2;
+    // The owner of a lambda parameter is the enclosing method, so a local variable and a lambda
+    // parameter might have the same name and the same owner. Use pos to differentiate this case.
+    return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);
   }
 
   /**
@@ -70,7 +75,8 @@ public class LocalVariable extends JavaExpression {
 
   @Override
   public int hashCode() {
-    return vs.hashCode();
+    VarSymbol vs = (VarSymbol) element;
+    return Objects.hash(vs.pos, vs.name, vs.owner);
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -56,7 +56,7 @@ public class LocalVariable extends JavaExpression {
    * @return true if the two elements are the same
    */
   protected static boolean sameElement(Element element1, Element element2) {
-    return vs1.equals(vs2);
+    return element1.equals(element2);
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/LocalVariable.java
@@ -1,7 +1,6 @@
 package org.checkerframework.dataflow.expression;
 
 import com.sun.tools.javac.code.Symbol.VarSymbol;
-import java.util.Objects;
 import javax.lang.model.element.Element;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
@@ -57,11 +56,7 @@ public class LocalVariable extends JavaExpression {
    * @return true if the two elements are the same
    */
   protected static boolean sameElement(Element element1, Element element2) {
-    VarSymbol vs1 = (VarSymbol) element1;
-    VarSymbol vs2 = (VarSymbol) element2;
-    // The owner of a lambda parameter is the enclosing method, so a local variable and a lambda
-    // parameter might have the same name and the same owner. Use pos to differentiate this case.
-    return vs1.pos == vs2.pos && vs1.name == vs2.name && vs1.owner.equals(vs2.owner);
+    return vs1.equals(vs2);
   }
 
   /**
@@ -75,8 +70,7 @@ public class LocalVariable extends JavaExpression {
 
   @Override
   public int hashCode() {
-    VarSymbol vs = (VarSymbol) element;
-    return Objects.hash(vs.pos, vs.name, vs.owner);
+    return vs.hashCode();
   }
 
   @Override


### PR DESCRIPTION
**Summary**:
I've been profiling my checker that uses Dataflow, and
LocalVariable.hashCode came out **very hot** both on CPU and memory
allocation profiles.

`equals/hashCode` methods build a bunch of strings which is very 
expensive when you e.g. put your LocalVariables into a HashMap.

The new implementation of equals compares `Name name` and `Symbol owner`
using their intrinsic equality. Which should be fine with Names since
these are all interned. I'm not 100% sure about Symbols but it looks
like those are also properly unique.

The implementation of hashCode now follows that of equal. Note that I
dropped `TypeAnnotationUtils.unannotatedType(vs.type)` from `hashCode`
as it seems to be redundant and produces a new type that may be
structurally equivalent but not referentially equal to some existing
type.

**Test plan:**
1. CF's `./gradlew test` passes with the new implementation. 
2. Our internal checker tests also pass. 
3. Moreover, there were basically no difference in checker
    reports when ran against our internal code before and after the change
    which is a good indicator that the change is safe to do.