### PR TITLE
Use a different work around for a captured type variable javac bug.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -5055,11 +5055,22 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
             typeVarToAnnotatedTypeArg, typeVariable.getUpperBound());
     AnnotatedTypeMirror upperBound =
         AnnotatedTypes.annotatedGLB(this, typeVarUpperBound, wildcard.getExtendsBound());
-    // There is a bug in javac such that the upper bound of the captured type variable is not the
-    // greatest lower bound. So the captureTypeVar.getUnderlyingType().getUpperBound() may not
-    // be the same type as upperbound.getUnderlyingType().  See
-    // framework/tests/all-systems/Issue4890Interfaces.java,
-    // framework/tests/all-systems/Issue4890.java and framework/tests/all-systems/Issue4877.java.
+    if (upperBound.getKind() == TypeKind.INTERSECTION
+        && capturedTypeVar.getUpperBound().getKind() != TypeKind.INTERSECTION) {
+      // There is a bug in javac such that the upper bound of the captured type variable is not the
+      // greatest lower bound. So the captureTypeVar.getUnderlyingType().getUpperBound() may not
+      // be the same type as upperbound.getUnderlyingType().  See
+      // framework/tests/all-systems/Issue4890Interfaces.java,
+      // framework/tests/all-systems/Issue4890.java and framework/tests/all-systems/Issue4877.java.
+      // (I think this is  https://bugs.openjdk.java.net/browse/JDK-8039222.)
+      for (AnnotatedTypeMirror bound : ((AnnotatedIntersectionType) upperBound).getBounds()) {
+        if (types.isSameType(
+            bound.underlyingType, capturedTypeVar.getUpperBound().getUnderlyingType())) {
+          upperBound = bound;
+        }
+      }
+    }
+
     capturedTypeVar.setUpperBound(upperBound);
 
     // typeVariable's lower bound is a NullType, so there's nothing to substitute.

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -1069,7 +1069,20 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
         return false;
       }
     }
-    return isSubtypeCaching(subtypeUpperBound, supertype);
+    try {
+      return isSubtypeCaching(subtypeUpperBound, supertype);
+    } catch (BugInCF e) {
+      if (TypesUtils.isCapturedTypeVariable(subtype.underlyingType)) {
+        // The upper bound of captured type variable may be computed incorrectly by javac. javac
+        // computes the upper bound as a declared type, when it should be an intersection type.
+        // (This is a bug in the GLB algorithm; see
+        // https://bugs.openjdk.java.net/browse/JDK-8039222)
+        // In this case, the upperbound is not a subtype of `supertype` and the Checker Framework
+        // crashes. So catch that crash and just return false.
+        return false;
+      }
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
This fixes a crash in my java8inference branch where the Checker Framework has a different type than javac.