### PR TITLE
`getQualifierKind()` throws an exception rather than returning null.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,11 @@
-Version 3.29.1 (February 1, 2023)
+Version 3.30.0 (February 1, 2023)
 --------------------------------
 
 **User-visible changes:**
 
 **Implementation details:**
+
+`getQualifierKind()` throws an exception rather than returning null.
 
 **Closed issues:**
 

--- a/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/ElementQualifierHierarchy.java
@@ -164,12 +164,16 @@ public abstract class ElementQualifierHierarchy implements QualifierHierarchy {
   /**
    * Returns the qualifier kind for the given annotation.
    *
-   * @param anno annotation mirror
+   * @param anno an annotation mirror that is in this hierarchy
    * @return the qualifier kind for the given annotation
    */
   protected QualifierKind getQualifierKind(AnnotationMirror anno) {
     String name = AnnotationUtils.annotationName(anno);
-    return getQualifierKind(name);
+    QualifierKind result = getQualifierKind(name);
+    if (result == null) {
+      throw new BugInCF("No qualifier kind for " + anno);
+    }
+    return result;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
@@ -4,7 +4,6 @@ import com.sun.source.tree.BinaryTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.SimpleTreeVisitor;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 
@@ -22,7 +21,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 public abstract class TreeAnnotator extends SimpleTreeVisitor<Void, AnnotatedTypeMirror> {
 
   /** The type factory. */
-  protected final @Nullable AnnotatedTypeFactory atypeFactory;
+  protected final AnnotatedTypeFactory atypeFactory;
 
   /**
    * Create a new TreeAnnotator.

--- a/framework/src/main/java/org/checkerframework/framework/util/DefaultQualifierKindHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/DefaultQualifierKindHierarchy.java
@@ -111,8 +111,12 @@ public class DefaultQualifierKindHierarchy implements QualifierKindHierarchy {
   }
 
   @Override
-  public @Nullable QualifierKind getQualifierKind(@CanonicalName String name) {
-    return nameToQualifierKind.get(name);
+  public QualifierKind getQualifierKind(@CanonicalName String name) {
+    QualifierKind result = nameToQualifierKind.get(name);
+    if (result == null) {
+      throw new BugInCF("getQualifierKind(%s) => null", name);
+    }
+    return result;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/util/QualifierKindHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/QualifierKindHierarchy.java
@@ -80,14 +80,13 @@ public interface QualifierKindHierarchy {
   List<? extends QualifierKind> allQualifierKinds();
 
   /**
-   * Returns the {@link QualifierKind} for the given annotation class name, or null if one does not
-   * exist.
+   * Returns the {@link QualifierKind} for the given annotation class name. Throws an exception if
+   * one does not exist.
    *
    * @param name canonical name of an annotation class
-   * @return the {@link QualifierKind} for the given annotation class name, or null if one does not
-   *     exist
+   * @return the {@link QualifierKind} for the given annotation class name
    */
-  @Nullable QualifierKind getQualifierKind(@CanonicalName String name);
+  QualifierKind getQualifierKind(@CanonicalName String name);
 
   /**
    * Returns the canonical name of {@code clazz}. Throws a {@link TypeSystemError} if {@code clazz}


### PR DESCRIPTION
Merge before #5566