### PR TITLE
Fix crash in WPI when running MustCallInferenceLogic

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -197,7 +197,7 @@ public class WholeProgramInferenceJavaParserStorage
    * @param fieldElt a field
    * @return the annotations for a field
    */
-  private FieldAnnos getFieldAnnos(VariableElement fieldElt) {
+  private @Nullable FieldAnnos getFieldAnnos(VariableElement fieldElt) {
     String className = ElementUtils.getEnclosingClassName(fieldElt);
     // Read in classes for the element.
     getFileForElement(fieldElt);
@@ -357,7 +357,7 @@ public class WholeProgramInferenceJavaParserStorage
   @Override
   public boolean addFieldDeclarationAnnotation(VariableElement field, AnnotationMirror anno) {
     FieldAnnos fieldAnnos = getFieldAnnos(field);
-    boolean isNewAnnotation = fieldAnnos.addDeclarationAnnotation(anno);
+    boolean isNewAnnotation = fieldAnnos != null && fieldAnnos.addDeclarationAnnotation(anno);
     if (isNewAnnotation) {
       modifiedFiles.add(getFileForElement(field));
     }


### PR DESCRIPTION
The crash occurs in the code that supports inferring declaration annotations with ajava-based WPI. @Nargeshdb, can you review this? (I've asked @mernst to add you as a member of the organization so that I can officially assign you as a reviewer.)