### PR TITLE
Don't infer contract annotations about instance fields on static methods.

### DIFF
--- a/checker/tests/ainfer-nullness/non-annotated/Bug.java
+++ b/checker/tests/ainfer-nullness/non-annotated/Bug.java
@@ -1,0 +1,61 @@
+import org.checkerframework.checker.initialization.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+public class Bug {
+  /** Actions that MultiVersionControl can perform. */
+  static enum Action {
+    /** Clone a repository. */
+    CLONE,
+    /** Show the working tree status. */
+    STATUS,
+    /** Pull changes from upstream. */
+    PULL,
+    /** List the known repositories. */
+    LIST
+  }
+  private @MonotonicNonNull Action action;
+  public static String home = System.getProperty("user.home");
+  void other() {
+    this.action = Action.LIST;
+    expandTilde("");
+  }
+  /**
+   * Replace "~" by the expansion of "$HOME".
+   *
+   * @param path the input path, which might contain "~"
+   * @return path with "~" expanded
+   */
+  private static String expandTilde(String path) {
+    return path.replaceFirst("^~", home);
+  }
+
+  public static void main(String[] args) {
+    Bug b = new Bug();
+    Bug.expandTilde("");
+
+  }
+
+  Bug() {
+    parseArgs(new String[0]);
+  }
+  @EnsuresNonNull("action")
+  public void parseArgs(@UnknownInitialization Bug this, String[] args) {
+    String actionString = args[0];
+    if ("checkout".startsWith(actionString)) {
+      action = Action.CLONE;
+    } else if ("clone".startsWith(actionString)) {
+      action = Action.CLONE;
+    } else if ("list".startsWith(actionString)) {
+      action = Action.LIST;
+    } else if ("pull".startsWith(actionString)) {
+      action = Action.PULL;
+    } else if ("status".startsWith(actionString)) {
+      action = Action.STATUS;
+    } else if ("update".startsWith(actionString)) {
+      action = Action.PULL;
+    } else {
+      System.out.printf("Unrecognized action \"%s\"", actionString);
+      System.exit(1);
+    }
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -383,6 +383,10 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
         // places the annotations incorrectly on the class declarations.
         continue;
       }
+      if (ElementUtils.isStatic(methodElt) && !ElementUtils.isStatic(fieldElement)) {
+        // A static method can't have precondition annotations about instance fields.
+        continue;
+      }
       FieldAccess fa =
           new FieldAccess(
               (ElementUtils.isStatic(fieldElement) ? classNameReceiver : thisReference),


### PR DESCRIPTION
This should fix https://github.com/mernst/checker-framework/tree/wpi-multi-version-control-onlyone.