### PR TITLE
WPI: do not crash when a lambda parameter is re-assinged

### DIFF
--- a/checker/tests/ainfer-testchecker/non-annotated/LambdaParamCrash.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/LambdaParamCrash.java
@@ -1,0 +1,25 @@
+// A test case that caused an assertion to be violated when inferring something
+// about e1, the parameter of the lambda. This test case is based on a crash
+// encountered in the wild.
+
+import java.io.IOException;
+import java.util.function.BiConsumer;
+
+@SuppressWarnings("all") // only checking for crashes
+public class LambdaParamCrash {
+
+  void groupAndSend() {
+    addListener(
+        (r, e1) -> {
+          if (e1 == null) {
+            e1 = badResponse();
+          }
+        });
+  }
+
+  private IOException badResponse() {
+    return new IOException();
+  }
+
+  public static <T> void addListener(BiConsumer<? super T, ? super Throwable> action) {}
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -411,11 +411,19 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
 
     ExecutableElement methodElt = (ExecutableElement) paramElt.getEnclosingElement();
 
+    int i = methodElt.getParameters().indexOf(paramElt);
+    if (i == -1) {
+      // When paramElt is the parameter of a lambda contained in another
+      // method body, the enclosing element is the outer method body
+      // rather than the lambda itself (which has no element). WPI
+      // does not support inferring types for lambda parameters, so
+      // ignore it.
+      return;
+    }
+
     AnnotatedTypeMirror paramATM = atypeFactory.getAnnotatedType(paramElt);
     AnnotatedTypeMirror argATM = atypeFactory.getAnnotatedType(rhsTree);
     atypeFactory.wpiAdjustForUpdateNonField(argATM);
-    int i = methodElt.getParameters().indexOf(paramElt);
-    assert i != -1;
     T paramAnnotations =
         storage.getParameterAnnotations(methodElt, i, paramATM, paramElt, atypeFactory);
     String file = storage.getFileForElement(methodElt);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -419,6 +419,13 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       // An ArrayCreationNode with a null tree is created when the
       // parameter is a variable-length list. We are ignoring it for now.
       // See Issue 682: https://github.com/typetools/checker-framework/issues/682
+      if (showWpiFailedInferences) {
+        printFailedInferenceDebugMessage(
+            "Could not update from formal parameter "
+                + "assignment, because an ArrayCreationNode with a null tree is created when "
+                + "the parameter is a variable-length list.\nParameter: "
+                + paramElt);
+      }
       return;
     }
 
@@ -431,6 +438,13 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       // rather than the lambda itself (which has no element). WPI
       // does not support inferring types for lambda parameters, so
       // ignore it.
+      if (showWpiFailedInferences) {
+        printFailedInferenceDebugMessage(
+            "Could not update from formal "
+                + "parameter assignment inside a lambda expression, because lambda parameters "
+                + "cannot be annotated.\nParameter: "
+                + paramElt);
+      }
       return;
     }
 


### PR DESCRIPTION
Based on a crash encountered by @Nargeshdb. The previous logic was too stringent: there is not a guarantee that the existence of a formal parameter Element implies the existence of an enclosing ExecutableElement for which that Element is a parameter, because lambda expressions are not represented by Elements, but their parameters are.