### PR TITLE
Improve performance of TransferResult.getRegularStore

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -28,6 +28,9 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
   /** The 'else' result store. */
   protected final S elseStore;
 
+  /** The regular result store. */
+  protected final S store;
+
   /**
    * Create a new {@link #ConditionalTransferResult(AbstractValue, Store, Store, Map, boolean)},
    * using {@code null} for {@link #exceptionalStores}.
@@ -113,12 +116,13 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
     this.thenStore = thenStore;
     this.elseStore = elseStore;
     this.storeChanged = storeChanged;
+    this.store = thenStore.leastUpperBound(elseStore);
   }
 
   /** The regular result store. */
   @Override
   public S getRegularStore() {
-    return thenStore.leastUpperBound(elseStore);
+    return store;
   }
 
   @Override


### PR DESCRIPTION
The call to TransferResult.getRegularStore() for conditional blocks was expensive because it computed the least upper bound of else and then store for each call. This PR should fix this performance issue. 