### PR TITLE
Fix varargs-related IndexOutOfBoundsException during WPI

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -517,10 +517,14 @@ task ainferTestCheckerGenerateJaifs(type: Test) {
     doLast {
         copyNonannotatedToAnnotatedDirectory("ainfer-testchecker")
 
-        // JAIF-based WPI fails these tests, which was added for stub-based WPI.
+        // JAIF-based WPI fails these tests, which were added for stub-based WPI.
         // See issue here: https://github.com/typetools/checker-framework/issues/3009
         delete('tests/ainfer-testchecker/annotated/ConflictingAnnotationsTest.java')
         delete('tests/ainfer-testchecker/annotated/MultiDimensionalArrays.java')
+        // The AFU's annotator.Main produces a non-compilable source file when JAIF-based WPI
+        // is run on this test, so it is also excluded. The test works for stub- and ajava-based
+        // WPI.
+        delete('tests/ainfer-testchecker/annotated/AnonymousAndInnerClass.java')
 
         // Inserting annotations from .jaif files in-place.
         String jaifsDir = "tests/ainfer-testchecker/inference-output";

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -521,10 +521,6 @@ task ainferTestCheckerGenerateJaifs(type: Test) {
         // See issue here: https://github.com/typetools/checker-framework/issues/3009
         delete('tests/ainfer-testchecker/annotated/ConflictingAnnotationsTest.java')
         delete('tests/ainfer-testchecker/annotated/MultiDimensionalArrays.java')
-        // The AFU's annotator.Main produces a non-compilable source file when JAIF-based WPI
-        // is run on this test, so it is also excluded. The test works for stub- and ajava-based
-        // WPI.
-        delete('tests/ainfer-testchecker/annotated/AnonymousAndInnerClass.java')
 
         // Inserting annotations from .jaif files in-place.
         String jaifsDir = "tests/ainfer-testchecker/inference-output";

--- a/checker/tests/ainfer-testchecker/non-annotated/AnonymousAndInnerClass.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/AnonymousAndInnerClass.java
@@ -1,0 +1,41 @@
+// This test is copied from the all-systems tests, and can be removed from the
+// AinferTestChecker test suite once the all-systems tests pass.
+// For WPI, this test is actually useful for testing that varargs are handled properly.
+
+public class AnonymousAndInnerClass {
+  class MyInnerClass {
+    public MyInnerClass() {}
+
+    public MyInnerClass(String s) {}
+
+    public MyInnerClass(int... i) {}
+  }
+
+  static class MyClass {
+    public MyClass() {}
+
+    public MyClass(String s) {}
+
+    public MyClass(int... i) {}
+  }
+
+  void test(AnonymousAndInnerClass outer, String tainted) {
+    new MyClass() {};
+    new MyClass(tainted) {};
+    new MyClass(1, 2, 3) {};
+    new MyClass(1) {};
+    new MyInnerClass() {};
+    new MyInnerClass(tainted) {};
+    new MyInnerClass(1) {};
+    new MyInnerClass(1, 2, 3) {};
+    this.new MyInnerClass() {};
+    this.new MyInnerClass(tainted) {};
+    this.new MyInnerClass(1) {};
+    this.new MyInnerClass(1, 2, 3) {};
+    outer.new MyInnerClass() {};
+    outer.new MyInnerClass(tainted) {};
+    outer.new MyInnerClass(tainted) {};
+    outer.new MyInnerClass(1) {};
+    outer.new MyInnerClass(1, 2, 3) {};
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -214,6 +214,14 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
 
       VariableElement ve;
       boolean varargsParam = i >= methodElt.getParameters().size() - 1 && methodElt.isVarArgs();
+      if (varargsParam && this.atypeFactory.wpiOutputFormat == OutputFormat.JAIF) {
+        // The AFU's annotator.Main produces a non-compilable source file when JAIF-based WPI
+        // tries to output an annotated varargs parameter, such as when running the test
+        // checker/tests/ainfer-testchecker/non-annotated/AnonymousAndInnerClass.java.
+        // Until that bug is fixed, do not attempt to infer information about varargs parameters
+        // in JAIF mode.
+        return;
+      }
       if (varargsParam) {
         ve = methodElt.getParameters().get(methodElt.getParameters().size() - 1);
       } else {

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -207,11 +207,8 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       Tree argTree = arg.getTree();
 
       VariableElement ve;
-      boolean varargsParam = i >= methodElt.getParameters().size();
-      // If the access would be out-of-bounds, that means that the executable element must
-      // be a varargs method.
+      boolean varargsParam = i >= methodElt.getParameters().size() - 1 && methodElt.isVarArgs();
       if (varargsParam) {
-        assert methodElt.isVarArgs();
         ve = methodElt.getParameters().get(methodElt.getParameters().size() - 1);
       } else {
         ve = methodElt.getParameters().get(i);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -136,6 +136,11 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       return;
     }
 
+    // Don't infer types for code that can't be annotated anyway.
+    if (!storage.hasStorageLocationForMethod(constructorElt)) {
+      return;
+    }
+
     List<Node> arguments = objectCreationNode.getArguments();
     updateInferredExecutableParameterTypes(constructorElt, arguments);
     updateContracts(Analysis.BeforeOrAfter.BEFORE, constructorElt, store);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -47,6 +47,7 @@ import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
+import scenelib.annotations.util.JVMNames;
 
 /**
  * This is the primary implementation of {@link
@@ -151,6 +152,12 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
 
     // Don't infer types for code that can't be annotated anyway.
     if (!storage.hasStorageLocationForMethod(constructorElt)) {
+      if (showWpiFailedInferences) {
+        printFailedInferenceDebugMessage(
+            "WPI could not store information"
+                + "about this constructor: "
+                + JVMNames.getJVMMethodSignature(constructorElt));
+      }
       return;
     }
 
@@ -233,6 +240,13 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
         // checker/tests/ainfer-testchecker/non-annotated/AnonymousAndInnerClass.java.
         // Until that bug is fixed, do not attempt to infer information about varargs parameters
         // in JAIF mode.
+        if (showWpiFailedInferences) {
+          printFailedInferenceDebugMessage(
+              "Annotations cannot be placed on varargs parametersin -Ainfer=jaifs mode, because the"
+                  + " JAIF format does not correctly support it.\n"
+                  + "The signature of the method whose varargs parameter was not annotated is: "
+                  + JVMNames.getJVMMethodSignature(methodElt));
+        }
         return;
       }
       if (varargsParam) {

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -205,8 +205,20 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       Node arg = arguments.get(i);
       Tree argTree = arg.getTree();
 
-      VariableElement ve = methodElt.getParameters().get(i);
+      VariableElement ve;
+      boolean varargsParam = i >= methodElt.getParameters().size();
+      // If the access would be out-of-bounds, that means that the executable element must
+      // be a varargs method.
+      if (varargsParam) {
+        assert methodElt.isVarArgs();
+        ve = methodElt.getParameters().get(methodElt.getParameters().size() - 1);
+      } else {
+        ve = methodElt.getParameters().get(i);
+      }
       AnnotatedTypeMirror paramATM = atypeFactory.getAnnotatedType(ve);
+      if (varargsParam) {
+        paramATM = ((AnnotatedArrayType) paramATM).getComponentType();
+      }
       AnnotatedTypeMirror argATM = atypeFactory.getAnnotatedType(argTree);
       atypeFactory.wpiAdjustForUpdateNonField(argATM);
       T paramAnnotations =

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -45,6 +45,7 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
+import org.checkerframework.javacutil.TypesUtils;
 
 /**
  * This is the primary implementation of {@link
@@ -216,10 +217,18 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
         ve = methodElt.getParameters().get(i);
       }
       AnnotatedTypeMirror paramATM = atypeFactory.getAnnotatedType(ve);
-      if (varargsParam) {
-        paramATM = ((AnnotatedArrayType) paramATM).getComponentType();
-      }
       AnnotatedTypeMirror argATM = atypeFactory.getAnnotatedType(argTree);
+      if (varargsParam) {
+        // argATM needs to be turned into an array type, so that the type structure
+        // matches paramATM.
+        AnnotatedTypeMirror argArray =
+            AnnotatedTypeMirror.createType(
+                TypesUtils.createArrayType(argATM.getUnderlyingType(), atypeFactory.types),
+                atypeFactory,
+                false);
+        ((AnnotatedArrayType) argArray).setComponentType(argATM);
+        argATM = argArray;
+      }
       atypeFactory.wpiAdjustForUpdateNonField(argATM);
       T paramAnnotations =
           storage.getParameterAnnotations(methodElt, i, paramATM, ve, atypeFactory);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -243,8 +243,12 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
         }
       }
       atypeFactory.wpiAdjustForUpdateNonField(argATM);
+      // If storage.getParameterAnnotations receives an index that's larger than the size
+      // of the parameter list, scenes-backed inference can create duplicate entries
+      // for the varargs parameter (it indexes inferred annotations by the parameter number).
+      int paramIndex = varargsParam ? methodElt.getParameters().size() - 1 : i;
       T paramAnnotations =
-          storage.getParameterAnnotations(methodElt, i, paramATM, ve, atypeFactory);
+          storage.getParameterAnnotations(methodElt, paramIndex, paramATM, ve, atypeFactory);
       updateAnnotationSet(paramAnnotations, TypeUseLocation.PARAMETER, argATM, paramATM, file);
     }
   }

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -876,33 +876,15 @@ public class WholeProgramInferenceJavaParserStorage
 
       if (index >= parameterTypes.size()) {
         // Handle varargs
-        AnnotatedTypeMirror varargsType = parameterTypes.get(parameterTypes.size() - 1);
-        if (varargsType == null) {
-          varargsType =
-              AnnotatedTypeMirror.createType(
-                  TypesUtils.createArrayType(type.getUnderlyingType(), atf.types), atf, false);
-          parameterTypes.set(parameterTypes.size() - 1, varargsType);
-        } else if (varargsType.getKind() != TypeKind.ARRAY) {
-          // This is a kludge, because there isn't enough information at this point to determine for
-          // sure whether the last "in-range" parameter was an array or the first varargs
-          // element. If it was the first varargs element, then varargsType might not be an
-          // array, so create an array type that wraps varargsType instead, and insert it
-          // back into parameterTypes.
-          AnnotatedTypeMirror componentType = varargsType;
-          varargsType =
-              AnnotatedTypeMirror.createType(
-                  TypesUtils.createArrayType(type.getUnderlyingType(), atf.types), atf, false);
-          ((AnnotatedArrayType) varargsType).setComponentType(componentType);
-          parameterTypes.set(parameterTypes.size() - 1, varargsType);
-        }
-        return varargsType;
-      } else {
-        if (parameterTypes.get(index) == null) {
-          parameterTypes.set(
-              index, AnnotatedTypeMirror.createType(type.getUnderlyingType(), atf, false));
-        }
-        return parameterTypes.get(index);
+        index = parameterTypes.size() - 1;
       }
+
+      if (parameterTypes.get(index) == null) {
+        parameterTypes.set(
+            index, AnnotatedTypeMirror.createType(type.getUnderlyingType(), atf, false));
+      }
+      return parameterTypes.get(index);
+
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -332,9 +332,7 @@ public class WholeProgramInferenceJavaParserStorage
       }
     }
 
-    // Must check both new and current in case a varargs entry was mistakenly not
-    // an array the first time it is updated.
-    if (newATM.getKind() == TypeKind.ARRAY && curATM.getKind() == TypeKind.ARRAY) {
+    if (newATM.getKind() == TypeKind.ARRAY) {
       AnnotatedArrayType newAAT = (AnnotatedArrayType) newATM;
       AnnotatedArrayType oldAAT = (AnnotatedArrayType) curATM;
       AnnotatedArrayType aatToUpdate = (AnnotatedArrayType) typeToUpdate;
@@ -882,6 +880,7 @@ public class WholeProgramInferenceJavaParserStorage
         parameterTypes.set(
             index, AnnotatedTypeMirror.createType(type.getUnderlyingType(), atf, false));
       }
+
       return parameterTypes.get(index);
     }
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -65,7 +65,6 @@ import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.Pair;
 import org.checkerframework.javacutil.TreeUtils;
-import org.checkerframework.javacutil.TypesUtils;
 import scenelib.annotations.util.JVMNames;
 
 /**
@@ -884,7 +883,6 @@ public class WholeProgramInferenceJavaParserStorage
             index, AnnotatedTypeMirror.createType(type.getUnderlyingType(), atf, false));
       }
       return parameterTypes.get(index);
-
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -871,11 +871,6 @@ public class WholeProgramInferenceJavaParserStorage
             new ArrayList<>(Collections.nCopies(declaration.getParameters().size(), null));
       }
 
-      if (index >= parameterTypes.size()) {
-        // Handle varargs
-        index = parameterTypes.size() - 1;
-      }
-
       if (parameterTypes.get(index) == null) {
         parameterTypes.set(
             index, AnnotatedTypeMirror.createType(type.getUnderlyingType(), atf, false));

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -514,7 +514,7 @@ public class WholeProgramInferenceScenesStorage
         return;
       }
     }
-    updateTypeElementFromATM(type, 1, defLoc, rhsATM, lhsATM, ignoreIfAnnotated);
+    updateTypeElementFromATM(type, defLoc, rhsATM, lhsATM, ignoreIfAnnotated);
     modifiedScenes.add(jaifPath);
   }
 
@@ -722,7 +722,7 @@ public class WholeProgramInferenceScenesStorage
       ATypeElement typeToUpdate,
       TypeUseLocation defLoc,
       boolean ignoreIfAnnotated) {
-    updateTypeElementFromATM(typeToUpdate, 1, defLoc, newATM, curATM, ignoreIfAnnotated);
+    updateTypeElementFromATM(typeToUpdate, defLoc, newATM, curATM, ignoreIfAnnotated);
   }
 
   ///
@@ -804,7 +804,6 @@ public class WholeProgramInferenceScenesStorage
    * is not a problem to remove all annotations before inserting the new annotations.
    *
    * @param typeToUpdate the ATypeElement that will be updated
-   * @param idx used to write annotations on compound types of an ATypeElement
    * @param defLoc the location where the annotation will be added
    * @param newATM the AnnotatedTypeMirror whose annotations will be added to the ATypeElement
    * @param curATM used to check if the element which will be updated has explicit annotations in
@@ -814,22 +813,17 @@ public class WholeProgramInferenceScenesStorage
    */
   private void updateTypeElementFromATM(
       ATypeElement typeToUpdate,
-      int idx,
       TypeUseLocation defLoc,
       AnnotatedTypeMirror newATM,
       AnnotatedTypeMirror curATM,
       boolean ignoreIfAnnotated) {
     // Clears only the annotations that are supported by the relevant AnnotatedTypeFactory.
     // The others stay intact.
-    if (idx == 1) {
-      // This if avoids clearing the annotations multiple times in cases
-      // of type variables and compound types.
-      Set<Annotation> annosToRemove = getSupportedAnnosInSet(typeToUpdate.tlAnnotationsHere);
-      // This method may be called consecutive times for the same ATypeElement.  Each time it is
-      // called, the AnnotatedTypeMirror has a better type estimate for the ATypeElement. Therefore,
-      // it is not a problem to remove all annotations before inserting the new annotations.
-      typeToUpdate.tlAnnotationsHere.removeAll(annosToRemove);
-    }
+    Set<Annotation> annosToRemove = getSupportedAnnosInSet(typeToUpdate.tlAnnotationsHere);
+    // This method may be called consecutive times for the same ATypeElement.  Each time it is
+    // called, the AnnotatedTypeMirror has a better type estimate for the ATypeElement. Therefore,
+    // it is not a problem to remove all annotations before inserting the new annotations.
+    typeToUpdate.tlAnnotationsHere.removeAll(annosToRemove);
 
     // Only update the ATypeElement if there are no explicit annotations.
     if (curATM.getExplicitAnnotations().isEmpty() || !ignoreIfAnnotated) {
@@ -859,8 +853,7 @@ public class WholeProgramInferenceScenesStorage
       AnnotatedArrayType oldAAT = (AnnotatedArrayType) curATM;
       updateTypeElementFromATM(
           typeToUpdate.innerTypes.getVivify(
-              TypePathEntry.getTypePathEntryListFromBinary(Collections.nCopies(2 * idx, 0))),
-          idx + 1,
+              TypePathEntry.getTypePathEntryListFromBinary(Collections.nCopies(2, 0))),
           defLoc,
           newAAT.getComponentType(),
           oldAAT.getComponentType(),


### PR DESCRIPTION
This problem was discovered by running stub-based WPI on the all-systems tests. There are a few remaining issues there other than this one, but they all seem pretty minor, and all seem to be related to purity. (They seem especially minor compared to the problems we encountered when we tried the same thing with ajava-based WPI.)