### PR TITLE
Make the Label class public

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -6,6 +6,8 @@ package org.checkerframework.dataflow.cfg.builder;
  * generated unique names.
  */
 public class Label {
+  
+  /** Unique id counter that incremented in {@code #uniqueName}. */
   private static int uid = 0;
 
   protected final String name;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -5,7 +5,7 @@ package org.checkerframework.dataflow.cfg.builder;
  * Labels get their names either from labeled statements in the source code or from internally
  * generated unique names.
  */
-class Label {
+public class Label {
   private static int uid = 0;
 
   protected final String name;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -6,7 +6,7 @@ package org.checkerframework.dataflow.cfg.builder;
  * generated unique names.
  */
 public class Label {
-  
+
   /** Unique id counter that incremented in {@code #uniqueName}. */
   private static int uid = 0;
 


### PR DESCRIPTION
This enables greater extensibility in CFG construction; see https://github.com/typetools/checker-framework/issues/5151#issuecomment-1148026783