### PR TITLE
add error when writing an explicit @MustCall annotation on a non-final class declaration (@InheritableMustCall should be used instead)

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -64,15 +64,6 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
     return super.visitReturn(node, p);
   }
 
-  /*  @Override
-  public void processClassTree(ClassTree tree) {
-    // Check if an explicit @MustCall annotation is present on a non-final class
-    // declaration. If so, issue an error suggesting that @InheritableMustCall is
-    // probably what the programmer means, for usability.
-    if (atypeFactory.getExp)
-    super.processClassTree(tree);
-  }*/
-
   @Override
   protected boolean validateType(Tree tree, AnnotatedTypeMirror type) {
     if (TreeUtils.isClassTree(tree)) {

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -64,30 +64,57 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
     return super.visitReturn(node, p);
   }
 
+  /*  @Override
+  public void processClassTree(ClassTree tree) {
+    // Check if an explicit @MustCall annotation is present on a non-final class
+    // declaration. If so, issue an error suggesting that @InheritableMustCall is
+    // probably what the programmer means, for usability.
+    if (atypeFactory.getExp)
+    super.processClassTree(tree);
+  }*/
+
   @Override
   protected boolean validateType(Tree tree, AnnotatedTypeMirror type) {
     if (TreeUtils.isClassTree(tree)) {
       Element classEle = TreeUtils.elementFromDeclaration((ClassTree) tree);
       AnnotationMirror inheritableMustCall =
           atypeFactory.getDeclAnnotation(classEle, InheritableMustCall.class);
-      if (inheritableMustCall != null) {
-        AnnotationMirror explict = atypeFactory.fromElement(classEle).getAnnotation();
-        if (explict != null) {
+      if (inheritableMustCall == null) {
+        if (!ElementUtils.isFinal(classEle)) {
+          // There is no @InheritableMustCall annotation and this is a non-final class.
+          // Check if an explicit @MustCall annotation is present. If so, issue an error suggesting
+          // that @InheritableMustCall is probably what the programmer means, for usability.
+          List<? extends AnnotationMirror> explicitAnnos = classEle.getAnnotationMirrors();
+          if (explicitAnnos.stream()
+              .anyMatch(
+                  a ->
+                      AnnotationUtils.areSameByName(
+                          a, "org.checkerframework.checker.mustcall.qual.MustCall"))) {
+            checker.reportError(
+                tree, "mustcall.not.inheritable", ElementUtils.getQualifiedName(classEle));
+          }
+        }
+      } else {
+        // There is an @InheritableMustCall annotation
+        AnnotationMirror explicit = atypeFactory.fromElement(classEle).getAnnotation();
+        if (explicit != null) {
           List<String> mustCallVal =
               AnnotationUtils.getElementValueArray(
                   inheritableMustCall, atypeFactory.inheritableMustCallValueElement, String.class);
           AnnotationMirror inheritedMCAnno = atypeFactory.createMustCall(mustCallVal);
 
           // Issue an error if there is an inconsistent, user-written @MustCall annotation.
-          AnnotationMirror writtenMCAnno = type.getAnnotation();
-          if (writtenMCAnno != null
-              && !atypeFactory.getQualifierHierarchy().isSubtype(inheritedMCAnno, writtenMCAnno)) {
+          AnnotationMirror effectiveMCAnno = type.getAnnotation();
+          if (effectiveMCAnno != null
+              && !atypeFactory
+                  .getQualifierHierarchy()
+                  .isSubtype(inheritedMCAnno, effectiveMCAnno)) {
 
             checker.reportError(
                 tree,
                 "inconsistent.mustcall.subtype",
-                classEle.getSimpleName(),
-                writtenMCAnno,
+                ElementUtils.getQualifiedName(classEle),
+                effectiveMCAnno,
                 inheritableMustCall);
             return false;
           }

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/messages.properties
@@ -1,2 +1,3 @@
 inconsistent.mustcall.subtype=%s is annotated as %s, but one of its supertypes is annotated %s
 createsmustcallfor.target.unparseable=The method %s is annotated as @CreatesMustCallFor, but the target (%s) was unparseable in the current context. Rewrite your code so that the relevant expression is a local variable.
+mustcall.not.inheritable=Non-final class %s is annotated with an explicit, non-inheritable @MustCall annotation, so this class' subclasses will not inherit its must-call obligations. Use @InheritableMustCall instead.

--- a/checker/tests/mustcall-nolightweightownership/BorrowOnReturn.java
+++ b/checker/tests/mustcall-nolightweightownership/BorrowOnReturn.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.mustcall.qual.*;
 
 class BorrowOnReturn {
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
   }
 

--- a/checker/tests/mustcall/BorrowOnReturn.java
+++ b/checker/tests/mustcall/BorrowOnReturn.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.mustcall.qual.*;
 
 class BorrowOnReturn {
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
   }
 

--- a/checker/tests/mustcall/CreatesMustCallForSimple.java
+++ b/checker/tests/mustcall/CreatesMustCallForSimple.java
@@ -2,7 +2,8 @@
 
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForSimple {
+@InheritableMustCall("a")
+class CreatesMustCallForSimple {
 
   @CreatesMustCallFor
   void reset() {}

--- a/checker/tests/mustcall/ListOfMustCall.java
+++ b/checker/tests/mustcall/ListOfMustCall.java
@@ -4,7 +4,8 @@
 import java.util.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class ListOfMustCall {
+@InheritableMustCall("a")
+class ListOfMustCall {
   static void test(ListOfMustCall lm) {
     List<ListOfMustCall> l = new ArrayList<>();
     // add(E e) takes an object of the type argument's type

--- a/checker/tests/mustcall/NotInheritableMustCallOnClassError.java
+++ b/checker/tests/mustcall/NotInheritableMustCallOnClassError.java
@@ -1,0 +1,11 @@
+// A test that checks that writing @MustCall instead of @InheritableMustCall
+// on a class declaration generates an error, as discussed in
+// https://github.com/typetools/checker-framework/issues/5181.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("foo")
+// :: error: mustcall.not.inheritable
+public class NotInheritableMustCallOnClassError {
+  public void foo() {}
+}

--- a/checker/tests/mustcall/NotInheritableMustCallOnFinalClassNoError.java
+++ b/checker/tests/mustcall/NotInheritableMustCallOnFinalClassNoError.java
@@ -1,0 +1,8 @@
+// A test that checks that writing @MustCall instead of @InheritableMustCall
+// on a class declaration does not generate an error when the class is final.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+@MustCall("foo") public final class NotInheritableMustCallOnFinalClassNoError {
+  public void foo() {}
+}

--- a/checker/tests/mustcall/PolyTests.java
+++ b/checker/tests/mustcall/PolyTests.java
@@ -2,7 +2,8 @@
 
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class PolyTests {
+@InheritableMustCall("close")
+class PolyTests {
   static @PolyMustCall Object id(@PolyMustCall Object obj) {
     return obj;
   }

--- a/checker/tests/resourceleak-nocreatesmustcallfor/CreatesMustCallForSimpler.java
+++ b/checker/tests/resourceleak-nocreatesmustcallfor/CreatesMustCallForSimpler.java
@@ -5,7 +5,8 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForSimpler {
+@InheritableMustCall("a")
+class CreatesMustCallForSimpler {
 
   @CreatesMustCallFor
   void reset() {}

--- a/checker/tests/resourceleak-nocreatesmustcallfor/SocketContainer.java
+++ b/checker/tests/resourceleak-nocreatesmustcallfor/SocketContainer.java
@@ -7,7 +7,8 @@ import java.net.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class SocketContainer {
+@InheritableMustCall("close")
+class SocketContainer {
   @Owning Socket sock;
 
   public SocketContainer(String host, int port) throws Exception {

--- a/checker/tests/resourceleak-nolightweightownership/ACOwning.java
+++ b/checker/tests/resourceleak-nolightweightownership/ACOwning.java
@@ -8,7 +8,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACOwning {
 
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     void a() {}
   }
 

--- a/checker/tests/resourceleak-permitinitializationleak/SocketContainer.java
+++ b/checker/tests/resourceleak-permitinitializationleak/SocketContainer.java
@@ -7,7 +7,8 @@ import java.net.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class SocketContainer {
+@InheritableMustCall("close")
+class SocketContainer {
   @Owning Socket sock;
 
   public SocketContainer(String host, int port) throws Exception {

--- a/checker/tests/resourceleak-permitstaticowning/StaticOwningField.java
+++ b/checker/tests/resourceleak-permitstaticowning/StaticOwningField.java
@@ -6,7 +6,8 @@ import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.mustcall.qual.Owning;
 
-@MustCall("close") class StaticOwningField implements Closeable {
+@InheritableMustCall("close")
+class StaticOwningField implements Closeable {
 
   // Instance field
 

--- a/checker/tests/resourceleak/ACExceptionalExitPointTest.java
+++ b/checker/tests/resourceleak/ACExceptionalExitPointTest.java
@@ -4,7 +4,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACExceptionalExitPointTest {
 
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
 
     @This Foo b() {

--- a/checker/tests/resourceleak/ACMethodInvocationTest.java
+++ b/checker/tests/resourceleak/ACMethodInvocationTest.java
@@ -4,7 +4,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACMethodInvocationTest {
 
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
 
     @This Foo b() {

--- a/checker/tests/resourceleak/ACOwning.java
+++ b/checker/tests/resourceleak/ACOwning.java
@@ -3,7 +3,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACOwning {
 
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     void a() {}
   }
 
@@ -60,7 +61,7 @@ class ACOwning {
     takeOwnership(new Foo(), makeFoo());
   }
 
-  @MustCall({})
+  @InheritableMustCall({})
   // :: error: super.invocation
   private class SubFoo extends Foo {
 

--- a/checker/tests/resourceleak/ACRegularExitPointTest.java
+++ b/checker/tests/resourceleak/ACRegularExitPointTest.java
@@ -6,7 +6,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACRegularExitPointTest {
 
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
 
     @This Foo b() {
@@ -16,7 +17,7 @@ class ACRegularExitPointTest {
     void c(@CalledMethods("a") Foo this) {}
   }
 
-  @MustCall("a") class SubFoo extends Foo {}
+  class SubFoo extends Foo {}
 
   Foo makeFoo() {
     return new Foo();

--- a/checker/tests/resourceleak/COInSubtype.java
+++ b/checker/tests/resourceleak/COInSubtype.java
@@ -11,7 +11,8 @@ class COInSubtype {
     void resetFoo() {}
   }
 
-  @MustCall("a") static class Bar extends Foo {
+  @InheritableMustCall("a")
+  static class Bar extends Foo {
     void a() {}
   }
 

--- a/checker/tests/resourceleak/CheckFields.java
+++ b/checker/tests/resourceleak/CheckFields.java
@@ -4,7 +4,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class CheckFields {
 
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     void a() {}
 
     void c() {}
@@ -14,7 +15,8 @@ class CheckFields {
     return new Foo();
   }
 
-  @MustCall("b") static class FooField {
+  @InheritableMustCall("b")
+  static class FooField {
     private final @Owning Foo finalOwningFoo;
     // :: error: required.method.not.called
     private final @Owning Foo finalOwningFooWrong;
@@ -130,7 +132,8 @@ class CheckFields {
     }
   }
 
-  @MustCall("f") static class NestedWrong2 {
+  @InheritableMustCall("f")
+  static class NestedWrong2 {
     // Non-final owning fields also require the surrounding class to have an appropriate MC
     // annotation.
     // :: error: required.method.not.called
@@ -146,7 +149,8 @@ class CheckFields {
     void f() {}
   }
 
-  @MustCall("f") static class NestedRight {
+  @InheritableMustCall("f")
+  static class NestedRight {
     // Non-final owning fields also require the surrounding class to have an appropriate MC
     // annotation.
     @Owning Foo foo;

--- a/checker/tests/resourceleak/CreatesMustCallForIndirect.java
+++ b/checker/tests/resourceleak/CreatesMustCallForIndirect.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForIndirect {
+@InheritableMustCall("a")
+class CreatesMustCallForIndirect {
 
   @CreatesMustCallFor
   void reset() {}

--- a/checker/tests/resourceleak/CreatesMustCallForOverride.java
+++ b/checker/tests/resourceleak/CreatesMustCallForOverride.java
@@ -3,7 +3,8 @@
 
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForOverride {
+@InheritableMustCall("a")
+class CreatesMustCallForOverride {
   @CreatesMustCallFor
   @Override
   // :: error: creates.mustcall.for.override.invalid

--- a/checker/tests/resourceleak/CreatesMustCallForRepeat.java
+++ b/checker/tests/resourceleak/CreatesMustCallForRepeat.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForRepeat {
+@InheritableMustCall("a")
+class CreatesMustCallForRepeat {
 
   @CreatesMustCallFor("this")
   @CreatesMustCallFor("#1")

--- a/checker/tests/resourceleak/CreatesMustCallForSimple.java
+++ b/checker/tests/resourceleak/CreatesMustCallForSimple.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForSimple {
+@InheritableMustCall("a")
+class CreatesMustCallForSimple {
 
   @CreatesMustCallFor
   void reset() {}

--- a/checker/tests/resourceleak/CreatesMustCallForSimpler.java
+++ b/checker/tests/resourceleak/CreatesMustCallForSimpler.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForSimpler {
+@InheritableMustCall("a")
+class CreatesMustCallForSimpler {
 
   @CreatesMustCallFor
   void reset() {}

--- a/checker/tests/resourceleak/CreatesMustCallForTargets.java
+++ b/checker/tests/resourceleak/CreatesMustCallForTargets.java
@@ -5,7 +5,8 @@ import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("a") class CreatesMustCallForTargets {
+@InheritableMustCall("a")
+class CreatesMustCallForTargets {
   @Owning InputStream is1;
 
   @CreatesMustCallFor

--- a/checker/tests/resourceleak/Enclosing.java
+++ b/checker/tests/resourceleak/Enclosing.java
@@ -3,7 +3,8 @@
 import org.checkerframework.checker.mustcall.qual.*;
 
 class Enclosing {
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     void a() {}
   }
 

--- a/checker/tests/resourceleak/IgnoredExceptionECM.java
+++ b/checker/tests/resourceleak/IgnoredExceptionECM.java
@@ -4,7 +4,8 @@
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("foo") class IgnoredExceptionECM {
+@InheritableMustCall("foo")
+class IgnoredExceptionECM {
 
   @Owning
   @MustCall("toString") Object obj;

--- a/checker/tests/resourceleak/MCAOwningField.java
+++ b/checker/tests/resourceleak/MCAOwningField.java
@@ -5,7 +5,8 @@ import java.net.Socket;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("stop") class MCAOwningField {
+@InheritableMustCall("stop")
+class MCAOwningField {
 
   @Owning final Socket s;
 

--- a/checker/tests/resourceleak/ManualMustCallEmptyOnConstructor.java
+++ b/checker/tests/resourceleak/ManualMustCallEmptyOnConstructor.java
@@ -8,7 +8,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 class ManualMustCallEmptyOnConstructor {
 
   // Test that writing @MustCall({}) on a constructor results in an error
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     final @Owning InputStream is;
 
     // :: error: inconsistent.constructor.type

--- a/checker/tests/resourceleak/MustCallAliasOwningField.java
+++ b/checker/tests/resourceleak/MustCallAliasOwningField.java
@@ -4,7 +4,7 @@ import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-public @MustCall("shutdown") class MustCallAliasOwningField {
+public @InheritableMustCall("shutdown") class MustCallAliasOwningField {
 
   private final @Owning BufferedInputStream input;
 

--- a/checker/tests/resourceleak/NonFinalFieldOnlyOverwrittenIfNull.java
+++ b/checker/tests/resourceleak/NonFinalFieldOnlyOverwrittenIfNull.java
@@ -4,11 +4,12 @@
 import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
-import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-@MustCall("close") class NonFinalFieldOnlyOverwrittenIfNull {
+@InheritableMustCall("close")
+class NonFinalFieldOnlyOverwrittenIfNull {
   @Owning @MonotonicNonNull InputStream is;
 
   @CreatesMustCallFor

--- a/checker/tests/resourceleak/NonFinalFieldOnlyOverwrittenIfNull2.java
+++ b/checker/tests/resourceleak/NonFinalFieldOnlyOverwrittenIfNull2.java
@@ -4,11 +4,12 @@
 import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
-import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-@MustCall("close") class NonFinalFieldOnlyOverwrittenIfNull2 {
+@InheritableMustCall("close")
+class NonFinalFieldOnlyOverwrittenIfNull2 {
   @Owning @MonotonicNonNull InputStream is;
 
   @CreatesMustCallFor

--- a/checker/tests/resourceleak/RequiresCalledMethodsTest.java
+++ b/checker/tests/resourceleak/RequiresCalledMethodsTest.java
@@ -4,13 +4,15 @@ import org.checkerframework.checker.mustcall.qual.*;
 
 public class RequiresCalledMethodsTest {
 
-  @MustCall("a") static class Foo {
+  @InheritableMustCall("a")
+  static class Foo {
     void a() {}
 
     void c() {}
   }
 
-  @MustCall("releaseFoo") static class FooField {
+  @InheritableMustCall("releaseFoo")
+  static class FooField {
     private @Owning Foo foo = null;
 
     @RequiresCalledMethods(

--- a/checker/tests/resourceleak/SocketContainer.java
+++ b/checker/tests/resourceleak/SocketContainer.java
@@ -7,7 +7,8 @@ import java.net.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class SocketContainer {
+@InheritableMustCall("close")
+class SocketContainer {
   @Owning Socket sock;
 
   public SocketContainer(String host, int port) throws Exception {

--- a/checker/tests/resourceleak/SocketContainer2.java
+++ b/checker/tests/resourceleak/SocketContainer2.java
@@ -6,7 +6,8 @@ import java.net.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class SocketContainer2 {
+@InheritableMustCall("close")
+class SocketContainer2 {
 
   @Owning Socket sock = new Socket();
 

--- a/checker/tests/resourceleak/SocketContainer3.java
+++ b/checker/tests/resourceleak/SocketContainer3.java
@@ -6,7 +6,8 @@ import java.net.*;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("close") class SocketContainer3 {
+@InheritableMustCall("close")
+class SocketContainer3 {
   @Owning Socket sock = null;
 
   public SocketContainer3(String host, int port) throws Exception {

--- a/checker/tests/resourceleak/SocketField.java
+++ b/checker/tests/resourceleak/SocketField.java
@@ -6,7 +6,8 @@ import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 import org.checkerframework.dataflow.qual.Pure;
 
-@MustCall("closeSocket") class SocketField {
+@InheritableMustCall("closeSocket")
+class SocketField {
   protected @Owning Socket socket = null;
 
   @CreatesMustCallFor("this")

--- a/checker/tests/resourceleak/TernaryExpressions.java
+++ b/checker/tests/resourceleak/TernaryExpressions.java
@@ -4,7 +4,8 @@ import org.checkerframework.common.returnsreceiver.qual.*;
 
 class TernaryExpressions {
 
-  @MustCall("a") class Foo {
+  @InheritableMustCall("a")
+  class Foo {
     void a() {}
 
     @This Foo b() {
@@ -104,9 +105,11 @@ class TernaryExpressions {
     return b ? x : makeFoo();
   }
 
-  @MustCall("toString") static class Sub1 extends Object {}
+  @InheritableMustCall("toString")
+  static class Sub1 extends Object {}
 
-  @MustCall("clone") static class Sub2 extends Object {}
+  @InheritableMustCall("clone")
+  static class Sub2 extends Object {}
 
   static void testTernarySubtyping(boolean b) {
     // :: error: required.method.not.called

--- a/checker/tests/resourceleak/TwoResourcesECM.java
+++ b/checker/tests/resourceleak/TwoResourcesECM.java
@@ -8,7 +8,8 @@ import java.net.Socket;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
-@MustCall("dispose") class TwoResourcesECM {
+@InheritableMustCall("dispose")
+class TwoResourcesECM {
   @Owning Socket s1, s2;
 
   // The contracts.postcondition error below is thrown because s1 is not final,


### PR DESCRIPTION
fixes #5181 