### PR TITLE
Viewpoint adapt during WPI at method call sites

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -23,6 +23,7 @@ import org.checkerframework.checker.index.qual.PolySameLen;
 import org.checkerframework.checker.index.qual.SameLen;
 import org.checkerframework.checker.index.qual.SameLenBottom;
 import org.checkerframework.checker.index.qual.SameLenUnknown;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.basetype.BaseAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.expression.ArrayCreation;
@@ -177,14 +178,19 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
      * If the collections are disjoint, returns null. Otherwise, returns their union. The
      * collections must not contain duplicates.
      */
-    private Set<String> unionIfNotDisjoint(Collection<String> c1, Collection<String> c2) {
+    private @Nullable Set<String> unionIfNotDisjoint(Collection<String> c1, Collection<String> c2) {
       Set<String> result = new TreeSet<>(c1);
+      boolean disjoint = true;
       for (String s : c2) {
         if (!result.add(s)) {
-          return null;
+          disjoint = false;
         }
       }
-      return result;
+      if (!disjoint) {
+        return result;
+      } else {
+        return null;
+      }
     }
 
     // The GLB of two SameLen annotations is the union of the two sets of arrays, or is bottom

--- a/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
+++ b/checker/tests/ainfer-index/non-annotated/ContainsSubstring.java
@@ -4,9 +4,6 @@
 
 public class ContainsSubstring {
 
-  @SuppressWarnings("samelen") // TODO: caused by a bug related to viewpoint adaptation. Make WPI
-  // actually viewpoint-adapt the annotations that it infers, then
-  // remove this warning suppression.
   public static void run() {
     String word1 = "\"Hamburg\"";
     String word2 = "burg";

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -15,14 +15,9 @@ import com.sun.source.util.TreePath;
 import com.sun.tools.javac.tree.JCTree;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -33,6 +28,7 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.expression.FormalParameter;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.JavaExpressionConverter;
@@ -651,6 +647,49 @@ public class DependentTypesHelper {
           "delocalize(%s, %s) created %s%n",
           atm, TreeUtils.toStringTruncated(methodDeclTree, 65), stringToJavaExpr);
     }
+    convertAnnotatedTypeMirror(stringToJavaExpr, atm);
+  }
+
+  /**
+   * Delocalizes dependent type annotations in {@code atm} so that they can be placed on the
+   * declaration of the given method being invoked. Used by whole program inference to infer
+   * dependent types for method parameters based on the actual arguments used at call sites.
+   *
+   * @param atm the annotated type mirror to delocalize
+   * @param path path to the method invocation
+   * @param arguments the actual arguments to the method
+   * @param methodElt the declaration of the method being invoked
+   */
+  public void delocalizeAtCallsite(
+      AnnotatedTypeMirror atm, TreePath path, List<Node> arguments, ExecutableElement methodElt) {
+
+    if (!hasDependentType(atm)) {
+      return;
+    }
+
+    List<JavaExpression> argsAsExprs =
+        arguments.stream().map(LocalVariable::fromNode).collect(Collectors.toList());
+
+    StringToJavaExpression stringToJavaExpr =
+        stringExpr -> {
+          JavaExpression expr =
+              StringToJavaExpression.atPath(stringExpr, path, factory.getChecker());
+          JavaExpressionConverter jec =
+              new JavaExpressionConverter() {
+                @Override
+                public JavaExpression convert(JavaExpression javaExpr) {
+                  // if javaExpr is an argument to the method,
+                  // then return formal parameter expression.
+                  int index = argsAsExprs.indexOf(javaExpr);
+                  if (index != -1) {
+                    return FormalParameter.getFormalParameters(methodElt).get(index);
+                  }
+                  return super.convert(javaExpr);
+                }
+              };
+          return jec.convert(expr);
+        };
+
     convertAnnotatedTypeMirror(stringToJavaExpr, atm);
   }
 


### PR DESCRIPTION
Based on the suggestion from @smillst.

I'm concerned that this PR computes a `TreePath` sometimes when it doesn't really need one, which I think I remember might be relatively expensive, but I'm not sure how to check whether the `TreePath` will be necessary earlier than in `DependentTypesHelper`. I'd appreciate any suggestions (or a reassurance that it's fine, if it is fine).

Also fixes a bug in GLB in the SameLen checker that I encountered while testing this fix: the `unionIfNotDisjoint` helper method for SameLen's GLB just did not do what its specification said, leading to infuriating test failures caused by the GLB of `@SameLen("#1")` and `@SameLen("#1")` being `@SameLenBottom`. If you'd like, I could pull that out into a separate PR, but I kept it here since I don't have a separate test case.