### PR TITLE
Widen a char to an int or long should be `@SignedPositiveFromUnsigned`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -199,6 +199,11 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
       result.add(UNSIGNED);
       return result;
     }
+    if ((widenedTypeKind == TypeKind.INT || widenedTypeKind == TypeKind.LONG)
+        && typeKind == TypeKind.CHAR) {
+      result.add(SIGNED_POSITIVE_FROM_UNSIGNED);
+      return result;
+    }
     return annos;
   }
 

--- a/checker/tests/signedness/AdditionWithChar.java
+++ b/checker/tests/signedness/AdditionWithChar.java
@@ -2,7 +2,6 @@ public class AdditionWithChar {
   int i2;
 
   void additionWithChar(int i1, char c) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i2 = i1 + c;
   }
 }

--- a/checker/tests/signedness/CharCastedToInt.java
+++ b/checker/tests/signedness/CharCastedToInt.java
@@ -1,8 +1,6 @@
 public class CharCastedToInt {
   int charCastToInt(char c) {
-    // :: error: (argument)
     intParameter((int) c);
-    // :: error: (return)
     return (int) c;
   }
 

--- a/checker/tests/signedness/CharComparisons.java
+++ b/checker/tests/signedness/CharComparisons.java
@@ -5,25 +5,25 @@ public class CharComparisons {
   @Unsigned byte b;
 
   void unsignedComparison(char c, @Unsigned byte b) {
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     boolean res = c > b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = c >= b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = c < b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = c <= b;
     res = c == b;
   }
 
   void unsignedComparisonFields() {
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     boolean res = this.c > this.b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = this.c >= this.b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = this.c < this.b;
-    // :: error: (comparison.unsignedlhs)
+    // :: error: (comparison.unsignedrhs)
     res = this.c <= this.b;
     res = this.c == this.b;
   }

--- a/checker/tests/signedness/CompareChars.java
+++ b/checker/tests/signedness/CompareChars.java
@@ -4,13 +4,9 @@
 public class CompareChars {
   void compareUnsignedChars(char c2) {
     char c1 = 'a';
-    // :: error: (comparison.unsignedrhs)
     boolean res = c1 > c2;
-    // :: error: (comparison.unsignedrhs)
     res = c1 >= c2;
-    // :: error: (comparison.unsignedrhs)
     res = c1 < c2;
-    // :: error: (comparison.unsignedrhs)
     res = c1 <= c2;
   }
 }

--- a/checker/tests/signedness/CompoundAssignmentsSignedness2.java
+++ b/checker/tests/signedness/CompoundAssignmentsSignedness2.java
@@ -2,77 +2,62 @@
 
 public class CompoundAssignmentsSignedness2 {
   void additionWithCompoundAssignment(char c, int i1) {
-    // :: error: (compound.assignment) :: error: (compound.assignment.mixed.unsigned.expression)
     i1 += c;
   }
 
   void additionWithoutCompoundAssignment1(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = (int) (i1 + c);
   }
 
   void additionWithoutCompoundAssignment2(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = i1 + c;
   }
 
   void subtractionWithCompoundAssignment(char c, int i1) {
-    // :: error: (compound.assignment) :: error: (compound.assignment.mixed.unsigned.expression)
     i1 -= c;
   }
 
   void subtractionWithoutCompoundAssignment1(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = (int) (i1 - c);
   }
 
   void subtractionWithoutCompoundAssignment2(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = i1 - c;
   }
 
   void multiplicationWithCompoundAssignment(char c, int i1) {
-    // :: error: (compound.assignment) :: error: (compound.assignment.mixed.unsigned.expression)
     i1 *= c;
   }
 
   void multiplicationWithoutCompoundAssignment1(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = (int) (i1 * c);
   }
 
   void multiplicationWithoutCompoundAssignment2(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     i1 = i1 * c;
   }
 
   void divisionWithCompoundAssignment(char c, int i1) {
-    // :: error: (compound.assignment) :: error: (compound.assignment.unsigned.expression)
     i1 /= c;
   }
 
   void divisionWithoutCompoundAssignment1(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.unsignedrhs)
     i1 = (int) (i1 / c);
   }
 
   void divisionWithoutCompoundAssignment2(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.unsignedrhs)
     i1 = i1 / c;
   }
 
   void modulusWithCompoundAssignment(char c, int i1) {
-    // :: error: (compound.assignment) :: error: (compound.assignment.unsigned.expression)
     i1 %= c;
   }
 
   void modulusWithoutCompoundAssignment1(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.unsignedrhs)
     i1 = (int) (i1 % c);
   }
 
   void modulusWithoutCompoundAssignment2(char c, int i1) {
-    // :: error: (assignment) :: error: (operation.unsignedrhs)
     i1 = i1 % c;
   }
 }

--- a/checker/tests/signedness/Issue3710.java
+++ b/checker/tests/signedness/Issue3710.java
@@ -3,23 +3,19 @@
 public class Issue3710 {
   int returnIntWithLocalVariable(char c) {
     int i = c;
-    // :: error: (return)
     return i;
   }
 
   long returnLongWithLocalVariable(char c) {
     long l = c;
-    // :: error: (return)
     return l;
   }
 
   int returnIntWithoutLocalVariable(char c) {
-    // :: error: (return)
     return c;
   }
 
   long returnLongWithoutLocalVariable(char c) {
-    // :: error: (return)
     return c;
   }
 }

--- a/checker/tests/signedness/SignednessAssignments.java
+++ b/checker/tests/signedness/SignednessAssignments.java
@@ -78,9 +78,7 @@ public class SignednessAssignments {
     // :: error: (assignment)
     @SignedPositive int i4 = uB;
 
-    // :: error: (assignment)
     @SignedPositive int i6 = uc;
-    // :: error: (assignment)
     @SignedPositive int i8 = uC;
 
     // :: error: (assignment)
@@ -113,9 +111,7 @@ public class SignednessAssignments {
     // :: error: (assignment)
     @SignedPositive long i4 = uB;
 
-    // :: error: (assignment)
     @SignedPositive long i6 = uc;
-    // :: error: (assignment)
     @SignedPositive long i8 = uC;
 
     // :: error: (assignment)

--- a/checker/tests/signedness/WideningConversion.java
+++ b/checker/tests/signedness/WideningConversion.java
@@ -16,11 +16,8 @@ public class WideningConversion {
 
   void compare() {
     boolean b;
-    // :: error: (comparison.unsignedlhs)
     b = c1 > c2;
-    // :: error: (comparison.unsignedlhs)
     b = c1 > i2;
-    // :: error: (comparison.unsignedrhs)
     b = i1 > c2;
     b = i1 > i2;
   }
@@ -28,23 +25,16 @@ public class WideningConversion {
   void plus() {
     // Not just "int si" because it's defaulted to TOP so every assignment would work.
     @Signed int si;
-    // :: error: (assignment)
     si = c1 + c2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedlhs)
     si = c1 + i2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     si = i1 + c2;
     si = i1 + i2;
 
-    // :: error: (assignment)
     si = c1 + c2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedlhs)
     si = c1 + si2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
     si = si1 + c2;
     si = si1 + si2;
 
-    // :: error: (assignment)
     si = c1 + c2;
     // :: error: (assignment)
     si = c1 + ui2;
@@ -55,17 +45,17 @@ public class WideningConversion {
 
     @Unsigned int ui;
     ui = c1 + c2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedlhs)
+    // :: error: (assignment)
     ui = c1 + i2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
+    // :: error: (assignment)
     ui = i1 + c2;
     // :: error: (assignment)
     ui = i1 + i2;
 
     ui = c1 + c2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedlhs)
+    // :: error: (assignment)
     ui = c1 + si2;
-    // :: error: (assignment) :: error: (operation.mixed.unsignedrhs)
+    // :: error: (assignment)
     ui = si1 + c2;
     // :: error: (assignment)
     ui = si1 + si2;
@@ -84,17 +74,17 @@ public class WideningConversion {
 
     char c;
     c = (char) (c1 + c2);
-    // :: warning: (cast.unsafe) :: error: (operation.mixed.unsignedlhs)
+    // :: warning: (cast.unsafe)
     c = (char) (c1 + i2);
-    // :: warning: (cast.unsafe) :: error: (operation.mixed.unsignedrhs)
+    // :: warning: (cast.unsafe)
     c = (char) (i1 + c2);
     // :: warning: (cast.unsafe)
     c = (char) (i1 + i2);
 
     c = (char) (c1 + c2);
-    // :: warning: (cast.unsafe) :: error: (operation.mixed.unsignedlhs)
+    // :: warning: (cast.unsafe)
     c = (char) (c1 + si2);
-    // :: warning: (cast.unsafe) :: error: (operation.mixed.unsignedrhs)
+    // :: warning: (cast.unsafe)
     c = (char) (si1 + c2);
     // :: warning: (cast.unsafe)
     c = (char) (si1 + si2);

--- a/checker/tests/signedness/WideningInitialization.java
+++ b/checker/tests/signedness/WideningInitialization.java
@@ -4,38 +4,31 @@ public class WideningInitialization {
   public int findLineNr(int pc, char startPC, char lineNr) {
     int ln = 0;
     for (int i = 0; i < 3; i++) {
-      // :: error: (comparison.unsignedlhs)
       if (startPC <= pc) {
         ln = lineNr;
       } else {
-        // :: error: (return)
         return ln;
       }
     }
-    // :: error: (return)
     return ln;
   }
 
   public int findLineNr2(char lineNr) {
     int ln = 0;
     ln = lineNr;
-    // :: error: (return)
     return ln;
   }
 
   public void findLineNr3a(char lineNr) {
-    // :: error: (assignment)
     @Signed int ln = lineNr;
   }
 
   public int findLineNr3b(char lineNr) {
     int ln = lineNr;
-    // :: error: (return)
     return ln;
   }
 
   public int findLineNr4(char lineNr) {
-    // :: error: (return)
     return lineNr;
   }
 }


### PR DESCRIPTION
From the [JLS](https://docs.oracle.com/javase/specs/jls/se17/html/jls-5.html#jls-5.1.2)

> A widening conversion of a char to an integral type T zero-extends the representation of the char value to fill the wider format.

```
@Unsigned char s = ...;
@Signed int i = s; // this should be legal
```

(This reverts part of the changes from https://github.com/typetools/checker-framework/pull/5048.)