### PR TITLE
Fix handling of primitives in TypesUtils#leastUpperBound

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -869,9 +869,11 @@ public final class TypesUtils {
     }
     // Special case for primitives.
     if (isPrimitive(t1) || isPrimitive(t2)) {
-      if (types.isAssignable(t1, t2)) {
+      // NOTE: we need to know which type is primitive because e.g. int and Integer are assignable
+      // to each other.
+      if (isPrimitive(t1) && types.isAssignable(t1, t2)) {
         return t2;
-      } else if (types.isAssignable(t2, t1)) {
+      } else if (isPrimitive(t2) && types.isAssignable(t2, t1)) {
         return t1;
       } else {
         Elements elements = processingEnv.getElementUtils();


### PR DESCRIPTION
**Summary**:
The previous version would return incorrect lub in some cases, e.g.:
```
TypesUtils.leastUpperBound(t1=Integer, t2=int) == int
```
This is because int and Integer are assignable **to each other** according to `Types#isAssignableTo`, 
so just checking assignability is not enough to figure out which type to return.

**Test plan**:
I tested the change in my project. Not sure whether/what tests I should add to CF as `javacutil` doesn't have its own test suite. 