### PR TITLE
Signedness Checker: non-number, non-char casts are @Signed

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
@@ -282,6 +282,7 @@ public class SignednessVisitor extends BaseTypeVisitor<SignednessAnnotatedTypeFa
   @Override
   protected boolean isTypeCastSafe(AnnotatedTypeMirror castType, AnnotatedTypeMirror exprType) {
     if (atypeFactory.isNotNumberOrChar(castType)) {
+      // If the cast is not a number or a char, then it is legal.
       return true;
     }
     return super.isTypeCastSafe(castType, exprType);

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
@@ -280,6 +280,14 @@ public class SignednessVisitor extends BaseTypeVisitor<SignednessAnnotatedTypeFa
   }
 
   @Override
+  protected boolean isTypeCastSafe(AnnotatedTypeMirror castType, AnnotatedTypeMirror exprType) {
+    if (atypeFactory.isNotNumberOrChar(castType)) {
+      return true;
+    }
+    return super.isTypeCastSafe(castType, exprType);
+  }
+
+  @Override
   protected Set<? extends AnnotationMirror> getExceptionParameterLowerBoundAnnotations() {
     return Collections.singleton(atypeFactory.SIGNED);
   }

--- a/checker/tests/signedness/SignednessNumberCasts.java
+++ b/checker/tests/signedness/SignednessNumberCasts.java
@@ -1,0 +1,18 @@
+import org.checkerframework.checker.signedness.qual.Signed;
+
+public class SignednessNumberCasts {
+  Double d2;
+
+  void test(MyClass<?> o, MyClass<? extends Number> signed) {
+    @Signed SignednessNumberCasts j = (SignednessNumberCasts) o.get();
+    // :: error: (assignment)
+    @Signed int i = (Integer) o.get();
+    @Signed int i2 = (Integer) signed.get();
+    Double d = (Double) o.get();
+    d2 = (Double) signed.get();
+  }
+
+  static interface MyClass<T> {
+    T get();
+  }
+}


### PR DESCRIPTION
In the Signedness Checker, casts to non-number, non-char types are defaulted to `@Signed`, if the type of the expression is not `@Unsigned`.