### PR TITLE
Add -AinferOutputOriginal option

### DIFF
--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -683,6 +683,11 @@ Type-checking modes:  enable/disable functionality
   Using \<-Ainfer=stubs> produces \<.astub> files.
   Using \<-Ainfer=ajava> produces \<.ajava> files.
   You must also supply \<-Awarns>, or the inference output may be incomplete.
+\item \<-AinferOutputOriginal>
+  When outputting \<.ajava> files when running with \<-Ainfer=ajava>,
+  also output a copy of the original file with no inferred annotations,
+  but with the formatting of a \<.ajava> file, to permit use of \<diff>
+  to view the inferred annotations. Must be combined with \<-Ainfer=ajava>.
 \item \<-AshowSuppressWarningsStrings>
   With each warning, show all possible strings to suppress that warning.
 \item \<-AwarnUnneededSuppressions>

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -102,7 +102,7 @@ public class WholeProgramInferenceJavaParserStorage
   /** Mapping from source file to the wrapper for the compilation unit parsed from that file. */
   private Map<String, CompilationUnitAnnos> sourceToAnnos = new HashMap<>();
 
-  /** Whether the -AinferOutputOriginal option was supplied to the checker. */
+  /** Whether the {@code -AinferOutputOriginal} option was supplied to the checker. */
   private final boolean inferOutputOriginal;
 
   /**

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -30,6 +30,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -100,14 +102,20 @@ public class WholeProgramInferenceJavaParserStorage
   /** Mapping from source file to the wrapper for the compilation unit parsed from that file. */
   private Map<String, CompilationUnitAnnos> sourceToAnnos = new HashMap<>();
 
+  /** Whether the -AinferOutputOriginal option was supplied to the checker. */
+  private final boolean inferOutputOriginal;
+
   /**
    * Constructs a new {@code WholeProgramInferenceJavaParser} that has not yet inferred any
    * annotations.
    *
    * @param atypeFactory the associated type factory
+   * @param inferOutputOriginal whether the -AinferOutputOriginal option was supplied to the checker
    */
-  public WholeProgramInferenceJavaParserStorage(AnnotatedTypeFactory atypeFactory) {
+  public WholeProgramInferenceJavaParserStorage(
+      AnnotatedTypeFactory atypeFactory, boolean inferOutputOriginal) {
     this.atypeFactory = atypeFactory;
+    this.inferOutputOriginal = inferOutputOriginal;
   }
 
   @Override
@@ -715,7 +723,6 @@ public class WholeProgramInferenceJavaParserStorage
     for (String path : modifiedFiles) {
       CompilationUnitAnnos root = sourceToAnnos.get(path);
       prepareCompilationUnitForWriting(root);
-      root.transferAnnotations(checker);
       String packageDir = AJAVA_FILES_PATH;
       if (root.compilationUnit.getPackageDeclaration().isPresent()) {
         packageDir +=
@@ -737,26 +744,44 @@ public class WholeProgramInferenceJavaParserStorage
         name = name.substring(0, name.length() - ".java".length());
       }
 
-      name += "-" + checker.getClass().getCanonicalName() + ".ajava";
-      String outputPath = packageDir + File.separator + name;
-      try {
-        FileWriter writer = new FileWriter(outputPath);
-
-        // JavaParser can output using lexical preserving printing, which writes the file such that
-        // its formatting is close to the original source file it was parsed from as
-        // possible. Currently, this feature is very buggy and crashes when adding annotations in
-        // certain locations. This implementation could be used instead if it's fixed in JavaParser.
-        // LexicalPreservingPrinter.print(root.declaration, writer);
-
-        DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
-        writer.write(prettyPrinter.print(root.compilationUnit));
-        writer.close();
-      } catch (IOException e) {
-        throw new BugInCF("Error while writing ajava file " + outputPath, e);
+      String nameWithChecker = name + "-" + checker.getClass().getCanonicalName() + ".ajava";
+      String outputPath = packageDir + File.separator + nameWithChecker;
+      if (this.inferOutputOriginal) {
+        String outputPathNoCheckerName = packageDir + File.separator + name + ".ajava";
+        // Avoid re-writing this file for each checker that was run.
+        if (Files.notExists(Paths.get(outputPathNoCheckerName))) {
+          writeAjavaFile(outputPathNoCheckerName, root);
+        }
       }
+      root.transferAnnotations(checker);
+      writeAjavaFile(outputPath, root);
     }
 
     modifiedFiles.clear();
+  }
+
+  /**
+   * Write an ajava file to disk.
+   *
+   * @param outputPath the path to which the ajava file should be written
+   * @param root the compilation unit to be written
+   */
+  private void writeAjavaFile(String outputPath, CompilationUnitAnnos root) {
+    try {
+      FileWriter writer = new FileWriter(outputPath);
+
+      // JavaParser can output using lexical preserving printing, which writes the file such that
+      // its formatting is close to the original source file it was parsed from as
+      // possible. Currently, this feature is very buggy and crashes when adding annotations in
+      // certain locations. This implementation could be used instead if it's fixed in JavaParser.
+      // LexicalPreservingPrinter.print(root.declaration, writer);
+
+      DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+      writer.write(prettyPrinter.print(root.compilationUnit));
+      writer.close();
+    } catch (IOException e) {
+      throw new BugInCF("Error while writing ajava file " + outputPath, e);
+    }
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -203,6 +203,10 @@ import org.plumelib.util.UtilPlume;
   // "-Ainfer=stubs" or "-Ainfer=jaifs".
   "infer",
 
+  // Whether to output a copy of each file for which annotations were inferred, formatted
+  // as an ajava file. Can only be used with -Ainfer=ajava
+  "inferOutputOriginal",
+
   // With each warning, in addition to the concrete error key,
   // output the SuppressWarnings strings that can be used to
   // suppress that warning.

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -581,10 +581,18 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
                   + " should be one of: -Ainfer=jaifs, -Ainfer=stubs, -Ainfer=ajava");
       }
       boolean showWpiFailedInferences = checker.hasOption("showWpiFailedInferences");
+      boolean inferOutputOriginal = checker.hasOption("inferOutputOriginal");
+      if (inferOutputOriginal && wpiOutputFormat != WholeProgramInference.OutputFormat.AJAVA) {
+        checker.message(
+            Diagnostic.Kind.WARNING,
+            "-AinferOutputOriginal only works with -Ainfer=ajava, so it is being ignored.");
+      }
       if (wpiOutputFormat == WholeProgramInference.OutputFormat.AJAVA) {
         wholeProgramInference =
             new WholeProgramInferenceImplementation<AnnotatedTypeMirror>(
-                this, new WholeProgramInferenceJavaParserStorage(this), showWpiFailedInferences);
+                this,
+                new WholeProgramInferenceJavaParserStorage(this, inferOutputOriginal),
+                showWpiFailedInferences);
       } else {
         wholeProgramInference =
             new WholeProgramInferenceImplementation<ATypeElement>(


### PR DESCRIPTION
This option is useful because it permits `diff`ing between the `.ajava` files produced by WPI and the originals. Without this option, `diff`ing is difficult because there are usually many formatting differences.

I'm not sure how (or whether) to write a test for this. I tested it manually on the icalavailable project from plume-lib and it worked as expected.