### PR TITLE
Correct when to use the "pre-conversion" node's value.

### DIFF
--- a/checker/tests/interning/InternUnbox.java
+++ b/checker/tests/interning/InternUnbox.java
@@ -1,0 +1,12 @@
+public class InternUnbox {
+  void method() {
+    Boolean leftBoolean = getBooleanValue();
+    createBooleanCFValue(!leftBoolean);
+  }
+
+  private void createBooleanCFValue(boolean b) {}
+
+  private Boolean getBooleanValue() {
+    return Boolean.FALSE;
+  }
+}

--- a/checker/tests/signedness/Desugar.java
+++ b/checker/tests/signedness/Desugar.java
@@ -1,0 +1,31 @@
+import java.util.Map;
+import org.checkerframework.checker.signedness.qual.PolySigned;
+import org.checkerframework.checker.signedness.qual.Signed;
+
+public class Desugar {
+
+  void test(int x) {
+    int i = getI();
+    Integer box = i;
+    @Signed Integer boxy = box;
+    @Signed Integer box2 = method(box);
+  }
+
+  @PolySigned Integer method(@PolySigned Integer i) {
+    return i;
+  }
+
+  @Signed int getI() {
+    return 0;
+  }
+
+  void test2(Map<Integer, String> nonceMap, String nextInvo) {
+    int invoNonce = calcNonce(nextInvo);
+    Integer key = invoNonce;
+    String enterInvo = nonceMap.get(key);
+  }
+
+  private @Signed int calcNonce(String invocation) {
+    return 0;
+  }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -256,6 +256,9 @@ public abstract class AbstractAnalysis<
     if (cfg == null) {
       return null;
     }
+    if (isRunning) {
+      return cfg.getTreeLookup().get(t);
+    }
     return cfg.getNodesCorrespondingToTree(t);
   }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -261,7 +261,7 @@ public abstract class AbstractAnalysis<
 
   @Override
   public @Nullable V getValue(Tree t) {
-    // we don't have a org.checkerframework.dataflow fact about the current node yet
+    // Dataflow is analyzing the tree, so no value is available.
     if (t == currentTree) {
       return null;
     }
@@ -272,11 +272,11 @@ public abstract class AbstractAnalysis<
     return result;
   }
 
-  private @Nullable V getValueHelper(Set<Node> nodesCorrespondingToTree) {
-
+  private @Nullable V getValueHelper(@Nullable Set<Node> nodesCorrespondingToTree) {
     if (nodesCorrespondingToTree == null) {
       return null;
     }
+
     V merged = null;
     for (Node aNode : nodesCorrespondingToTree) {
       if (aNode.isLValue()) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -256,9 +256,6 @@ public abstract class AbstractAnalysis<
     if (cfg == null) {
       return null;
     }
-    if (isRunning) {
-      return cfg.getTreeLookup().get(t);
-    }
     return cfg.getNodesCorrespondingToTree(t);
   }
 
@@ -268,7 +265,15 @@ public abstract class AbstractAnalysis<
     if (t == currentTree) {
       return null;
     }
-    Set<Node> nodesCorrespondingToTree = getNodesForTree(t);
+    V result = getValueHelper(getNodesForTree(t));
+    if (result == null) {
+      result = getValueHelper(cfg.getTreeLookup().get(t));
+    }
+    return result;
+  }
+
+  private @Nullable V getValueHelper(Set<Node> nodesCorrespondingToTree) {
+
     if (nodesCorrespondingToTree == null) {
       return null;
     }
@@ -284,6 +289,7 @@ public abstract class AbstractAnalysis<
         merged = merged.leastUpperBound(v);
       }
     }
+
     return merged;
   }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -262,23 +262,29 @@ public abstract class AbstractAnalysis<
   @Override
   public @Nullable V getValue(Tree t) {
     // Dataflow is analyzing the tree, so no value is available.
-    if (t == currentTree) {
+    if (t == currentTree || cfg == null) {
       return null;
     }
-    V result = getValueHelper(getNodesForTree(t));
+    V result = getValue(getNodesForTree(t));
     if (result == null) {
-      result = getValueHelper(cfg.getTreeLookup().get(t));
+      result = getValue(cfg.getTreeLookup().get(t));
     }
     return result;
   }
 
-  private @Nullable V getValueHelper(@Nullable Set<Node> nodesCorrespondingToTree) {
-    if (nodesCorrespondingToTree == null) {
+  /**
+   * Returns the least upper bound of the values of {@code nodes}.
+   *
+   * @param nodes a set of nodes
+   * @return the least upper bound of the values of {@code nodes}
+   */
+  private @Nullable V getValue(@Nullable Set<Node> nodes) {
+    if (nodes == null) {
       return null;
     }
 
     V merged = null;
-    for (Node aNode : nodesCorrespondingToTree) {
+    for (Node aNode : nodes) {
       if (aNode.isLValue()) {
         return null;
       }

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1689,7 +1689,8 @@ public abstract class GenericAnnotatedTypeFactory<
     return varargtype;
   }
 
-  /* Returns the type of a right-hand side of an assignment for unary operation like prefix or
+  /**
+   * Returns the type of a right-hand side of an assignment for unary operation like prefix or
    * postfix increment or decrement.
    *
    * @param tree unary operation tree for compound assignment


### PR DESCRIPTION
When getting the type of a tree, if dataflow does not have a value for the "post-conversion" (aka "desugared") node corresponding to the tree, use the node corresponding to the tree itself.