### PR TITLE
Add failing test case for subclassing lombok builders

### DIFF
--- a/checker/tests/calledmethods-lombok/LombokBuilderSubclassExample.java
+++ b/checker/tests/calledmethods-lombok/LombokBuilderSubclassExample.java
@@ -1,0 +1,29 @@
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+@Builder(builderClassName = "LBSEBuilder")
+@Value public class LombokBuilderSubclassExample {
+
+  @NonNull Integer attribute;
+
+  public static LombokBuilderSubclassExample builder() {
+    return new LombokBuilderSubclassExampleBuilder();
+  }
+
+  public static class LombokBuilderSubclassExampleBuilder extends LBSEBuilder {
+
+    @Override
+    public LombokBuilderSubclassExample build() {
+      final LombokBuilderSubclassExample result = super.build();
+      // here result.getAttribute() is guaranteed to be non null, so we do not have to check this
+      // ourselves
+
+      if (result.getAttribute() < 0) {
+        throw new IllegalArgumentException("attribute must be >= 0");
+      }
+
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
This test case shows that with checker framework's builder checker you can not easily extend generated builders without running  into a `finalizer.invocation` error.
To be fair, I have not run this test case, because I am unsure how to do this exactly, but it should be quite close to something that is reproducible. The error, specifically, is of the form
`[finalizer.invocation] This finalizer cannot be invoked, because the following methods have not been called: attribute()
      final LombokBuilderSubclassExample result = super.build();`

Maybe the solution (for this example) is to annotate the generated method `LBSEBuilder#build()` with `@CalledMethods("attribute")`, but I am not entirely sure.