### PR TITLE
Update Checker Framework Gradle plugin version numbers.

### DIFF
--- a/docs/examples/errorprone/build.gradle
+++ b/docs/examples/errorprone/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'java'
     id 'net.ltgt.errorprone' version '2.0.2'
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.10'
+    id 'org.checkerframework' version '0.6.11'
 }
 
 apply plugin: 'org.checkerframework'

--- a/docs/examples/lombok/build.gradle
+++ b/docs/examples/lombok/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'java'
     id "io.freefair.lombok" version "5.3.3.3"
     // Checker Framework pluggable type-checking
-    id 'org.checkerframework' version '0.6.10'
+    id 'org.checkerframework' version '0.6.11'
 }
 
 apply plugin: 'org.checkerframework'


### PR DESCRIPTION
The test should pass after https://github.com/kelloggm/checkerframework-gradle-plugin/pull/196 is merged.