### PR TITLE
Remove test of javac

### DIFF
--- a/framework/tests/framework/AnnotatedVoidMethod.java
+++ b/framework/tests/framework/AnnotatedVoidMethod.java
@@ -1,8 +1,0 @@
-import org.checkerframework.framework.testchecker.util.*;
-
-public class AnnotatedVoidMethod {
-  // :: error: annotation type not applicable to this kind of declaration
-  public @Odd void method() {
-    return;
-  }
-}


### PR DESCRIPTION
This doesn't test anything useful about the Checker Framework, and the test is flaky because different versions of javac use slightly different error message text (e.g., this test fails under JDK 18).