### PR TITLE
WPI: Avoid NPE due to out-of-compilation-unit inference

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -1419,6 +1419,11 @@ public class WholeProgramInferenceJavaParserStorage
 
       for (int i = 0; i < parameterTypes.size(); i++) {
         AnnotatedTypeMirror inferredType = parameterTypes.get(i);
+        if (inferredType == null) {
+          // Can occur if the only places that this method was called were
+          // outside the compilation unit.
+          continue;
+        }
         Parameter param = declaration.getParameter(i);
         Type javaParserType = param.getType();
         if (param.isVarArgs()) {


### PR DESCRIPTION
No test for this, because out-of-compilation-unit tests are difficult/impossible to write as unit tests. Based on a report from @Nargeshdb of a crash when running WPI on HBase. Despite the lack of tests, I'll note that `parameterTypes` is specified as `@MonotonicNonNull List<@Nullable AnnotatedTypeMirror>`, so it's clear that null-checking an element from it is clearly the right thing to do.