### PR TITLE
Remove the --notest option to release_build.py

### DIFF
--- a/docs/developer/release/release_build.py
+++ b/docs/developer/release/release_build.py
@@ -61,16 +61,11 @@ import sys
 debug = False
 ant_debug = ""
 
-# Currently only affects the Checker Framework tests, which run the longest.
-notest = False
-
 
 def print_usage():
     """Print usage information."""
     print("Usage:    python3 release_build.py [options]")
     print("\n  --debug  turns on debugging mode which produces verbose output")
-    print("\n  --notest  disables tests to speed up scripts; for debugging only")
-
 
 def clone_or_update_repos():
     """Clone the relevant repos from scratch or update them if they exist and
@@ -225,8 +220,7 @@ def build_annotation_tools_release(version, afu_interm_dir):
     execute(ant_cmd)
 
     # Deploy to intermediate site
-    gradle_cmd = "./gradlew %s -Pafu.version=%s -Pdeploy-dir=%s" % (
-        "releaseBuildWithoutTest" if notest else "releaseBuild",
+    gradle_cmd = "./gradlew releaseBuildWithoutTest -Pafu.version=%s -Pdeploy-dir=%s" % (
         version,
         afu_interm_dir,
     )
@@ -383,8 +377,6 @@ def main(argv):
     debug = has_command_line_option(argv, "--debug")
     if debug:
         ant_debug = "-debug"
-    global notest
-    notest = has_command_line_option(argv, "--notest")
 
     afu_date = get_afu_date()
 

--- a/docs/developer/release/release_push.py
+++ b/docs/developer/release/release_push.py
@@ -14,9 +14,9 @@ import os
 from os.path import expanduser
 
 from release_vars import AFU_LIVE_RELEASES_DIR
+from release_vars import ANNO_FILE_UTILITIES
 from release_vars import CF_VERSION
 from release_vars import CHECKER_FRAMEWORK
-from release_vars import ANNO_TOOLS
 from release_vars import CHECKER_LIVE_RELEASES_DIR
 from release_vars import CHECKLINK
 from release_vars import DEV_SITE_DIR
@@ -387,7 +387,7 @@ def main(argv):
         execute(ant_cmd, True, False, CHECKER_FRAMEWORK)
 
         ant_cmd = "./gradlew test"
-        execute(ant_cmd, True, False, ANNO_TOOLS)
+        execute(ant_cmd, True, False, ANNO_FILE_UTILITIES)
 
     # The Central repository is a repository of build artifacts for build programs like Maven and Ivy.
     # This step stages (but doesn't release) the Checker Framework's Maven artifacts in the Sonatypes

--- a/docs/developer/release/release_push.py
+++ b/docs/developer/release/release_push.py
@@ -16,6 +16,7 @@ from os.path import expanduser
 from release_vars import AFU_LIVE_RELEASES_DIR
 from release_vars import CF_VERSION
 from release_vars import CHECKER_FRAMEWORK
+from release_vars import ANNO_TOOLS
 from release_vars import CHECKER_LIVE_RELEASES_DIR
 from release_vars import CHECKLINK
 from release_vars import DEV_SITE_DIR
@@ -384,6 +385,9 @@ def main(argv):
     if prompt_yes_no("Perform this step?", True):
         ant_cmd = "./gradlew allTests"
         execute(ant_cmd, True, False, CHECKER_FRAMEWORK)
+
+        ant_cmd = "./gradlew test"
+        execute(ant_cmd, True, False, ANNO_TOOLS)
 
     # The Central repository is a repository of build artifacts for build programs like Maven and Ivy.
     # This step stages (but doesn't release) the Checker Framework's Maven artifacts in the Sonatypes


### PR DESCRIPTION
Instead, run the AFU tests with the Checker Framework tests in the release_push.py script.  This step can be skipped, so there's no need for an option.