### PR TITLE
Avoid concurrent modification exception

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeReplacer.java
@@ -1,5 +1,7 @@
 package org.checkerframework.framework.type;
 
+import java.util.ArrayList;
+import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -146,10 +148,16 @@ public class AnnotatedTypeReplacer extends DoubleAnnotatedTypeScanner<Void> {
           to.removeAnnotationInHierarchy(top);
         }
       } else {
+        List<AnnotationMirror> toRemove = new ArrayList<>(1);
         for (final AnnotationMirror toPrimaryAnno : to.getAnnotations()) {
           if (from.getAnnotationInHierarchy(toPrimaryAnno) == null) {
-            to.removeAnnotation(toPrimaryAnno);
+            // Doing the removal here directly can lead to a ConcurrentModificationException,
+            // because this loop is iterating over the annotations in to.
+            toRemove.add(toPrimaryAnno);
           }
+        }
+        for (AnnotationMirror annoToRemove : toRemove) {
+          to.removeAnnotation(annoToRemove);
         }
       }
     } else {


### PR DESCRIPTION
I don't have a minimized test case, unfortunately. @dd482IT encountered this crash when running WPI + the Nullness Checker on [randoop](github.com/randoop/randoop) with this (partial) stack trace:
```
  Exception: java.util.ConcurrentModificationException; java.util.ConcurrentModificationException
        at java.base/java.util.TreeMap$PrivateEntryIterator.nextEntry(TreeMap.java:1208)
        at java.base/java.util.TreeMap$KeyIterator.next(TreeMap.java:1262)
        at java.base/java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1047)
        at org.checkerframework.framework.type.AnnotatedTypeReplacer.resolvePrimaries(AnnotatedTypeReplacer.java:149)
```

It looks to me like the problem is that `to.getAnnotations()` iterates over the annotations in `to`, but `removeAnnotation` removes an annotation from the backing list that the iterator has a view of.