### PR TITLE
Fix issue with multiple identical Nodes in MustCallConsistencyAnalyzer

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -160,13 +161,13 @@ class MustCallConsistencyAnalyzer {
    * A cache for the result of calling {@code ResourceLeakAnnotatedTypeFactory.getStoreAfter()} on a
    * node. The cache prevents repeatedly computing least upper bounds on stores
    */
-  private Map<Node, CFStore> cmStoreAfter = new LinkedHashMap<>();
+  private IdentityHashMap<Node, CFStore> cmStoreAfter = new IdentityHashMap<>();
 
   /**
    * A cache for the result of calling {@code MustCallAnnotatedTypeFactory.getStoreAfter()} on a
    * node. The cache prevents repeatedly computing least upper bounds on stores
    */
-  private Map<Node, CFStore> mcStoreAfter = new LinkedHashMap<>();
+  private IdentityHashMap<Node, CFStore> mcStoreAfter = new IdentityHashMap<>();
 
   /** The Resource Leak Checker, used to issue errors. */
   private final ResourceLeakChecker checker;

--- a/checker/tests/resourceleak/MultipleIdenticalReturns.java
+++ b/checker/tests/resourceleak/MultipleIdenticalReturns.java
@@ -1,0 +1,37 @@
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * tests that the detector works properly in the presence of multiple identical return statements in
+ * a method
+ */
+class MultipleIdenticalReturns {
+  static class Repro {
+    private java.lang.ClassLoader loader;
+
+    public Object loadClass(final String className) throws ClassNotFoundException {
+      final String classFile = className.replace('.', '/');
+      Object RC = null;
+      if (RC != null) {
+        return RC;
+      }
+      try (InputStream is = loader.getResourceAsStream(classFile + ".class")) {
+        // no warning here, since parse() is invoked in parser
+        ClassParser parser = new ClassParser();
+        RC = parser.parse();
+        return RC;
+      } catch (final IOException e) {
+        throw new ClassNotFoundException(className + " not found: " + e, e);
+      }
+    }
+  }
+
+  @org.checkerframework.checker.mustcall.qual.InheritableMustCall("parse")
+  static class ClassParser {
+    public ClassParser() {}
+
+    public Object parse() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
The caches in `MustCallConsistencyAnalyzer` must be `IdentityHashMap`s to avoid caching the wrong result for a `Node`.  