### PR TITLE
Annotation declarations are declarations

### DIFF
--- a/checker/tests/ainfer-testchecker/non-annotated/OptionGroup.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/OptionGroup.java
@@ -1,0 +1,18 @@
+// This annotation from plume-lib options caused an error in
+// a version of ajava-based WPI. The problem was that annotation
+// declarations weren't considered possible declarations when checking
+// whether a location can store a declaration annotation.
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface OptionGroup {
+
+  String value();
+
+  boolean unpublicized() default false;
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
@@ -8,6 +8,7 @@ import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.StubUnit;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -219,6 +220,11 @@ public class JavaParserUtil {
     Optional<EnumDeclaration> enumDecl = root.getEnumByName(name);
     if (enumDecl.isPresent()) {
       return enumDecl.get();
+    }
+
+    Optional<AnnotationDeclaration> annoDecl = root.getAnnotationDeclarationByName(name);
+    if (annoDecl.isPresent()) {
+      return annoDecl.get();
     }
 
     Optional<CompilationUnit.Storage> storage = root.getStorage();


### PR DESCRIPTION
Fixes a crash that occurs when running WPI on plume-lib's options project, which had [this stacktrace](https://pastebin.com/raw/v4w9B2WR) recorded by @dd482IT.