### PR TITLE
Remove method that isn't called anymore.

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -75,38 +74,6 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
 
     debugSpew = spew;
     this.postInit();
-  }
-
-  // Could move this to a public method on the checker class
-  public ExecutableElement findJavaOverride(ExecutableElement overrider, TypeMirror parentType) {
-    if (parentType.getKind() != TypeKind.NONE) {
-      if (debugSpew) {
-        System.err.println("Searching for overridden methods from " + parentType);
-      }
-
-      TypeElement overriderClass = (TypeElement) overrider.getEnclosingElement();
-      TypeElement elem = (TypeElement) ((DeclaredType) parentType).asElement();
-      if (debugSpew) {
-        System.err.println("necessary TypeElements acquired: " + elem);
-      }
-
-      for (Element e : elem.getEnclosedElements()) {
-        if (debugSpew) {
-          System.err.println("Considering element " + e);
-        }
-        if (e.getKind() == ElementKind.METHOD || e.getKind() == ElementKind.CONSTRUCTOR) {
-          ExecutableElement ex = (ExecutableElement) e;
-          boolean overrides = elements.overrides(overrider, ex, overriderClass);
-          if (overrides) {
-            return ex;
-          }
-        }
-      }
-      if (debugSpew) {
-        System.err.println("Done considering elements of " + parentType);
-      }
-    }
-    return null;
   }
 
   public boolean isPolymorphicType(TypeElement cls) {

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -76,6 +76,12 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
     this.postInit();
   }
 
+  /**
+   * Returns true if the given type is polymorphic.
+   *
+   * @param cls the type to test
+   * @return true if the given type is polymorphic
+   */
   public boolean isPolymorphicType(TypeElement cls) {
     assert (cls != null);
     return getDeclAnnotation(cls, PolyUIType.class) != null


### PR DESCRIPTION
Calls to it were removed in d7149190dc06ab63c71af0bb7a07cf13db18b6b4 and replaced with calls to ` AnnotatedTypes#overriddenMethods`.