### PR TITLE
Cache the result of TypeFactory.getStoreAfter() in MustCallConsistencyAnalyzer

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -148,10 +148,16 @@ class MustCallConsistencyAnalyzer {
    */
   private final ResourceLeakAnnotatedTypeFactory typeFactory;
 
-  /** This map keeps the result of ResourceLeakAnnotatedTypeFactory.getStoreAfter() for each node */
+  /**
+   * A cache for the result of calling {@code ResourceLeakAnnotatedTypeFactory.getStoreAfter()} on a
+   * node. The cache prevents repeatedly computing least upper bounds on stores
+   */
   private Map<Node, CFStore> cmStoreAfter = new LinkedHashMap<>();
 
-  /** This map keeps the result of MustCallAnnotatedTypeFactory.getStoreAfter() for each node */
+  /**
+   * A cache for the result of calling {@code MustCallAnnotatedTypeFactory.getStoreAfter()} on a
+   * node. The cache prevents repeatedly computing least upper bounds on stores
+   */
   private Map<Node, CFStore> mcStoreAfter = new LinkedHashMap<>();
 
   /** The Resource Leak Checker, used to issue errors. */


### PR DESCRIPTION
This PR cache the store after each node in MustCallConsistencyAnalyzer. 