### PR TITLE
Add APIs to WPI for inferring 1) annotations on class declarations and 2) formal parameter annotations

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
@@ -123,7 +123,7 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
   /**
    * Using a MultiGraphQualifierHierarchy to enable tests with Annotations that contain fields.
    *
-   * @see AinferSiblingWithFields.
+   * @see AinferSiblingWithFields
    */
   protected class AinferTestQualifierHierarchy extends MostlyNoElementQualifierHierarchy {
 

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
@@ -105,7 +105,7 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
   protected class AinferTestTreeAnnotator extends TreeAnnotator {
 
     /**
-     * Create a new TreeAnnotator.
+     * Create a new AinferTestTreeAnnotator.
      *
      * @param atypeFactory the type factory
      */

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
@@ -109,7 +109,6 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
       WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
       TypeElement classElt = TreeUtils.elementFromDeclaration(classTree);
       if (wpi != null && classElt.getSimpleName().contentEquals("IShouldBeSibling1")) {
-        System.out.println("adding Sibling1 annotation to this classElt: " + classElt);
         wpi.addClassDeclarationAnnotation(classElt, SIBLING1);
       }
       return super.visitClass(classTree, type);

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
@@ -7,8 +7,8 @@ import java.lang.annotation.Target;
 
 /**
  * A declaration annotation used to test that the API for inferring declaration annotations on
- * parameters works properly. The presence of this annotation indicates that the check should treat
- * the annotated element as if it were annotated as {@link AinferSibling1}.
+ * parameters works properly. The presence of this annotation indicates that the checker should
+ * treat the annotated element as if it were annotated as {@link AinferSibling1}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
@@ -1,0 +1,15 @@
+package org.checkerframework.checker.testchecker.ainfer.qual;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A dummy declaration annotation used to test that the API for inferring declaration annotations on
+ * parameters works properly. The presence of this annotation indicates that the check should treat
+ * the annotated element as if it were annotated as {@link AinferSibling1}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface AinferTreatAsSibling1 {}

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A dummy declaration annotation used to test that the API for inferring declaration annotations on
+ * A declaration annotation used to test that the API for inferring declaration annotations on
  * parameters works properly. The presence of this annotation indicates that the check should treat
  * the annotated element as if it were annotated as {@link AinferSibling1}.
  */

--- a/checker/tests/ainfer-testchecker/non-annotated/IShouldBeSibling1.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/IShouldBeSibling1.java
@@ -1,0 +1,14 @@
+// Tests the feature that allows checkers to add annotations onto a class
+// declaration, which is used for custom inference logic. There is custom
+// logic in the AinferTestChecker specifically for classes with the name
+// "IShouldBeSibling1" that infers an @Sibling1 annotation for them.
+
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferSibling1;
+
+@SuppressWarnings("super.invocation") // Intentional.
+public class IShouldBeSibling1 {
+  public static void test(IShouldBeSibling1 s1) {
+    // :: warning: assignment
+    @AinferSibling1 IShouldBeSibling1 s = s1;
+  }
+}

--- a/checker/tests/ainfer-testchecker/non-annotated/TreatAsSibling1InferenceTest.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/TreatAsSibling1InferenceTest.java
@@ -1,0 +1,13 @@
+// A simple test that the @AinferTreatAsSibling1 can be inferred.
+// This test does actually test inference: the AinferTestChecker's TreeAnnotator
+// has logic to add the @AinferTreatAsSibling1 annotation to parameters with
+// the name "iShouldBeTreatedAsSibling1".
+
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferSibling1;
+
+public class TreatAsSibling1InferenceTest {
+  public void test(Object iShouldBeTreatedAsSibling1) {
+    // :: warning: assignment
+    @AinferSibling1 Object x = iShouldBeTreatedAsSibling1;
+  }
+}

--- a/checker/tests/ainfer-testchecker/non-annotated/TreatAsSibling1Test.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/TreatAsSibling1Test.java
@@ -1,0 +1,11 @@
+// A simple test that the @AinferTreatAsSibling1 annotation works as intended.
+// This test doesn't actually test inference: it's a test for the AinferTestChecker.
+
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferSibling1;
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferTreatAsSibling1;
+
+public class TreatAsSibling1Test {
+  public void test(@AinferTreatAsSibling1 Object y) {
+    @AinferSibling1 Object x = y;
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/SceneToStubWriter.java
@@ -540,16 +540,16 @@ public final class SceneToStubWriter {
         printWriter.println("@AnnotatedFor(\"" + checker.getClass().getCanonicalName() + "\")");
       }
       printWriter.print(indents(i));
-      if (aClass.isEnum(nameToPrint)) {
-        printWriter.print("enum ");
-      } else {
-        printWriter.print("class ");
-      }
       if (i == classNames.length - 1) {
         // Only print class annotations on the innermost class, which corresponds to aClass.
         // If there should be class annotations on another class, it will have its own stub
         // file, which will eventually be merged with this one.
         printWriter.print(formatAnnotations(aClass.getAnnotations()));
+      }
+      if (aClass.isEnum(nameToPrint)) {
+        printWriter.print("enum ");
+      } else {
+        printWriter.print("class ");
       }
       printWriter.print(nameToPrint);
       printTypeParameters(typeElements[i], printWriter);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
@@ -196,9 +196,22 @@ public interface WholeProgramInference {
    */
   void addFieldDeclarationAnnotation(VariableElement fieldElt, AnnotationMirror anno);
 
+  /**
+   * Adds a declaration annotation to a formal parameter.
+   *
+   * @param methodElt the method whose formal parameter will be annotated
+   * @param index the index of the parameter (0-indexed)
+   * @param anno the annotation to add
+   */
   void addDeclarationAnnotationToFormalParameter(
       ExecutableElement methodElt, int index, AnnotationMirror anno);
 
+  /**
+   * Adds an annotation to a class declaration.
+   *
+   * @param classElt the class declaration to annotate
+   * @param anno the annotation to add
+   */
   void addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno);
 
   /**

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInference.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.analysis.Analysis;
@@ -194,6 +195,11 @@ public interface WholeProgramInference {
    * @param anno the declaration annotation to add to the field
    */
   void addFieldDeclarationAnnotation(VariableElement fieldElt, AnnotationMirror anno);
+
+  void addDeclarationAnnotationToFormalParameter(
+      ExecutableElement methodElt, int index, AnnotationMirror anno);
+
+  void addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno);
 
   /**
    * Writes the inferred results to a file. Ideally, it should be called at the end of the

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -763,6 +763,34 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
     }
   }
 
+  @Override
+  public void addDeclarationAnnotationToFormalParameter(
+      ExecutableElement methodElt, int index, AnnotationMirror anno) {
+    if (!ElementUtils.isElementFromSourceCode(methodElt)) {
+      return;
+    }
+
+    String file = storage.getFileForElement(methodElt);
+    boolean isNewAnnotation =
+        storage.addDeclarationAnnotationToFormalParameter(methodElt, index, anno);
+    if (isNewAnnotation) {
+      storage.setFileModified(file);
+    }
+  }
+
+  @Override
+  public void addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno) {
+    if (!ElementUtils.isElementFromSourceCode(classElt)) {
+      return;
+    }
+
+    String file = storage.getFileForElement(classElt);
+    boolean isNewAnnotation = storage.addClassDeclarationAnnotation(classElt, anno);
+    if (isNewAnnotation) {
+      storage.setFileModified(file);
+    }
+  }
+
   /**
    * Updates the set of annotations in a location in a program.
    *

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -374,7 +374,7 @@ public class WholeProgramInferenceJavaParserStorage
   public boolean addDeclarationAnnotationToFormalParameter(
       ExecutableElement methodElt, int index, AnnotationMirror anno) {
     CallableDeclarationAnnos methodAnnos = getMethodAnnos(methodElt);
-    boolean isNewAnnotation = methodAnnos.addDeclarationAnnotationForParams(anno, index);
+    boolean isNewAnnotation = methodAnnos.addDeclarationAnnotationToFormalParameter(anno, index);
     if (isNewAnnotation) {
       modifiedFiles.add(getFileForElement(methodElt));
     }
@@ -633,6 +633,8 @@ public class WholeProgramInferenceJavaParserStorage
            *
            * @param tree tree to add. Its corresponding element is used as the key for {@code
            *     classToAnnos}.
+           * @param javaParserNode the node corresponding to the declaration, which is used to place
+           *     annotations on the class itself. Can be null, e.g. for an anonymous class.
            */
           private void addClass(ClassTree tree, @Nullable TypeDeclaration<?> javaParserNode) {
             addClass(tree, null, javaParserNode);
@@ -1027,13 +1029,13 @@ public class WholeProgramInferenceJavaParserStorage
      * Annotations on the declaration of the class (note that despite the name, these can also be
      * type annotations).
      */
-    private @MonotonicNonNull Set<AnnotationMirror> declarationAnnotations = null;
+    private @MonotonicNonNull Set<AnnotationMirror> classAnnotations = null;
 
     /**
      * The Java Parser TypeDeclaration representing the class's declaration. Used for placing
      * annotations inferred on the class declaration itself.
      */
-    private @MonotonicNonNull TypeDeclaration<?> declaration = null;
+    private @MonotonicNonNull TypeDeclaration<?> classDeclaration;
 
     /**
      * Create a new ClassOrInterfaceAnnos.
@@ -1042,9 +1044,7 @@ public class WholeProgramInferenceJavaParserStorage
      *     used for placing annotations on the class declaration
      */
     public ClassOrInterfaceAnnos(@Nullable TypeDeclaration<?> javaParserNode) {
-      if (javaParserNode != null) {
-        declaration = javaParserNode;
-      }
+      classDeclaration = javaParserNode;
     }
 
     /**
@@ -1054,11 +1054,11 @@ public class WholeProgramInferenceJavaParserStorage
      * @return true if this is a new annotation for this class
      */
     public boolean addAnnotationToClassDeclaration(AnnotationMirror annotation) {
-      if (declarationAnnotations == null) {
-        declarationAnnotations = new HashSet<>();
+      if (classAnnotations == null) {
+        classAnnotations = new HashSet<>();
       }
 
-      return declarationAnnotations.add(annotation);
+      return classAnnotations.add(annotation);
     }
 
     /**
@@ -1070,9 +1070,9 @@ public class WholeProgramInferenceJavaParserStorage
         callableAnnos.transferAnnotations();
       }
 
-      if (declarationAnnotations != null && declaration != null) {
-        for (AnnotationMirror annotation : declarationAnnotations) {
-          declaration.addAnnotation(
+      if (classAnnotations != null && classDeclaration != null) {
+        for (AnnotationMirror annotation : classAnnotations) {
+          classDeclaration.addAnnotation(
               AnnotationMirrorToAnnotationExprConversion.annotationMirrorToAnnotationExpr(
                   annotation));
         }
@@ -1226,7 +1226,8 @@ public class WholeProgramInferenceJavaParserStorage
      * @param index index of the parameter
      * @return true if {@code annotation} wasn't previously stored for this parameter
      */
-    public boolean addDeclarationAnnotationForParams(AnnotationMirror annotation, int index) {
+    public boolean addDeclarationAnnotationToFormalParameter(
+        AnnotationMirror annotation, int index) {
       if (paramsDeclAnnos == null) {
         paramsDeclAnnos = new HashSet<>();
       }

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -1037,7 +1037,7 @@ public class WholeProgramInferenceJavaParserStorage
     private @MonotonicNonNull TypeDeclaration<?> declaration = null;
 
     /**
-     * Create a new ClassOrInterfaceAnnos
+     * Create a new ClassOrInterfaceAnnos.
      *
      * @param javaParserNode the java parser node corresponding to the class declaration, which is
      *     used for placing annotations on the class declaration

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -1071,7 +1071,7 @@ public class WholeProgramInferenceJavaParserStorage
         callableAnnos.transferAnnotations();
       }
 
-      if (declarationAnnotations != null) {
+      if (declarationAnnotations != null && declaration != null) {
         for (AnnotationMirror annotation : declarationAnnotations) {
           declaration.addAnnotation(
               AnnotationMirrorToAnnotationExprConversion.annotationMirrorToAnnotationExpr(
@@ -1377,7 +1377,7 @@ public class WholeProgramInferenceJavaParserStorage
         }
       }
 
-      if (declarationAnnotations != null) {
+      if (declarationAnnotations != null && declaration != null) {
         for (AnnotationMirror annotation : declarationAnnotations) {
           declaration.addAnnotation(
               AnnotationMirrorToAnnotationExprConversion.annotationMirrorToAnnotationExpr(

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -157,6 +157,9 @@ public class WholeProgramInferenceScenesStorage
         ClassSymbol enclosingClass = ((VarSymbol) elt).enclClass();
         className = enclosingClass.flatname.toString();
         break;
+      case CLASS:
+        className = ElementUtils.getBinaryName((TypeElement) elt);
+        break;
       default:
         throw new BugInCF("What element? %s %s", elt.getKind(), elt);
     }

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -409,7 +409,7 @@ public class WholeProgramInferenceScenesStorage
 
     AClass classAnnos =
         getClassAnnos(
-            classElt.getQualifiedName().toString(),
+            ElementUtils.getBinaryName(classElt),
             getFileForElement(classElt),
             (ClassSymbol) classElt);
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -377,6 +378,41 @@ public class WholeProgramInferenceScenesStorage
     Annotation sceneAnno = AnnotationConverter.annotationMirrorToAnnotation(anno);
 
     boolean isNewAnnotation = fieldAnnos.tlAnnotationsHere.add(sceneAnno);
+    return isNewAnnotation;
+  }
+
+  @Override
+  public boolean addDeclarationAnnotationToFormalParameter(
+      ExecutableElement methodElt, int index, AnnotationMirror anno) {
+    if (!ElementUtils.isElementFromSourceCode(methodElt)) {
+      return false;
+    }
+
+    VariableElement paramElt = methodElt.getParameters().get(index);
+    AnnotatedTypeMirror paramAType = atypeFactory.getAnnotatedType(paramElt);
+    ATypeElement paramAnnos =
+        getParameterAnnotations(methodElt, index, paramAType, paramElt, atypeFactory);
+    Annotation sceneAnno = AnnotationConverter.annotationMirrorToAnnotation(anno);
+
+    boolean isNewAnnotation = paramAnnos.tlAnnotationsHere.add(sceneAnno);
+    return isNewAnnotation;
+  }
+
+  @Override
+  public boolean addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno) {
+    if (!ElementUtils.isElementFromSourceCode(classElt)) {
+      return false;
+    }
+
+    AClass classAnnos =
+        getClassAnnos(
+            classElt.getQualifiedName().toString(),
+            getFileForElement(classElt),
+            (ClassSymbol) classElt);
+
+    Annotation sceneAnno = AnnotationConverter.annotationMirrorToAnnotation(anno);
+
+    boolean isNewAnnotation = classAnnos.tlAnnotationsHere.add(sceneAnno);
     return isNewAnnotation;
   }
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceStorage.java
@@ -4,6 +4,7 @@ import com.sun.source.tree.ClassTree;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -146,6 +147,11 @@ public interface WholeProgramInferenceStorage<T> {
    *     otherwise
    */
   public boolean addFieldDeclarationAnnotation(VariableElement fieldElt, AnnotationMirror anno);
+
+  boolean addDeclarationAnnotationToFormalParameter(
+      ExecutableElement methodElt, int index, AnnotationMirror anno);
+
+  boolean addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno);
 
   /**
    * Obtain the type from a storage location.

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceStorage.java
@@ -148,10 +148,27 @@ public interface WholeProgramInferenceStorage<T> {
    */
   public boolean addFieldDeclarationAnnotation(VariableElement fieldElt, AnnotationMirror anno);
 
-  boolean addDeclarationAnnotationToFormalParameter(
+  /**
+   * Adds a declaration annotation to a formal parameter.
+   *
+   * @param methodElt the method whose formal parameter will be annotated
+   * @param index the index of the parameter (0-indexed)
+   * @param anno the annotation to add
+   * @return true if {@code anno} is a new declaration annotation for {@code methodElt}, false
+   *     otherwise
+   */
+  public boolean addDeclarationAnnotationToFormalParameter(
       ExecutableElement methodElt, int index, AnnotationMirror anno);
 
-  boolean addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno);
+  /**
+   * Adds an annotation to a class declaration.
+   *
+   * @param classElt the class declaration to annotate
+   * @param anno the annotation to add
+   * @return true if {@code anno} is a new declaration annotation for {@code classElt}, false
+   *     otherwise
+   */
+  public boolean addClassDeclarationAnnotation(TypeElement classElt, AnnotationMirror anno);
 
   /**
    * Obtain the type from a storage location.


### PR DESCRIPTION
This PR is based on work by @Nargeshdb in [this branch](https://github.com/Nargeshdb/checker-framework/tree/inference). I copied over the code implementing the APIs themselves and have added inference logic and test cases to the `AinferTestChecker` to test the two new APIs.

The goal of these APIs is to support inference of `@MustCall` annotations on class declarations and `@Owning` annotations on method parameters, respectively. @Nargeshdb will follow this PR with implementations of those features.

Getting these APIs to pass the tests required two small bug fixes, both related to stub-based WPI:
* `SceneToStubWriter` printed class declaration annotations after the `class`, which is the wrong place: the annotations should be before the `class` keyword. Previously, we didn't have a test for `SceneToStubWriter` where a class-level annotation was inferred.
* `WholeProgramInferenceScenesStorage` could not locate the annotation file associated with an element whose type was `CLASS`.