### PR TITLE
Performance Issue

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -989,7 +989,8 @@ public abstract class CFAbstractTransfer<
    * @return whether to perform whole-program inference on the tree
    */
   private boolean shouldPerformWholeProgramInference(Tree tree) {
-    return infer && (tree == null || !analysis.checker.shouldSuppressWarnings(tree, ""));
+    @Nullable TreePath path = this.analysis.atypeFactory.getPath(tree);
+    return infer && (tree == null || !analysis.checker.shouldSuppressWarnings(path, ""));
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2023,9 +2023,6 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
           "Checker must provide a SuppressWarnings prefix."
               + " SourceChecker#getSuppressWarningsPrefixes was not overridden correctly.");
     }
-    if (shouldSuppress(getSuppressWarningsStringsFromOption(), errKey)) {
-      return true;
-    }
 
     if (shouldSuppress(getSuppressWarningsStringsFromOption(), errKey)) {
       // If the error key matches a warning string in the -AsuppressWarnings, then suppress
@@ -2035,6 +2032,25 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
 
     // trees.getPath might be slow, but this is only used in error reporting
     @Nullable TreePath path = trees.getPath(this.currentRoot, tree);
+
+    return shouldSuppressWarnings(path, errKey);
+  }
+
+  /**
+   * Determines whether all the warnings pertaining to a given tree path should be suppressed.
+   * Returns true if the path is within the scope of a @SuppressWarnings annotation, one of whose
+   * values suppresses all the checker's warnings.
+   *
+   * @param path the TreePath that might be a source of, or related to, a warning
+   * @param errKey the error key the checker is emitting
+   * @return true if no warning should be emitted for the given path because it is contained by a
+   *     declaration with an appropriately-valued {@code @SuppressWarnings} annotation; false
+   *     otherwise
+   */
+  public boolean shouldSuppressWarnings(@Nullable TreePath path, String errKey) {
+    if (path == null) {
+      return false;
+    }
 
     @Nullable VariableTree var = TreePathUtil.enclosingVariable(path);
     if (var != null && shouldSuppressWarnings(TreeUtils.elementFromTree(var), errKey)) {


### PR DESCRIPTION
This PR addresses a performance issue in WPI. This PR replaced the expensive call `trees.getPath` with `atypeFactory.getPath` for checking whether whole-program inference should be performed or not for each tree.