### PR TITLE
Set environment variable before invoking `wpi-many.sh`

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -771,6 +771,7 @@ task wpiManyTest(group: "Verification") {
         def typecheckFilesDir = "${project.projectDir}/build/wpi-many-tests-results/"
         try {
             exec {
+                environment CHECKERFRAMEWORK: "${projectDir}/.."
                 commandLine 'bin/wpi-many.sh',
                         '-i', "${project.projectDir}/tests/wpi-many/testin.txt",
                         '-o', "${project.projectDir}/build/wpi-many-tests",


### PR DESCRIPTION
Maybe a better approach would be for the `wpi*` scripts to default CHECKERFRAMEWORK to scriptsdirectory/../.. .