### PR TITLE
Add a dataflow test for constant propagation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -984,6 +984,7 @@ subprojects {
             if (project.name.is('dataflow')) {
                 dependsOn('liveVariableTest')
                 dependsOn('issue3447Test')
+                dependsOn('constantPropagationTest')
             }
         }
 

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -124,6 +124,45 @@ task issue3447Test(dependsOn: [assemble, compileTestJava], group: 'Verification'
     }
 }
 
+task constantPropagationTest(dependsOn: [assemble, compileTestJava], group: 'Verification') {
+    description 'Test the constant propagation analysis for dataflow framework.'
+    inputs.file('tests/constant-propagation/Expected.txt')
+    inputs.file('tests/constant-propagation/Test.java')
+
+    outputs.file('tests/constant-propagation/Out.txt')
+    outputs.file('tests/constant-propagation/Test.class')
+
+    delete('tests/constant-propagation/Out.txt')
+    delete('tests/constant-propagation/Test.class')
+    doLast {
+        javaexec {
+            workingDir = 'tests/constant-propagation'
+            if (!JavaVersion.current().java9Compatible) {
+                jvmArgs += "-Xbootclasspath/p:${configurations.javacJar.asPath}".toString()
+            }
+            else if (JavaVersion.current() > JavaVersion.VERSION_11) {
+                jvmArgs += [
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+                        "--add-opens", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                ]
+            }
+            classpath = sourceSets.test.runtimeClasspath
+            classpath += sourceSets.test.output
+            mainClass = 'constantpropagation.ConstantPropagation'
+        }
+        exec {
+            workingDir = 'tests/constant-propagation'
+            executable 'diff'
+            args = ['-u', 'Expected.txt', 'Out.txt']
+        }
+    }
+}
+
 apply from: rootProject.file("gradle-mvn-push.gradle")
 
 /** Adds information to the publication for uploading the dataflow artifacts to Maven repositories. */

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -125,7 +125,7 @@ task issue3447Test(dependsOn: [assemble, compileTestJava], group: 'Verification'
 }
 
 task constantPropagationTest(dependsOn: [assemble, compileTestJava], group: 'Verification') {
-    description 'Test the constant propagation analysis for dataflow framework.'
+    description 'Test the constant propagation analysis of the dataflow framework.'
     inputs.file('tests/constant-propagation/Expected.txt')
     inputs.file('tests/constant-propagation/Test.java')
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -212,7 +212,7 @@ public class CFGVisualizeLauncher {
    * @param method name of the method to generate the CFG for
    * @return control flow graph of the specified method
    */
-  public ControlFlowGraph generateMethodCFG(String file, String clas, final String method) {
+  protected ControlFlowGraph generateMethodCFG(String file, String clas, final String method) {
 
     CFGProcessor cfgProcessor = new CFGProcessor(clas, method);
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -212,7 +212,7 @@ public class CFGVisualizeLauncher {
    * @param method name of the method to generate the CFG for
    * @return control flow graph of the specified method
    */
-  protected ControlFlowGraph generateMethodCFG(String file, String clas, final String method) {
+  public ControlFlowGraph generateMethodCFG(String file, String clas, final String method) {
 
     CFGProcessor cfgProcessor = new CFGProcessor(clas, method);
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
@@ -168,6 +168,6 @@ public class ConstantPropagationStore implements Store<ConstantPropagationStore>
   @Override
   @SuppressWarnings("nullness")
   public String visualize(CFGVisualizer<?, ConstantPropagationStore, ?> viz) {
-    return viz.visualizeStoreKeyVal("constant propagation", null);
+    return viz.visualizeStoreKeyVal("constant propagation", toString());
   }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/constantpropagation/ConstantPropagationStore.java
@@ -166,7 +166,6 @@ public class ConstantPropagationStore implements Store<ConstantPropagationStore>
    * visualization.
    */
   @Override
-  @SuppressWarnings("nullness")
   public String visualize(CFGVisualizer<?, ConstantPropagationStore, ?> viz) {
     return viz.visualizeStoreKeyVal("constant propagation", toString());
   }

--- a/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
+++ b/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
@@ -1,0 +1,42 @@
+package constantpropagation;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Map;
+import org.checkerframework.dataflow.analysis.AnalysisResult;
+import org.checkerframework.dataflow.analysis.ForwardAnalysis;
+import org.checkerframework.dataflow.analysis.ForwardAnalysisImpl;
+import org.checkerframework.dataflow.cfg.visualize.CFGVisualizeLauncher;
+import org.checkerframework.dataflow.constantpropagation.Constant;
+import org.checkerframework.dataflow.constantpropagation.ConstantPropagationStore;
+import org.checkerframework.dataflow.constantpropagation.ConstantPropagationTransfer;
+
+public class ConstantPropagation {
+
+  /**
+   * The main method expects to be run in dataflow/tests/constant-propagation directory.
+   *
+   * @param args not used
+   */
+  public static void main(String[] args) {
+
+    String inputFile = "Test.java";
+    String method = "test";
+    String clazz = "Test";
+    String outputFile = "Out.txt";
+
+    ConstantPropagationTransfer transfer = new ConstantPropagationTransfer();
+    ForwardAnalysis<Constant, ConstantPropagationStore, ConstantPropagationTransfer>
+        forwardAnalysis = new ForwardAnalysisImpl<>(transfer);
+    CFGVisualizeLauncher cfgVisualizeLauncher = new CFGVisualizeLauncher();
+    Map<String, Object> res =
+        cfgVisualizeLauncher.generateStringOfCFG(inputFile, method, clazz, true, forwardAnalysis);
+    AnalysisResult<Constant, ConstantPropagationStore> result = forwardAnalysis.getResult();
+    try (FileWriter out = new FileWriter(outputFile)) {
+      out.write(res.get("stringGraph").toString());
+      out.write("\n");
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
+++ b/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
@@ -3,11 +3,8 @@ package constantpropagation;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Map;
-import org.checkerframework.dataflow.analysis.AnalysisResult;
 import org.checkerframework.dataflow.analysis.ForwardAnalysis;
 import org.checkerframework.dataflow.analysis.ForwardAnalysisImpl;
-import org.checkerframework.dataflow.cfg.ControlFlowGraph;
-import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizeLauncher;
 import org.checkerframework.dataflow.constantpropagation.Constant;
 import org.checkerframework.dataflow.constantpropagation.ConstantPropagationStore;
@@ -33,13 +30,6 @@ public class ConstantPropagation {
     CFGVisualizeLauncher cfgVisualizeLauncher = new CFGVisualizeLauncher();
     Map<String, Object> res =
         cfgVisualizeLauncher.generateStringOfCFG(inputFile, method, clazz, true, forwardAnalysis);
-    // analysis has run, so we can get the result
-    AnalysisResult<Constant, ConstantPropagationStore> result = forwardAnalysis.getResult();
-    ControlFlowGraph cfg = cfgVisualizeLauncher.generateMethodCFG(inputFile, clazz, method);
-    for (Node node : cfg.getAllNodes()) {
-      result.getStoreBefore(node);
-      result.getStoreAfter(node);
-    }
     try (FileWriter out = new FileWriter(outputFile)) {
       out.write(res.get("stringGraph").toString());
       out.write("\n");

--- a/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
+++ b/dataflow/src/test/java/constantpropagation/ConstantPropagation.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import org.checkerframework.dataflow.analysis.AnalysisResult;
 import org.checkerframework.dataflow.analysis.ForwardAnalysis;
 import org.checkerframework.dataflow.analysis.ForwardAnalysisImpl;
+import org.checkerframework.dataflow.cfg.ControlFlowGraph;
+import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.cfg.visualize.CFGVisualizeLauncher;
 import org.checkerframework.dataflow.constantpropagation.Constant;
 import org.checkerframework.dataflow.constantpropagation.ConstantPropagationStore;
@@ -31,7 +33,13 @@ public class ConstantPropagation {
     CFGVisualizeLauncher cfgVisualizeLauncher = new CFGVisualizeLauncher();
     Map<String, Object> res =
         cfgVisualizeLauncher.generateStringOfCFG(inputFile, method, clazz, true, forwardAnalysis);
+    // analysis has run, so we can get the result
     AnalysisResult<Constant, ConstantPropagationStore> result = forwardAnalysis.getResult();
+    ControlFlowGraph cfg = cfgVisualizeLauncher.generateMethodCFG(inputFile, clazz, method);
+    for (Node node : cfg.getAllNodes()) {
+      result.getStoreBefore(node);
+      result.getStoreAfter(node);
+    }
     try (FileWriter out = new FileWriter(outputFile)) {
       out.write(res.get("stringGraph").toString());
       out.write("\n");

--- a/dataflow/tests/constant-propagation/Expected.txt
+++ b/dataflow/tests/constant-propagation/Expected.txt
@@ -1,0 +1,79 @@
+2 -> 3 EACH_TO_EACH
+3 -> 4 EACH_TO_EACH
+4 -> 8 THEN_TO_BOTH
+4 -> 10 ELSE_TO_BOTH
+8 -> 11 EACH_TO_EACH
+10 -> 11 EACH_TO_EACH
+11 -> 0 EACH_TO_EACH
+
+2:
+Process order: 1
+TransferInput#0
+Before:   constant propagation = {}
+~~~~~~~~~
+<entry>
+
+3:
+Process order: 2
+TransferInput#1
+Before:   constant propagation = {}
+~~~~~~~~~
+a   [ VariableDeclaration ]
+0   [ IntegerLiteral ]    > 0
+a = 0   [ Assignment ]    > 0
+b   [ VariableDeclaration ]
+a   [ LocalVariable ]    > 0
+5   [ IntegerLiteral ]    > 5
+(a > 5)   [ GreaterThan ]
+~~~~~~~~~
+AnalysisResult#1
+After:   constant propagation = {a=0}
+
+4:
+Process order: 3
+TransferInput#10
+Before:   constant propagation = {a=0}
+~~~~~~~~~
+ConditionalBlock: then: 8, else: 10
+
+8:
+Process order: 4
+TransferInput#12
+Before:   constant propagation = {a=0}
+~~~~~~~~~
+b   [ LocalVariable ]
+3   [ IntegerLiteral ]    > 3
+b = 3   [ Assignment ]    > 3
+~~~~~~~~~
+AnalysisResult#3
+After:   constant propagation = {a=0, b=3}
+
+10:
+Process order: 5
+TransferInput#13
+Before:   constant propagation = {a=0}
+~~~~~~~~~
+b   [ LocalVariable ]
+4   [ IntegerLiteral ]    > 4
+b = 4   [ Assignment ]    > 4
+~~~~~~~~~
+AnalysisResult#5
+After:   constant propagation = {a=0, b=4}
+
+11:
+Process order: 6
+TransferInput#23
+Before:   constant propagation = {a=0, b=T}
+~~~~~~~~~
+b   [ LocalVariable ]    > T
+return b   [ Return ]
+~~~~~~~~~
+AnalysisResult#7
+After:   constant propagation = {a=0, b=T}
+
+0:
+Process order: 7
+TransferInput#27
+Before:   constant propagation = {a=0, b=T}
+~~~~~~~~~
+<exit>

--- a/dataflow/tests/constant-propagation/Expected.txt
+++ b/dataflow/tests/constant-propagation/Expected.txt
@@ -42,8 +42,8 @@ TransferInput#12
 Before:   constant propagation = {a=0}
 ~~~~~~~~~
 b   [ LocalVariable ]
-3   [ IntegerLiteral ]    > 3
-b = 3   [ Assignment ]    > 3
+3   [ IntegerLiteral ]
+b = 3   [ Assignment ]
 ~~~~~~~~~
 AnalysisResult#3
 After:   constant propagation = {a=0, b=3}
@@ -54,8 +54,8 @@ TransferInput#13
 Before:   constant propagation = {a=0}
 ~~~~~~~~~
 b   [ LocalVariable ]
-4   [ IntegerLiteral ]    > 4
-b = 4   [ Assignment ]    > 4
+4   [ IntegerLiteral ]
+b = 4   [ Assignment ]
 ~~~~~~~~~
 AnalysisResult#5
 After:   constant propagation = {a=0, b=4}
@@ -65,7 +65,7 @@ Process order: 6
 TransferInput#23
 Before:   constant propagation = {a=0, b=T}
 ~~~~~~~~~
-b   [ LocalVariable ]    > T
+b   [ LocalVariable ]
 return b   [ Return ]
 ~~~~~~~~~
 AnalysisResult#7

--- a/dataflow/tests/constant-propagation/Expected.txt
+++ b/dataflow/tests/constant-propagation/Expected.txt
@@ -42,11 +42,11 @@ TransferInput#12
 Before:   constant propagation = {a=0}
 ~~~~~~~~~
 b   [ LocalVariable ]
-3   [ IntegerLiteral ]
-b = 3   [ Assignment ]
+a   [ LocalVariable ]
+b = a   [ Assignment ]
 ~~~~~~~~~
 AnalysisResult#3
-After:   constant propagation = {a=0, b=3}
+After:   constant propagation = {a=0, b=0}
 
 10:
 Process order: 5

--- a/dataflow/tests/constant-propagation/Test.java
+++ b/dataflow/tests/constant-propagation/Test.java
@@ -2,7 +2,7 @@ public class Test {
   public int test() {
     int a = 0, b;
     if (a > 5) {
-      b = 3;
+      b = a;
     } else {
       b = 4;
     }

--- a/dataflow/tests/constant-propagation/Test.java
+++ b/dataflow/tests/constant-propagation/Test.java
@@ -1,0 +1,11 @@
+public class Test {
+  public int test() {
+    int a = 0, b;
+    if (a > 5) {
+      b = 3;
+    } else {
+      b = 4;
+    }
+    return b;
+  }
+}


### PR DESCRIPTION
Currently we only have dataflow tests for backward analysis; constant propagation covers the forward analysis case.  The code is based heavily on the existing dataflow tests.

This was originally written in the hopes of having a test exposing the issue addressed by #5210.  It doesn't do that, unfortunately (that failure relies on more complex transfer functions), but I think it's still useful.