### PR TITLE
Avoid crash in `AnnotatedTypeMirror.fromExpression`; fixes #5323

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -1985,7 +1985,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     }
     // An implicit receiver is the first enclosing type that is a subtype of the type where the
     // element is declared.
-    while (!isSubtype(thisType.getUnderlyingType(), typeOfImplicitReceiver)) {
+    while (thisType != null && !isSubtype(thisType.getUnderlyingType(), typeOfImplicitReceiver)) {
       thisType = thisType.getEnclosingType();
     }
     return thisType;


### PR DESCRIPTION
I couldn't easily create a small, reproducible test case, but I am hopeful that this fixes #5323.