### PR TITLE
Work around a javac bug.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -33,6 +33,7 @@ import javax.lang.model.type.TypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.framework.util.AnnotationMirrorSet;
@@ -357,7 +358,13 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   public AnnotatedTypeMirror visitMethodInvocation(
       MethodInvocationTree node, AnnotatedTypeFactory f) {
     AnnotatedExecutableType ex = f.methodFromUse(node).executableType;
-    return f.applyCaptureConversion(ex.getReturnType().asUse());
+    AnnotatedTypeMirror returnT = ex.getReturnType().asUse();
+    if (TypesUtils.isCapturedTypeVariable(returnT.getUnderlyingType())
+        && !TypesUtils.isCapturedTypeVariable(TreeUtils.typeOf(node))) {
+      // This seems to be a bug in javac.
+      returnT = ((AnnotatedTypeVariable) returnT).getUpperBound();
+    }
+    return f.applyCaptureConversion(returnT);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -361,7 +361,9 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     AnnotatedTypeMirror returnT = ex.getReturnType().asUse();
     if (TypesUtils.isCapturedTypeVariable(returnT.getUnderlyingType())
         && !TypesUtils.isCapturedTypeVariable(TreeUtils.typeOf(node))) {
-      // This seems to be a bug in javac.
+      // Sometimes javac types an expression as the upper bound of a captured type variable instead
+      // of the captured type variable itself. This seems to be a bug in javac. Detect this case and
+      // match the annotated type to the Java type.
       returnT = ((AnnotatedTypeVariable) returnT).getUpperBound();
     }
     return f.applyCaptureConversion(returnT);


### PR DESCRIPTION
Sometimes javac types an expression as the upper bound of a captured type variable instead of the captured type variable itself.  Detect this case and match the annotated type to the java type.