### PR TITLE
Add copyJarToDist to developer manual.

### DIFF
--- a/docs/developer/developer-manual.html
+++ b/docs/developer/developer-manual.html
@@ -139,6 +139,7 @@ Frequently-used tasks:
 <ul>
   <li> <code>assemble</code>: builds all jars.
   <li> <code>build</code>: <code>assemble</code>, plus runs all JUnit tests.
+  <li> <code>copyJarsToDist</code>: builds only the jars required to use checker/bin/javac; faster than assemble.
   <li> <code>allTests</code>: runs all tests.
   <li> <code>reformat</code>: reformats Java files.
   <li> <code>NameOfJUnitTest</code>: runs the JUnit test with that name; for example, <code>NullnessTest</code>.


### PR DESCRIPTION
`assemble` is a standard Gradle task that builds all of the jars of a project including Javadoc jars.  If you just want to build enough of the jars to use checker/bin/javac, run `./gradlew copyJarsToDist`.  