### PR TITLE
Rename `getPurityKinds()` to `getPurityAnnotations()`

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/util/PurityChecker.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/util/PurityChecker.java
@@ -218,6 +218,10 @@ public class PurityChecker {
       return super.visitCatch(node, ignore);
     }
 
+    /** Represents a method that is both deterministic and side-effect free. */
+    private static final EnumSet<Pure.Kind> detAndSeFree =
+        EnumSet.of(Kind.DETERMINISTIC, Kind.SIDE_EFFECT_FREE);
+
     @Override
     public Void visitMethodInvocation(MethodInvocationTree node, Void ignore) {
       ExecutableElement elt = TreeUtils.elementFromUse(node);
@@ -227,8 +231,8 @@ public class PurityChecker {
         EnumSet<Pure.Kind> purityKinds =
             (assumeDeterministic && assumeSideEffectFree)
                 // Avoid computation if not necessary
-                ? EnumSet.of(Kind.DETERMINISTIC, Kind.SIDE_EFFECT_FREE)
-                : PurityUtils.getPurityKinds(annoProvider, elt);
+                ? detAndSeFree
+                : PurityUtils.getPurityAnnotations(annoProvider, elt);
         boolean det = assumeDeterministic || purityKinds.contains(Kind.DETERMINISTIC);
         boolean seFree = assumeSideEffectFree || purityKinds.contains(Kind.SIDE_EFFECT_FREE);
         if (!det && !seFree) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/util/PurityUtils.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/util/PurityUtils.java
@@ -31,7 +31,7 @@ public class PurityUtils {
    * @return whether the method has any purity annotations
    */
   public static boolean hasPurityAnnotation(AnnotationProvider provider, MethodTree methodTree) {
-    return !getPurityKinds(provider, methodTree).isEmpty();
+    return !getPurityAnnotations(provider, methodTree).isEmpty();
   }
 
   /**
@@ -43,7 +43,7 @@ public class PurityUtils {
    */
   public static boolean hasPurityAnnotation(
       AnnotationProvider provider, ExecutableElement methodElement) {
-    return !getPurityKinds(provider, methodElement).isEmpty();
+    return !getPurityAnnotations(provider, methodElement).isEmpty();
   }
 
   /**
@@ -70,7 +70,7 @@ public class PurityUtils {
    */
   public static boolean isDeterministic(
       AnnotationProvider provider, ExecutableElement methodElement) {
-    EnumSet<Pure.Kind> kinds = getPurityKinds(provider, methodElement);
+    EnumSet<Pure.Kind> kinds = getPurityAnnotations(provider, methodElement);
     return kinds.contains(Kind.DETERMINISTIC);
   }
 
@@ -98,24 +98,52 @@ public class PurityUtils {
    */
   public static boolean isSideEffectFree(
       AnnotationProvider provider, ExecutableElement methodElement) {
-    EnumSet<Pure.Kind> kinds = getPurityKinds(provider, methodElement);
+    EnumSet<Pure.Kind> kinds = getPurityAnnotations(provider, methodElement);
     return kinds.contains(Kind.SIDE_EFFECT_FREE);
   }
 
   /**
-   * Returns the types of purity of the method {@code methodTree}.
+   * Returns the purity annotations of the method {@code methodTree}.
+   *
+   * @param provider how to get annotations
+   * @param methodTree a method to test
+   * @return the types of purity of the method {@code methodTree}
+   * @deprecated use {@code getPurityAnnotations}
+   */
+  @Deprecated // 2022-09-27
+  public static EnumSet<Pure.Kind> getPurityKinds(
+      AnnotationProvider provider, MethodTree methodTree) {
+    return getPurityAnnotations(provider, methodTree);
+  }
+
+  /**
+   * Returns the purity annotations on the method {@code methodTree}.
    *
    * @param provider how to get annotations
    * @param methodTree a method to test
    * @return the types of purity of the method {@code methodTree}
    */
-  public static EnumSet<Pure.Kind> getPurityKinds(
+  public static EnumSet<Pure.Kind> getPurityAnnotations(
       AnnotationProvider provider, MethodTree methodTree) {
     ExecutableElement methodElement = TreeUtils.elementFromDeclaration(methodTree);
     if (methodElement == null) {
       throw new BugInCF("Could not find element for tree: " + methodTree);
     }
-    return getPurityKinds(provider, methodElement);
+    return getPurityAnnotations(provider, methodElement);
+  }
+
+  /**
+   * Returns the purity annotations on the method {@code methodElement}.
+   *
+   * @param provider how to get annotations
+   * @param methodElement a method to test
+   * @return the types of purity of the method {@code methodElement}
+   * @deprecated use {@code getPurityAnnotations}
+   */
+  @Deprecated // 2022-09-27
+  public static EnumSet<Pure.Kind> getPurityKinds(
+      AnnotationProvider provider, ExecutableElement methodElement) {
+    return getPurityAnnotations(provider, methodElement);
   }
 
   /**
@@ -125,9 +153,9 @@ public class PurityUtils {
    * @param methodElement a method to test
    * @return the types of purity of the method {@code methodElement}
    */
-  // TODO: should the return type be an EnumSet?
-  public static EnumSet<Pure.Kind> getPurityKinds(
+  public static EnumSet<Pure.Kind> getPurityAnnotations(
       AnnotationProvider provider, ExecutableElement methodElement) {
+    // Special case for record accessors
     if (ElementUtils.isRecordAccessor(methodElement)) {
       return EnumSet.of(Kind.DETERMINISTIC, Kind.SIDE_EFFECT_FREE);
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,9 @@ introduced since JDK 11).
 
 **Implementation details:**
 
-Deprecated `TreeUtils.constructor()` in favor of `TreeUtils.elementFromUse()`.
+Deprecated methods:
+ * `TreeUtils.constructor()` => `TreeUtils.elementFromUse()`
+ * `PurityUtils.getPurityKinds()` => `PurityUtils.getPurityAnnotations()`
 
 Use `TreeUtils.elementFromDeclaration` and `TreeUtils.elementFromUse` in
 preference to `TreeUtils.elementFromTree`, when possible.

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -977,7 +977,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     // check "no" purity
-    EnumSet<Pure.Kind> kinds = PurityUtils.getPurityKinds(atypeFactory, node);
+    EnumSet<Pure.Kind> kinds = PurityUtils.getPurityAnnotations(atypeFactory, node);
     // @Deterministic makes no sense for a void method or constructor
     boolean isDeterministic = kinds.contains(Pure.Kind.DETERMINISTIC);
     if (isDeterministic) {
@@ -3707,9 +3707,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
       // check purity annotations
       EnumSet<Pure.Kind> superPurity =
-          PurityUtils.getPurityKinds(atypeFactory, overridden.getElement());
+          PurityUtils.getPurityAnnotations(atypeFactory, overridden.getElement());
       EnumSet<Pure.Kind> subPurity =
-          PurityUtils.getPurityKinds(atypeFactory, overrider.getElement());
+          PurityUtils.getPurityAnnotations(atypeFactory, overrider.getElement());
       if (!subPurity.containsAll(superPurity)) {
         checker.reportError(
             overriderTree,


### PR DESCRIPTION
This change makes clearer where the information comes from, and is more consistent with clients such as `hasPurityAnnotation()`.