### PR TITLE
WPI: Fix crash caused by delocalizeAtCallsite not handling possible nulls caused by out-of-scope variables in annotations

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UBQualifier.java
@@ -125,6 +125,11 @@ public abstract class UBQualifier {
     List<String> sequences =
         AnnotationUtils.getElementValueArray(
             ltLengthOfAnno, ubChecker.ltLengthOfValueElement, String.class);
+    if (sequences.isEmpty()) {
+      // These annotations can be created by delocalization of an LTLengthOf annotation
+      // that only contains local variables at a call site.
+      return UpperBoundUnknownQualifier.UNKNOWN;
+    }
     List<String> offsets =
         AnnotationUtils.getElementValueArray(
             ltLengthOfAnno,
@@ -147,6 +152,11 @@ public abstract class UBQualifier {
     List<String> sequences =
         AnnotationUtils.getElementValueArray(
             substringIndexForAnno, ubChecker.substringIndexForValueElement, String.class);
+    if (sequences.isEmpty()) {
+      // These annotations can be created by delocalization of a SubstringIndexFor annotation
+      // that only contains local variables at a call site.
+      return UpperBoundUnknownQualifier.UNKNOWN;
+    }
     List<String> offsets =
         AnnotationUtils.getElementValueArray(
             substringIndexForAnno, ubChecker.substringIndexForOffsetElement, String.class);
@@ -169,7 +179,8 @@ public abstract class UBQualifier {
     List<String> sequences =
         AnnotationUtils.getElementValueArray(am, ubChecker.ltEqLengthOfValueElement, String.class);
     if (sequences.isEmpty()) {
-      // How did this AnnotationMirror even get made?  It seems invalid.
+      // These annotations can be created by delocalization of an LTEqLengthOf annotation
+      // that only contains local variables at a call site.
       return UpperBoundUnknownQualifier.UNKNOWN;
     }
     List<String> offset = Collections.nCopies(sequences.size(), "-1");
@@ -188,6 +199,11 @@ public abstract class UBQualifier {
       AnnotationMirror am, String extraOffset, UpperBoundChecker ubChecker) {
     List<String> sequences =
         AnnotationUtils.getElementValueArray(am, ubChecker.ltOMLengthOfValueElement, String.class);
+    if (sequences.isEmpty()) {
+      // These annotations can be created by delocalization of an LTOMLengthOf annotation
+      // that only contains local variables at a call site.
+      return UpperBoundUnknownQualifier.UNKNOWN;
+    }
     List<String> offset = Collections.nCopies(sequences.size(), "1");
     return createUBQualifier(sequences, offset, extraOffset);
   }

--- a/checker/tests/ainfer-index/non-annotated/DelocalizeAtCallsites.java
+++ b/checker/tests/ainfer-index/non-annotated/DelocalizeAtCallsites.java
@@ -1,0 +1,60 @@
+// test for crashes when delocalizing array variables, indices, array creation expressions, etc
+// in annotations
+
+import org.checkerframework.checker.index.qual.IndexFor;
+import org.checkerframework.checker.index.qual.LessThan;
+
+public class DelocalizeAtCallsites {
+
+  void a1(int[][] a, @IndexFor("#1") int y) {
+    int[] z = a[y];
+  }
+
+  void a2(int y, int x) {
+
+  }
+
+  void testArrayAccess() {
+    int[][] arr = new int[5][5];
+    int x1 = 3;
+    @SuppressWarnings("all")
+    @IndexFor(value={"arr[x1]", "arr"}) int y1 = 2;
+    // test that out-of-scope indices are handled properly
+    a1(arr, y1);
+    // test that out-of-scope arrays are handled properly
+    a2(y1, x1);
+  }
+
+  void a3(int x) { }
+
+  void testArrayCreation() {
+    int x = 10;
+    @SuppressWarnings("all")
+    @IndexFor("new int[x]") int y = 0;
+    a3(y);
+    @SuppressWarnings("all")
+    @IndexFor("new int[x]{x, x, x, x, x, x, x, x, x, x}") int z = 0;
+    a3(z);
+  }
+
+  void testBinary() {
+    int x1 = 5;
+    @LessThan("x1 + 1") int y = 4;
+    a3(y);
+  }
+
+  void testUnary() {
+    int x1 = 5;
+    @LessThan("x1++") int y = 4;
+    a3(y);
+  }
+
+  public int f;
+
+  void testFieldAccess() {
+    DelocalizeAtCallsites d = new DelocalizeAtCallsites();
+    d.f = 3;
+    @LessThan("d.f") int y = 2;
+    a3(y);
+  }
+}


### PR DESCRIPTION
In #5321, we added the ability for WPI to viewpoint adapt annotations at callsites by delocalizing arguments. That PR used `null` to represent annotation arguments that could not be delocalized. Unfortunately, I failed to notice that for annotations with arguments with more complex expression types (like binary expressions, array accesses, field accesses, etc) this would cause null-pointer exceptions as local variables in those expressions are converted to null. This PR handles all these cases safely by converting the whole expression to null if any of its constituent parts are null. It's a bit ugly in that I ended up re-implementing about half of `JavaExpressionConverter` to include null-handling, but it works as intended.