### PR TITLE
Fix ajava-based WPI generating malformed annotation with String constants containing escapable characters

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -28,6 +28,7 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.expression.ArrayCreation;
 import org.checkerframework.dataflow.expression.ClassName;
 import org.checkerframework.dataflow.expression.JavaExpression;
+import org.checkerframework.dataflow.expression.ValueLiteral;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.ElementQualifierHierarchy;
 import org.checkerframework.framework.type.QualifierHierarchy;
@@ -140,6 +141,8 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     return !expr.containsUnknown()
         && !(expr instanceof ArrayCreation)
         && !(expr instanceof ClassName)
+        // avoid SameLen expressions with e.g. literal String constants
+        && !(expr instanceof ValueLiteral)
         // Big expressions cause a stack overflow in JavaExpressionParseUtil.
         // So limit them to an arbitrary length of 999.
         && expr.toString().length() < 1000;

--- a/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
+++ b/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
@@ -1,0 +1,17 @@
+// Based on a snippet of code that caused a malformed ajava file to be
+// produced by WPI. The offending ajava file contained an @SameLen annotation
+// whose argument was a constant String, e.g., @SameLen({ ""Hamburg"", "word1" })
+
+public class ContainsSubstring {
+
+  public static void run() {
+    String word1 = "Hamburg";
+    String word2 = "burg";
+    System.out.println(compute(word1, word2));
+  }
+
+  public static boolean compute(String word1, String word2) {
+    // content doesn't matter
+    return false;
+  }
+}

--- a/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
+++ b/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
@@ -4,8 +4,11 @@
 
 public class ContainsSubstring {
 
+  @SuppressWarnings("samelen") // TODO: caused by a bug related to viewpoint adaptation. Make WPI
+  // actually viewpoint-adapt the annotations that it infers, then
+  // remove this warning suppression.
   public static void run() {
-    String word1 = "Hamburg";
+    String word1 = "\"Hamburg\"";
     String word2 = "burg";
     System.out.println(compute(word1, word2));
   }

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -226,6 +226,9 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
   private void updateInferredExecutableParameterTypes(
       ExecutableElement methodElt, List<Node> arguments) {
 
+    // TODO: updates must be viewpoint adapted to the method invocation before
+    // they are stored on the method body
+
     String file = storage.getFileForElement(methodElt);
 
     for (int i = 0; i < arguments.size(); i++) {
@@ -300,6 +303,7 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       int paramIndex = varargsParam ? methodElt.getParameters().size() - 1 : i;
       T paramAnnotations =
           storage.getParameterAnnotations(methodElt, paramIndex, paramATM, ve, atypeFactory);
+      // TODO: viewpoint adapt argATM here?
       updateAnnotationSet(paramAnnotations, TypeUseLocation.PARAMETER, argATM, paramATM, file);
     }
   }

--- a/framework/src/main/java/org/checkerframework/framework/ajava/AnnotationMirrorToAnnotationExprConversion.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/AnnotationMirrorToAnnotationExprConversion.java
@@ -22,6 +22,7 @@ import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.expr.StringLiteralExpr;
 import com.github.javaparser.ast.expr.UnaryExpr;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.utils.StringEscapeUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -214,7 +215,7 @@ public class AnnotationMirrorToAnnotationExprConversion {
 
     @Override
     public Expression visitString(String value, Void p) {
-      return new StringLiteralExpr(value);
+      return new StringLiteralExpr(StringEscapeUtils.escapeJava(value));
     }
 
     @Override


### PR DESCRIPTION
This PR actually (partially) addresses three related bugs, all of which are triggered by the new test case I added (ContainsString.java):
* ajava-based WPI generated malformed annotations when an annotation value contained a string literal with escapable characters such as ". The specific cause of this was `@SameLen(""Hamburg"")` being generated; that should have been `@SameLen("\"Hamburg\"")`.
* The SameLen Checker shouldn't have been inferring annotations with manifest string literals in the first place. I fixed that here, too, and also modified the test to force the Value Checker to elicit the above bug without the fix in this PR.
* The test still fails without a warning suppression, because WPI isn't correctly viewpoint adapting to the method when inferring parameter types. I didn't fix that here, since I think it will be a more invasive change that should be done separately, but I did leave some TODOs where I think those changes should go. @smillst, this is what I emailed you about a few minutes ago.