### PR TITLE
Fix WPI crash when delocalizing deterministic method calls

### DIFF
--- a/checker/tests/ainfer-index/non-annotated/RequireJavadocCrash.java
+++ b/checker/tests/ainfer-index/non-annotated/RequireJavadocCrash.java
@@ -1,0 +1,22 @@
+// Based on a crash encountered when runnnig WPI on plume-lib's RequireJavadoc.
+
+import org.plumelib.options.Options;
+
+public class RequireJavadocCrash {
+
+  public static void main(String[] args) {
+    RequireJavadocCrash rj = new RequireJavadocCrash();
+    Options options =
+        new Options(
+            "java org.plumelib.javadoc.RequireJavadoc [options] [directory-or-file ...]", rj);
+    String[] remainingArgs = options.parse(true, args);
+
+    rj.setJavaFiles(remainingArgs);
+  }
+
+  private RequireJavadocCrash() {}
+
+  private void setJavaFiles(String[] args) {
+
+  }
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -38,6 +39,7 @@ import org.checkerframework.dataflow.expression.FormalParameter;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.JavaExpressionConverter;
 import org.checkerframework.dataflow.expression.LocalVariable;
+import org.checkerframework.dataflow.expression.MethodCall;
 import org.checkerframework.dataflow.expression.ThisReference;
 import org.checkerframework.dataflow.expression.Unknown;
 import org.checkerframework.framework.source.SourceChecker;
@@ -714,7 +716,32 @@ public class DependentTypesHelper {
                 public JavaExpression visitThisReference(ThisReference thisRef, Void unused) {
                   return null;
                 }
+
+                @Override
+                public JavaExpression visitMethodCall(MethodCall methodCall, Void unused) {
+                  // To delocalize a method call, first delocalize its receiver and its
+                  // parameters. If any of them are null - that is, represent local variables
+                  // - return null, because the method call expression shouldn't be included
+                  // in the delocalized result.
+                  JavaExpression convertedReceiver = convert(methodCall.getReceiver());
+                  if (convertedReceiver == null) {
+                    return null;
+                  }
+                  List<JavaExpression> convertedArgs =
+                      methodCall.getArguments().stream()
+                          .map(this::convert)
+                          .collect(Collectors.toList());
+                  if (convertedArgs.contains(null)) {
+                    return null;
+                  }
+                  return new MethodCall(
+                      methodCall.getType(),
+                      methodCall.getElement(),
+                      convertedReceiver,
+                      convertedArgs);
+                }
               };
+
           return jec.convert(expr);
         };
 


### PR DESCRIPTION
Fixes a regression introduced in #5321, based on a crash discovered by @dd482IT when running WPI on require-javadoc.