### PR TITLE
Ensure inferred IntRange annos are no wider than is possible for the Java type.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -253,7 +253,7 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
   @Override
   protected void applyInferredAnnotations(AnnotatedTypeMirror type, CFValue as) {
-    // Inference can widen an IntRange beyond that values possible for the Java type. Change the
+    // Inference can widen an IntRange beyond the values possible for the Java type. Change the
     // annotation here so it is no wider than is possible.
     TypeMirror t = as.getUnderlyingType();
     Set<AnnotationMirror> inferredAnnos = as.getAnnotations();

--- a/framework/tests/value/TooWideRange.java
+++ b/framework/tests/value/TooWideRange.java
@@ -1,0 +1,26 @@
+// test case for https://github.com/typetools/checker-framework/issues/5486
+
+public class TooWideRange {
+  // From StringsPlume
+  @org.checkerframework.dataflow.qual.Pure
+  public static  @org.checkerframework.common.value.qual.IntRange(from = -2147483648, to = 2147483647) int count(String s, int ch) {
+    int result = 0;
+    int pos = s.indexOf(ch);
+    while (pos > -1) {
+      result++;
+      pos = s.indexOf(ch, pos + 1);
+    }
+    return result;
+  }
+
+  // From ArraysPlume
+  @org.checkerframework.dataflow.qual.Pure
+  public static  @org.checkerframework.common.value.qual.IntRange(from = -2147483648, to = 2147483647) int indexOfEq(Object[] a, Object elt) {
+    for (int i = 0; i < a.length; i++) {
+      if (elt == a[i]) {
+        return i;
+      }
+    }
+    return -1;
+  }
+}


### PR DESCRIPTION
Fixes #5486.