### PR TITLE
Add more map copying to AnalysisResult

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -151,7 +151,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> impl
     finalLocalValues.putAll(other.finalLocalValues);
   }
 
-  /** Make copies of certain internal IdentityHashMaps, if they have not been copied already */
+  /** Make copies of certain internal IdentityHashMaps, if they have not been copied already. */
   private void copyMapsIfNeeded() {
     if (!mapsCopied) {
       nodeValues = new IdentityHashMap<>(nodeValues);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -143,17 +143,21 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> impl
    * @param other an analysis result to combine with this
    */
   public void combine(AnalysisResult<V, S> other) {
+    copyMapsIfNeeded();
+    nodeValues.putAll(other.nodeValues);
+    mergeTreeLookup(treeLookup, other.treeLookup);
+    postfixLookup.putAll(other.postfixLookup);
+    stores.putAll(other.stores);
+    finalLocalValues.putAll(other.finalLocalValues);
+  }
+
+  private void copyMapsIfNeeded() {
     if (!mapsCopied) {
       nodeValues = new IdentityHashMap<>(nodeValues);
       treeLookup = new IdentityHashMap<>(treeLookup);
       postfixLookup = new IdentityHashMap<>(postfixLookup);
       mapsCopied = true;
     }
-    nodeValues.putAll(other.nodeValues);
-    mergeTreeLookup(treeLookup, other.treeLookup);
-    postfixLookup.putAll(other.postfixLookup);
-    stores.putAll(other.stores);
-    finalLocalValues.putAll(other.finalLocalValues);
   }
 
   /**
@@ -413,6 +417,10 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> impl
     if (transferInput == null) {
       return null;
     }
+    // Calling Analysis.runAnalysisFor() may mutate the internal nodeValues map inside an
+    // AbstractAnalysis object, and by default the AnalysisResult constructor just wraps this map
+    // without copying it.  So here the AnalysisResult maps must be copied, to preserve them.
+    copyMapsIfNeeded();
     return runAnalysisFor(node, preOrPost, transferInput, nodeValues, analysisCaches);
   }
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AnalysisResult.java
@@ -151,6 +151,7 @@ public class AnalysisResult<V extends AbstractValue<V>, S extends Store<S>> impl
     finalLocalValues.putAll(other.finalLocalValues);
   }
 
+  /** Make copies of certain internal IdentityHashMaps, if they have not been copied already */
   private void copyMapsIfNeeded() {
     if (!mapsCopied) {
       nodeValues = new IdentityHashMap<>(nodeValues);


### PR DESCRIPTION
This fixes a crash in NullAway discovered when trying to update to 3.23.0; see https://github.com/uber/NullAway/issues/623.  It is a follow-up to https://github.com/typetools/checker-framework/pull/5178.  In that change I missed a case where the maps inside `AnalysisResult` need to be copied (see code comments for details).

I am open to suggestions on how to add a test for this.  I think the Checker Framework tests passed before because Checker Framework checkers almost always end up calling `AnalysisResult.combine()`, which ends up copying the maps anyway; NullAway does not call this method.