### PR TITLE
Temporarily disable running spotlessCheck with the build task.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,9 @@ allprojects {
   }
 
   spotless {
+    // TODO: Temporarily disable running spotlessCheck with the build task.
+    enforceCheck false
+
     format 'misc', {
       // define the files to apply `misc` to
       target '*.gradle', '*.md', '.gitignore'

--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,7 @@ allprojects {
   }
 
   spotless {
-    // TODO: Temporarily disable running spotlessCheck with the build task.
+    // TODO: Remove the line below.
     enforceCheck false
 
     format 'misc', {


### PR DESCRIPTION
Fixes #5319.