### PR TITLE
Fix crash in WPI when receiver type is null

### DIFF
--- a/checker/tests/ainfer-resourceleak/non-annotated/HadoopCrash.java
+++ b/checker/tests/ainfer-resourceleak/non-annotated/HadoopCrash.java
@@ -1,0 +1,9 @@
+class NullReceiverTest {
+  public static void testReceiver(NullReceiverTest nrt){
+    nrt.nullReceiver();
+  }
+
+  public static NullReceiverTest nullReceiver() {
+    return new NullReceiverTest();
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -256,6 +256,10 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       AnnotatedTypeMirror receiverArgATM = atypeFactory.getReceiverType(invocationTree);
       AnnotatedExecutableType methodDeclType = atypeFactory.getAnnotatedType(methodElt);
       AnnotatedTypeMirror receiverParamATM = methodDeclType.getReceiverType();
+      if (receiverParamATM == null) {
+        // receiver type is null for static methods and constructors
+        return;
+      }
       atypeFactory.wpiAdjustForUpdateNonField(receiverArgATM);
       T receiverAnnotations =
           storage.getReceiverAnnotations(methodElt, receiverParamATM, atypeFactory);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -256,20 +256,19 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
       AnnotatedTypeMirror receiverArgATM = atypeFactory.getReceiverType(invocationTree);
       AnnotatedExecutableType methodDeclType = atypeFactory.getAnnotatedType(methodElt);
       AnnotatedTypeMirror receiverParamATM = methodDeclType.getReceiverType();
-      if (receiverParamATM == null) {
-        // receiver type is null for static methods and constructors
-        return;
+      // update the set of annotations for the receiver type if it is not null.
+      if (receiverParamATM != null) {
+        atypeFactory.wpiAdjustForUpdateNonField(receiverArgATM);
+        T receiverAnnotations =
+            storage.getReceiverAnnotations(methodElt, receiverParamATM, atypeFactory);
+        if (this.atypeFactory instanceof GenericAnnotatedTypeFactory) {
+          ((GenericAnnotatedTypeFactory) this.atypeFactory)
+              .getDependentTypesHelper()
+              .delocalizeAtCallsite(receiverArgATM, invocationTree, arguments, receiver, methodElt);
+        }
+        updateAnnotationSet(
+            receiverAnnotations, TypeUseLocation.RECEIVER, receiverArgATM, receiverParamATM, file);
       }
-      atypeFactory.wpiAdjustForUpdateNonField(receiverArgATM);
-      T receiverAnnotations =
-          storage.getReceiverAnnotations(methodElt, receiverParamATM, atypeFactory);
-      if (this.atypeFactory instanceof GenericAnnotatedTypeFactory) {
-        ((GenericAnnotatedTypeFactory) this.atypeFactory)
-            .getDependentTypesHelper()
-            .delocalizeAtCallsite(receiverArgATM, invocationTree, arguments, receiver, methodElt);
-      }
-      updateAnnotationSet(
-          receiverAnnotations, TypeUseLocation.RECEIVER, receiverArgATM, receiverParamATM, file);
     }
 
     for (int i = 0; i < arguments.size(); i++) {


### PR DESCRIPTION
The crash occurs in `updateInferredExecutableParameterTypes` when it tries to get the annotations for the receiver type of static method calls.

