### PR TITLE
WPI: use AnnotationSet to store declaration annotations

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -1036,7 +1036,7 @@ public class WholeProgramInferenceJavaParserStorage
      * Annotations on the declaration of the class (note that despite the name, these can also be
      * type annotations).
      */
-    private @MonotonicNonNull Set<AnnotationMirror> classAnnotations = null;
+    private @MonotonicNonNull AnnotationMirrorSet classAnnotations = null;
 
     /**
      * The Java Parser TypeDeclaration representing the class's declaration. Used for placing

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -75,6 +75,7 @@ import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.GenericAnnotatedTypeFactory;
+import org.checkerframework.framework.util.AnnotationMirrorSet;
 import org.checkerframework.framework.util.JavaParserUtil;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
@@ -1061,7 +1062,7 @@ public class WholeProgramInferenceJavaParserStorage
      */
     public boolean addAnnotationToClassDeclaration(AnnotationMirror annotation) {
       if (classAnnotations == null) {
-        classAnnotations = new HashSet<>();
+        classAnnotations = new AnnotationMirrorSet();
       }
 
       return classAnnotations.add(annotation);
@@ -1219,7 +1220,7 @@ public class WholeProgramInferenceJavaParserStorage
      */
     public boolean addDeclarationAnnotation(AnnotationMirror annotation) {
       if (declarationAnnotations == null) {
-        declarationAnnotations = new HashSet<>(1);
+        declarationAnnotations = new AnnotationMirrorSet();
       }
 
       return declarationAnnotations.add(annotation);
@@ -1503,7 +1504,7 @@ public class WholeProgramInferenceJavaParserStorage
      */
     public boolean addDeclarationAnnotation(AnnotationMirror annotation) {
       if (declarationAnnotations == null) {
-        declarationAnnotations = new HashSet<>(1);
+        declarationAnnotations = new AnnotationMirrorSet();
       }
 
       return declarationAnnotations.add(annotation);


### PR DESCRIPTION
@Nargeshdb encountered duplicate declaration annotations while working on RLC inference that was caused by the use of `HashSet` rather than `AnnotationSet` here. I tested these changes on the example she provided, but that example requires a fair amount of code in `MustCallInferenceLogic` that's not yet ready to be PR'd, so this will be untested for now. @Nargeshdb will include that test in a future PR, once its dependencies are merged.