### PR TITLE
Resource Leak Checker: Fix ClassCastException when rhs of an assignment in try-with-resources is a field

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1052,8 +1052,12 @@ class MustCallConsistencyAnalyzer {
         }
       }
     } else if (lhsElement.getKind() == ElementKind.RESOURCE_VARIABLE && isMustCallClose(rhs)) {
-      removeObligationsContainingVarIfNotDerivedFromMustCallAlias(
-          obligations, (LocalVariableNode) rhs);
+      if (rhs instanceof FieldAccessNode) {
+        // Handling of @Owning fields is a completely separate check.
+      } else if (rhs instanceof LocalVariableNode) {
+        removeObligationsContainingVarIfNotDerivedFromMustCallAlias(
+            obligations, (LocalVariableNode) rhs);
+      }
     } else if (lhs instanceof LocalVariableNode) {
       LocalVariableNode lhsVar = (LocalVariableNode) lhs;
       updateObligationsForPseudoAssignment(obligations, assignmentNode, lhsVar, rhs);

--- a/checker/tests/resourceleak/HDFSReport2.java
+++ b/checker/tests/resourceleak/HDFSReport2.java
@@ -1,0 +1,22 @@
+import java.io.Closeable;
+
+class RamDiskAsyncLazyPersistService {
+
+  public interface FsVolumeReference extends Closeable {}
+
+  class ReplicaLazyPersistTask implements Runnable {
+    private final FsVolumeReference targetVolume;
+
+    ReplicaLazyPersistTask(FsVolumeReference targetVolume) {
+      this.targetVolume = targetVolume;
+    }
+
+    @Override
+    public void run() {
+      try (FsVolumeReference ref = this.targetVolume) {
+
+      } catch (Exception e) {
+      }
+    }
+  }
+}


### PR DESCRIPTION
I encountered this problem when running RLC on Hadoop project.