### PR TITLE
During WPI, always include all true purity annotations in WPI output, even if that annotation is already known to be true

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaTest.java
@@ -26,6 +26,7 @@ public class AinferTestCheckerAjavaTest extends CheckerFrameworkPerDirectoryTest
         "ainfer-testchecker/non-annotated",
         "-Anomsgtext",
         "-Ainfer=ajava",
+        "-Aajava=tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.ajava",
         "-Awarns");
   }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerJaifsTest.java
@@ -24,6 +24,11 @@ public class AinferTestCheckerJaifsTest extends CheckerFrameworkPerDirectoryTest
         "ainfer-testchecker/non-annotated",
         "-Anomsgtext",
         "-Ainfer=jaifs",
+        // Use a stub file here, even though this is a JAIF test. This test can't pass without an
+        // external file that specifies that a method is pure, and there is no way to directly pass
+        // a JAIF file (in a real WPI run, the JAIF file's annotations would have been inserted into
+        // the source).
+        "-Astubs=tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.astub",
         "-Awarns");
   }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerStubsTest.java
@@ -26,6 +26,7 @@ public class AinferTestCheckerStubsTest extends CheckerFrameworkPerDirectoryTest
         "ainfer-testchecker/non-annotated",
         "-Anomsgtext",
         "-Ainfer=stubs",
+        "-Astubs=tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.astub",
         "-Awarns");
   }
 

--- a/checker/tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.ajava
+++ b/checker/tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.ajava
@@ -1,0 +1,35 @@
+// This test checks that purity annotations are emitted, as expected,
+// when an astub/ajava/jaif file with existing purity annotations is
+// supplied.
+
+import org.checkerframework.checker.testchecker.ainfer.qual.Sibling1;
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+
+@org.checkerframework.framework.qual.AnnotatedFor("org.checkerframework.checker.testchecker.ainfer.AinferTestChecker")
+public class ExistingPurityAnnotations {
+
+    Object obj;
+
+    @org.checkerframework.dataflow.qual.Pure
+    public Object pureMethod (Object object) {
+        return null;
+    }
+
+    @SuppressWarnings("ainfertest")
+    @EnsuresQualifierIf(expression="#1", result=true, qualifier=Sibling1.class)
+    public boolean checkSibling1(Object obj1) {
+        return true;
+    }
+
+    public @Sibling1 Object usePureMethod() {
+
+        if (checkSibling1(obj)) {
+            // If pureMethod doesn't have (and can't infer) an @Pure annotation, this call should
+            // unrefine the type of obj, and an error will be issued when
+            // we try to return obj on the next line.
+            pureMethod(obj);
+            return obj;
+        }
+        return null;
+    }
+}

--- a/checker/tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.astub
+++ b/checker/tests/ainfer-testchecker/input-annotation-files/ExistingPurityAnnotations-org.checkerframework.checker.testchecker.ainfer.AinferTestChecker.astub
@@ -1,0 +1,14 @@
+import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.checker.testchecker.ainfer.qual.Sibling1;
+import org.checkerframework.checker.testchecker.ainfer.qual.DefaultType;
+import org.checkerframework.framework.qual.AnnotatedFor;
+
+@AnnotatedFor("org.checkerframework.checker.testchecker.ainfer.AinferTestChecker")
+class ExistingPurityAnnotations {
+
+  // methods:
+
+  @Pure
+  java.lang.Object pureMethod(@Sibling1 java.lang.Object object);
+
+}

--- a/checker/tests/ainfer-testchecker/input-annotation-files/README.md
+++ b/checker/tests/ainfer-testchecker/input-annotation-files/README.md
@@ -1,0 +1,3 @@
+This directory contains annotations files to use as input to WPI while running
+the -Ainfer test checker tests. All .ajava, .astub, and .jaif files in this directory will
+be passed to the checker, as appropriate.

--- a/checker/tests/ainfer-testchecker/input-annotation-files/README.md
+++ b/checker/tests/ainfer-testchecker/input-annotation-files/README.md
@@ -1,3 +1,3 @@
 This directory contains annotations files to use as input to WPI while running
-the -Ainfer test checker tests. All .ajava, .astub, and .jaif files in this directory will
-be passed to the checker, as appropriate.
+the -Ainfer test checker tests. You must modify the relevant test to pass an annotation
+file: files in this directory are not passed automatically.

--- a/checker/tests/ainfer-testchecker/non-annotated/ExistingPurityAnnotations.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/ExistingPurityAnnotations.java
@@ -9,12 +9,12 @@ public class ExistingPurityAnnotations {
 
   Object obj;
 
-  public Object pureMethod (Object object) {
+  public Object pureMethod(Object object) {
     return null;
   }
 
   @SuppressWarnings("ainfertest")
-  @EnsuresQualifierIf(expression="#1", result=true, qualifier=Sibling1.class)
+  @EnsuresQualifierIf(expression = "#1", result = true, qualifier = Sibling1.class)
   public boolean checkSibling1(Object obj1) {
     return true;
   }

--- a/checker/tests/ainfer-testchecker/non-annotated/ExistingPurityAnnotations.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/ExistingPurityAnnotations.java
@@ -1,0 +1,33 @@
+// This test checks that purity annotations are emitted, as expected,
+// when an astub/ajava/jaif file with existing purity annotations is
+// supplied.
+
+import org.checkerframework.checker.testchecker.ainfer.qual.Sibling1;
+import org.checkerframework.framework.qual.EnsuresQualifierIf;
+
+public class ExistingPurityAnnotations {
+
+  Object obj;
+
+  public Object pureMethod (Object object) {
+    return null;
+  }
+
+  @SuppressWarnings("ainfertest")
+  @EnsuresQualifierIf(expression="#1", result=true, qualifier=Sibling1.class)
+  public boolean checkSibling1(Object obj1) {
+    return true;
+  }
+
+  public @Sibling1 Object usePureMethod() {
+
+    if (checkSibling1(obj)) {
+      // If pureMethod doesn't have (and can't infer) an @Pure annotation, this call should
+      // unrefine the type of obj, and an error will be issued when
+      // we try to return obj on the next line.
+      pureMethod(obj);
+      return obj;
+    }
+    return null;
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1007,7 +1007,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     if (suggestPureMethods && !TreeUtils.isSynthetic(node)) {
       // Issue a warning if the method is pure, but not annotated as such.
       EnumSet<Pure.Kind> additionalKinds = r.getKinds().clone();
-      additionalKinds.removeAll(kinds);
+      if (!(infer && inferPurity)) {
+        // During WPI, propagate all purity kinds, even those that are already
+        // present (because they were inferred in a previous WPI round).
+        additionalKinds.removeAll(kinds);
+      }
       if (TreeUtils.isConstructor(node)) {
         additionalKinds.remove(Pure.Kind.DETERMINISTIC);
       }


### PR DESCRIPTION
I expect that merging this PR will fix the currently-failing master CI build, which is caused by WPI only outputting inferred purity annotations every other round (i.e., when those purity annotations aren't already in its input stub/ajava file).