### PR TITLE
Resource Leak Checker: Add a check to avoid mapping multiple keys to a ternary expression for tempVarToTree

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -231,7 +231,9 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
    * @param tree the tree of the expression the tempvar represents
    */
   /* package-private */ void addTempVar(LocalVariableNode tmpVar, Tree tree) {
-    tempVarToTree.put(tmpVar, tree);
+    if (!tempVarToTree.containsValue(tree)) {
+      tempVarToTree.put(tmpVar, tree);
+    }
   }
 
   /**

--- a/checker/tests/resourceleak/HDFSReport.java
+++ b/checker/tests/resourceleak/HDFSReport.java
@@ -1,0 +1,18 @@
+class Handler extends Thread {
+  boolean running;
+  static class Call { boolean isResponseDeferred() { return true; } }
+  @Override
+  public void run() {
+    while (running) {
+      Call call = null;
+      try {
+        if (running) {
+          continue;
+        }
+      } catch (Exception e) {
+      } finally {
+        String s = call.isResponseDeferred() ? ", deferred" : "";
+      }
+    }
+  }
+}

--- a/checker/tests/resourceleak/HDFSReport.java
+++ b/checker/tests/resourceleak/HDFSReport.java
@@ -1,6 +1,12 @@
 class Handler extends Thread {
   boolean running;
-  static class Call { boolean isResponseDeferred() { return true; } }
+
+  static class Call {
+    boolean isResponseDeferred() {
+      return true;
+    }
+  }
+
   @Override
   public void run() {
     while (running) {


### PR DESCRIPTION
Fixes [#5136](https://github.com/typetools/checker-framework/issues/5136)