### PR TITLE
When no information about a field is in the store, use top when deciding whether a precondition is met

### DIFF
--- a/checker/tests/nullness/PreconditionFieldNotInStore.java
+++ b/checker/tests/nullness/PreconditionFieldNotInStore.java
@@ -1,0 +1,25 @@
+// This test checks that a precondition can use the declared type
+// of a field when it isn't in the store. Based on a false positive
+// encountered in BCELUtil while testing WPI.
+
+import java.io.PrintStream;
+
+class PreconditionFieldNotInStore {
+
+  private @org.checkerframework.checker.nullness.qual.MonotonicNonNull String filename;
+
+  @org.checkerframework.framework.qual.RequiresQualifier(
+      expression = {"this.filename"},
+      qualifier = org.checkerframework.checker.nullness.qual.Nullable.class)
+  @org.checkerframework.checker.nullness.qual.NonNull String getIndentString() {
+    return "indentString";
+  }
+
+  public void logStackTrace(PrintStream logfile, int[] ste_arr) {
+    for (int ii = 2; ii < ste_arr.length; ii++) {
+      int ste = ste_arr[ii];
+      logfile.printf("%s  %s%n", getIndentString(), ste);
+    }
+    logfile.flush();
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1821,11 +1821,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         Set<AnnotationMirror> annos = value.getAnnotations();
         inferredAnno = hierarchy.findAnnotationInSameHierarchy(annos, anno);
       } else if (exprJe instanceof FieldAccess) {
-        // A field may not be in the store, in which case its declared type
-        // should be used, instead.
-        AnnotatedTypeMirror declType =
-            atypeFactory.getAnnotatedType(((FieldAccess) exprJe).getField());
-        inferredAnno = declType.getAnnotationInHierarchy(anno);
+        // If a field is not in the store (possible if no refinement
+        // of the field has occurred), use top instead of automatically
+        // issuing a warning.
+        inferredAnno = atypeFactory.getQualifierHierarchy().getTopAnnotation(anno);
       }
       if (!checkContract(exprJe, anno, inferredAnno, store)) {
         if (exprJe != null) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -85,6 +85,7 @@ import org.checkerframework.dataflow.analysis.TransferResult;
 import org.checkerframework.dataflow.cfg.node.BooleanLiteralNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
+import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.JavaExpressionScanner;
 import org.checkerframework.dataflow.expression.LocalVariable;
@@ -1819,6 +1820,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         QualifierHierarchy hierarchy = atypeFactory.getQualifierHierarchy();
         Set<AnnotationMirror> annos = value.getAnnotations();
         inferredAnno = hierarchy.findAnnotationInSameHierarchy(annos, anno);
+      } else if (exprJe instanceof FieldAccess) {
+        // A field may not be in the store, in which case its declared type
+        // should be used, instead.
+        AnnotatedTypeMirror declType =
+            atypeFactory.getAnnotatedType(((FieldAccess) exprJe).getField());
+        inferredAnno = declType.getAnnotationInHierarchy(anno);
       }
       if (!checkContract(exprJe, anno, inferredAnno, store)) {
         if (exprJe != null) {


### PR DESCRIPTION
I encountered this problem when running WPI on BCELUtil (hence the new test case), but it appears to be general: when no information is available in the store about a field at a method's call site, an error is issued about a violated precondition if such a precondition exists for that field. This doesn't make sense - the store doesn't always track all fields, so I think the declared type should be used instead when there is no information in the store.

This change causes a Nullness Checker test to fail (and possibly others - I haven't run anything but the Nullness tests). I'd like to get a discussion going around that test and what the expected behavior is, because IMO the current expected warnings don't match the documentation of `@RequiresNonNull`. In particular, the failure is:
```
    2 expected diagnostics were not found:
    Issue1096.java:37: error: (contracts.precondition)
    Issue1096.java:53: error: (contracts.precondition)
```

Issue #1096 is about non-null fields of fully-initialized objects. These failures, though, are in places where the object is specifically known **not** to be fully-initialized, like this one:
```
  void foo(@UnknownInitialization PreCond this) {
    // The receiver is not fully initialized, so raise an error.
    // :: error: (contracts.precondition)
    early();
  }
```
(This is the error above on line 37.) I agree that there ought to be an error from the Nullness Checker here in the abstract sense - this code is obviously unsafe with respect to nullness, because `early` has a pre-condition requiring one of the fields of `PreCond` to be non-null, and the receiver in this example is not fully-initialized. In particular, the definition of `early()` says:
```
  @RequiresNonNull("this.f")
  void early(@UnknownInitialization PreCond this) {
    f.toString();
  }
```

However, this conflicts with the documentation of `@RequiresNonNull` and `@NonNull`, which say (1) that `@RequiresNonNull` means that the target expression must `@NonNull`, and (2) that "for fields of a class, the `@NonNull` annotation indicates that this field is never `null` *after the class has been fully initialized*." (emphasis original)

I think that in the general case, using the declared type of a field when checking a method precondition is the right thing to do. However, it seems to me that in the specific case of the Nullness Checker, checking the precondition also requires checking the initialization status of the object. @smillst @mernst what do you all think about this situation? What is the desired behavior?