### PR TITLE
Rename `@Value` test annotation to `@ValueTypeAnno`

### DIFF
--- a/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
@@ -51,7 +51,7 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     return new FlowQualifierHierarchy(this.getSupportedTypeQualifiers(), elements);
   }
 
-  /** FlowQualifierHierarchy: {@code @Value(a) <: @Value(b) iff a == b} */
+  /** FlowQualifierHierarchy: {@code @ValueTypeAnno(a) <: @ValueValueTypeAnno(b) iff a == b} */
   class FlowQualifierHierarchy extends MostlyNoElementQualifierHierarchy {
     final QualifierKind VALUE_KIND;
 

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/util/FlowTestAnnotatedTypeFactory.java
@@ -27,7 +27,7 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
   public FlowTestAnnotatedTypeFactory(BaseTypeChecker checker) {
     super(checker, true);
-    VALUE = AnnotationBuilder.fromClass(elements, Value.class);
+    VALUE = AnnotationBuilder.fromClass(elements, ValueTypeAnno.class);
     BOTTOM = AnnotationBuilder.fromClass(elements, Bottom.class);
     TOP = AnnotationBuilder.fromClass(elements, Unqualified.class);
 
@@ -43,7 +43,8 @@ public class FlowTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
   @Override
   protected Set<Class<? extends Annotation>> createSupportedTypeQualifiers() {
     return new HashSet<Class<? extends Annotation>>(
-        Arrays.asList(Value.class, Odd.class, MonotonicOdd.class, Unqualified.class, Bottom.class));
+        Arrays.asList(
+            ValueTypeAnno.class, Odd.class, MonotonicOdd.class, Unqualified.class, Bottom.class));
   }
 
   @Override

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/util/ValueTypeAnno.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/util/ValueTypeAnno.java
@@ -7,6 +7,6 @@ import org.checkerframework.framework.qual.SubtypeOf;
 
 @SubtypeOf(Unqualified.class)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-public @interface Value {
+public @interface ValueTypeAnno {
   int value() default 0;
 }

--- a/framework/tests/flow/CustomContractWithArgs.java
+++ b/framework/tests/flow/CustomContractWithArgs.java
@@ -37,7 +37,7 @@ public class CustomContractWithArgs {
   class Base {
     Object o;
 
-    @Value(10) Object o10;
+    @ValueTypeAnno(10) Object o10;
 
     @EnsuresValue(value = "o", targetValue = 10)
     void ensures() {

--- a/framework/tests/flow/CustomContractWithArgs.java
+++ b/framework/tests/flow/CustomContractWithArgs.java
@@ -2,11 +2,11 @@ import org.checkerframework.framework.qual.ConditionalPostconditionAnnotation;
 import org.checkerframework.framework.qual.PostconditionAnnotation;
 import org.checkerframework.framework.qual.PreconditionAnnotation;
 import org.checkerframework.framework.qual.QualifierArgument;
-import org.checkerframework.framework.testchecker.util.Value;
+import org.checkerframework.framework.testchecker.util.ValueTypeAnno;
 
 public class CustomContractWithArgs {
   // Postcondition for Value
-  @PostconditionAnnotation(qualifier = Value.class)
+  @PostconditionAnnotation(qualifier = ValueTypeAnno.class)
   @interface EnsuresValue {
     public String[] value();
 
@@ -15,7 +15,7 @@ public class CustomContractWithArgs {
   }
 
   // Conditional postcondition for LTLengthOf
-  @ConditionalPostconditionAnnotation(qualifier = Value.class)
+  @ConditionalPostconditionAnnotation(qualifier = ValueTypeAnno.class)
   @interface EnsuresValueIf {
     public boolean result();
 
@@ -26,7 +26,7 @@ public class CustomContractWithArgs {
   }
 
   // Precondition for LTLengthOf
-  @PreconditionAnnotation(qualifier = Value.class)
+  @PreconditionAnnotation(qualifier = ValueTypeAnno.class)
   @interface RequiresValue {
     public String[] value();
 
@@ -37,7 +37,8 @@ public class CustomContractWithArgs {
   class Base {
     Object o;
 
-    @ValueTypeAnno(10) Object o10;
+    @ValueTypeAnno(10)
+    Object o10;
 
     @EnsuresValue(value = "o", targetValue = 10)
     void ensures() {

--- a/framework/tests/flow/MetaPostcondition.java
+++ b/framework/tests/flow/MetaPostcondition.java
@@ -87,11 +87,11 @@ public class MetaPostcondition {
   }
 
   // basic postcondition test
-  void tnm1(@Odd String p1, @Value String p2) {
+  void tnm1(@Odd String p1, @ValueTypeAnno String p2) {
     // :: error: (assignment)
     @Odd String l1 = f1;
     // :: error: (assignment)
-    @Value String l2 = f2;
+    @ValueTypeAnno String l2 = f2;
 
     // :: error: (flowexpr.parse.error.postcondition)
     error2(p1, p2);

--- a/framework/tests/flow/MetaPrecondition.java
+++ b/framework/tests/flow/MetaPrecondition.java
@@ -11,7 +11,7 @@ public class MetaPrecondition {
   @RequiresOdd("f1")
   void requiresF1() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f1;
   }
 
@@ -19,7 +19,7 @@ public class MetaPrecondition {
   @RequiresOdd("f1")
   int requiresF1AndPure() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f1;
     return 1;
   }
@@ -28,7 +28,7 @@ public class MetaPrecondition {
   // :: error: (flowexpr.parse.error)
   void error() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     // :: error: (assignment)
     @Odd String l2 = f1;
   }
@@ -36,16 +36,16 @@ public class MetaPrecondition {
   @RequiresOdd("#1")
   void requiresParam(String p) {
     // :: error: (assignment)
-    @Value String l1 = p;
+    @ValueTypeAnno String l1 = p;
     @Odd String l2 = p;
   }
 
   @RequiresOdd({"#1", "#2"})
   void requiresParams(String p1, String p2) {
     // :: error: (assignment)
-    @Value String l1 = p1;
+    @ValueTypeAnno String l1 = p1;
     // :: error: (assignment)
-    @Value String l2 = p2;
+    @ValueTypeAnno String l2 = p2;
     @Odd String l3 = p1;
     @Odd String l4 = p2;
   }

--- a/framework/tests/flow/Postcondition.java
+++ b/framework/tests/flow/Postcondition.java
@@ -38,35 +38,35 @@ public class Postcondition {
     throw new RuntimeException();
   }
 
-  @EnsuresQualifier(expression = "f1", qualifier = Value.class)
+  @EnsuresQualifier(expression = "f1", qualifier = ValueTypeAnno.class)
   // :: error: (contracts.postcondition)
   void valueF1() {}
 
-  @EnsuresQualifier(expression = "---", qualifier = Value.class)
+  @EnsuresQualifier(expression = "---", qualifier = ValueTypeAnno.class)
   // :: error: (flowexpr.parse.error)
   void error() {}
 
-  @EnsuresQualifier(expression = "#1.#2", qualifier = Value.class)
+  @EnsuresQualifier(expression = "#1.#2", qualifier = ValueTypeAnno.class)
   // :: error: (flowexpr.parse.error)
   void error2(final String p1, final String p2) {}
 
-  @EnsuresQualifier(expression = "f1", qualifier = Value.class)
+  @EnsuresQualifier(expression = "f1", qualifier = ValueTypeAnno.class)
   void exception() {
     throw new RuntimeException();
   }
 
-  @EnsuresQualifier(expression = "#1", qualifier = Value.class)
+  @EnsuresQualifier(expression = "#1", qualifier = ValueTypeAnno.class)
   void param1(final @ValueTypeAnno String f) {}
 
   @EnsuresQualifier(
       expression = {"#1", "#2"},
-      qualifier = Value.class)
+      qualifier = ValueTypeAnno.class)
   // :: error: (flowexpr.parameter.not.final)
   void param2(@ValueTypeAnno String f, @ValueTypeAnno String g) {
     f = g;
   }
 
-  @EnsuresQualifier(expression = "#1", qualifier = Value.class)
+  @EnsuresQualifier(expression = "#1", qualifier = ValueTypeAnno.class)
   // :: error: (flowexpr.parse.index.too.big)
   void param3() {}
 
@@ -116,7 +116,7 @@ public class Postcondition {
   /** *** many postcondition ***** */
   @EnsuresQualifier.List({
     @EnsuresQualifier(expression = "f1", qualifier = Odd.class),
-    @EnsuresQualifier(expression = "f2", qualifier = Value.class)
+    @EnsuresQualifier(expression = "f2", qualifier = ValueTypeAnno.class)
   })
   void oddValueF1(@ValueTypeAnno String p1) {
     f1 = null;
@@ -124,7 +124,7 @@ public class Postcondition {
   }
 
   @EnsuresQualifier(expression = "f1", qualifier = Odd.class)
-  @EnsuresQualifier(expression = "f2", qualifier = Value.class)
+  @EnsuresQualifier(expression = "f2", qualifier = ValueTypeAnno.class)
   void oddValueF1_repeated1(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
@@ -133,14 +133,14 @@ public class Postcondition {
   @EnsuresQualifier.List({
     @EnsuresQualifier(expression = "f1", qualifier = Odd.class),
   })
-  @EnsuresQualifier(expression = "f2", qualifier = Value.class)
+  @EnsuresQualifier(expression = "f2", qualifier = ValueTypeAnno.class)
   void oddValueF1_repeated2(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
   }
 
   @EnsuresQualifier(expression = "f1", qualifier = Odd.class)
-  @EnsuresQualifier.List({@EnsuresQualifier(expression = "f2", qualifier = Value.class)})
+  @EnsuresQualifier.List({@EnsuresQualifier(expression = "f2", qualifier = ValueTypeAnno.class)})
   void oddValueF1_repeated3(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
@@ -148,7 +148,7 @@ public class Postcondition {
 
   @EnsuresQualifier.List({
     @EnsuresQualifier(expression = "f1", qualifier = Odd.class),
-    @EnsuresQualifier(expression = "f2", qualifier = Value.class)
+    @EnsuresQualifier(expression = "f2", qualifier = ValueTypeAnno.class)
   })
   // :: error: (contracts.postcondition)
   void oddValueF1_invalid(@ValueTypeAnno String p1) {}
@@ -264,7 +264,7 @@ public class Postcondition {
   /** *** many conditional postcondition ***** */
   @EnsuresQualifierIf.List({
     @EnsuresQualifierIf(result = true, expression = "f1", qualifier = Odd.class),
-    @EnsuresQualifierIf(result = false, expression = "f1", qualifier = Value.class)
+    @EnsuresQualifierIf(result = false, expression = "f1", qualifier = ValueTypeAnno.class)
   })
   boolean condsOddF1(boolean b, @ValueTypeAnno String p1) {
     if (b) {
@@ -277,7 +277,7 @@ public class Postcondition {
 
   @EnsuresQualifierIf.List({
     @EnsuresQualifierIf(result = true, expression = "f1", qualifier = Odd.class),
-    @EnsuresQualifierIf(result = false, expression = "f1", qualifier = Value.class)
+    @EnsuresQualifierIf(result = false, expression = "f1", qualifier = ValueTypeAnno.class)
   })
   boolean condsOddF1_invalid(boolean b, @ValueTypeAnno String p1) {
     if (b) {

--- a/framework/tests/flow/Postcondition.java
+++ b/framework/tests/flow/Postcondition.java
@@ -56,13 +56,13 @@ public class Postcondition {
   }
 
   @EnsuresQualifier(expression = "#1", qualifier = Value.class)
-  void param1(final @Value String f) {}
+  void param1(final @ValueTypeAnno String f) {}
 
   @EnsuresQualifier(
       expression = {"#1", "#2"},
       qualifier = Value.class)
   // :: error: (flowexpr.parameter.not.final)
-  void param2(@Value String f, @Value String g) {
+  void param2(@ValueTypeAnno String f, @ValueTypeAnno String g) {
     f = g;
   }
 
@@ -118,14 +118,14 @@ public class Postcondition {
     @EnsuresQualifier(expression = "f1", qualifier = Odd.class),
     @EnsuresQualifier(expression = "f2", qualifier = Value.class)
   })
-  void oddValueF1(@Value String p1) {
+  void oddValueF1(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
   }
 
   @EnsuresQualifier(expression = "f1", qualifier = Odd.class)
   @EnsuresQualifier(expression = "f2", qualifier = Value.class)
-  void oddValueF1_repeated1(@Value String p1) {
+  void oddValueF1_repeated1(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
   }
@@ -134,14 +134,14 @@ public class Postcondition {
     @EnsuresQualifier(expression = "f1", qualifier = Odd.class),
   })
   @EnsuresQualifier(expression = "f2", qualifier = Value.class)
-  void oddValueF1_repeated2(@Value String p1) {
+  void oddValueF1_repeated2(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
   }
 
   @EnsuresQualifier(expression = "f1", qualifier = Odd.class)
   @EnsuresQualifier.List({@EnsuresQualifier(expression = "f2", qualifier = Value.class)})
-  void oddValueF1_repeated3(@Value String p1) {
+  void oddValueF1_repeated3(@ValueTypeAnno String p1) {
     f1 = null;
     f2 = p1;
   }
@@ -151,7 +151,7 @@ public class Postcondition {
     @EnsuresQualifier(expression = "f2", qualifier = Value.class)
   })
   // :: error: (contracts.postcondition)
-  void oddValueF1_invalid(@Value String p1) {}
+  void oddValueF1_invalid(@ValueTypeAnno String p1) {}
 
   @EnsuresQualifier.List({
     @EnsuresQualifier(expression = "--", qualifier = Odd.class),
@@ -160,14 +160,14 @@ public class Postcondition {
   void error2() {}
 
   // basic postcondition test
-  void tnm1(@Odd String p1, @Value String p2) {
+  void tnm1(@Odd String p1, @ValueTypeAnno String p2) {
     // :: error: (assignment)
     @Odd String l1 = f1;
     // :: error: (assignment)
-    @Value String l2 = f2;
+    @ValueTypeAnno String l2 = f2;
     oddValueF1(p2);
     @Odd String l3 = f1;
-    @Value String l4 = f2;
+    @ValueTypeAnno String l4 = f2;
 
     // :: error: (flowexpr.parse.error.postcondition)
     error2();
@@ -266,7 +266,7 @@ public class Postcondition {
     @EnsuresQualifierIf(result = true, expression = "f1", qualifier = Odd.class),
     @EnsuresQualifierIf(result = false, expression = "f1", qualifier = Value.class)
   })
-  boolean condsOddF1(boolean b, @Value String p1) {
+  boolean condsOddF1(boolean b, @ValueTypeAnno String p1) {
     if (b) {
       f1 = null;
       return true;
@@ -279,7 +279,7 @@ public class Postcondition {
     @EnsuresQualifierIf(result = true, expression = "f1", qualifier = Odd.class),
     @EnsuresQualifierIf(result = false, expression = "f1", qualifier = Value.class)
   })
-  boolean condsOddF1_invalid(boolean b, @Value String p1) {
+  boolean condsOddF1_invalid(boolean b, @ValueTypeAnno String p1) {
     if (b) {
       // :: error: (contracts.conditional.postcondition)
       return true;
@@ -296,18 +296,18 @@ public class Postcondition {
     return "";
   }
 
-  void t6(@Odd String p1, @Value String p2) {
+  void t6(@Odd String p1, @ValueTypeAnno String p2) {
     condsOddF1(true, p2);
     // :: error: (assignment)
     @Odd String l1 = f1;
     // :: error: (assignment)
-    @Value String l2 = f1;
+    @ValueTypeAnno String l2 = f1;
     if (condsOddF1(false, p2)) {
       @Odd String l3 = f1;
       // :: error: (assignment)
-      @Value String l4 = f1;
+      @ValueTypeAnno String l4 = f1;
     } else {
-      @Value String l5 = f1;
+      @ValueTypeAnno String l5 = f1;
       // :: error: (assignment)
       @Odd String l6 = f1;
     }

--- a/framework/tests/flow/Precondition.java
+++ b/framework/tests/flow/Precondition.java
@@ -25,7 +25,7 @@ public class Precondition {
     return 1;
   }
 
-  @RequiresQualifier(expression = "f1", qualifier = Value.class)
+  @RequiresQualifier(expression = "f1", qualifier = ValueTypeAnno.class)
   void requiresF1Value() {
     // :: error: (assignment)
     @Odd String l1 = f1;
@@ -118,7 +118,7 @@ public class Precondition {
   }
 
   /** *** multiple preconditions ***** */
-  @RequiresQualifier(expression = "f1", qualifier = Value.class)
+  @RequiresQualifier(expression = "f1", qualifier = ValueTypeAnno.class)
   @RequiresQualifier(expression = "f2", qualifier = Odd.class)
   void multi() {
     @ValueTypeAnno String l1 = f1;
@@ -130,7 +130,7 @@ public class Precondition {
   }
 
   @RequiresQualifier.List({
-    @RequiresQualifier(expression = "f1", qualifier = Value.class),
+    @RequiresQualifier(expression = "f1", qualifier = ValueTypeAnno.class),
     @RequiresQualifier(expression = "f2", qualifier = Odd.class)
   })
   void multi_explicit_requiresqualifierlist() {
@@ -142,7 +142,7 @@ public class Precondition {
     @Odd String l4 = f1;
   }
 
-  @RequiresQualifier.List({@RequiresQualifier(expression = "--", qualifier = Value.class)})
+  @RequiresQualifier.List({@RequiresQualifier(expression = "--", qualifier = ValueTypeAnno.class)})
   // :: error: (flowexpr.parse.error)
   void error2() {}
 

--- a/framework/tests/flow/Precondition.java
+++ b/framework/tests/flow/Precondition.java
@@ -12,7 +12,7 @@ public class Precondition {
   @RequiresQualifier(expression = "f1", qualifier = Odd.class)
   void requiresF1() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f1;
   }
 
@@ -20,7 +20,7 @@ public class Precondition {
   @RequiresQualifier(expression = "f1", qualifier = Odd.class)
   int requiresF1AndPure() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f1;
     return 1;
   }
@@ -29,14 +29,14 @@ public class Precondition {
   void requiresF1Value() {
     // :: error: (assignment)
     @Odd String l1 = f1;
-    @Value String l2 = f1;
+    @ValueTypeAnno String l2 = f1;
   }
 
   @RequiresQualifier(expression = "---", qualifier = Odd.class)
   // :: error: (flowexpr.parse.error)
   void error() {
     // :: error: (assignment)
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     // :: error: (assignment)
     @Odd String l2 = f1;
   }
@@ -44,7 +44,7 @@ public class Precondition {
   @RequiresQualifier(expression = "#1", qualifier = Odd.class)
   void requiresParam(String p) {
     // :: error: (assignment)
-    @Value String l1 = p;
+    @ValueTypeAnno String l1 = p;
     @Odd String l2 = p;
   }
 
@@ -53,9 +53,9 @@ public class Precondition {
       qualifier = Odd.class)
   void requiresParams(String p1, String p2) {
     // :: error: (assignment)
-    @Value String l1 = p1;
+    @ValueTypeAnno String l1 = p1;
     // :: error: (assignment)
-    @Value String l2 = p2;
+    @ValueTypeAnno String l2 = p2;
     @Odd String l3 = p1;
     @Odd String l4 = p2;
   }
@@ -94,7 +94,7 @@ public class Precondition {
     requiresF1();
   }
 
-  void t4(@Odd String p1, String p2, @Value String p3) {
+  void t4(@Odd String p1, String p2, @ValueTypeAnno String p3) {
     f1 = p1;
     requiresF1();
     f1 = p3;
@@ -121,10 +121,10 @@ public class Precondition {
   @RequiresQualifier(expression = "f1", qualifier = Value.class)
   @RequiresQualifier(expression = "f2", qualifier = Odd.class)
   void multi() {
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f2;
     // :: error: (assignment)
-    @Value String l3 = f2;
+    @ValueTypeAnno String l3 = f2;
     // :: error: (assignment)
     @Odd String l4 = f1;
   }
@@ -134,10 +134,10 @@ public class Precondition {
     @RequiresQualifier(expression = "f2", qualifier = Odd.class)
   })
   void multi_explicit_requiresqualifierlist() {
-    @Value String l1 = f1;
+    @ValueTypeAnno String l1 = f1;
     @Odd String l2 = f2;
     // :: error: (assignment)
-    @Value String l3 = f2;
+    @ValueTypeAnno String l3 = f2;
     // :: error: (assignment)
     @Odd String l4 = f1;
   }
@@ -146,7 +146,7 @@ public class Precondition {
   // :: error: (flowexpr.parse.error)
   void error2() {}
 
-  void t5(@Odd String p1, String p2, @Value String p3) {
+  void t5(@Odd String p1, String p2, @ValueTypeAnno String p3) {
     // :: error: (contracts.precondition)
     multi();
     f1 = p3;

--- a/framework/tests/flow/Values.java
+++ b/framework/tests/flow/Values.java
@@ -46,24 +46,24 @@ public class Values {
     }
   }
 
-  void foo(@Value Object o) {}
+  void foo(@ValueTypeAnno Object o) {}
 
-  void foo1(@Value(1) Object o) {}
+  void foo1(@ValueTypeAnno(1) Object o) {}
 
-  void foo2(@Value(2) Object o) {}
+  void foo2(@ValueTypeAnno(2) Object o) {}
 
   @SuppressWarnings("flowtest:return")
-  @Value Object get() {
+  @ValueTypeAnno Object get() {
     return null;
   }
 
   @SuppressWarnings("flowtest:return")
-  @Value(1) Object get1() {
+  @ValueTypeAnno(1) Object get1() {
     return null;
   }
 
   @SuppressWarnings("flowtest:return")
-  @Value(2) Object get2() {
+  @ValueTypeAnno(2) Object get2() {
     return null;
   }
 }


### PR DESCRIPTION
This eliminates the need to format all occurrences of `@Value` as type annotations.