### PR TITLE
Use `tree` for Trees (AST nodes), reserving `node` for CFG nodes

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
@@ -40,33 +40,33 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
    * Issue an error at every EnsuresCalledMethodsVarArgs annotation, because using it is unsound.
    */
   @Override
-  public Void visitAnnotation(final AnnotationTree node, final Void p) {
-    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+  public Void visitAnnotation(final AnnotationTree tree, final Void p) {
+    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(tree);
     if (AnnotationUtils.areSameByName(
         anno, "org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsVarArgs")) {
       // We can't verify these yet.  Emit an error (which will have to be suppressed) for now.
-      checker.report(node, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.unverified"));
+      checker.report(tree, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.unverified"));
     }
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement elt = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement elt = TreeUtils.elementFromDeclaration(tree);
     AnnotationMirror ecmva = atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethodsVarArgs.class);
     if (ecmva != null) {
       if (!elt.isVarArgs()) {
-        checker.report(node, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.invalid"));
+        checker.report(tree, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.invalid"));
       }
     }
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
 
     if (checker.getBooleanOption(CalledMethodsChecker.COUNT_FRAMEWORK_BUILD_CALLS)) {
-      ExecutableElement element = TreeUtils.elementFromUse(node);
+      ExecutableElement element = TreeUtils.elementFromUse(tree);
       for (BuilderFrameworkSupport builderFrameworkSupport :
           ((CalledMethodsAnnotatedTypeFactory) getTypeFactory()).getBuilderFrameworkSupports()) {
         if (builderFrameworkSupport.isBuilderBuildMethod(element)) {
@@ -75,13 +75,13 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
         }
       }
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   /** Turns some method.invocation errors into finalizer.invocation errors. */
   @Override
   protected void reportMethodInvocabilityError(
-      MethodInvocationTree node, AnnotatedTypeMirror found, AnnotatedTypeMirror expected) {
+      MethodInvocationTree tree, AnnotatedTypeMirror found, AnnotatedTypeMirror expected) {
 
     AnnotationMirror expectedCM = expected.getAnnotation(CalledMethods.class);
     if (expectedCM != null) {
@@ -98,9 +98,9 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
         }
       }
 
-      checker.reportError(node, "finalizer.invocation", missingMethods.toString());
+      checker.reportError(tree, "finalizer.invocation", missingMethods.toString());
     } else {
-      super.reportMethodInvocabilityError(node, found, expected);
+      super.reportMethodInvocabilityError(tree, found, expected);
     }
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/fenum/FenumVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/fenum/FenumVisitor.java
@@ -25,31 +25,31 @@ public class FenumVisitor extends BaseTypeVisitor<FenumAnnotatedTypeFactory> {
   }
 
   @Override
-  public Void visitBinary(BinaryTree node, Void p) {
-    if (!TreeUtils.isStringConcatenation(node)) {
+  public Void visitBinary(BinaryTree tree, Void p) {
+    if (!TreeUtils.isStringConcatenation(tree)) {
       // TODO: ignore string concatenations
 
       // The Fenum Checker is only concerned with primitive types, so just check that
       // the primary annotations are equivalent.
-      AnnotatedTypeMirror lhsAtm = atypeFactory.getAnnotatedType(node.getLeftOperand());
-      AnnotatedTypeMirror rhsAtm = atypeFactory.getAnnotatedType(node.getRightOperand());
+      AnnotatedTypeMirror lhsAtm = atypeFactory.getAnnotatedType(tree.getLeftOperand());
+      AnnotatedTypeMirror rhsAtm = atypeFactory.getAnnotatedType(tree.getRightOperand());
 
       Set<AnnotationMirror> lhs = lhsAtm.getEffectiveAnnotations();
       Set<AnnotationMirror> rhs = rhsAtm.getEffectiveAnnotations();
       QualifierHierarchy qualHierarchy = atypeFactory.getQualifierHierarchy();
       if (!(qualHierarchy.isSubtype(lhs, rhs) || qualHierarchy.isSubtype(rhs, lhs))) {
-        checker.reportError(node, "binary", lhsAtm, rhsAtm);
+        checker.reportError(tree, "binary", lhsAtm, rhsAtm);
       }
     }
-    return super.visitBinary(node, p);
+    return super.visitBinary(tree, p);
   }
 
   @Override
-  public Void visitSwitch(SwitchTree node, Void p) {
-    ExpressionTree expr = node.getExpression();
+  public Void visitSwitch(SwitchTree tree, Void p) {
+    ExpressionTree expr = tree.getExpression();
     AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(expr);
 
-    for (CaseTree caseExpr : node.getCases()) {
+    for (CaseTree caseExpr : tree.getCases()) {
       List<? extends ExpressionTree> realCaseExprs = TreeUtils.caseTreeGetExpressions(caseExpr);
       // Check all the case options against the switch expression type:
       for (ExpressionTree realCaseExpr : realCaseExprs) {
@@ -60,7 +60,7 @@ public class FenumVisitor extends BaseTypeVisitor<FenumAnnotatedTypeFactory> {
         this.commonAssignmentCheck(exprType, caseType, caseExpr, "type.incompatible");
       }
     }
-    return super.visitSwitch(node, p);
+    return super.visitSwitch(tree, p);
   }
 
   @Override

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterTreeUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterTreeUtil.java
@@ -161,14 +161,14 @@ public class FormatterTreeUtil {
   }
 
   /**
-   * Returns true if {@code node} is a call to a method annotated with {@code @FormatMethod}.
+   * Returns true if {@code tree} is a call to a method annotated with {@code @FormatMethod}.
    *
-   * @param node a method call
+   * @param tree a method call
    * @param atypeFactory a type factory
-   * @return true if {@code node} is a call to a method annotated with {@code @FormatMethod}
+   * @return true if {@code tree} is a call to a method annotated with {@code @FormatMethod}
    */
-  public boolean isFormatMethodCall(MethodInvocationTree node, AnnotatedTypeFactory atypeFactory) {
-    ExecutableElement method = TreeUtils.elementFromUse(node);
+  public boolean isFormatMethodCall(MethodInvocationTree tree, AnnotatedTypeFactory atypeFactory) {
+    ExecutableElement method = TreeUtils.elementFromUse(tree);
     AnnotationMirror anno = atypeFactory.getDeclAnnotation(method, FormatMethod.class);
     return anno != null;
   }
@@ -289,16 +289,16 @@ public class FormatterTreeUtil {
                     return first.accept(
                         new SimpleTreeVisitor<InvocationType, Class<Void>>() {
                           @Override
-                          protected InvocationType defaultAction(Tree node, Class<Void> p) {
+                          protected InvocationType defaultAction(Tree tree, Class<Void> p) {
                             // just a normal array
                             return InvocationType.ARRAY;
                           }
 
                           @Override
-                          public InvocationType visitTypeCast(TypeCastTree node, Class<Void> p) {
+                          public InvocationType visitTypeCast(TypeCastTree tree, Class<Void> p) {
                             // it's a (Object[])null
                             return atypeFactory
-                                        .getAnnotatedType(node.getExpression())
+                                        .getAnnotatedType(tree.getExpression())
                                         .getUnderlyingType()
                                         .getKind()
                                     == TypeKind.NULL

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
@@ -42,21 +42,21 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(tree);
     if (atypeFactory.getDeclAnnotation(methodElement, FormatMethod.class) != null) {
       int formatStringIndex = FormatterVisitor.formatStringIndex(methodElement);
       if (formatStringIndex == -1) {
-        checker.reportError(node, "format.method", methodElement.getSimpleName());
+        checker.reportError(tree, "format.method", methodElement.getSimpleName());
       }
     }
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
     FormatterTreeUtil ftu = atypeFactory.treeUtil;
-    FormatCall fc = ftu.create(node, atypeFactory);
+    FormatCall fc = ftu.create(tree, atypeFactory);
     if (fc != null) {
       MethodTree enclosingMethod =
           TreePathUtil.enclosingMethod(atypeFactory.getPath(fc.invocationTree));
@@ -112,7 +112,7 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
                   default:
                     if (!fc.isValidArgument(formatCat, argType)) {
                       // II.3
-                      ExecutableElement method = TreeUtils.elementFromUse(node);
+                      ExecutableElement method = TreeUtils.elementFromUse(tree);
                       CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
                       ftu.failure(
                           arg, "argument", "in varargs position", methodName, argType, formatCat);
@@ -152,12 +152,12 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
 
       // Support -Ainfer command-line argument.
       WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
-      if (wpi != null && forwardsArguments(node, enclosingMethod)) {
+      if (wpi != null && forwardsArguments(tree, enclosingMethod)) {
         wpi.addMethodDeclarationAnnotation(
             TreeUtils.elementFromDeclaration(enclosingMethod), atypeFactory.FORMATMETHOD);
       }
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectTypeFactory.java
@@ -256,23 +256,23 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
    * Get the effect of a method call at its callsite, acknowledging polymorphic instantiation using
    * type use annotations.
    *
-   * @param node the method invocation as an AST node
+   * @param tree the method invocation as an AST node
    * @param callerReceiver the type of the receiver object if available. Used to resolve direct
    *     calls like "super()"
    * @param methodElt the element of the callee method
    * @return the computed effect (SafeEffect or UIEffect) for the method call
    */
   public Effect getComputedEffectAtCallsite(
-      MethodInvocationTree node,
+      MethodInvocationTree tree,
       AnnotatedTypeMirror.AnnotatedDeclaredType callerReceiver,
       ExecutableElement methodElt) {
     Effect targetEffect = getDeclaredEffect(methodElt);
     if (targetEffect.isPoly()) {
       AnnotatedTypeMirror srcType = null;
-      if (node.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT) {
-        ExpressionTree src = ((MemberSelectTree) node.getMethodSelect()).getExpression();
+      if (tree.getMethodSelect().getKind() == Tree.Kind.MEMBER_SELECT) {
+        ExpressionTree src = ((MemberSelectTree) tree.getMethodSelect()).getExpression();
         srcType = getAnnotatedType(src);
-      } else if (node.getMethodSelect().getKind() == Tree.Kind.IDENTIFIER) {
+      } else if (tree.getMethodSelect().getKind() == Tree.Kind.IDENTIFIER) {
         // Tree.Kind.IDENTIFIER, e.g. a direct call like "super()"
         if (callerReceiver == null) {
           // Not enought information provided to instantiate this type-polymorphic effects
@@ -280,7 +280,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         }
         srcType = callerReceiver;
       } else {
-        throw new TypeSystemError("Unexpected getMethodSelect() kind at callsite " + node);
+        throw new TypeSystemError("Unexpected getMethodSelect() kind at callsite " + tree);
       }
 
       // Instantiate type-polymorphic effects
@@ -392,14 +392,14 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
    * @param declaringType the type declaring the override
    * @param overridingMethod the method override itself
    * @param issueConflictWarning whether or not to issue warnings
-   * @param errorNode the method declaration node; used for reporting errors
+   * @param errorTree the method declaration AST node; used for reporting errors
    * @return the min and max inherited effects
    */
   public Effect.EffectRange findInheritedEffectRange(
       TypeElement declaringType,
       ExecutableElement overridingMethod,
       boolean issueConflictWarning,
-      Tree errorNode) {
+      Tree errorTree) {
     assert (declaringType != null);
     ExecutableElement uiOverridden = null;
     ExecutableElement safeOverridden = null;
@@ -440,7 +440,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
         safeOverridden = overriddenMethodElt;
         if (isUI) {
           checker.reportError(
-              errorNode,
+              errorTree,
               "override.effect",
               declaringType,
               overridingMethod,
@@ -448,7 +448,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
               safeOverridden);
         } else if (isPolyUI) {
           checker.reportError(
-              errorNode,
+              errorTree,
               "override.effect.polymorphic",
               declaringType,
               overridingMethod,
@@ -470,7 +470,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
                       || uiAnonClasses.contains(declaringType));
           if (!isAnonInstantiation && !overriddenType.hasAnnotation(UI.class)) {
             checker.reportError(
-                errorNode,
+                errorTree,
                 "override.effect.nonui",
                 declaringType,
                 overridingMethod,
@@ -486,7 +486,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
       // There may be more than two parent methods, but for now it's
       // enough to know there are at least 2 in conflict.
       checker.reportWarning(
-          errorNode,
+          errorTree,
           "override.effect.warning.inheritance",
           declaringType,
           overridingMethod,
@@ -593,7 +593,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
     */
 
     @Override
-    public Void visitMethod(MethodTree node, AnnotatedTypeMirror type) {
+    public Void visitMethod(MethodTree tree, AnnotatedTypeMirror type) {
       AnnotatedTypeMirror.AnnotatedExecutableType methType =
           (AnnotatedTypeMirror.AnnotatedExecutableType) type;
       // Effect e = getDeclaredEffect(methType.getElement());
@@ -617,7 +617,7 @@ public class GuiEffectTypeFactory extends BaseAnnotatedTypeFactory {
                 ? PolyUI.class
                 : fromElement(cls).hasAnnotation(UI.class) ? UI.class : AlwaysSafe.class);
       }
-      return super.visitMethod(node, type);
+      return super.visitMethod(tree, type);
     }
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/i18n/I18nAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18n/I18nAnnotatedTypeFactory.java
@@ -53,7 +53,7 @@ public class I18nAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       type.removeAnnotation(LOCALIZED);
       return null;
     }

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterTreeUtil.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterTreeUtil.java
@@ -439,16 +439,16 @@ public class I18nFormatterTreeUtil {
                     return first.accept(
                         new SimpleTreeVisitor<InvocationType, Class<Void>>() {
                           @Override
-                          protected InvocationType defaultAction(Tree node, Class<Void> p) {
+                          protected InvocationType defaultAction(Tree tree, Class<Void> p) {
                             // just a normal array
                             return InvocationType.ARRAY;
                           }
 
                           @Override
-                          public InvocationType visitTypeCast(TypeCastTree node, Class<Void> p) {
+                          public InvocationType visitTypeCast(TypeCastTree tree, Class<Void> p) {
                             // it's a (Object[])null
                             return atypeFactory
-                                        .getAnnotatedType(node.getExpression())
+                                        .getAnnotatedType(tree.getExpression())
                                         .getUnderlyingType()
                                         .getKind()
                                     == TypeKind.NULL

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenAnnotatedTypeFactory.java
@@ -304,9 +304,9 @@ public class SameLenAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     // Case "new array" for "new T[a.length]"
     @Override
-    public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
-      if (node.getDimensions().size() == 1) {
-        Tree dimensionTree = node.getDimensions().get(0);
+    public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror type) {
+      if (tree.getDimensions().size() == 1) {
+        Tree dimensionTree = tree.getDimensions().get(0);
         ExpressionTree sequenceTree =
             IndexUtil.getLengthSequenceTree(dimensionTree, imf, processingEnv);
         if (sequenceTree != null) {

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -563,25 +563,25 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
     }
 
     @Override
-    public Void visitLiteral(LiteralTree node, AnnotatedTypeMirror type) {
+    public Void visitLiteral(LiteralTree tree, AnnotatedTypeMirror type) {
       // Could also handle long literals, but array indexes are always ints.
-      if (node.getKind() == Tree.Kind.INT_LITERAL) {
-        type.addAnnotation(createLiteral(((Integer) node.getValue()).intValue()));
+      if (tree.getKind() == Tree.Kind.INT_LITERAL) {
+        type.addAnnotation(createLiteral(((Integer) tree.getValue()).intValue()));
       }
-      return super.visitLiteral(node, type);
+      return super.visitLiteral(tree, type);
     }
 
     /* Handles case 3. */
     @Override
-    public Void visitUnary(UnaryTree node, AnnotatedTypeMirror type) {
+    public Void visitUnary(UnaryTree tree, AnnotatedTypeMirror type) {
       // Dataflow refines this type if possible
-      if (node.getKind() == Tree.Kind.BITWISE_COMPLEMENT) {
+      if (tree.getKind() == Tree.Kind.BITWISE_COMPLEMENT) {
         addAnnotationForBitwiseComplement(
-            getSearchIndexAnnotatedTypeFactory().getAnnotatedType(node.getExpression()), type);
+            getSearchIndexAnnotatedTypeFactory().getAnnotatedType(tree.getExpression()), type);
       } else {
         type.addAnnotation(UNKNOWN);
       }
-      return super.visitUnary(node, type);
+      return super.visitUnary(tree, type);
     }
 
     /**
@@ -622,10 +622,10 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
     }
 
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       // Dataflow refines this type if possible
       type.addAnnotation(UNKNOWN);
-      return super.visitCompoundAssignment(node, type);
+      return super.visitCompoundAssignment(tree, type);
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -73,10 +73,10 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
 
   /** Warns about LTLengthOf annotations with arguments whose lengths do not match. */
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
-    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
+    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(tree);
     if (atypeFactory.areSameByClass(anno, LTLengthOf.class)) {
-      List<? extends ExpressionTree> args = node.getArguments();
+      List<? extends ExpressionTree> args = tree.getArguments();
       if (args.size() == 2) {
         // If offsets are provided, there must be the same number of them as there are
         // arrays.
@@ -88,7 +88,7 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
                 anno, atypeFactory.ltLengthOfOffsetElement, String.class, Collections.emptyList());
         if (sequences.size() != offsets.size() && !offsets.isEmpty()) {
           checker.reportError(
-              node, "different.length.sequences.offsets", sequences.size(), offsets.size());
+              tree, "different.length.sequences.offsets", sequences.size(), offsets.size());
           return null;
         }
       }
@@ -102,11 +102,11 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
 
       // check that each expression is parsable at the declaration of this class
       ClassTree enclosingClass = TreePathUtil.enclosingClass(getCurrentPath());
-      checkEffectivelyFinalAndParsable(seq, enclosingClass, node);
-      checkEffectivelyFinalAndParsable(from, enclosingClass, node);
-      checkEffectivelyFinalAndParsable(to, enclosingClass, node);
+      checkEffectivelyFinalAndParsable(seq, enclosingClass, tree);
+      checkEffectivelyFinalAndParsable(from, enclosingClass, tree);
+      checkEffectivelyFinalAndParsable(to, enclosingClass, tree);
     }
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationAnnotatedTypeFactory.java
@@ -776,9 +776,9 @@ public abstract class InitializationAnnotatedTypeFactory<
     }
 
     @Override
-    public Void visitMethod(MethodTree node, AnnotatedTypeMirror p) {
-      Void result = super.visitMethod(node, p);
-      if (TreeUtils.isConstructor(node)) {
+    public Void visitMethod(MethodTree tree, AnnotatedTypeMirror p) {
+      Void result = super.visitMethod(tree, p);
+      if (TreeUtils.isConstructor(tree)) {
         assert p instanceof AnnotatedExecutableType;
         AnnotatedExecutableType exeType = (AnnotatedExecutableType) p;
         DeclaredType underlyingType = (DeclaredType) exeType.getReturnType().getUnderlyingType();
@@ -789,11 +789,11 @@ public abstract class InitializationAnnotatedTypeFactory<
     }
 
     @Override
-    public Void visitNewClass(NewClassTree node, AnnotatedTypeMirror p) {
-      super.visitNewClass(node, p);
+    public Void visitNewClass(NewClassTree tree, AnnotatedTypeMirror p) {
+      super.visitNewClass(tree, p);
       boolean allInitialized = true;
-      Type type = ((JCTree) node).type;
-      for (ExpressionTree a : node.getArguments()) {
+      Type type = ((JCTree) tree).type;
+      for (ExpressionTree a : tree.getArguments()) {
         final AnnotatedTypeMirror t = getAnnotatedType(a);
         allInitialized &= (isInitialized(t) || isFbcBottom(t));
       }
@@ -814,11 +814,11 @@ public abstract class InitializationAnnotatedTypeFactory<
     }
 
     @Override
-    public Void visitMemberSelect(MemberSelectTree node, AnnotatedTypeMirror annotatedTypeMirror) {
-      if (TreeUtils.isArrayLengthAccess(node)) {
+    public Void visitMemberSelect(MemberSelectTree tree, AnnotatedTypeMirror annotatedTypeMirror) {
+      if (TreeUtils.isArrayLengthAccess(tree)) {
         annotatedTypeMirror.replaceAnnotation(INITIALIZED);
       }
-      return super.visitMemberSelect(node, annotatedTypeMirror);
+      return super.visitMemberSelect(tree, annotatedTypeMirror);
     }
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -335,7 +335,12 @@ public class InitializationVisitor<
     return super.visitMethod(tree, p);
   }
 
-  /** Returns the full list of annotations on the receiver. */
+  /**
+   * Returns the full list of annotations on the receiver.
+   *
+   * @param tree a method declaration
+   * @return all the annotations on the method's receiver
+   */
   private List<? extends AnnotationMirror> getAllReceiverAnnotations(MethodTree tree) {
     // TODO: get access to a Types instance and use it to get receiver type
     // Or, extend ExecutableElement with such a method.

--- a/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/initialization/InitializationVisitor.java
@@ -134,11 +134,11 @@ public class InitializationVisitor<
   }
 
   @Override
-  public Void visitVariable(VariableTree node, Void p) {
+  public Void visitVariable(VariableTree tree, Void p) {
     // is this a field (and not a local variable)?
-    if (TreeUtils.elementFromDeclaration(node).getKind().isField()) {
+    if (TreeUtils.elementFromDeclaration(tree).getKind().isField()) {
       Set<AnnotationMirror> annotationMirrors =
-          atypeFactory.getAnnotatedType(node).getExplicitAnnotations();
+          atypeFactory.getAnnotatedType(tree).getExplicitAnnotations();
       // Fields cannot have commitment annotations.
       for (Class<? extends Annotation> c : atypeFactory.getInitializationAnnotations()) {
         for (AnnotationMirror a : annotationMirrors) {
@@ -146,13 +146,13 @@ public class InitializationVisitor<
             continue; // unknown initialization is allowed
           }
           if (atypeFactory.areSameByClass(a, c)) {
-            checker.reportError(node, "initialization.field.type", node);
+            checker.reportError(tree, "initialization.field.type", tree);
             break;
           }
         }
       }
     }
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   @Override
@@ -218,9 +218,9 @@ public class InitializationVisitor<
   }
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, Void p) {
-    AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(node.getExpression());
-    AnnotatedTypeMirror castType = atypeFactory.getAnnotatedType(node);
+  public Void visitTypeCast(TypeCastTree tree, Void p) {
+    AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(tree.getExpression());
+    AnnotatedTypeMirror castType = atypeFactory.getAnnotatedType(tree);
     AnnotationMirror exprAnno = null, castAnno = null;
 
     // find commitment annotation
@@ -250,24 +250,24 @@ public class InitializationVisitor<
 
     if (!isSubtype) {
       checker.reportError(
-          node,
+          tree,
           "initialization.cast",
           annoFormatter.formatAnnotationMirror(exprAnno),
           annoFormatter.formatAnnotationMirror(castAnno));
       return p; // suppress cast.unsafe warning
     }
 
-    return super.visitTypeCast(node, p);
+    return super.visitTypeCast(tree, p);
   }
 
   protected final List<VariableTree> initializedFields;
 
   @Override
-  public void processClassTree(ClassTree node) {
+  public void processClassTree(ClassTree tree) {
     // go through all members and look for initializers.
     // save all fields that are initialized and do not report errors about
     // them later when checking constructors.
-    for (Tree member : node.getMembers()) {
+    for (Tree member : tree.getMembers()) {
       if (member.getKind() == Tree.Kind.BLOCK && !((BlockTree) member).isStatic()) {
         BlockTree block = (BlockTree) member;
         Store store = atypeFactory.getRegularExitStore(block);
@@ -285,10 +285,10 @@ public class InitializationVisitor<
       }
     }
 
-    super.processClassTree(node);
+    super.processClassTree(tree);
 
     // Warn about uninitialized static fields.
-    Tree.Kind nodeKind = node.getKind();
+    Tree.Kind nodeKind = tree.getKind();
     // Skip interfaces (and annotations, which are interfaces).  In an interface, every static
     // field must be initialized.  Java forbids uninitialized variables and static initalizer
     // blocks.
@@ -296,7 +296,7 @@ public class InitializationVisitor<
       boolean isStatic = true;
       // See GenericAnnotatedTypeFactory.performFlowAnalysis for why we use
       // the regular exit store of the class here.
-      Store store = atypeFactory.getRegularExitStore(node);
+      Store store = atypeFactory.getRegularExitStore(tree);
       // Add field values for fields with an initializer.
       for (FieldInitialValue<Value> fieldInitialValue :
           store.getAnalysis().getFieldInitialValues()) {
@@ -306,21 +306,21 @@ public class InitializationVisitor<
       }
 
       List<AnnotationMirror> receiverAnnotations = Collections.emptyList();
-      checkFieldsInitialized(node, isStatic, store, receiverAnnotations);
+      checkFieldsInitialized(tree, isStatic, store, receiverAnnotations);
     }
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    if (TreeUtils.isConstructor(node)) {
+  public Void visitMethod(MethodTree tree, Void p) {
+    if (TreeUtils.isConstructor(tree)) {
       Collection<? extends AnnotationMirror> returnTypeAnnotations =
-          AnnotationUtils.getExplicitAnnotationsOnConstructorResult(node);
+          AnnotationUtils.getExplicitAnnotationsOnConstructorResult(tree);
       // check for invalid constructor return type
       for (Class<? extends Annotation> c :
           atypeFactory.getInvalidConstructorReturnTypeAnnotations()) {
         for (AnnotationMirror a : returnTypeAnnotations) {
           if (atypeFactory.areSameByClass(a, c)) {
-            checker.reportError(node, "initialization.constructor.return.type", node);
+            checker.reportError(tree, "initialization.constructor.return.type", tree);
             break;
           }
         }
@@ -328,24 +328,24 @@ public class InitializationVisitor<
 
       // Check that all fields have been initialized at the end of the constructor.
       boolean isStatic = false;
-      Store store = atypeFactory.getRegularExitStore(node);
-      List<? extends AnnotationMirror> receiverAnnotations = getAllReceiverAnnotations(node);
-      checkFieldsInitialized(node, isStatic, store, receiverAnnotations);
+      Store store = atypeFactory.getRegularExitStore(tree);
+      List<? extends AnnotationMirror> receiverAnnotations = getAllReceiverAnnotations(tree);
+      checkFieldsInitialized(tree, isStatic, store, receiverAnnotations);
     }
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   /** Returns the full list of annotations on the receiver. */
-  private List<? extends AnnotationMirror> getAllReceiverAnnotations(MethodTree node) {
+  private List<? extends AnnotationMirror> getAllReceiverAnnotations(MethodTree tree) {
     // TODO: get access to a Types instance and use it to get receiver type
     // Or, extend ExecutableElement with such a method.
     // Note that we cannot use the receiver type from AnnotatedExecutableType, because that
     // would only have the nullness annotations; here we want to see all annotations on the
     // receiver.
     List<? extends AnnotationMirror> rcvannos = null;
-    if (TreeUtils.isConstructor(node)) {
+    if (TreeUtils.isConstructor(tree)) {
       com.sun.tools.javac.code.Symbol meth =
-          (com.sun.tools.javac.code.Symbol) TreeUtils.elementFromDeclaration(node);
+          (com.sun.tools.javac.code.Symbol) TreeUtils.elementFromDeclaration(tree);
       rcvannos = meth.getRawTypeAttributes();
       if (rcvannos == null) {
         rcvannos = Collections.emptyList();
@@ -358,7 +358,7 @@ public class InitializationVisitor<
    * Checks that all fields (all static fields if {@code staticFields} is true) are initialized in
    * the given store.
    *
-   * @param node a {@link ClassTree} if {@code staticFields} is true; a {@link MethodTree} for a
+   * @param tree a {@link ClassTree} if {@code staticFields} is true; a {@link MethodTree} for a
    *     constructor if {@code staticFields} is false. This is where errors are reported, if they
    *     are not reported at the fields themselves
    * @param staticFields whether to check static fields or instance fields
@@ -372,7 +372,7 @@ public class InitializationVisitor<
   // GenericAnnotatedTypeFactory.initializationStaticStore and
   // GenericAnnotatedTypeFactory.initializationStore.
   protected void checkFieldsInitialized(
-      Tree node,
+      Tree tree,
       boolean staticFields,
       Store store,
       List<? extends AnnotationMirror> receiverAnnotations) {
@@ -384,8 +384,8 @@ public class InitializationVisitor<
     // Compact canonical record constructors do not generate visible assignments in the source,
     // but by definition they assign to all the record's fields so we don't need to
     // check for uninitialized fields in them:
-    if (node.getKind() == Tree.Kind.METHOD
-        && TreeUtils.isCompactCanonicalRecordConstructor((MethodTree) node)) {
+    if (tree.getKind() == Tree.Kind.METHOD
+        && TreeUtils.isCompactCanonicalRecordConstructor((MethodTree) tree)) {
       return;
     }
 
@@ -408,7 +408,7 @@ public class InitializationVisitor<
     // is the default constructor.
     // Errors are issued at the constructor declaration if the field is non-static and the
     // constructor is non-default.
-    boolean errorAtField = staticFields || TreeUtils.isSynthetic((MethodTree) node);
+    boolean errorAtField = staticFields || TreeUtils.isSynthetic((MethodTree) tree);
 
     String FIELDS_UNINITIALIZED_KEY =
         (staticFields
@@ -439,7 +439,7 @@ public class InitializationVisitor<
         for (VariableTree f : violatingFields) {
           fieldsString.add(f.getName());
         }
-        checker.reportError(node, FIELDS_UNINITIALIZED_KEY, fieldsString);
+        checker.reportError(tree, FIELDS_UNINITIALIZED_KEY, fieldsString);
       }
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
@@ -169,45 +169,45 @@ public class InterningAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
-      if (TreeUtils.isCompileTimeString(node)) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
+      if (TreeUtils.isCompileTimeString(tree)) {
         type.replaceAnnotation(INTERNED);
-      } else if (TreeUtils.isStringConcatenation(node)) {
+      } else if (TreeUtils.isStringConcatenation(tree)) {
         type.replaceAnnotation(TOP);
       } else if (type.getKind().isPrimitive()
-          || node.getKind() == Tree.Kind.EQUAL_TO
-          || node.getKind() == Tree.Kind.NOT_EQUAL_TO) {
+          || tree.getKind() == Tree.Kind.EQUAL_TO
+          || tree.getKind() == Tree.Kind.NOT_EQUAL_TO) {
         type.replaceAnnotation(INTERNED);
       } else {
         type.replaceAnnotation(TOP);
       }
-      return super.visitBinary(node, type);
+      return super.visitBinary(tree, type);
     }
 
     /* Compound assignments never result in an interned result.
      */
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(TOP);
-      return super.visitCompoundAssignment(node, type);
+      return super.visitCompoundAssignment(tree, type);
     }
 
     @Override
-    public Void visitTypeCast(TypeCastTree node, AnnotatedTypeMirror type) {
-      if (TreeUtils.typeOf(node.getType()).getKind().isPrimitive()) {
+    public Void visitTypeCast(TypeCastTree tree, AnnotatedTypeMirror type) {
+      if (TreeUtils.typeOf(tree.getType()).getKind().isPrimitive()) {
         type.replaceAnnotation(INTERNED);
       }
-      return super.visitTypeCast(node, type);
+      return super.visitTypeCast(tree, type);
     }
 
     @Override
-    public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror type) {
-      Element e = TreeUtils.elementFromUse(node);
+    public Void visitIdentifier(IdentifierTree tree, AnnotatedTypeMirror type) {
+      Element e = TreeUtils.elementFromUse(tree);
       if (atypeFactory.getDeclAnnotation(e, FindDistinct.class) != null) {
         // TODO: See note above about this being a poor implementation.
         type.replaceAnnotation(INTERNED_DISTINCT);
       }
-      return super.visitIdentifier(node, type);
+      return super.visitIdentifier(tree, type);
     }
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
@@ -107,19 +107,19 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
 
   /** Checks comparison operators, == and !=, for INTERNING violations. */
   @Override
-  public Void visitBinary(BinaryTree node, Void p) {
+  public Void visitBinary(BinaryTree tree, Void p) {
 
     // No checking unless the operator is "==" or "!=".
-    if (!(node.getKind() == Tree.Kind.EQUAL_TO || node.getKind() == Tree.Kind.NOT_EQUAL_TO)) {
-      return super.visitBinary(node, p);
+    if (!(tree.getKind() == Tree.Kind.EQUAL_TO || tree.getKind() == Tree.Kind.NOT_EQUAL_TO)) {
+      return super.visitBinary(tree, p);
     }
 
-    ExpressionTree leftOp = node.getLeftOperand();
-    ExpressionTree rightOp = node.getRightOperand();
+    ExpressionTree leftOp = tree.getLeftOperand();
+    ExpressionTree rightOp = tree.getRightOperand();
 
     // Check passes if either arg is null.
     if (leftOp.getKind() == Tree.Kind.NULL_LITERAL || rightOp.getKind() == Tree.Kind.NULL_LITERAL) {
-      return super.visitBinary(node, p);
+      return super.visitBinary(tree, p);
     }
 
     AnnotatedTypeMirror left = atypeFactory.getAnnotatedType(leftOp);
@@ -127,12 +127,12 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
 
     // If either argument is a primitive, check passes due to auto-unboxing
     if (left.getKind().isPrimitive() || right.getKind().isPrimitive()) {
-      return super.visitBinary(node, p);
+      return super.visitBinary(tree, p);
     }
 
     if (left.hasEffectiveAnnotation(INTERNED_DISTINCT)
         || right.hasEffectiveAnnotation(INTERNED_DISTINCT)) {
-      return super.visitBinary(node, p);
+      return super.visitBinary(tree, p);
     }
 
     // If shouldCheckExpression returns true for either the LHS or RHS,
@@ -162,22 +162,22 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
     // with the interning check.
 
     if (!shouldCheckExpression(leftOp) && !shouldCheckExpression(rightOp)) {
-      return super.visitBinary(node, p);
+      return super.visitBinary(tree, p);
     }
 
     // Syntactic checks for legal uses of ==
-    if (suppressInsideComparison(node)) {
-      return super.visitBinary(node, p);
+    if (suppressInsideComparison(tree)) {
+      return super.visitBinary(tree, p);
     }
-    if (suppressEarlyEquals(node)) {
-      return super.visitBinary(node, p);
+    if (suppressEarlyEquals(tree)) {
+      return super.visitBinary(tree, p);
     }
-    if (suppressEarlyCompareTo(node)) {
-      return super.visitBinary(node, p);
+    if (suppressEarlyCompareTo(tree)) {
+      return super.visitBinary(tree, p);
     }
 
     if (suppressEqualsIfClassIsAnnotated(left, right)) {
-      return super.visitBinary(node, p);
+      return super.visitBinary(tree, p);
     }
 
     Element leftElt = TypesUtils.getTypeElement(left.getUnderlyingType());
@@ -194,7 +194,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
             && atypeFactory.getDeclAnnotation(rightElt, UsesObjectEquals.class) != null))) {
       checker.reportError(rightOp, "not.interned");
     }
-    return super.visitBinary(node, p);
+    return super.visitBinary(tree, p);
   }
 
   /**
@@ -202,25 +202,25 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    * equality is safe.
    */
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-    if (isInvocationOfEquals(node)) {
-      AnnotatedTypeMirror receiverType = atypeFactory.getReceiverType(node);
-      AnnotatedTypeMirror comp = atypeFactory.getAnnotatedType(node.getArguments().get(0));
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
+    if (isInvocationOfEquals(tree)) {
+      AnnotatedTypeMirror receiverType = atypeFactory.getReceiverType(tree);
+      AnnotatedTypeMirror comp = atypeFactory.getAnnotatedType(tree.getArguments().get(0));
 
       if (this.checker.getLintOption("dotequals", true)
           && receiverType.hasEffectiveAnnotation(INTERNED)
           && comp.hasEffectiveAnnotation(INTERNED)) {
-        checker.reportWarning(node, "unnecessary.equals");
+        checker.reportWarning(tree, "unnecessary.equals");
       }
     }
 
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   // Ensure that method annotations are not written on methods they don't apply to.
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement methElt = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement methElt = TreeUtils.elementFromDeclaration(tree);
     boolean hasCompareToMethodAnno =
         atypeFactory.getDeclAnnotation(methElt, CompareToMethod.class) != null;
     boolean hasEqualsMethodAnno =
@@ -230,15 +230,15 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
     int params = methElt.getParameters().size();
     if (hasCompareToMethodAnno && !(params == 1 || params == 2)) {
       checker.reportError(
-          node, "invalid.method.annotation", "@CompareToMethod", "1 or 2", methElt, params);
+          tree, "invalid.method.annotation", "@CompareToMethod", "1 or 2", methElt, params);
     } else if (hasEqualsMethodAnno && !(params == 1 || params == 2)) {
       checker.reportError(
-          node, "invalid.method.annotation", "@EqualsMethod", "1 or 2", methElt, params);
+          tree, "invalid.method.annotation", "@EqualsMethod", "1 or 2", methElt, params);
     } else if (hasInternMethodAnno && !(params == 0)) {
-      checker.reportError(node, "invalid.method.annotation", "@InternMethod", "0", methElt, params);
+      checker.reportError(tree, "invalid.method.annotation", "@InternMethod", "0", methElt, params);
     }
 
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   /**
@@ -403,11 +403,11 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
   /**
    * Returns the method that overrides Object.equals, or null.
    *
-   * @param node a class
+   * @param tree a class
    * @return the class's implementation of equals, or null
    */
-  private MethodTree equalsImplementation(ClassTree node) {
-    List<? extends Tree> members = node.getMembers();
+  private MethodTree equalsImplementation(ClassTree tree) {
+    List<? extends Tree> members = tree.getMembers();
     for (Tree member : members) {
       if (member instanceof MethodTree) {
         MethodTree mTree = (MethodTree) member;
@@ -427,11 +427,11 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    * idiom of writing an equals method with a non-Object parameter, in addition to the equals method
    * that overrides {@link Object#equals(Object)}.
    *
-   * @param node a method invocation node
-   * @return true iff {@code node} is a invocation of {@code equals()}
+   * @param tree a method invocation tree
+   * @return true iff {@code tree} is a invocation of {@code equals()}
    */
-  public static boolean isInvocationOfEquals(MethodInvocationTree node) {
-    ExecutableElement method = TreeUtils.elementFromUse(node);
+  public static boolean isInvocationOfEquals(MethodInvocationTree tree) {
+    ExecutableElement method = TreeUtils.elementFromUse(tree);
     return (method.getParameters().size() == 1
         && method.getReturnType().getKind() == TypeKind.BOOLEAN
         // method symbols only have simple names
@@ -454,19 +454,19 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    *       statement returns zero, and the comparison tests "this" against the method's parameter
    * </ol>
    *
-   * @param node the comparison to check
+   * @param binaryTree the comparison to check
    * @return true if one of the supported heuristics is matched, false otherwise
    */
   // TODO: handle != comparisons too!
   // TODO: handle more methods, such as early return from addAll when this == arg
-  private boolean suppressInsideComparison(final BinaryTree node) {
+  private boolean suppressInsideComparison(final BinaryTree binaryTree) {
     // Only handle == binary trees
-    if (node.getKind() != Tree.Kind.EQUAL_TO) {
+    if (binaryTree.getKind() != Tree.Kind.EQUAL_TO) {
       return false;
     }
 
-    ExpressionTree left = node.getLeftOperand();
-    ExpressionTree right = node.getRightOperand();
+    ExpressionTree left = binaryTree.getLeftOperand();
+    ExpressionTree right = binaryTree.getRightOperand();
 
     // Only valid if we're comparing identifiers.
     if (!(left.getKind() == Tree.Kind.IDENTIFIER && right.getKind() == Tree.Kind.IDENTIFIER)) {
@@ -495,12 +495,12 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
       // Set ifStatementTree and methodTree
       {
         TreePath ppath = parentPath;
-        Tree tree;
-        while ((tree = ppath.getLeaf()) != null) {
-          if (tree.getKind() == Tree.Kind.IF) {
-            ifStatementTree = tree;
-          } else if (tree.getKind() == Tree.Kind.METHOD) {
-            methodTree = (MethodTree) tree;
+        Tree candidateTree;
+        while ((candidateTree = ppath.getLeaf()) != null) {
+          if (candidateTree.getKind() == Tree.Kind.IF) {
+            ifStatementTree = candidateTree;
+          } else if (candidateTree.getKind() == Tree.Kind.METHOD) {
+            methodTree = (MethodTree) candidateTree;
             break;
           }
           ppath = ppath.getParentPath();
@@ -619,19 +619,19 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    * (a == b) || (a != null && a.equals(b))
    * }</pre>
    *
-   * Returns true iff the given node fits this pattern.
+   * Returns true iff the given tree fits this pattern.
    *
-   * @return true iff the node fits a pattern such as (a == b || a.equals(b))
+   * @return true iff the tree fits a pattern such as (a == b || a.equals(b))
    */
-  private boolean suppressEarlyEquals(final BinaryTree node) {
+  private boolean suppressEarlyEquals(final BinaryTree topBinaryTree) {
     // Only handle == binary trees
-    if (node.getKind() != Tree.Kind.EQUAL_TO) {
+    if (topBinaryTree.getKind() != Tree.Kind.EQUAL_TO) {
       return false;
     }
 
     // should strip parens
-    final ExpressionTree left = TreeUtils.withoutParens(node.getLeftOperand());
-    final ExpressionTree right = TreeUtils.withoutParens(node.getRightOperand());
+    final ExpressionTree left = TreeUtils.withoutParens(topBinaryTree.getLeftOperand());
+    final ExpressionTree right = TreeUtils.withoutParens(topBinaryTree.getRightOperand());
 
     // looking for ((a == b || a.equals(b))
     Heuristics.Matcher matcherEqOrEquals =
@@ -658,7 +658,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
             ExpressionTree rightTree = tree.getRightOperand();
 
             if (tree.getKind() == Tree.Kind.CONDITIONAL_OR) {
-              if (TreeUtils.sameTree(leftTree, node)) {
+              if (TreeUtils.sameTree(leftTree, topBinaryTree)) {
                 // left is "a==b"
                 // check right, which should be a.equals(b) or b.equals(a) or
                 // similar
@@ -741,18 +741,18 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
 
   /**
    * Pattern matches to prevent false positives of the form {@code (a == b || a.compareTo(b) == 0)}.
-   * Returns true iff the given node fits this pattern.
+   * Returns true iff the given tree fits this pattern.
    *
-   * @return true iff the node fits the pattern (a == b || a.compareTo(b) == 0)
+   * @return true iff the tree fits the pattern (a == b || a.compareTo(b) == 0)
    */
-  private boolean suppressEarlyCompareTo(final BinaryTree node) {
+  private boolean suppressEarlyCompareTo(final BinaryTree topBinaryTree) {
     // Only handle == binary trees
-    if (node.getKind() != Tree.Kind.EQUAL_TO) {
+    if (topBinaryTree.getKind() != Tree.Kind.EQUAL_TO) {
       return false;
     }
 
-    ExpressionTree left = TreeUtils.withoutParens(node.getLeftOperand());
-    ExpressionTree right = TreeUtils.withoutParens(node.getRightOperand());
+    ExpressionTree left = TreeUtils.withoutParens(topBinaryTree.getLeftOperand());
+    ExpressionTree right = TreeUtils.withoutParens(topBinaryTree.getRightOperand());
 
     // Only valid if we're comparing identifiers.
     if (!(left.getKind() == Tree.Kind.IDENTIFIER && right.getKind() == Tree.Kind.IDENTIFIER)) {
@@ -789,7 +789,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
               @InternedDistinct ExpressionTree leftTree = tree.getLeftOperand(); // looking for a==b
               ExpressionTree rightTree = tree.getRightOperand(); // looking for a.compareTo(b) == 0
               // or b.compareTo(a) == 0
-              if (leftTree != node) {
+              if (leftTree != topBinaryTree) {
                 return false;
               }
               if (rightTree.getKind() != Tree.Kind.EQUAL_TO) {

--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningVisitor.java
@@ -621,6 +621,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    *
    * Returns true iff the given tree fits this pattern.
    *
+   * @param topBinaryTree the binary operation to check
    * @return true iff the tree fits a pattern such as (a == b || a.equals(b))
    */
   private boolean suppressEarlyEquals(final BinaryTree topBinaryTree) {
@@ -743,6 +744,7 @@ public final class InterningVisitor extends BaseTypeVisitor<InterningAnnotatedTy
    * Pattern matches to prevent false positives of the form {@code (a == b || a.compareTo(b) == 0)}.
    * Returns true iff the given tree fits this pattern.
    *
+   * @param topBinaryTree the binary operation to check
    * @return true iff the tree fits the pattern (a == b || a.compareTo(b) == 0)
    */
   private boolean suppressEarlyCompareTo(final BinaryTree topBinaryTree) {

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockTreeAnnotator.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockTreeAnnotator.java
@@ -20,7 +20,7 @@ public class LockTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+  public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
     // For any binary operation whose LHS or RHS can be a non-boolean type, and whose resulting
     // type is necessarily boolean, the resulting annotation on the boolean type must be
     // @GuardedBy({}).
@@ -29,7 +29,7 @@ public class LockTreeAnnotator extends TreeAnnotator {
     // @GuardedBy({}) since for such operators, both operands are of type @GuardedBy({}) boolean
     // to begin with.
 
-    if (TreeUtils.isBinaryComparison(node) || TypesUtils.isString(type.getUnderlyingType())) {
+    if (TreeUtils.isBinaryComparison(tree) || TypesUtils.isString(type.getUnderlyingType())) {
       // A boolean or String is always @GuardedBy({}). LockVisitor determines whether
       // the LHS and RHS of this operation can be legally dereferenced.
       type.replaceAnnotation(((LockAnnotatedTypeFactory) atypeFactory).GUARDEDBY);
@@ -37,23 +37,23 @@ public class LockTreeAnnotator extends TreeAnnotator {
       return null;
     }
 
-    return super.visitBinary(node, type);
+    return super.visitBinary(tree, type);
   }
 
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
     if (TypesUtils.isString(type.getUnderlyingType())) {
       type.replaceAnnotation(((LockAnnotatedTypeFactory) atypeFactory).GUARDEDBY);
     }
 
-    return super.visitCompoundAssignment(node, type);
+    return super.visitCompoundAssignment(tree, type);
   }
 
   @Override
-  public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+  public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror type) {
     if (!type.isAnnotatedInHierarchy(((LockAnnotatedTypeFactory) atypeFactory).NEWOBJECT)) {
       type.replaceAnnotation(((LockAnnotatedTypeFactory) atypeFactory).NEWOBJECT);
     }
-    return super.visitNewArray(node, type);
+    return super.visitNewArray(tree, type);
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockVisitor.java
@@ -90,26 +90,26 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
   }
 
   @Override
-  public Void visitVariable(VariableTree node, Void p) { // visit a variable declaration
+  public Void visitVariable(VariableTree tree, Void p) { // visit a variable declaration
     // A user may not annotate a primitive type, a boxed primitive type or a String
     // with any qualifier from the @GuardedBy hierarchy.
     // They are immutable, so there is no need to guard them.
 
-    TypeMirror tm = TreeUtils.typeOf(node);
+    TypeMirror tm = TreeUtils.typeOf(tree);
 
     if (TypesUtils.isBoxedPrimitive(tm) || TypesUtils.isPrimitive(tm) || TypesUtils.isString(tm)) {
-      AnnotatedTypeMirror atm = atypeFactory.getAnnotatedType(node);
+      AnnotatedTypeMirror atm = atypeFactory.getAnnotatedType(tree);
       if (atm.hasExplicitAnnotationRelaxed(atypeFactory.GUARDSATISFIED)
           || atm.hasExplicitAnnotationRelaxed(atypeFactory.GUARDEDBY)
           || atm.hasExplicitAnnotation(atypeFactory.GUARDEDBYUNKNOWN)
           || atm.hasExplicitAnnotation(atypeFactory.GUARDEDBYBOTTOM)) {
-        checker.reportError(node, "immutable.type.guardedby");
+        checker.reportError(tree, "immutable.type.guardedby");
       }
     }
 
-    issueErrorIfMoreThanOneGuardedByAnnotationPresent(node);
+    issueErrorIfMoreThanOneGuardedByAnnotationPresent(tree);
 
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   /**
@@ -154,20 +154,20 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
    * issues an error if a synchronized method has a @LockingFree, @SideEffectFree, or @Pure
    * annotation.
    *
-   * @param node the MethodTree of the method definition to visit
+   * @param tree the MethodTree of the method definition to visit
    */
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(tree);
 
-    issueErrorIfMoreThanOneLockPreconditionMethodAnnotationPresent(methodElement, node);
+    issueErrorIfMoreThanOneLockPreconditionMethodAnnotationPresent(methodElement, tree);
 
     SideEffectAnnotation sea = atypeFactory.methodSideEffectAnnotation(methodElement, true);
 
     if (sea == SideEffectAnnotation.MAYRELEASELOCKS) {
       boolean issueGSwithMRLWarning = false;
 
-      VariableTree receiver = node.getReceiverParameter();
+      VariableTree receiver = tree.getReceiverParameter();
       if (receiver != null) {
         if (atypeFactory.getAnnotatedType(receiver).hasAnnotation(checkerGuardSatisfiedClass)) {
           issueGSwithMRLWarning = true;
@@ -175,7 +175,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
       }
 
       if (!issueGSwithMRLWarning) { // Skip loop if we already decided to issue the warning.
-        for (VariableTree vt : node.getParameters()) {
+        for (VariableTree vt : tree.getParameters()) {
           if (atypeFactory.getAnnotatedType(vt).hasAnnotation(checkerGuardSatisfiedClass)) {
             issueGSwithMRLWarning = true;
             break;
@@ -184,30 +184,30 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
       }
 
       if (issueGSwithMRLWarning) {
-        checker.reportError(node, "guardsatisfied.with.mayreleaselocks");
+        checker.reportError(tree, "guardsatisfied.with.mayreleaselocks");
       }
     }
 
     // Issue an error if a non-constructor method definition has a return type of
     // @GuardSatisfied without an index.
     if (methodElement != null && methodElement.getKind() != ElementKind.CONSTRUCTOR) {
-      AnnotatedTypeMirror returnTypeATM = atypeFactory.getAnnotatedType(node).getReturnType();
+      AnnotatedTypeMirror returnTypeATM = atypeFactory.getAnnotatedType(tree).getReturnType();
 
       if (returnTypeATM != null && returnTypeATM.hasAnnotation(GuardSatisfied.class)) {
         int returnGuardSatisfiedIndex = atypeFactory.getGuardSatisfiedIndex(returnTypeATM);
 
         if (returnGuardSatisfiedIndex == -1) {
-          checker.reportError(node, "guardsatisfied.return.must.have.index");
+          checker.reportError(tree, "guardsatisfied.return.must.have.index");
         }
       }
     }
 
     if (!sea.isWeakerThan(SideEffectAnnotation.LOCKINGFREE)
         && methodElement.getModifiers().contains(Modifier.SYNCHRONIZED)) {
-      checker.reportError(node, "lockingfree.synchronized.method", sea);
+      checker.reportError(tree, "lockingfree.synchronized.method", sea);
     }
 
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   /**
@@ -219,7 +219,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
    *   <li>{@code @javax.annotation.concurrent.GuardedBy}
    * </ul>
    *
-   * @param methodElement the ExecutableElement for the method call referred to by {@code node}
+   * @param methodElement the ExecutableElement for the method call referred to by {@code tree}
    * @param treeForErrorReporting the MethodTree used to report the error
    */
   private void issueErrorIfMoreThanOneLockPreconditionMethodAnnotationPresent(
@@ -515,16 +515,17 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
    * Also check that matching @GuardSatisfied(index) on a method's formal receiver/parameters
    * matches those in corresponding locations on the method call site.
    *
-   * @param node the MethodInvocationTree of the method call being visited
+   * @param methodInvocationTree the MethodInvocationTree of the method call being visited
    */
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-    ExecutableElement methodElement = TreeUtils.elementFromUse(node);
+  public Void visitMethodInvocation(MethodInvocationTree methodInvocationTree, Void p) {
+    ExecutableElement methodElement = TreeUtils.elementFromUse(methodInvocationTree);
 
     SideEffectAnnotation seaOfInvokedMethod =
         atypeFactory.methodSideEffectAnnotation(methodElement, false);
 
-    MethodTree enclosingMethod = TreePathUtil.enclosingMethod(atypeFactory.getPath(node));
+    MethodTree enclosingMethod =
+        TreePathUtil.enclosingMethod(atypeFactory.getPath(methodInvocationTree));
 
     ExecutableElement enclosingMethodElement = null;
     if (enclosingMethod != null) {
@@ -537,7 +538,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
       if (seaOfInvokedMethod.isWeakerThan(seaOfContainingMethod)) {
         checker.reportError(
-            node,
+            methodInvocationTree,
             "method.guarantee.violated",
             seaOfContainingMethod.getNameOfSideEffectAnnotation(),
             enclosingMethodElement.getSimpleName(),
@@ -549,7 +550,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     if (methodElement != null) {
       // Handle releasing of explicit locks. Verify that the lock expression is effectively
       // final.
-      ExpressionTree receiverTree = TreeUtils.getReceiverTree(node);
+      ExpressionTree receiverTree = TreeUtils.getReceiverTree(methodInvocationTree);
 
       ensureReceiverOfExplicitUnlockCallIsEffectivelyFinal(methodElement, receiverTree);
 
@@ -591,7 +592,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
             ensureExpressionIsEffectivelyFinal(receiverTree);
           }
         } else if (expr.equals("#1")) {
-          ExpressionTree firstParameter = node.getArguments().get(0);
+          ExpressionTree firstParameter = methodInvocationTree.getArguments().get(0);
           if (firstParameter != null) {
             ensureExpressionIsEffectivelyFinal(firstParameter);
           }
@@ -602,11 +603,12 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     // Check that matching @GuardSatisfied(index) on a method's formal receiver/parameters
     // matches those in corresponding locations on the method call site.
 
-    ParameterizedExecutableType mType = atypeFactory.methodFromUse(node);
+    ParameterizedExecutableType mType = atypeFactory.methodFromUse(methodInvocationTree);
     AnnotatedExecutableType invokedMethod = mType.executableType;
 
     List<AnnotatedTypeMirror> paramTypes =
-        AnnotatedTypes.adaptParameters(atypeFactory, invokedMethod, node.getArguments());
+        AnnotatedTypes.adaptParameters(
+            atypeFactory, invokedMethod, methodInvocationTree.getArguments());
 
     // Index on @GuardSatisfied at each location. -1 when no @GuardSatisfied annotation was
     // present.
@@ -631,7 +633,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
       if (methodDefinitionReceiver != null
           && methodDefinitionReceiver.hasAnnotation(checkerGuardSatisfiedClass)) {
         guardSatisfiedIndex[0] = atypeFactory.getGuardSatisfiedIndex(methodDefinitionReceiver);
-        methodCallReceiver = atypeFactory.getReceiverType(node);
+        methodCallReceiver = atypeFactory.getReceiverType(methodInvocationTree);
       }
     }
 
@@ -654,10 +656,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         methodCallReceiver == null
             ? null
             : methodCallReceiver.getAnnotationInHierarchy(atypeFactory.GUARDEDBYUNKNOWN));
-    for (ExpressionTree tree : node.getArguments()) {
+    for (ExpressionTree argTree : methodInvocationTree.getArguments()) {
       passedArgAnnotations.add(
           atypeFactory
-              .getAnnotatedType(tree)
+              .getAnnotatedType(argTree)
               .getAnnotationInHierarchy(atypeFactory.GUARDEDBYUNKNOWN));
     }
 
@@ -702,7 +704,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
                 String formalParam2 = "parameter #" + j; // j, not j-1, so the index is 1-based
 
                 checker.reportError(
-                    node,
+                    methodInvocationTree,
                     "guardsatisfied.parameters.must.match",
                     formalParam1,
                     formalParam2,
@@ -717,7 +719,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
       }
     }
 
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(methodInvocationTree, p);
   }
 
   /**
@@ -766,10 +768,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
    * <p>Additionally, a synchronized block may not be present in a method that has a @LockingFree
    * guarantee or stronger. An error is issued in this case.
    *
-   * @param node the SynchronizedTree for the synchronized block being visited
+   * @param tree the SynchronizedTree for the synchronized block being visited
    */
   @Override
-  public Void visitSynchronized(SynchronizedTree node, Void p) {
+  public Void visitSynchronized(SynchronizedTree tree, Void p) {
     ProcessingEnvironment processingEnvironment = checker.getProcessingEnvironment();
 
     javax.lang.model.util.Types types = processingEnvironment.getTypeUtils();
@@ -779,7 +781,7 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
     TypeMirror lockInterfaceTypeMirror =
         TypesUtils.typeFromClass(Lock.class, types, processingEnvironment.getElementUtils());
 
-    ExpressionTree synchronizedExpression = node.getExpression();
+    ExpressionTree synchronizedExpression = tree.getExpression();
 
     ensureExpressionIsEffectivelyFinal(synchronizedExpression);
 
@@ -787,10 +789,10 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
         types.erasure(atypeFactory.getAnnotatedType(synchronizedExpression).getUnderlyingType());
 
     if (types.isSubtype(expressionType, lockInterfaceTypeMirror)) {
-      checker.reportError(node, "explicit.lock.synchronized");
+      checker.reportError(tree, "explicit.lock.synchronized");
     }
 
-    MethodTree enclosingMethod = TreePathUtil.enclosingMethod(atypeFactory.getPath(node));
+    MethodTree enclosingMethod = TreePathUtil.enclosingMethod(atypeFactory.getPath(tree));
 
     ExecutableElement methodElement = null;
     if (enclosingMethod != null) {
@@ -801,11 +803,11 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
 
       if (!seaOfContainingMethod.isWeakerThan(SideEffectAnnotation.LOCKINGFREE)) {
         checker.reportError(
-            node, "synchronized.block.in.lockingfree.method", seaOfContainingMethod);
+            tree, "synchronized.block.in.lockingfree.method", seaOfContainingMethod);
       }
     }
 
-    return super.visitSynchronized(node, p);
+    return super.visitSynchronized(tree, p);
   }
 
   /**
@@ -1065,15 +1067,15 @@ public class LockVisitor extends BaseTypeVisitor<LockAnnotatedTypeFactory> {
   }
 
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, Void p) {
-    if (TreeUtils.isStringCompoundConcatenation(node)) {
-      ExpressionTree rightTree = node.getExpression();
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, Void p) {
+    if (TreeUtils.isStringCompoundConcatenation(tree)) {
+      ExpressionTree rightTree = tree.getExpression();
       if (!TypesUtils.isString(TreeUtils.typeOf(rightTree))) {
         checkPreconditionsForImplicitToStringCall(rightTree);
       }
     }
 
-    return super.visitCompoundAssignment(node, p);
+    return super.visitCompoundAssignment(tree, p);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -415,8 +415,8 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
     }
 
     @Override
-    public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror type) {
-      Element elt = TreeUtils.elementFromUse(node);
+    public Void visitIdentifier(IdentifierTree tree, AnnotatedTypeMirror type) {
+      Element elt = TreeUtils.elementFromUse(tree);
       if (elt.getKind() == ElementKind.PARAMETER
           && (checker.hasOption(MustCallChecker.NO_LIGHTWEIGHT_OWNERSHIP)
               || getDeclAnnotation(elt, Owning.class) == null)) {
@@ -425,7 +425,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
       if (isResourceVariable(elt)) {
         type.replaceAnnotation(withoutClose(type.getAnnotationInHierarchy(TOP)));
       }
-      return super.visitIdentifier(node, type);
+      return super.visitIdentifier(tree, type);
     }
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -50,7 +50,7 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
   }
 
   @Override
-  public Void visitReturn(ReturnTree node, Void p) {
+  public Void visitReturn(ReturnTree tree, Void p) {
     // Only check return types if ownership is being transferred.
     if (!checker.hasOption(MustCallChecker.NO_LIGHTWEIGHT_OWNERSHIP)) {
       MethodTree enclosingMethod = TreePathUtil.enclosingMethod(this.getCurrentPath());
@@ -66,7 +66,7 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
         }
       }
     }
-    return super.visitReturn(node, p);
+    return super.visitReturn(tree, p);
   }
 
   @Override
@@ -190,7 +190,7 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
 
   @Override
   protected boolean skipReceiverSubtypeCheck(
-      MethodInvocationTree node,
+      MethodInvocationTree tree,
       AnnotatedTypeMirror methodDefinitionReceiver,
       AnnotatedTypeMirror methodCallReceiver) {
     // It does not make sense for receivers to have must-call obligations. If the receiver of a
@@ -321,7 +321,7 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
    * explanation of why this is necessary to avoid false positives.
    */
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
     return null;
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagationTreeAnnotator.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/KeyForPropagationTreeAnnotator.java
@@ -98,8 +98,8 @@ public class KeyForPropagationTreeAnnotator extends TreeAnnotator {
 
   /** Transfers annotations to type if the left hand side is a variable declaration. */
   @Override
-  public Void visitNewClass(NewClassTree node, AnnotatedTypeMirror type) {
-    keyForPropagator.propagateNewClassTree(node, type, (KeyForAnnotatedTypeFactory) atypeFactory);
-    return super.visitNewClass(node, type);
+  public Void visitNewClass(NewClassTree tree, AnnotatedTypeMirror type) {
+    keyForPropagator.propagateNewClassTree(tree, type, (KeyForAnnotatedTypeFactory) atypeFactory);
+    return super.visitNewClass(tree, type);
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessAnnotatedTypeFactory.java
@@ -559,17 +559,17 @@ public class NullnessAnnotatedTypeFactory
     }
 
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
       return null;
     }
 
     @Override
-    public Void visitUnary(UnaryTree node, AnnotatedTypeMirror type) {
+    public Void visitUnary(UnaryTree tree, AnnotatedTypeMirror type) {
       return null;
     }
 
     @Override
-    public Void visitTypeCast(TypeCastTree node, AnnotatedTypeMirror type) {
+    public Void visitTypeCast(TypeCastTree tree, AnnotatedTypeMirror type) {
       if (type.getKind().isPrimitive()) {
         AnnotationMirror NONNULL = ((NullnessAnnotatedTypeFactory) atypeFactory).NONNULL;
         // If a @Nullable expression is cast to a primitive, then an unboxing.of.nullable
@@ -579,7 +579,7 @@ public class NullnessAnnotatedTypeFactory
           type.addAnnotation(NONNULL);
         }
       }
-      return super.visitTypeCast(node, type);
+      return super.visitTypeCast(tree, type);
     }
   }
 
@@ -591,16 +591,16 @@ public class NullnessAnnotatedTypeFactory
     }
 
     @Override
-    public Void visitMemberSelect(MemberSelectTree node, AnnotatedTypeMirror type) {
+    public Void visitMemberSelect(MemberSelectTree tree, AnnotatedTypeMirror type) {
 
-      Element elt = TreeUtils.elementFromUse(node);
+      Element elt = TreeUtils.elementFromUse(tree);
       assert elt != null;
       return null;
     }
 
     @Override
-    public Void visitVariable(VariableTree node, AnnotatedTypeMirror type) {
-      Element elt = TreeUtils.elementFromDeclaration(node);
+    public Void visitVariable(VariableTree tree, AnnotatedTypeMirror type) {
+      Element elt = TreeUtils.elementFromDeclaration(tree);
       if (elt.getKind() == ElementKind.EXCEPTION_PARAMETER) {
         if (!type.isAnnotatedInHierarchy(NONNULL)) {
           // case 9. exception parameter
@@ -611,9 +611,9 @@ public class NullnessAnnotatedTypeFactory
     }
 
     @Override
-    public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror type) {
+    public Void visitIdentifier(IdentifierTree tree, AnnotatedTypeMirror type) {
 
-      Element elt = TreeUtils.elementFromUse(node);
+      Element elt = TreeUtils.elementFromUse(tree);
       assert elt != null;
 
       if (elt.getKind() == ElementKind.EXCEPTION_PARAMETER) {
@@ -628,14 +628,14 @@ public class NullnessAnnotatedTypeFactory
 
     // The result of a binary operation is always non-null.
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(NONNULL);
       return null;
     }
 
     // The result of a compound operation is always non-null.
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(NONNULL);
       // Commitment will run after for initialization defaults
       return null;
@@ -643,20 +643,20 @@ public class NullnessAnnotatedTypeFactory
 
     // The result of a unary operation is always non-null.
     @Override
-    public Void visitUnary(UnaryTree node, AnnotatedTypeMirror type) {
+    public Void visitUnary(UnaryTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(NONNULL);
       return null;
     }
 
     // The result of newly allocated structures is always non-null.
     @Override
-    public Void visitNewClass(NewClassTree node, AnnotatedTypeMirror type) {
+    public Void visitNewClass(NewClassTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(NONNULL);
       return null;
     }
 
     @Override
-    public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+    public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror type) {
       // The result of newly allocated structures is always non-null.
       if (!type.isAnnotatedInHierarchy(NONNULL)) {
         type.replaceAnnotation(NONNULL);
@@ -1007,7 +1007,7 @@ public class NullnessAnnotatedTypeFactory
   /**
    * Returns true if {@code node} is an invocation of Map.get.
    *
-   * @param node a node
+   * @param node a CFG node
    * @return true if {@code node} is an invocation of Map.get
    */
   public boolean isMapGet(Node node) {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -291,6 +291,9 @@ public class NullnessVisitor
   /**
    * Determine whether all dimensions given in a new array expression have zero as length. For
    * example "new Object[0][0];". Also true for empty dimensions, as in "new Object[] {...}".
+   *
+   * @param tree the constructor invocation to check
+   * @return true if every array dimention has a size of zero
    */
   private static boolean isNewArrayAllZeroDims(NewArrayTree tree) {
     boolean isAllZeros = true;
@@ -421,6 +424,8 @@ public class NullnessVisitor
 
   /**
    * Reports an error if a comparison of a @NonNull expression with the null literal is performed.
+   *
+   * @param tree a tree that might be a comparison of a @NonNull expression with the null literal
    */
   protected void checkForRedundantTests(BinaryTree tree) {
 

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -241,60 +241,60 @@ public class NullnessVisitor
 
   /** Case 1: Check for null dereferencing. */
   @Override
-  public Void visitMemberSelect(MemberSelectTree node, Void p) {
-    Element e = TreeUtils.elementFromUse(node);
+  public Void visitMemberSelect(MemberSelectTree tree, Void p) {
+    Element e = TreeUtils.elementFromUse(tree);
     if (e.getKind() == ElementKind.CLASS) {
-      if (atypeFactory.containsNullnessAnnotation(null, node.getExpression())) {
-        checker.reportError(node, "nullness.on.outer");
+      if (atypeFactory.containsNullnessAnnotation(null, tree.getExpression())) {
+        checker.reportError(tree, "nullness.on.outer");
       }
-    } else if (!(TreeUtils.isSelfAccess(node)
-        || node.getExpression().getKind() == Tree.Kind.PARAMETERIZED_TYPE
+    } else if (!(TreeUtils.isSelfAccess(tree)
+        || tree.getExpression().getKind() == Tree.Kind.PARAMETERIZED_TYPE
         // case 8. static member access
         || ElementUtils.isStatic(e))) {
-      checkForNullability(node.getExpression(), DEREFERENCE_OF_NULLABLE);
+      checkForNullability(tree.getExpression(), DEREFERENCE_OF_NULLABLE);
     }
 
-    return super.visitMemberSelect(node, p);
+    return super.visitMemberSelect(tree, p);
   }
 
   /** Case 2: Check for implicit {@code .iterator} call. */
   @Override
-  public Void visitEnhancedForLoop(EnhancedForLoopTree node, Void p) {
-    checkForNullability(node.getExpression(), ITERATING_NULLABLE);
-    return super.visitEnhancedForLoop(node, p);
+  public Void visitEnhancedForLoop(EnhancedForLoopTree tree, Void p) {
+    checkForNullability(tree.getExpression(), ITERATING_NULLABLE);
+    return super.visitEnhancedForLoop(tree, p);
   }
 
   /** Case 3: Check for array dereferencing. */
   @Override
-  public Void visitArrayAccess(ArrayAccessTree node, Void p) {
-    checkForNullability(node.getExpression(), ACCESSING_NULLABLE);
-    return super.visitArrayAccess(node, p);
+  public Void visitArrayAccess(ArrayAccessTree tree, Void p) {
+    checkForNullability(tree.getExpression(), ACCESSING_NULLABLE);
+    return super.visitArrayAccess(tree, p);
   }
 
   @Override
-  public Void visitNewArray(NewArrayTree node, Void p) {
-    AnnotatedArrayType type = atypeFactory.getAnnotatedType(node);
+  public Void visitNewArray(NewArrayTree tree, Void p) {
+    AnnotatedArrayType type = atypeFactory.getAnnotatedType(tree);
     AnnotatedTypeMirror componentType = type.getComponentType();
     if (componentType.hasEffectiveAnnotation(NONNULL)
-        && !isNewArrayAllZeroDims(node)
-        && !isNewArrayInToArray(node)
+        && !isNewArrayAllZeroDims(tree)
+        && !isNewArrayInToArray(tree)
         && !TypesUtils.isPrimitive(componentType.getUnderlyingType())
         && (checker.getLintOption("soundArrayCreationNullness", false)
             // temporary, for backward compatibility
             || checker.getLintOption("forbidnonnullarraycomponents", false))) {
-      checker.reportError(node, "new.array", componentType.getAnnotations(), type.toString());
+      checker.reportError(tree, "new.array", componentType.getAnnotations(), type.toString());
     }
 
-    return super.visitNewArray(node, p);
+    return super.visitNewArray(tree, p);
   }
 
   /**
    * Determine whether all dimensions given in a new array expression have zero as length. For
    * example "new Object[0][0];". Also true for empty dimensions, as in "new Object[] {...}".
    */
-  private static boolean isNewArrayAllZeroDims(NewArrayTree node) {
+  private static boolean isNewArrayAllZeroDims(NewArrayTree tree) {
     boolean isAllZeros = true;
-    for (ExpressionTree dim : node.getDimensions()) {
+    for (ExpressionTree dim : tree.getDimensions()) {
       if (dim instanceof LiteralTree) {
         Object val = ((LiteralTree) dim).getValue();
         if (!(val instanceof Number) || !Integer.valueOf(0).equals(val)) {
@@ -310,17 +310,17 @@ public class NullnessVisitor
   }
 
   /**
-   * Return true if the given node is "new X[]", in the context "toArray(new X[])".
+   * Return true if the given tree is "new X[]", in the context "toArray(new X[])".
    *
-   * @param node a node to test
-   * @return true if the node is a new array within acall to toArray()
+   * @param tree a tree to test
+   * @return true if the tree is a new array within acall to toArray()
    */
-  private boolean isNewArrayInToArray(NewArrayTree node) {
-    if (node.getDimensions().size() != 1) {
+  private boolean isNewArrayInToArray(NewArrayTree tree) {
+    if (tree.getDimensions().size() != 1) {
       return false;
     }
 
-    ExpressionTree dim = node.getDimensions().get(0);
+    ExpressionTree dim = tree.getDimensions().get(0);
     ProcessingEnvironment env = checker.getProcessingEnvironment();
 
     if (!TreeUtils.isMethodInvocation(dim, collectionSize, env)) {
@@ -356,19 +356,19 @@ public class NullnessVisitor
 
   /** Case 4: Check for thrown exception nullness. */
   @Override
-  protected void checkThrownExpression(ThrowTree node) {
-    checkForNullability(node.getExpression(), THROWING_NULLABLE);
+  protected void checkThrownExpression(ThrowTree tree) {
+    checkForNullability(tree.getExpression(), THROWING_NULLABLE);
   }
 
   /** Case 5: Check for synchronizing locks. */
   @Override
-  public Void visitSynchronized(SynchronizedTree node, Void p) {
-    checkForNullability(node.getExpression(), LOCKING_NULLABLE);
-    return super.visitSynchronized(node, p);
+  public Void visitSynchronized(SynchronizedTree tree, Void p) {
+    checkForNullability(tree.getExpression(), LOCKING_NULLABLE);
+    return super.visitSynchronized(tree, p);
   }
 
   @Override
-  public Void visitAssert(AssertTree node, Void p) {
+  public Void visitAssert(AssertTree tree, Void p) {
     // See also
     // org.checkerframework.dataflow.cfg.builder.CFGBuilder.CFGTranslationPhaseOne.visitAssert
 
@@ -379,7 +379,7 @@ public class NullnessVisitor
 
     boolean doVisitAssert;
     if (checker.hasOption("assumeAssertionsAreEnabled")
-        || CFCFGBuilder.assumeAssertionsActivatedForAssertTree(checker, node)) {
+        || CFCFGBuilder.assumeAssertionsActivatedForAssertTree(checker, tree)) {
       doVisitAssert = true;
     } else if (checker.hasOption("assumeAssertionsAreDisabled")) {
       doVisitAssert = false;
@@ -388,17 +388,17 @@ public class NullnessVisitor
     }
 
     if (doVisitAssert) {
-      checkForNullability(node.getCondition(), CONDITION_NULLABLE);
-      return super.visitAssert(node, p);
+      checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
+      return super.visitAssert(tree, p);
     }
 
     return null;
   }
 
   @Override
-  public Void visitIf(IfTree node, Void p) {
-    checkForNullability(node.getCondition(), CONDITION_NULLABLE);
-    return super.visitIf(node, p);
+  public Void visitIf(IfTree tree, Void p) {
+    checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
+    return super.visitIf(tree, p);
   }
 
   @Override
@@ -422,10 +422,10 @@ public class NullnessVisitor
   /**
    * Reports an error if a comparison of a @NonNull expression with the null literal is performed.
    */
-  protected void checkForRedundantTests(BinaryTree node) {
+  protected void checkForRedundantTests(BinaryTree tree) {
 
-    final ExpressionTree leftOp = node.getLeftOperand();
-    final ExpressionTree rightOp = node.getRightOperand();
+    final ExpressionTree leftOp = tree.getLeftOperand();
+    final ExpressionTree rightOp = tree.getRightOperand();
 
     // respect command-line option
     if (!checker.getLintOption(
@@ -435,101 +435,101 @@ public class NullnessVisitor
     }
 
     // equality tests
-    if ((node.getKind() == Tree.Kind.EQUAL_TO || node.getKind() == Tree.Kind.NOT_EQUAL_TO)) {
+    if ((tree.getKind() == Tree.Kind.EQUAL_TO || tree.getKind() == Tree.Kind.NOT_EQUAL_TO)) {
       AnnotatedTypeMirror left = atypeFactory.getAnnotatedType(leftOp);
       AnnotatedTypeMirror right = atypeFactory.getAnnotatedType(rightOp);
       if (leftOp.getKind() == Tree.Kind.NULL_LITERAL && right.hasEffectiveAnnotation(NONNULL)) {
-        checker.reportWarning(node, "nulltest.redundant", rightOp.toString());
+        checker.reportWarning(tree, "nulltest.redundant", rightOp.toString());
       } else if (rightOp.getKind() == Tree.Kind.NULL_LITERAL
           && left.hasEffectiveAnnotation(NONNULL)) {
-        checker.reportWarning(node, "nulltest.redundant", leftOp.toString());
+        checker.reportWarning(tree, "nulltest.redundant", leftOp.toString());
       }
     }
   }
 
   /** Case 6: Check for redundant nullness tests Case 7: unboxing case: primitive operations. */
   @Override
-  public Void visitBinary(BinaryTree node, Void p) {
-    final ExpressionTree leftOp = node.getLeftOperand();
-    final ExpressionTree rightOp = node.getRightOperand();
+  public Void visitBinary(BinaryTree tree, Void p) {
+    final ExpressionTree leftOp = tree.getLeftOperand();
+    final ExpressionTree rightOp = tree.getRightOperand();
 
-    if (isUnboxingOperation(node)) {
+    if (isUnboxingOperation(tree)) {
       checkForNullability(leftOp, UNBOXING_OF_NULLABLE);
       checkForNullability(rightOp, UNBOXING_OF_NULLABLE);
     }
 
-    checkForRedundantTests(node);
+    checkForRedundantTests(tree);
 
-    return super.visitBinary(node, p);
+    return super.visitBinary(tree, p);
   }
 
   /** Case 7: unboxing case: primitive operation. */
   @Override
-  public Void visitUnary(UnaryTree node, Void p) {
-    checkForNullability(node.getExpression(), UNBOXING_OF_NULLABLE);
-    return super.visitUnary(node, p);
+  public Void visitUnary(UnaryTree tree, Void p) {
+    checkForNullability(tree.getExpression(), UNBOXING_OF_NULLABLE);
+    return super.visitUnary(tree, p);
   }
 
   /** Case 7: unboxing case: primitive operation. */
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, Void p) {
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, Void p) {
     // ignore String concatenation
-    if (!isString(node)) {
-      checkForNullability(node.getVariable(), UNBOXING_OF_NULLABLE);
-      checkForNullability(node.getExpression(), UNBOXING_OF_NULLABLE);
+    if (!isString(tree)) {
+      checkForNullability(tree.getVariable(), UNBOXING_OF_NULLABLE);
+      checkForNullability(tree.getExpression(), UNBOXING_OF_NULLABLE);
     }
-    return super.visitCompoundAssignment(node, p);
+    return super.visitCompoundAssignment(tree, p);
   }
 
   /** Case 7: unboxing case: casting to a primitive. */
   @Override
-  public Void visitTypeCast(TypeCastTree node, Void p) {
-    if (isPrimitive(node) && !isPrimitive(node.getExpression())) {
-      if (!checkForNullability(node.getExpression(), UNBOXING_OF_NULLABLE)) {
+  public Void visitTypeCast(TypeCastTree tree, Void p) {
+    if (isPrimitive(tree) && !isPrimitive(tree.getExpression())) {
+      if (!checkForNullability(tree.getExpression(), UNBOXING_OF_NULLABLE)) {
         // If unboxing of nullable is issued, don't issue any other errors.
         return null;
       }
     }
-    return super.visitTypeCast(node, p);
+    return super.visitTypeCast(tree, p);
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    if (TreeUtils.isConstructor(node)) {
-      List<? extends AnnotationTree> annoTrees = node.getModifiers().getAnnotations();
+  public Void visitMethod(MethodTree tree, Void p) {
+    if (TreeUtils.isConstructor(tree)) {
+      List<? extends AnnotationTree> annoTrees = tree.getModifiers().getAnnotations();
       if (atypeFactory.containsNullnessAnnotation(annoTrees)) {
-        checker.reportError(node, "nullness.on.constructor");
+        checker.reportError(tree, "nullness.on.constructor");
       }
     }
 
-    VariableTree receiver = node.getReceiverParameter();
+    VariableTree receiver = tree.getReceiverParameter();
     if (receiver != null) {
       List<? extends AnnotationTree> annoTrees = receiver.getModifiers().getAnnotations();
       Tree type = receiver.getType();
       if (atypeFactory.containsNullnessAnnotation(annoTrees, type)) {
-        checker.reportError(node, "nullness.on.receiver");
+        checker.reportError(tree, "nullness.on.receiver");
       }
     }
 
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
     if (!permitClearProperty) {
       ProcessingEnvironment env = checker.getProcessingEnvironment();
-      if (TreeUtils.isMethodInvocation(node, systemClearProperty, env)) {
-        String literal = literalFirstArgument(node);
+      if (TreeUtils.isMethodInvocation(tree, systemClearProperty, env)) {
+        String literal = literalFirstArgument(tree);
         if (literal == null
             || SystemGetPropertyHandler.predefinedSystemProperties.contains(literal)) {
-          checker.reportError(node, "clear.system.property");
+          checker.reportError(tree, "clear.system.property");
         }
       }
-      if (TreeUtils.isMethodInvocation(node, systemSetProperties, env)) {
-        checker.reportError(node, "clear.system.property");
+      if (TreeUtils.isMethodInvocation(tree, systemSetProperties, env)) {
+        checker.reportError(tree, "clear.system.property");
       }
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   /**
@@ -625,22 +625,22 @@ public class NullnessVisitor
 
   @Override
   protected void checkMethodInvocability(
-      AnnotatedExecutableType method, MethodInvocationTree node) {
+      AnnotatedExecutableType method, MethodInvocationTree tree) {
     if (method.getReceiverType() == null) {
       // Static methods don't have a receiver to check.
       return;
     }
 
-    if (!TreeUtils.isSelfAccess(node)
+    if (!TreeUtils.isSelfAccess(tree)
         &&
         // Static methods don't have a receiver
         method.getReceiverType() != null) {
       // TODO: should all or some constructors be excluded?
       // method.getElement().getKind() != ElementKind.CONSTRUCTOR) {
-      Set<AnnotationMirror> receiverAnnos = atypeFactory.getReceiverType(node).getAnnotations();
+      Set<AnnotationMirror> receiverAnnos = atypeFactory.getReceiverType(tree).getAnnotations();
       AnnotatedTypeMirror methodReceiver = method.getReceiverType().getErased();
       AnnotatedTypeMirror treeReceiver = methodReceiver.shallowCopy(false);
-      AnnotatedTypeMirror rcv = atypeFactory.getReceiverType(node);
+      AnnotatedTypeMirror rcv = atypeFactory.getReceiverType(tree);
       treeReceiver.addAnnotations(rcv.getEffectiveAnnotations());
       // If receiver is Nullable, then we don't want to issue a warning about method
       // invocability (we'd rather have only the "dereference.of.nullable" message).
@@ -648,7 +648,7 @@ public class NullnessVisitor
         return;
       }
     }
-    super.checkMethodInvocability(method, node);
+    super.checkMethodInvocability(method, tree);
   }
 
   /**
@@ -692,28 +692,28 @@ public class NullnessVisitor
   }
 
   @Override
-  public Void visitSwitch(SwitchTree node, Void p) {
-    checkForNullability(node.getExpression(), SWITCHING_NULLABLE);
-    return super.visitSwitch(node, p);
+  public Void visitSwitch(SwitchTree tree, Void p) {
+    checkForNullability(tree.getExpression(), SWITCHING_NULLABLE);
+    return super.visitSwitch(tree, p);
   }
 
   @Override
-  public Void visitForLoop(ForLoopTree node, Void p) {
-    if (node.getCondition() != null) {
+  public Void visitForLoop(ForLoopTree tree, Void p) {
+    if (tree.getCondition() != null) {
       // Condition is null e.g. in "for (;;) {...}"
-      checkForNullability(node.getCondition(), CONDITION_NULLABLE);
+      checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
     }
-    return super.visitForLoop(node, p);
+    return super.visitForLoop(tree, p);
   }
 
   @Override
-  public Void visitNewClass(NewClassTree node, Void p) {
-    ExpressionTree enclosingExpr = node.getEnclosingExpression();
+  public Void visitNewClass(NewClassTree tree, Void p) {
+    ExpressionTree enclosingExpr = tree.getEnclosingExpression();
     if (enclosingExpr != null) {
       checkForNullability(enclosingExpr, DEREFERENCE_OF_NULLABLE);
     }
-    AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(node);
-    ExpressionTree identifier = node.getIdentifier();
+    AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(tree);
+    ExpressionTree identifier = tree.getIdentifier();
     if (identifier instanceof AnnotatedTypeTree) {
       AnnotatedTypeTree t = (AnnotatedTypeTree) identifier;
       for (AnnotationMirror a : atypeFactory.getAnnotatedType(t).getAnnotations()) {
@@ -721,42 +721,42 @@ public class NullnessVisitor
         boolean nullnessCheckerAnno = containsSameByName(atypeFactory.getNullnessAnnotations(), a);
         if (nullnessCheckerAnno && !AnnotationUtils.areSame(NONNULL, a)) {
           // The type is not non-null => warning
-          checker.reportWarning(node, "new.class", type.getAnnotations());
+          checker.reportWarning(tree, "new.class", type.getAnnotations());
           // Note that other consistency checks are made by isValid.
         }
       }
       if (t.toString().contains("@PolyNull")) {
         // TODO: this is a hack, but PolyNull gets substituted
         // afterwards
-        checker.reportWarning(node, "new.class", type.getAnnotations());
+        checker.reportWarning(tree, "new.class", type.getAnnotations());
       }
     }
     // TODO: It might be nicer to introduce a framework-level
     // isValidNewClassType or some such.
-    return super.visitNewClass(node, p);
+    return super.visitNewClass(tree, p);
   }
 
   @Override
-  public Void visitWhileLoop(WhileLoopTree node, Void p) {
-    checkForNullability(node.getCondition(), CONDITION_NULLABLE);
-    return super.visitWhileLoop(node, p);
+  public Void visitWhileLoop(WhileLoopTree tree, Void p) {
+    checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
+    return super.visitWhileLoop(tree, p);
   }
 
   @Override
-  public Void visitDoWhileLoop(DoWhileLoopTree node, Void p) {
-    checkForNullability(node.getCondition(), CONDITION_NULLABLE);
-    return super.visitDoWhileLoop(node, p);
+  public Void visitDoWhileLoop(DoWhileLoopTree tree, Void p) {
+    checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
+    return super.visitDoWhileLoop(tree, p);
   }
 
   @Override
-  public Void visitConditionalExpression(ConditionalExpressionTree node, Void p) {
-    checkForNullability(node.getCondition(), CONDITION_NULLABLE);
-    return super.visitConditionalExpression(node, p);
+  public Void visitConditionalExpression(ConditionalExpressionTree tree, Void p) {
+    checkForNullability(tree.getCondition(), CONDITION_NULLABLE);
+    return super.visitConditionalExpression(tree, p);
   }
 
   @Override
-  protected void checkExceptionParameter(CatchTree node) {
-    VariableTree param = node.getParameter();
+  protected void checkExceptionParameter(CatchTree tree) {
+    VariableTree param = tree.getParameter();
     List<? extends AnnotationTree> annoTrees = param.getModifiers().getAnnotations();
     Tree paramType = param.getType();
     if (atypeFactory.containsNullnessAnnotation(annoTrees, paramType)) {
@@ -771,7 +771,7 @@ public class NullnessVisitor
   }
 
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
     // All annotation arguments are non-null and initialized, so no need to check them.
     return null;
   }

--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -251,7 +251,7 @@ public class OptionalVisitor
    *
    * <p>Prefer: {@code VAR.ifPresent(METHOD);}
    *
-   * @param an if statement that can perhaps be simplified
+   * @param tree an if statement that can perhaps be simplified
    */
   public void handleConditionalStatementIsPresentGet(IfTree tree) {
 

--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -175,6 +175,8 @@ public class OptionalVisitor
    * <p>Pattern match for: {@code VAR.isPresent() ? VAR.get().METHOD() : VALUE}
    *
    * <p>Prefer: {@code VAR.map(METHOD).orElse(VALUE);}
+   *
+   * @param tree a conditional expression that can perhaps be simplified
    */
   // TODO: Should handle this via a transfer function, instead of pattern-matching.
   public void handleTernaryIsPresentGet(ConditionalExpressionTree tree) {
@@ -248,6 +250,8 @@ public class OptionalVisitor
    * <p>Pattern match for: {@code if (VAR.isPresent()) { METHOD(VAR.get()); }}
    *
    * <p>Prefer: {@code VAR.ifPresent(METHOD);}
+   *
+   * @param an if statement that can perhaps be simplified
    */
   public void handleConditionalStatementIsPresentGet(IfTree tree) {
 
@@ -316,6 +320,8 @@ public class OptionalVisitor
    * <p>Pattern match for: {@code CREATION().ELIMINATION()}
    *
    * <p>Prefer: {@code VAR.ifPresent(METHOD);}
+   *
+   * @param tree a method invocation that can perhaps be simplified
    */
   public void handleCreationElimination(MethodInvocationTree tree) {
     if (!isOptionalElimation(tree)) {

--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -164,9 +164,9 @@ public class OptionalVisitor
   }
 
   @Override
-  public Void visitConditionalExpression(ConditionalExpressionTree node, Void p) {
-    handleTernaryIsPresentGet(node);
-    return super.visitConditionalExpression(node, p);
+  public Void visitConditionalExpression(ConditionalExpressionTree tree, Void p) {
+    handleTernaryIsPresentGet(tree);
+    return super.visitConditionalExpression(tree, p);
   }
 
   /**
@@ -177,15 +177,15 @@ public class OptionalVisitor
    * <p>Prefer: {@code VAR.map(METHOD).orElse(VALUE);}
    */
   // TODO: Should handle this via a transfer function, instead of pattern-matching.
-  public void handleTernaryIsPresentGet(ConditionalExpressionTree node) {
+  public void handleTernaryIsPresentGet(ConditionalExpressionTree tree) {
 
-    ExpressionTree condExpr = TreeUtils.withoutParens(node.getCondition());
+    ExpressionTree condExpr = TreeUtils.withoutParens(tree.getCondition());
     Pair<Boolean, ExpressionTree> isPresentCall = isCallToIsPresent(condExpr);
     if (isPresentCall == null) {
       return;
     }
-    ExpressionTree trueExpr = TreeUtils.withoutParens(node.getTrueExpression());
-    ExpressionTree falseExpr = TreeUtils.withoutParens(node.getFalseExpression());
+    ExpressionTree trueExpr = TreeUtils.withoutParens(tree.getTrueExpression());
+    ExpressionTree falseExpr = TreeUtils.withoutParens(tree.getFalseExpression());
     if (!isPresentCall.first) {
       ExpressionTree tmp = trueExpr;
       trueExpr = falseExpr;
@@ -208,7 +208,7 @@ public class OptionalVisitor
       ExecutableElement ele = TreeUtils.elementFromUse((MethodInvocationTree) trueExpr);
 
       checker.reportWarning(
-          node,
+          tree,
           "prefer.map.and.orelse",
           receiver,
           // The literal "CONTAININGCLASS::" is gross.
@@ -237,9 +237,9 @@ public class OptionalVisitor
   }
 
   @Override
-  public Void visitIf(IfTree node, Void p) {
-    handleConditionalStatementIsPresentGet(node);
-    return super.visitIf(node, p);
+  public Void visitIf(IfTree tree, Void p) {
+    handleConditionalStatementIsPresentGet(tree);
+    return super.visitIf(tree, p);
   }
 
   /**
@@ -249,16 +249,16 @@ public class OptionalVisitor
    *
    * <p>Prefer: {@code VAR.ifPresent(METHOD);}
    */
-  public void handleConditionalStatementIsPresentGet(IfTree node) {
+  public void handleConditionalStatementIsPresentGet(IfTree tree) {
 
-    ExpressionTree condExpr = TreeUtils.withoutParens(node.getCondition());
+    ExpressionTree condExpr = TreeUtils.withoutParens(tree.getCondition());
     Pair<Boolean, ExpressionTree> isPresentCall = isCallToIsPresent(condExpr);
     if (isPresentCall == null) {
       return;
     }
 
-    StatementTree thenStmt = skipBlocks(node.getThenStatement());
-    StatementTree elseStmt = skipBlocks(node.getElseStatement());
+    StatementTree thenStmt = skipBlocks(tree.getThenStatement());
+    StatementTree elseStmt = skipBlocks(tree.getElseStatement());
     if (!isPresentCall.first) {
       StatementTree tmp = thenStmt;
       thenStmt = elseStmt;
@@ -301,13 +301,13 @@ public class OptionalVisitor
       methodString = methodString.substring(0, dotPos) + "::" + methodString.substring(dotPos + 1);
     }
 
-    checker.reportWarning(node, "prefer.ifpresent", receiver, methodString);
+    checker.reportWarning(tree, "prefer.ifpresent", receiver, methodString);
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-    handleCreationElimination(node);
-    return super.visitMethodInvocation(node, p);
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
+    handleCreationElimination(tree);
+    return super.visitMethodInvocation(tree, p);
   }
 
   /**
@@ -317,17 +317,17 @@ public class OptionalVisitor
    *
    * <p>Prefer: {@code VAR.ifPresent(METHOD);}
    */
-  public void handleCreationElimination(MethodInvocationTree node) {
-    if (!isOptionalElimation(node)) {
+  public void handleCreationElimination(MethodInvocationTree tree) {
+    if (!isOptionalElimation(tree)) {
       return;
     }
-    ExpressionTree receiver = TreeUtils.getReceiverTree(node);
+    ExpressionTree receiver = TreeUtils.getReceiverTree(tree);
     if (!(receiver.getKind() == Tree.Kind.METHOD_INVOCATION
         && isOptionalCreation((MethodInvocationTree) receiver))) {
       return;
     }
 
-    checker.reportWarning(node, "introduce.eliminate");
+    checker.reportWarning(tree, "introduce.eliminate");
   }
 
   /**
@@ -336,18 +336,18 @@ public class OptionalVisitor
    * <p>Don't use Optional in fields and method parameters.
    */
   @Override
-  public Void visitVariable(VariableTree node, Void p) {
-    VariableElement ve = TreeUtils.elementFromDeclaration(node);
+  public Void visitVariable(VariableTree tree, Void p) {
+    VariableElement ve = TreeUtils.elementFromDeclaration(tree);
     TypeMirror tm = ve.asType();
     if (isOptionalType(tm)) {
-      ElementKind ekind = TreeUtils.elementFromDeclaration(node).getKind();
+      ElementKind ekind = TreeUtils.elementFromDeclaration(tree).getKind();
       if (ekind.isField()) {
-        checker.reportWarning(node, "optional.field");
+        checker.reportWarning(tree, "optional.field");
       } else if (ekind == ElementKind.PARAMETER) {
-        checker.reportWarning(node, "optional.parameter");
+        checker.reportWarning(tree, "optional.parameter");
       }
     }
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/propkey/PropertyKeyAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/propkey/PropertyKeyAnnotatedTypeFactory.java
@@ -82,16 +82,16 @@ public class PropertyKeyAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     // Result of binary op might not be a property key.
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
       type.removeAnnotation(theAnnot);
-      return null; // super.visitBinary(node, type);
+      return null; // super.visitBinary(tree, type);
     }
 
     // Result of unary op might not be a property key.
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       type.removeAnnotation(theAnnot);
-      return null; // super.visitCompoundAssignment(node, type);
+      return null; // super.visitCompoundAssignment(tree, type);
     }
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/regex/RegexAnnotatedTypeFactory.java
@@ -310,7 +310,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
       // Don't call super method which will try to create a LUB
       // Even when it is not yet valid: i.e. between a @PolyRegex and a @Regex
       return null;
@@ -399,10 +399,10 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     /** Case 2: Also handle compound String concatenation. */
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
-      if (TreeUtils.isStringCompoundConcatenation(node)) {
-        AnnotatedTypeMirror rhs = getAnnotatedType(node.getExpression());
-        AnnotatedTypeMirror lhs = getAnnotatedType(node.getVariable());
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
+      if (TreeUtils.isStringCompoundConcatenation(tree)) {
+        AnnotatedTypeMirror rhs = getAnnotatedType(tree.getExpression());
+        AnnotatedTypeMirror lhs = getAnnotatedType(tree.getVariable());
 
         final Integer lhsRegexCount = getMinimumRegexCount(lhs);
         final Integer rhsRegexCount = getMinimumRegexCount(rhs);
@@ -414,7 +414,7 @@ public class RegexAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
           type.addAnnotation(createRegexAnnotation(lCount + rCount));
         }
       }
-      return null; // super.visitCompoundAssignment(node, type);
+      return null; // super.visitCompoundAssignment(tree, type);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -62,16 +62,16 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement elt = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement elt = TreeUtils.elementFromDeclaration(tree);
     MustCallAnnotatedTypeFactory mcAtf =
         rlTypeFactory.getTypeFactoryOfSubchecker(MustCallChecker.class);
     List<String> cmcfValues = getCreatesMustCallForValues(elt, mcAtf, rlTypeFactory);
     if (!cmcfValues.isEmpty()) {
-      checkCreatesMustCallForOverrides(node, elt, mcAtf, cmcfValues);
-      checkCreatesMustCallForTargetsHaveNonEmptyMustCall(node, mcAtf);
+      checkCreatesMustCallForOverrides(tree, elt, mcAtf, cmcfValues);
+      checkCreatesMustCallForTargetsHaveNonEmptyMustCall(tree, mcAtf);
     }
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   /**
@@ -105,13 +105,13 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
   /**
    * Check that an overriding method does not reduce the number of created must-call obligations
    *
-   * @param node overriding method
+   * @param tree overriding method
    * @param elt element for overriding method
    * @param mcAtf the type factory
    * @param cmcfValues must call values created by overriding method
    */
   private void checkCreatesMustCallForOverrides(
-      MethodTree node,
+      MethodTree tree,
       ExecutableElement elt,
       MustCallAnnotatedTypeFactory mcAtf,
       List<String> cmcfValues) {
@@ -127,7 +127,7 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
         String actualClassname = ElementUtils.getEnclosingClassName(elt);
         String overriddenClassname = ElementUtils.getEnclosingClassName(overridden);
         checker.reportError(
-            node,
+            tree,
             "creates.mustcall.for.override.invalid",
             actualClassname + "#" + elt,
             overriddenClassname + "#" + overridden,
@@ -264,8 +264,8 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
   }
 
   @Override
-  public Void visitVariable(VariableTree node, Void p) {
-    Element varElement = TreeUtils.elementFromDeclaration(node);
+  public Void visitVariable(VariableTree tree, Void p) {
+    Element varElement = TreeUtils.elementFromDeclaration(tree);
 
     if (varElement.getKind().isField()
         && !checker.hasOption(MustCallChecker.NO_LIGHTWEIGHT_OWNERSHIP)
@@ -273,7 +273,7 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
       checkOwningField(varElement);
     }
 
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signature/SignatureAnnotatedTypeFactory.java
@@ -210,13 +210,13 @@ public class SignatureAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
-      if (TreeUtils.isStringCompoundConcatenation(node)) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
+      if (TreeUtils.isStringCompoundConcatenation(tree)) {
         type.removeAnnotationInHierarchy(SIGNATURE_UNKNOWN);
         // This could be made more precise.
         type.addAnnotation(SignatureUnknown.class);
       }
-      return null; // super.visitCompoundAssignment(node, type);
+      return null; // super.visitCompoundAssignment(tree, type);
     }
 
     /**

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessAnnotatedTypeFactory.java
@@ -408,11 +408,11 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
   /**
    * Returns true iff the given tree node is a mask operation (&amp; or |).
    *
-   * @param node a tree to test
+   * @param tree a tree to test
    * @return true iff node is a mask operation (&amp; or |)
    */
-  private boolean isMask(Tree node) {
-    Tree.Kind kind = node.getKind();
+  private boolean isMask(Tree tree) {
+    Tree.Kind kind = tree.getKind();
 
     return kind == Tree.Kind.AND || kind == Tree.Kind.OR;
   }
@@ -421,15 +421,15 @@ public class SignednessAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
   /**
    * Returns the type of a primitive cast, or null the argument is not a cast to a primitive.
    *
-   * @param node a tree that might be a cast to a primitive
+   * @param tree a tree that might be a cast to a primitive
    * @return type of a primitive cast, or null if not a cast to a primitive
    */
-  private PrimitiveTypeTree primitiveTypeCast(Tree node) {
-    if (node.getKind() != Tree.Kind.TYPE_CAST) {
+  private PrimitiveTypeTree primitiveTypeCast(Tree tree) {
+    if (tree.getKind() != Tree.Kind.TYPE_CAST) {
       return null;
     }
 
-    TypeCastTree cast = (TypeCastTree) node;
+    TypeCastTree cast = (TypeCastTree) tree;
     Tree castType = cast.getType();
 
     Tree underlyingType;

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsAnnotatedTypeFactory.java
@@ -412,13 +412,13 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
     // Handled completely by UnitsTreeAnnotator
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
       return null;
     }
 
     // Handled completely by UnitsTreeAnnotator
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
       return null;
     }
   }
@@ -431,10 +431,10 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
-      AnnotatedTypeMirror lht = getAnnotatedType(node.getLeftOperand());
-      AnnotatedTypeMirror rht = getAnnotatedType(node.getRightOperand());
-      Tree.Kind kind = node.getKind();
+    public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
+      AnnotatedTypeMirror lht = getAnnotatedType(tree.getLeftOperand());
+      AnnotatedTypeMirror rht = getAnnotatedType(tree.getRightOperand());
+      Tree.Kind kind = tree.getKind();
 
       // Remove Prefix.one
       if (UnitsRelationsTools.getPrefix(lht) == Prefix.one) {
@@ -455,7 +455,7 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                   + bestres
                   + " and current: "
                   + res);
-          return null; // super.visitBinary(node, type);
+          return null; // super.visitBinary(tree, type);
         }
 
         if (res != null) {
@@ -526,8 +526,8 @@ public class UnitsAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
-      ExpressionTree var = node.getVariable();
+    public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
+      ExpressionTree var = tree.getVariable();
       AnnotatedTypeMirror varType = getAnnotatedType(var);
 
       type.replaceAnnotations(varType.getAnnotations());

--- a/checker/src/main/java/org/checkerframework/checker/units/UnitsVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/units/UnitsVisitor.java
@@ -19,25 +19,25 @@ public class UnitsVisitor extends BaseTypeVisitor<UnitsAnnotatedTypeFactory> {
   }
 
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, Void p) {
-    ExpressionTree var = node.getVariable();
-    ExpressionTree expr = node.getExpression();
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, Void p) {
+    ExpressionTree var = tree.getVariable();
+    ExpressionTree expr = tree.getExpression();
     AnnotatedTypeMirror varType = atypeFactory.getAnnotatedType(var);
     AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(expr);
 
-    Tree.Kind kind = node.getKind();
+    Tree.Kind kind = tree.getKind();
 
     if ((kind == Tree.Kind.PLUS_ASSIGNMENT || kind == Tree.Kind.MINUS_ASSIGNMENT)) {
       if (!atypeFactory
           .getQualifierHierarchy()
           .isSubtype(exprType.getEffectiveAnnotations(), varType.getEffectiveAnnotations())) {
-        checker.reportError(node, "compound.assignment", varType, exprType);
+        checker.reportError(tree, "compound.assignment", varType, exprType);
       }
     } else if (!exprType.hasAnnotation(UnknownUnits.class)) {
       // Only allow mul/div with unqualified units
-      checker.reportError(node, "compound.assignment", varType, exprType);
+      checker.reportError(tree, "compound.assignment", varType, exprType);
     }
 
-    return null; // super.visitCompoundAssignment(node, p);
+    return null; // super.visitCompoundAssignment(tree, p);
   }
 }

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestVisitor.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestVisitor.java
@@ -23,12 +23,12 @@ public class AinferTestVisitor extends BaseTypeVisitor<AinferTestAnnotatedTypeFa
   }
 
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
-    Element anno = TreeInfo.symbol((JCTree) node.getAnnotationType());
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
+    Element anno = TreeInfo.symbol((JCTree) tree.getAnnotationType());
     if (anno.toString().equals(AinferDefaultType.class.getName())) {
-      checker.reportError(node, "annotation.not.allowed.in.src", anno.toString());
+      checker.reportError(tree, "annotation.not.allowed.in.src", anno.toString());
     }
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 
   @Override

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/disbaruse/DisbarUseVisitor.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/disbaruse/DisbarUseVisitor.java
@@ -28,30 +28,30 @@ public class DisbarUseVisitor extends BaseTypeVisitor<DisbarUseTypeFactory> {
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-    ExecutableElement methodElt = TreeUtils.elementFromUse(node);
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
+    ExecutableElement methodElt = TreeUtils.elementFromUse(tree);
     if (methodElt != null && atypeFactory.getDeclAnnotation(methodElt, DisbarUse.class) != null) {
-      checker.reportError(node, "disbar.use");
+      checker.reportError(tree, "disbar.use");
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   @Override
-  public Void visitNewClass(NewClassTree node, Void p) {
-    ExecutableElement consElt = TreeUtils.elementFromUse(node);
+  public Void visitNewClass(NewClassTree tree, Void p) {
+    ExecutableElement consElt = TreeUtils.elementFromUse(tree);
     if (consElt != null && atypeFactory.getDeclAnnotation(consElt, DisbarUse.class) != null) {
-      checker.reportError(node, "disbar.use");
+      checker.reportError(tree, "disbar.use");
     }
-    return super.visitNewClass(node, p);
+    return super.visitNewClass(tree, p);
   }
 
   @Override
-  public Void visitIdentifier(IdentifierTree node, Void p) {
+  public Void visitIdentifier(IdentifierTree tree, Void p) {
     MemberSelectTree enclosingMemberSel = enclosingMemberSelect();
     ExpressionTree[] expressionTrees =
         enclosingMemberSel == null
-            ? new ExpressionTree[] {node}
-            : new ExpressionTree[] {enclosingMemberSel, node};
+            ? new ExpressionTree[] {tree}
+            : new ExpressionTree[] {enclosingMemberSel, tree};
 
     for (ExpressionTree memberSel : expressionTrees) {
       final Element elem = TreeUtils.elementFromUse(memberSel);
@@ -64,6 +64,6 @@ public class DisbarUseVisitor extends BaseTypeVisitor<DisbarUseTypeFactory> {
       }
     }
 
-    return super.visitIdentifier(node, p);
+    return super.visitIdentifier(tree, p);
   }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGProcessor.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/CFGProcessor.java
@@ -33,9 +33,9 @@ public class CFGProcessor extends BasicTypeProcessor {
 
   /** AST for source file. */
   private @Nullable CompilationUnitTree rootTree;
-  /** Tree node for the specified class. */
+  /** AST node for the specified class. */
   private @Nullable ClassTree classTree;
-  /** Tree node for the specified method. */
+  /** AST node for the specified method. */
   private @Nullable MethodTree methodTree;
 
   /** Result of CFG process; is set by {@link #typeProcessingOver}. */
@@ -87,19 +87,19 @@ public class CFGProcessor extends BasicTypeProcessor {
     rootTree = root;
     return new TreePathScanner<Void, Void>() {
       @Override
-      public Void visitClass(ClassTree node, Void p) {
-        TypeElement el = TreeUtils.elementFromDeclaration(node);
+      public Void visitClass(ClassTree tree, Void p) {
+        TypeElement el = TreeUtils.elementFromDeclaration(tree);
         if (el != null && el.getSimpleName().contentEquals(className)) {
-          classTree = node;
+          classTree = tree;
         }
-        return super.visitClass(node, p);
+        return super.visitClass(tree, p);
       }
 
       @Override
-      public Void visitMethod(MethodTree node, Void p) {
-        ExecutableElement el = TreeUtils.elementFromDeclaration(node);
+      public Void visitMethod(MethodTree tree, Void p) {
+        ExecutableElement el = TreeUtils.elementFromDeclaration(tree);
         if (el != null && el.getSimpleName().contentEquals(methodName)) {
-          methodTree = node;
+          methodTree = tree;
           // Stop execution by throwing an exception. This makes sure that compilation
           // does not proceed, and thus the AST is not modified by further phases of the
           // compilation (and we save the work to do the compilation).

--- a/framework-test/src/taglet/java/org/checkerframework/taglet/ManualTaglet.java
+++ b/framework-test/src/taglet/java/org/checkerframework/taglet/ManualTaglet.java
@@ -96,28 +96,28 @@ public class ManualTaglet implements Taglet {
   static String getText(DocTree dt) {
     return new SimpleDocTreeVisitor<String, Void>() {
       @Override
-      public String visitUnknownBlockTag(UnknownBlockTagTree node, Void p) {
-        for (DocTree dt : node.getContent()) {
+      public String visitUnknownBlockTag(UnknownBlockTagTree tree, Void p) {
+        for (DocTree dt : tree.getContent()) {
           return dt.accept(this, null);
         }
         return "";
       }
 
       @Override
-      public String visitUnknownInlineTag(UnknownInlineTagTree node, Void p) {
-        for (DocTree dt : node.getContent()) {
+      public String visitUnknownInlineTag(UnknownInlineTagTree tree, Void p) {
+        for (DocTree dt : tree.getContent()) {
           return dt.accept(this, null);
         }
         return "";
       }
 
       @Override
-      public String visitText(TextTree node, Void p) {
-        return node.getBody();
+      public String visitText(TextTree tree, Void p) {
+        return tree.getBody();
       }
 
       @Override
-      protected String defaultAction(DocTree node, Void p) {
+      protected String defaultAction(DocTree tree, Void p) {
         return "";
       }
     }.visit(dt, null);

--- a/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/accumulation/AccumulationVisitor.java
@@ -23,14 +23,14 @@ public class AccumulationVisitor extends BaseTypeVisitor<AccumulationAnnotatedTy
 
   /** Checks each predicate annotation to make sure the predicate is well-formed. */
   @Override
-  public Void visitAnnotation(final AnnotationTree node, final Void p) {
-    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+  public Void visitAnnotation(final AnnotationTree tree, final Void p) {
+    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(tree);
     if (atypeFactory.isPredicate(anno)) {
       String errorMessage = atypeFactory.isValidPredicate(anno);
       if (errorMessage != null) {
-        checker.reportError(node, "predicate", errorMessage);
+        checker.reportError(tree, "predicate", errorMessage);
       }
     }
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 }

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingAnnotatedTypeFactory.java
@@ -70,9 +70,9 @@ public class AliasingAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     }
 
     @Override
-    public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror type) {
+    public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror type) {
       type.replaceAnnotation(UNIQUE);
-      return super.visitNewArray(node, type);
+      return super.visitNewArray(tree, type);
     }
   }
 

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -66,16 +66,16 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
    * The private method {@code isUniqueCheck} handles cases 2 and 3.
    */
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
     // The check only needs to be done for constructors with result type
     // @Unique. We also want to avoid visiting the <init> method.
     if (isInUniqueConstructor()) {
-      if (TreeUtils.isSuperConstructorCall(node)) {
+      if (TreeUtils.isSuperConstructorCall(tree)) {
         // Check if a call to super() might create an alias: that
         // happens when the parent's respective constructor is not @Unique.
-        AnnotatedTypeMirror superResult = atypeFactory.getAnnotatedType(node);
+        AnnotatedTypeMirror superResult = atypeFactory.getAnnotatedType(tree);
         if (!superResult.hasAnnotation(Unique.class)) {
-          checker.reportError(node, "unique.leaked");
+          checker.reportError(tree, "unique.leaked");
         }
       } else {
         // TODO: Currently the type of "this" doesn't always return the type of the
@@ -84,13 +84,13 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
         // in a @Unique constructor will be @Unique.
         Tree parent = getCurrentPath().getParentPath().getLeaf();
         boolean parentIsStatement = parent.getKind() == Tree.Kind.EXPRESSION_STATEMENT;
-        ExecutableElement methodElement = TreeUtils.elementFromUse(node);
+        ExecutableElement methodElement = TreeUtils.elementFromUse(tree);
         List<? extends VariableElement> params = methodElement.getParameters();
-        List<? extends ExpressionTree> args = node.getArguments();
+        List<? extends ExpressionTree> args = tree.getArguments();
         assert (args.size() == params.size())
             : "Number of arguments in"
                 + " the method call "
-                + node
+                + tree
                 + " is different from the "
                 + "number of parameters for the method declaration: "
                 + methodElement.getSimpleName();
@@ -105,7 +105,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
                 atypeFactory.getAnnotatedType(param).hasAnnotation(NonLeaked.class);
             boolean hasLeakedToResult =
                 atypeFactory.getAnnotatedType(param).hasAnnotation(LeakedToResult.class);
-            isUniqueCheck(node, parentIsStatement, hasNonLeaked, hasLeakedToResult);
+            isUniqueCheck(tree, parentIsStatement, hasNonLeaked, hasLeakedToResult);
           } else {
             // Not possible to leak reference here (case 1. from the javadoc).
           }
@@ -117,15 +117,15 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
         if (receiverType != null) {
           boolean hasNonLeaked = receiverType.hasAnnotation(NonLeaked.class);
           boolean hasLeakedToResult = receiverType.hasAnnotation(LeakedToResult.class);
-          isUniqueCheck(node, parentIsStatement, hasNonLeaked, hasLeakedToResult);
+          isUniqueCheck(tree, parentIsStatement, hasNonLeaked, hasLeakedToResult);
         }
       }
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   private void isUniqueCheck(
-      MethodInvocationTree node,
+      MethodInvocationTree tree,
       boolean parentIsStatement,
       boolean hasNonLeaked,
       boolean hasLeakedToResult) {
@@ -134,7 +134,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
       // visitMethodInvocation.
     } else {
       // May be leaked, raise warning.
-      checker.reportError(node, "unique.leaked");
+      checker.reportError(tree, "unique.leaked");
     }
   }
 
@@ -194,42 +194,42 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
   }
 
   @Override
-  public Void visitThrow(ThrowTree node, Void p) {
+  public Void visitThrow(ThrowTree tree, Void p) {
     // throw is also an escape mechanism. If an expression of type
     // @Unique is thrown, it is not @Unique anymore.
-    ExpressionTree exp = node.getExpression();
+    ExpressionTree exp = tree.getExpression();
     if (canBeLeaked(exp)) {
       checker.reportError(exp, "unique.leaked");
     }
-    return super.visitThrow(node, p);
+    return super.visitThrow(tree, p);
   }
 
   @Override
-  public Void visitVariable(VariableTree node, Void p) {
+  public Void visitVariable(VariableTree tree, Void p) {
     // Component types are not allowed to have the @Unique annotation.
-    AnnotatedTypeMirror varType = atypeFactory.getAnnotatedType(node);
-    VariableElement elt = TreeUtils.elementFromDeclaration(node);
+    AnnotatedTypeMirror varType = atypeFactory.getAnnotatedType(tree);
+    VariableElement elt = TreeUtils.elementFromDeclaration(tree);
     if (elt.getKind().isField() && varType.hasExplicitAnnotation(Unique.class)) {
-      checker.reportError(node, "unique.location.forbidden");
-    } else if (node.getType().getKind() == Tree.Kind.ARRAY_TYPE) {
+      checker.reportError(tree, "unique.location.forbidden");
+    } else if (tree.getType().getKind() == Tree.Kind.ARRAY_TYPE) {
       AnnotatedArrayType arrayType = (AnnotatedArrayType) varType;
       if (arrayType.getComponentType().hasAnnotation(Unique.class)) {
-        checker.reportError(node, "unique.location.forbidden");
+        checker.reportError(tree, "unique.location.forbidden");
       }
-    } else if (node.getType().getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
+    } else if (tree.getType().getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
       AnnotatedDeclaredType declaredType = (AnnotatedDeclaredType) varType;
       for (AnnotatedTypeMirror atm : declaredType.getTypeArguments()) {
         if (atm.hasAnnotation(Unique.class)) {
-          checker.reportError(node, "unique.location.forbidden");
+          checker.reportError(tree, "unique.location.forbidden");
         }
       }
     }
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   @Override
-  public Void visitNewArray(NewArrayTree node, Void p) {
-    List<? extends ExpressionTree> initializers = node.getInitializers();
+  public Void visitNewArray(NewArrayTree tree, Void p) {
+    List<? extends ExpressionTree> initializers = tree.getInitializers();
     if (initializers != null && !initializers.isEmpty()) {
       for (ExpressionTree exp : initializers) {
         if (canBeLeaked(exp)) {
@@ -237,7 +237,7 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
         }
       }
     }
-    return super.visitNewArray(node, p);
+    return super.visitNewArray(tree, p);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/aliasing/AliasingVisitor.java
@@ -124,6 +124,14 @@ public class AliasingVisitor extends BaseTypeVisitor<AliasingAnnotatedTypeFactor
     return super.visitMethodInvocation(tree, p);
   }
 
+  /**
+   * Possibly issue a "unique.leaked" error.
+   *
+   * @param tree a method invocation
+   * @param parentIsStatement is the parent of {@code tree} a statement?
+   * @param hasNonLeaked does the receiver have a {@code @NonLeaked} annotation?
+   * @param hasLeakedToResult does the receiver have a {@code @LeakedToResult} annotation?
+   */
   private void isUniqueCheck(
       MethodInvocationTree tree,
       boolean parentIsStatement,

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -861,6 +861,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
   }
 
+  /**
+   * Check the defaultc constructor.
+   *
+   * @param tree a class declaration
+   */
   protected void checkDefaultConstructor(ClassTree tree) {}
 
   /**
@@ -4347,6 +4352,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     return super.visitIdentifier(tree, p);
   }
 
+  /**
+   * Issues an error if access not allowed, based on an @Unused annotation.
+   *
+   * @param identifierTree the identifier being accessed; the method does nothing if it is not a
+   *     field
+   * @param p ignored
+   */
   protected void checkAccess(IdentifierTree identifierTree, Void p) {
     MemberSelectTree memberSel = enclosingMemberSelect();
     ExpressionTree tree;

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -861,7 +861,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
   }
 
-  protected void checkDefaultConstructor(ClassTree node) {}
+  protected void checkDefaultConstructor(ClassTree tree) {}
 
   /**
    * Checks that the method obeys override and subtype rules to all overridden methods. (Uses the
@@ -878,43 +878,43 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * Also, it issues a "missing.this" error for static method annotated receivers.
    */
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
+  public Void visitMethod(MethodTree tree, Void p) {
     // We copy the result from getAnnotatedType to ensure that circular types (e.g. K extends
     // Comparable<K>) are represented by circular AnnotatedTypeMirrors, which avoids problems
     // with later checks.
     // TODO: Find a cleaner way to ensure circular AnnotatedTypeMirrors.
-    AnnotatedExecutableType methodType = atypeFactory.getAnnotatedType(node).deepCopy();
+    AnnotatedExecutableType methodType = atypeFactory.getAnnotatedType(tree).deepCopy();
     MethodTree preMT = methodTree;
-    methodTree = node;
-    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(node);
+    methodTree = tree;
+    ExecutableElement methodElement = TreeUtils.elementFromDeclaration(tree);
 
-    warnAboutTypeAnnotationsTooEarly(node, node.getModifiers());
+    warnAboutTypeAnnotationsTooEarly(tree, tree.getModifiers());
 
-    if (node.getReturnType() != null) {
-      visitAnnotatedType(node.getModifiers().getAnnotations(), node.getReturnType());
+    if (tree.getReturnType() != null) {
+      visitAnnotatedType(tree.getModifiers().getAnnotations(), tree.getReturnType());
     }
 
     try {
-      if (TreeUtils.isAnonymousConstructor(node)) {
+      if (TreeUtils.isAnonymousConstructor(tree)) {
         // We shouldn't dig deeper
         return null;
       }
 
-      if (TreeUtils.isConstructor(node)) {
+      if (TreeUtils.isConstructor(tree)) {
         checkConstructorResult(methodType, methodElement);
       }
 
-      checkPurity(node);
+      checkPurity(tree);
 
       // Passing the whole method/constructor validates the return type
-      validateTypeOf(node);
+      validateTypeOf(tree);
 
       // Validate types in throws clauses
-      for (ExpressionTree thr : node.getThrows()) {
+      for (ExpressionTree thr : tree.getThrows()) {
         validateTypeOf(thr);
       }
 
-      atypeFactory.getDependentTypesHelper().checkMethodForErrorExpressions(node, methodType);
+      atypeFactory.getDependentTypesHelper().checkMethodForErrorExpressions(tree, methodType);
 
       // Check method overrides
       AnnotatedDeclaredType enclosingType =
@@ -930,7 +930,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         ExecutableElement overriddenMethodElt = pair.getValue();
         AnnotatedExecutableType overriddenMethodType =
             AnnotatedTypes.asMemberOf(types, atypeFactory, overriddenType, overriddenMethodElt);
-        if (!checkOverride(node, enclosingType, overriddenMethodType, overriddenType)) {
+        if (!checkOverride(tree, enclosingType, overriddenMethodType, overriddenType)) {
           // Stop at the first mismatch; this makes a difference only if
           // -Awarns is passed, in which case multiple warnings might be raised on
           // the same method, not adding any value. See Issue 373.
@@ -945,15 +945,15 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
       List<String> formalParamNames =
           CollectionsPlume.mapList(
-              (VariableTree param) -> param.getName().toString(), node.getParameters());
-      checkContractsAtMethodDeclaration(node, methodElement, formalParamNames, abstractMethod);
+              (VariableTree param) -> param.getName().toString(), tree.getParameters());
+      checkContractsAtMethodDeclaration(tree, methodElement, formalParamNames, abstractMethod);
 
       // Infer postconditions
       if (atypeFactory.getWholeProgramInference() != null) {
         assert ElementUtils.isElementFromSourceCode(methodElement);
 
         // TODO: Infer conditional postconditions too.
-        CFAbstractStore<?, ?> store = atypeFactory.getRegularExitStore(node);
+        CFAbstractStore<?, ?> store = atypeFactory.getRegularExitStore(tree);
         // The store is null if the method has no normal exit, for example if its body is a
         // throw statement.
         if (store != null) {
@@ -963,9 +963,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         }
       }
 
-      checkForPolymorphicQualifiers(node.getTypeParameters());
+      checkForPolymorphicQualifiers(tree.getTypeParameters());
 
-      return super.visitMethod(node, p);
+      return super.visitMethod(tree, p);
     } finally {
       methodTree = preMT;
     }
@@ -977,31 +977,31 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * AnnotatedTypeMirror.AnnotatedDeclaredType, AnnotatedTypeMirror.AnnotatedExecutableType,
    * AnnotatedTypeMirror.AnnotatedDeclaredType)}.
    *
-   * @param node the method tree to check
+   * @param tree the method tree to check
    */
-  protected void checkPurity(MethodTree node) {
+  protected void checkPurity(MethodTree tree) {
     if (!checkPurity) {
       return;
     }
 
-    if (!suggestPureMethods && !PurityUtils.hasPurityAnnotation(atypeFactory, node)) {
+    if (!suggestPureMethods && !PurityUtils.hasPurityAnnotation(atypeFactory, tree)) {
       // There is nothing to check.
       return;
     }
 
     // check "no" purity
-    EnumSet<Pure.Kind> kinds = PurityUtils.getPurityKinds(atypeFactory, node);
+    EnumSet<Pure.Kind> kinds = PurityUtils.getPurityKinds(atypeFactory, tree);
     // @Deterministic makes no sense for a void method or constructor
     boolean isDeterministic = kinds.contains(Pure.Kind.DETERMINISTIC);
     if (isDeterministic) {
-      if (TreeUtils.isConstructor(node)) {
-        checker.reportWarning(node, "purity.deterministic.constructor");
-      } else if (TreeUtils.typeOf(node.getReturnType()).getKind() == TypeKind.VOID) {
-        checker.reportWarning(node, "purity.deterministic.void.method");
+      if (TreeUtils.isConstructor(tree)) {
+        checker.reportWarning(tree, "purity.deterministic.constructor");
+      } else if (TreeUtils.typeOf(tree.getReturnType()).getKind() == TypeKind.VOID) {
+        checker.reportWarning(tree, "purity.deterministic.void.method");
       }
     }
 
-    TreePath body = atypeFactory.getPath(node.getBody());
+    TreePath body = atypeFactory.getPath(tree.getBody());
     PurityResult r;
     if (body == null) {
       r = new PurityResult();
@@ -1014,10 +1014,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
               checker.hasOption("assumeDeterministic") || checker.hasOption("assumePure"));
     }
     if (!r.isPure(kinds)) {
-      reportPurityErrors(r, node, kinds);
+      reportPurityErrors(r, tree, kinds);
     }
 
-    if (suggestPureMethods && !TreeUtils.isSynthetic(node)) {
+    if (suggestPureMethods && !TreeUtils.isSynthetic(tree)) {
       // Issue a warning if the method is pure, but not annotated as such.
       EnumSet<Pure.Kind> additionalKinds = r.getKinds().clone();
       if (!infer) {
@@ -1025,13 +1025,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // present (because they were inferred in a previous WPI round).
         additionalKinds.removeAll(kinds);
       }
-      if (TreeUtils.isConstructor(node)) {
+      if (TreeUtils.isConstructor(tree)) {
         additionalKinds.remove(Pure.Kind.DETERMINISTIC);
       }
       if (!additionalKinds.isEmpty()) {
         if (infer) {
           WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
-          ExecutableElement methodElt = TreeUtils.elementFromDeclaration(node);
+          ExecutableElement methodElt = TreeUtils.elementFromDeclaration(tree);
           if (additionalKinds.size() == 2) {
             wpi.addMethodDeclarationAnnotation(methodElt, PURE);
           } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
@@ -1043,11 +1043,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
           }
         } else {
           if (additionalKinds.size() == 2) {
-            checker.reportWarning(node, "purity.more.pure", node.getName());
+            checker.reportWarning(tree, "purity.more.pure", tree.getName());
           } else if (additionalKinds.contains(Pure.Kind.SIDE_EFFECT_FREE)) {
-            checker.reportWarning(node, "purity.more.sideeffectfree", node.getName());
+            checker.reportWarning(tree, "purity.more.sideeffectfree", tree.getName());
           } else if (additionalKinds.contains(Pure.Kind.DETERMINISTIC)) {
-            checker.reportWarning(node, "purity.more.deterministic", node.getName());
+            checker.reportWarning(tree, "purity.more.deterministic", tree.getName());
           } else {
             throw new BugInCF("Unexpected purity kind in " + additionalKinds);
           }
@@ -1084,11 +1084,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * Reports errors found during purity checking.
    *
    * @param result whether the method is deterministic and/or side-effect-free
-   * @param node the method
+   * @param tree the method
    * @param expectedKinds the expected purity for the method
    */
   protected void reportPurityErrors(
-      PurityResult result, MethodTree node, EnumSet<Pure.Kind> expectedKinds) {
+      PurityResult result, MethodTree tree, EnumSet<Pure.Kind> expectedKinds) {
     assert !result.isPure(expectedKinds);
     EnumSet<Pure.Kind> violations = EnumSet.copyOf(expectedKinds);
     violations.removeAll(result.getKinds());
@@ -1384,17 +1384,17 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   }
 
   @Override
-  public Void visitTypeParameter(TypeParameterTree node, Void p) {
-    if (node.getBounds().size() > 1) {
+  public Void visitTypeParameter(TypeParameterTree tree, Void p) {
+    if (tree.getBounds().size() > 1) {
       // The upper bound of the type parameter is an intersection
       AnnotatedTypeVariable type =
-          (AnnotatedTypeVariable) atypeFactory.getAnnotatedTypeFromTypeTree(node);
+          (AnnotatedTypeVariable) atypeFactory.getAnnotatedTypeFromTypeTree(tree);
       AnnotatedIntersectionType intersection = (AnnotatedIntersectionType) type.getUpperBound();
-      checkExplicitAnnotationsOnIntersectionBounds(intersection, node.getBounds());
+      checkExplicitAnnotationsOnIntersectionBounds(intersection, tree.getBounds());
     }
-    validateTypeOf(node);
+    validateTypeOf(tree);
 
-    return super.visitTypeParameter(node, p);
+    return super.visitTypeParameter(tree, p);
   }
 
   /**
@@ -1429,49 +1429,49 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   // **********************************************************************
 
   @Override
-  public Void visitVariable(VariableTree node, Void p) {
-    warnAboutTypeAnnotationsTooEarly(node, node.getModifiers());
+  public Void visitVariable(VariableTree tree, Void p) {
+    warnAboutTypeAnnotationsTooEarly(tree, tree.getModifiers());
 
-    visitAnnotatedType(node.getModifiers().getAnnotations(), node.getType());
+    visitAnnotatedType(tree.getModifiers().getAnnotations(), tree.getType());
 
     AnnotatedTypeMirror variableType;
     if (getCurrentPath().getParentPath() != null
         && getCurrentPath().getParentPath().getLeaf().getKind() == Tree.Kind.LAMBDA_EXPRESSION) {
-      // Calling getAnnotatedTypeLhs on a lambda parameter node is possibly expensive
+      // Calling getAnnotatedTypeLhs on a lambda parameter tree is possibly expensive
       // because caching is turned off.  This should be fixed by #979.
       // See https://github.com/typetools/checker-framework/issues/2853 for an example.
-      variableType = atypeFactory.getAnnotatedType(node);
+      variableType = atypeFactory.getAnnotatedType(tree);
     } else {
-      variableType = atypeFactory.getAnnotatedTypeLhs(node);
+      variableType = atypeFactory.getAnnotatedTypeLhs(tree);
     }
 
-    atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(variableType, node);
+    atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(variableType, tree);
     // If there's no assignment in this variable declaration, skip it.
-    if (node.getInitializer() != null) {
-      commonAssignmentCheck(node, node.getInitializer(), "assignment");
+    if (tree.getInitializer() != null) {
+      commonAssignmentCheck(tree, tree.getInitializer(), "assignment");
     } else {
-      // commonAssignmentCheck validates the type of node,
+      // commonAssignmentCheck validates the type of tree,
       // so only validate if commonAssignmentCheck wasn't called
-      validateTypeOf(node);
+      validateTypeOf(tree);
     }
-    return super.visitVariable(node, p);
+    return super.visitVariable(tree, p);
   }
 
   /**
    * Warn if a type annotation is written before a modifier such as "public" or before a declaration
    * annotation.
    *
-   * @param node a VariableTree or a MethodTree
-   * @param modifiersTree the modifiers sub-tree of node
+   * @param tree a VariableTree or a MethodTree
+   * @param modifiersTree the modifiers sub-tree of tree
    */
-  private void warnAboutTypeAnnotationsTooEarly(Tree node, ModifiersTree modifiersTree) {
+  private void warnAboutTypeAnnotationsTooEarly(Tree tree, ModifiersTree modifiersTree) {
 
     // Don't issue warnings about compiler-inserted modifiers.
     // This simple code completely igonores enum constants and try-with-resources declarations.
     // It could be made to catch some user errors in those locations, but it doesn't seem worth
     // the effort to do so.
-    if (node.getKind() == Tree.Kind.VARIABLE) {
-      ElementKind varKind = TreeUtils.elementFromDeclaration((VariableTree) node).getKind();
+    if (tree.getKind() == Tree.Kind.VARIABLE) {
+      ElementKind varKind = TreeUtils.elementFromDeclaration((VariableTree) tree).getKind();
       switch (varKind) {
         case ENUM_CONSTANT:
           // Enum constants are "public static final" by default, so the annotation always
@@ -1482,7 +1482,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
           // appears to be before "final".
           return;
         default:
-          if (TreeUtils.isAutoGeneratedRecordMember(node)) {
+          if (TreeUtils.isAutoGeneratedRecordMember(tree)) {
             // Annotations can appear on record fields before the class body, so don't
             // issue a warning about those.
             return;
@@ -1522,7 +1522,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
       }
       if (!badTypeAnnos.isEmpty()) {
         checker.reportWarning(
-            node, "type.anno.before.decl.anno", badTypeAnnos, annotations.get(lastDeclAnnoIndex));
+            tree, "type.anno.before.decl.anno", badTypeAnnos, annotations.get(lastDeclAnnoIndex));
       }
     }
 
@@ -1540,9 +1540,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         precedingTextLength += m.toString().length() + 1; // +1 for the space
       }
       int annoStartPos = ((JCTree) firstAnno).getStartPosition();
-      int varStartPos = ((JCTree) node).getStartPosition();
+      int varStartPos = ((JCTree) tree).getStartPosition();
       if (annoStartPos < varStartPos + precedingTextLength) {
-        checker.reportWarning(node, "type.anno.before.modifier", firstAnno, modifierSet);
+        checker.reportWarning(tree, "type.anno.before.modifier", firstAnno, modifierSet);
       }
     }
   }
@@ -1581,26 +1581,26 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * <p>If the subtype check fails, it issues a "assignment" error.
    */
   @Override
-  public Void visitAssignment(AssignmentTree node, Void p) {
-    commonAssignmentCheck(node.getVariable(), node.getExpression(), "assignment");
-    return super.visitAssignment(node, p);
+  public Void visitAssignment(AssignmentTree tree, Void p) {
+    commonAssignmentCheck(tree.getVariable(), tree.getExpression(), "assignment");
+    return super.visitAssignment(tree, p);
   }
 
   /**
-   * Performs a subtype check, to test whether the node expression iterable type is a subtype of the
+   * Performs a subtype check, to test whether the tree expression iterable type is a subtype of the
    * variable type in the enhanced for loop.
    *
    * <p>If the subtype check fails, it issues a "enhancedfor" error.
    */
   @Override
-  public Void visitEnhancedForLoop(EnhancedForLoopTree node, Void p) {
-    AnnotatedTypeMirror var = atypeFactory.getAnnotatedTypeLhs(node.getVariable());
-    AnnotatedTypeMirror iteratedType = atypeFactory.getIterableElementType(node.getExpression());
-    boolean valid = validateTypeOf(node.getVariable());
+  public Void visitEnhancedForLoop(EnhancedForLoopTree tree, Void p) {
+    AnnotatedTypeMirror var = atypeFactory.getAnnotatedTypeLhs(tree.getVariable());
+    AnnotatedTypeMirror iteratedType = atypeFactory.getIterableElementType(tree.getExpression());
+    boolean valid = validateTypeOf(tree.getVariable());
     if (valid) {
-      commonAssignmentCheck(var, iteratedType, node.getExpression(), "enhancedfor");
+      commonAssignmentCheck(var, iteratedType, tree.getExpression(), "enhancedfor");
     }
-    return super.visitEnhancedForLoop(node, p);
+    return super.visitEnhancedForLoop(tree, p);
   }
 
   /**
@@ -1615,19 +1615,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * </ul>
    */
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
 
     // Skip calls to the Enum constructor (they're generated by javac and
     // hard to check), also see CFGBuilder.visitMethodInvocation.
-    if (TreeUtils.elementFromUse(node) == null || TreeUtils.isEnumSuperCall(node)) {
-      return super.visitMethodInvocation(node, p);
+    if (TreeUtils.elementFromUse(tree) == null || TreeUtils.isEnumSuperCall(tree)) {
+      return super.visitMethodInvocation(tree, p);
     }
 
-    if (shouldSkipUses(node)) {
-      return super.visitMethodInvocation(node, p);
+    if (shouldSkipUses(tree)) {
+      return super.visitMethodInvocation(tree, p);
     }
 
-    ParameterizedExecutableType mType = atypeFactory.methodFromUse(node);
+    ParameterizedExecutableType mType = atypeFactory.methodFromUse(tree);
     AnnotatedExecutableType invokedMethod = mType.executableType;
     List<AnnotatedTypeMirror> typeargs = mType.typeArgs;
 
@@ -1636,7 +1636,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         if (typearg.getKind() == TypeKind.WILDCARD
             && ((AnnotatedWildcardType) typearg).isUninferredTypeArgument()) {
           checker.reportError(
-              node, "type.arguments.not.inferred", invokedMethod.getElement().getSimpleName());
+              tree, "type.arguments.not.inferred", invokedMethod.getElement().getSimpleName());
           break; // only issue error once per method
         }
       }
@@ -1650,53 +1650,53 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
     try {
       checkTypeArguments(
-          node,
+          tree,
           paramBounds,
           typeargs,
-          node.getTypeArguments(),
+          tree.getTypeArguments(),
           methodName,
           invokedMethod.getTypeVariables());
       List<AnnotatedTypeMirror> params =
-          AnnotatedTypes.adaptParameters(atypeFactory, invokedMethod, node.getArguments());
-      checkArguments(params, node.getArguments(), methodName, method.getParameters());
-      checkVarargs(invokedMethod, node);
+          AnnotatedTypes.adaptParameters(atypeFactory, invokedMethod, tree.getArguments());
+      checkArguments(params, tree.getArguments(), methodName, method.getParameters());
+      checkVarargs(invokedMethod, tree);
 
       if (ElementUtils.isMethod(
           invokedMethod.getElement(), vectorCopyInto, atypeFactory.getProcessingEnv())) {
-        typeCheckVectorCopyIntoArgument(node, params);
+        typeCheckVectorCopyIntoArgument(tree, params);
       }
 
       ExecutableElement invokedMethodElement = invokedMethod.getElement();
-      if (!ElementUtils.isStatic(invokedMethodElement) && !TreeUtils.isSuperConstructorCall(node)) {
-        checkMethodInvocability(invokedMethod, node);
+      if (!ElementUtils.isStatic(invokedMethodElement) && !TreeUtils.isSuperConstructorCall(tree)) {
+        checkMethodInvocability(invokedMethod, tree);
       }
 
       // check precondition annotations
       checkPreconditions(
-          node, atypeFactory.getContractsFromMethod().getPreconditions(invokedMethodElement));
+          tree, atypeFactory.getContractsFromMethod().getPreconditions(invokedMethodElement));
 
-      if (TreeUtils.isSuperConstructorCall(node)) {
-        checkSuperConstructorCall(node);
-      } else if (TreeUtils.isThisConstructorCall(node)) {
-        checkThisConstructorCall(node);
+      if (TreeUtils.isSuperConstructorCall(tree)) {
+        checkSuperConstructorCall(tree);
+      } else if (TreeUtils.isThisConstructorCall(tree)) {
+        checkThisConstructorCall(tree);
       }
     } catch (RuntimeException t) {
       // Sometimes the type arguments are inferred incorrectly, which causes crashes. Once
       // #979 is fixed this should be removed and crashes should be reported normally.
-      if (node.getTypeArguments().size() == typeargs.size()) {
+      if (tree.getTypeArguments().size() == typeargs.size()) {
         // They type arguments were explicitly written.
         throw t;
       }
       if (!atypeFactory.ignoreUninferredTypeArguments) {
         checker.reportError(
-            node, "type.arguments.not.inferred", invokedMethod.getElement().getSimpleName());
+            tree, "type.arguments.not.inferred", invokedMethod.getElement().getSimpleName());
       } // else ignore the crash.
     }
 
     // Do not call super, as that would observe the arguments without
     // a set assignment context.
-    scan(node.getMethodSelect(), p);
-    return null; // super.visitMethodInvocation(node, p);
+    scan(tree.getMethodSelect(), p);
+    return null; // super.visitMethodInvocation(tree, p);
   }
 
   /**
@@ -1906,20 +1906,20 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * <p>In other words, this method checks that the type argument of the receiver method is a
    * subtype of the component type of the passed array argument.
    *
-   * @param node a method invocation of {@code Vector.copyInto()}
+   * @param tree a method invocation of {@code Vector.copyInto()}
    * @param params the types of the parameters of {@code Vectory.copyInto()}
    */
   protected void typeCheckVectorCopyIntoArgument(
-      MethodInvocationTree node, List<? extends AnnotatedTypeMirror> params) {
+      MethodInvocationTree tree, List<? extends AnnotatedTypeMirror> params) {
     assert params.size() == 1
-        : "invalid no. of parameters " + params + " found for method invocation " + node;
-    assert node.getArguments().size() == 1
-        : "invalid no. of arguments in method invocation " + node;
+        : "invalid no. of parameters " + params + " found for method invocation " + tree;
+    assert tree.getArguments().size() == 1
+        : "invalid no. of arguments in method invocation " + tree;
 
-    AnnotatedTypeMirror passed = atypeFactory.getAnnotatedType(node.getArguments().get(0));
+    AnnotatedTypeMirror passed = atypeFactory.getAnnotatedType(tree.getArguments().get(0));
     AnnotatedArrayType passedAsArray = (AnnotatedArrayType) passed;
 
-    AnnotatedTypeMirror receiver = atypeFactory.getReceiverType(node);
+    AnnotatedTypeMirror receiver = atypeFactory.getReceiverType(tree);
     AnnotatedDeclaredType receiverAsVector =
         AnnotatedTypes.asSuper(atypeFactory, receiver, vectorType);
     if (receiverAsVector.getTypeArguments().isEmpty()) {
@@ -1928,7 +1928,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
     AnnotatedTypeMirror argComponent = passedAsArray.getComponentType();
     AnnotatedTypeMirror vectorTypeArg = receiverAsVector.getTypeArguments().get(0);
-    Tree errorLocation = node.getArguments().get(0);
+    Tree errorLocation = tree.getArguments().get(0);
     if (TypesUtils.isErasedSubtype(
         vectorTypeArg.getUnderlyingType(), argComponent.getUnderlyingType(), types)) {
       commonAssignmentCheck(argComponent, vectorTypeArg, errorLocation, "vector.copyinto");
@@ -1948,16 +1948,16 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * </ul>
    */
   @Override
-  public Void visitNewClass(NewClassTree node, Void p) {
-    if (checker.shouldSkipUses(TreeUtils.elementFromUse(node))) {
-      return super.visitNewClass(node, p);
+  public Void visitNewClass(NewClassTree tree, Void p) {
+    if (checker.shouldSkipUses(TreeUtils.elementFromUse(tree))) {
+      return super.visitNewClass(tree, p);
     }
 
-    ParameterizedExecutableType fromUse = atypeFactory.constructorFromUse(node);
+    ParameterizedExecutableType fromUse = atypeFactory.constructorFromUse(tree);
     AnnotatedExecutableType constructorType = fromUse.executableType;
     List<AnnotatedTypeMirror> typeargs = fromUse.typeArgs;
 
-    List<? extends ExpressionTree> passedArguments = node.getArguments();
+    List<? extends ExpressionTree> passedArguments = tree.getArguments();
     List<AnnotatedTypeMirror> params =
         AnnotatedTypes.adaptParameters(atypeFactory, constructorType, passedArguments);
 
@@ -1965,57 +1965,57 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     CharSequence constructorName = ElementUtils.getSimpleNameOrDescription(constructor);
 
     checkArguments(params, passedArguments, constructorName, constructor.getParameters());
-    checkVarargs(constructorType, node);
+    checkVarargs(constructorType, tree);
 
     List<AnnotatedTypeParameterBounds> paramBounds =
         CollectionsPlume.mapList(
             AnnotatedTypeVariable::getBounds, constructorType.getTypeVariables());
 
     checkTypeArguments(
-        node,
+        tree,
         paramBounds,
         typeargs,
-        node.getTypeArguments(),
+        tree.getTypeArguments(),
         constructorName,
         constructor.getTypeParameters());
 
-    boolean valid = validateTypeOf(node);
+    boolean valid = validateTypeOf(tree);
 
     if (valid) {
-      AnnotatedDeclaredType dt = atypeFactory.getAnnotatedType(node);
-      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(dt, node);
-      checkConstructorInvocation(dt, constructorType, node);
+      AnnotatedDeclaredType dt = atypeFactory.getAnnotatedType(tree);
+      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(dt, tree);
+      checkConstructorInvocation(dt, constructorType, tree);
     }
     // Do not call super, as that would observe the arguments without
     // a set assignment context.
-    scan(node.getEnclosingExpression(), p);
-    scan(node.getIdentifier(), p);
-    scan(node.getClassBody(), p);
+    scan(tree.getEnclosingExpression(), p);
+    scan(tree.getIdentifier(), p);
+    scan(tree.getClassBody(), p);
 
     return null;
   }
 
   @Override
-  public Void visitLambdaExpression(LambdaExpressionTree node, Void p) {
+  public Void visitLambdaExpression(LambdaExpressionTree tree, Void p) {
 
-    AnnotatedExecutableType functionType = atypeFactory.getFunctionTypeFromTree(node);
+    AnnotatedExecutableType functionType = atypeFactory.getFunctionTypeFromTree(tree);
 
-    if (node.getBody().getKind() != Tree.Kind.BLOCK) {
+    if (tree.getBody().getKind() != Tree.Kind.BLOCK) {
       // Check return type for single statement returns here.
       AnnotatedTypeMirror ret = functionType.getReturnType();
       if (ret.getKind() != TypeKind.VOID) {
-        commonAssignmentCheck(ret, (ExpressionTree) node.getBody(), "return");
+        commonAssignmentCheck(ret, (ExpressionTree) tree.getBody(), "return");
       }
     }
 
     // Check parameters
     for (int i = 0; i < functionType.getParameterTypes().size(); ++i) {
       AnnotatedTypeMirror lambdaParameter =
-          atypeFactory.getAnnotatedType(node.getParameters().get(i));
+          atypeFactory.getAnnotatedType(tree.getParameters().get(i));
       commonAssignmentCheck(
           lambdaParameter,
           functionType.getParameterTypes().get(i),
-          node.getParameters().get(i),
+          tree.getParameters().get(i),
           "lambda.param",
           i);
     }
@@ -2023,13 +2023,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     // TODO: Postconditions?
     // https://github.com/typetools/checker-framework/issues/801
 
-    return super.visitLambdaExpression(node, p);
+    return super.visitLambdaExpression(tree, p);
   }
 
   @Override
-  public Void visitMemberReference(MemberReferenceTree node, Void p) {
-    this.checkMethodReferenceAsOverride(node, p);
-    return super.visitMemberReference(node, p);
+  public Void visitMemberReference(MemberReferenceTree tree, Void p) {
+    this.checkMethodReferenceAsOverride(tree, p);
+    return super.visitMemberReference(tree, p);
   }
 
   /** A set containing {@code Tree.Kind.METHOD} and {@code Tree.Kind.LAMBDA_EXPRESSION}. */
@@ -2041,10 +2041,10 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * return type. If not, it issues a "return" error.
    */
   @Override
-  public Void visitReturn(ReturnTree node, Void p) {
+  public Void visitReturn(ReturnTree tree, Void p) {
     // Don't try to check return expressions for void methods.
-    if (node.getExpression() == null) {
-      return super.visitReturn(node, p);
+    if (tree.getExpression() == null) {
+      return super.visitReturn(tree, p);
     }
 
     Tree enclosing = TreePathUtil.enclosingOfKind(getCurrentPath(), methodAndLambdaExpression);
@@ -2055,7 +2055,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
       MethodTree enclosingMethod = TreePathUtil.enclosingMethod(getCurrentPath());
       boolean valid = validateTypeOf(enclosing);
       if (valid) {
-        ret = atypeFactory.getMethodReturnType(enclosingMethod, node);
+        ret = atypeFactory.getMethodReturnType(enclosingMethod, tree);
       }
     } else {
       AnnotatedExecutableType result =
@@ -2064,9 +2064,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     }
 
     if (ret != null) {
-      commonAssignmentCheck(ret, node.getExpression(), "return");
+      commonAssignmentCheck(ret, tree.getExpression(), "return");
     }
-    return super.visitReturn(node, p);
+    return super.visitReturn(tree, p);
   }
 
   /**
@@ -2074,14 +2074,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * casing, as annotation arguments form special trees.
    */
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
-    List<? extends ExpressionTree> args = node.getArguments();
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
+    List<? extends ExpressionTree> args = tree.getArguments();
     if (args.isEmpty()) {
       // Nothing to do if there are no annotation arguments.
       return null;
     }
 
-    TypeElement anno = (TypeElement) TreeInfo.symbol((JCTree) node.getAnnotationType());
+    TypeElement anno = (TypeElement) TreeInfo.symbol((JCTree) tree.getAnnotationType());
 
     Name annoName = anno.getQualifiedName();
     if (annoName.contentEquals(DefaultQualifier.class.getName())
@@ -2153,11 +2153,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * another failsafe guard and do the checks.
    */
   @Override
-  public Void visitConditionalExpression(ConditionalExpressionTree node, Void p) {
-    AnnotatedTypeMirror cond = atypeFactory.getAnnotatedType(node);
-    this.commonAssignmentCheck(cond, node.getTrueExpression(), "conditional");
-    this.commonAssignmentCheck(cond, node.getFalseExpression(), "conditional");
-    return super.visitConditionalExpression(node, p);
+  public Void visitConditionalExpression(ConditionalExpressionTree tree, Void p) {
+    AnnotatedTypeMirror cond = atypeFactory.getAnnotatedType(tree);
+    this.commonAssignmentCheck(cond, tree.getTrueExpression(), "conditional");
+    this.commonAssignmentCheck(cond, tree.getFalseExpression(), "conditional");
+    return super.visitConditionalExpression(tree, p);
   }
 
   /**
@@ -2225,13 +2225,13 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
   /** Performs assignability check. */
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, Void p) {
-    // If node is the tree representing the compounds assignment s += expr,
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, Void p) {
+    // If tree is the tree representing the compounds assignment s += expr,
     // Then this method should check whether s + expr can be assigned to s,
     // but the "s + expr" tree does not exist.  So instead, check that
     // s += expr can be assigned to s.
-    commonAssignmentCheck(node.getVariable(), node, "compound.assignment");
-    return super.visitCompoundAssignment(node, p);
+    commonAssignmentCheck(tree.getVariable(), tree, "compound.assignment");
+    return super.visitCompoundAssignment(tree, p);
   }
 
   // **********************************************************************
@@ -2239,18 +2239,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   // **********************************************************************
 
   @Override
-  public Void visitNewArray(NewArrayTree node, Void p) {
-    boolean valid = validateTypeOf(node);
+  public Void visitNewArray(NewArrayTree tree, Void p) {
+    boolean valid = validateTypeOf(tree);
 
-    if (valid && node.getType() != null) {
-      AnnotatedArrayType arrayType = atypeFactory.getAnnotatedType(node);
-      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(arrayType, node);
-      if (node.getInitializers() != null) {
-        checkArrayInitialization(arrayType.getComponentType(), node.getInitializers());
+    if (valid && tree.getType() != null) {
+      AnnotatedArrayType arrayType = atypeFactory.getAnnotatedType(tree);
+      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(arrayType, tree);
+      if (tree.getInitializers() != null) {
+        checkArrayInitialization(arrayType.getComponentType(), tree.getInitializers());
       }
     }
 
-    return super.visitNewArray(node, p);
+    return super.visitNewArray(tree, p);
   }
 
   /**
@@ -2417,26 +2417,26 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   }
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, Void p) {
-    // validate "node" instead of "node.getType()" to prevent duplicate errors.
-    boolean valid = validateTypeOf(node) && validateTypeOf(node.getExpression());
+  public Void visitTypeCast(TypeCastTree tree, Void p) {
+    // validate "tree" instead of "tree.getType()" to prevent duplicate errors.
+    boolean valid = validateTypeOf(tree) && validateTypeOf(tree.getExpression());
     if (valid) {
-      checkTypecastSafety(node);
-      checkTypecastRedundancy(node);
+      checkTypecastSafety(tree);
+      checkTypecastRedundancy(tree);
     }
     if (atypeFactory.getDependentTypesHelper().hasDependentAnnotations()) {
-      AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(node);
-      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(type, node.getType());
+      AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(tree);
+      atypeFactory.getDependentTypesHelper().checkTypeForErrorExpressions(type, tree.getType());
     }
 
-    if (node.getType().getKind() == Tree.Kind.INTERSECTION_TYPE) {
+    if (tree.getType().getKind() == Tree.Kind.INTERSECTION_TYPE) {
       AnnotatedIntersectionType intersection =
-          (AnnotatedIntersectionType) atypeFactory.getAnnotatedType(node);
+          (AnnotatedIntersectionType) atypeFactory.getAnnotatedType(tree);
       checkExplicitAnnotationsOnIntersectionBounds(
-          intersection, ((IntersectionTypeTree) node.getType()).getBounds());
+          intersection, ((IntersectionTypeTree) tree.getType()).getBounds());
     }
-    return super.visitTypeCast(node, p);
-    // return scan(node.getExpression(), p);
+    return super.visitTypeCast(tree, p);
+    // return scan(tree.getExpression(), p);
   }
 
   @Override
@@ -2474,20 +2474,20 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * #checkExceptionParameter} rather than this method to change the behavior of this check.
    */
   @Override
-  public Void visitCatch(CatchTree node, Void p) {
-    checkExceptionParameter(node);
-    return super.visitCatch(node, p);
+  public Void visitCatch(CatchTree tree, Void p) {
+    checkExceptionParameter(tree);
+    return super.visitCatch(tree, p);
   }
 
   /**
    * Checks the type of a thrown exception. Subclasses should override
-   * checkThrownExpression(ThrowTree node) rather than this method to change the behavior of this
+   * checkThrownExpression(ThrowTree tree) rather than this method to change the behavior of this
    * check.
    */
   @Override
-  public Void visitThrow(ThrowTree node, Void p) {
-    checkThrownExpression(node);
-    return super.visitThrow(node, p);
+  public Void visitThrow(ThrowTree tree, Void p) {
+    checkThrownExpression(tree);
+    return super.visitThrow(tree, p);
   }
 
   /**
@@ -2498,9 +2498,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * belong to the variable type or method return type.
    */
   @Override
-  public Void visitAnnotatedType(AnnotatedTypeTree node, Void p) {
-    visitAnnotatedType(null, node);
-    return super.visitAnnotatedType(node, p);
+  public Void visitAnnotatedType(AnnotatedTypeTree tree, Void p) {
+    visitAnnotatedType(null, tree);
+    return super.visitAnnotatedType(tree, p);
   }
 
   /**
@@ -2633,19 +2633,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * to enforce that exception parameter be annotated with other annotations can just override
    * {@link #getExceptionParameterLowerBoundAnnotations()}.
    *
-   * @param node CatchTree to check
+   * @param tree CatchTree to check
    */
-  protected void checkExceptionParameter(CatchTree node) {
+  protected void checkExceptionParameter(CatchTree tree) {
 
     Set<? extends AnnotationMirror> requiredAnnotations =
         getExceptionParameterLowerBoundAnnotationsCached();
-    AnnotatedTypeMirror exPar = atypeFactory.getAnnotatedType(node.getParameter());
+    AnnotatedTypeMirror exPar = atypeFactory.getAnnotatedType(tree.getParameter());
 
     for (AnnotationMirror required : requiredAnnotations) {
       AnnotationMirror found = exPar.getAnnotationInHierarchy(required);
       assert found != null;
       if (!atypeFactory.getQualifierHierarchy().isSubtype(required, found)) {
-        checker.reportError(node.getParameter(), "exception.parameter", found, required);
+        checker.reportError(tree.getParameter(), "exception.parameter", found, required);
       }
 
       if (exPar.getKind() == TypeKind.UNION) {
@@ -2653,7 +2653,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         for (AnnotatedTypeMirror alterntive : aut.getAlternatives()) {
           AnnotationMirror foundAltern = alterntive.getAnnotationInHierarchy(required);
           if (!atypeFactory.getQualifierHierarchy().isSubtype(required, foundAltern)) {
-            checker.reportError(node.getParameter(), "exception.parameter", foundAltern, required);
+            checker.reportError(tree.getParameter(), "exception.parameter", foundAltern, required);
           }
         }
       }
@@ -2689,17 +2689,17 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * #getExceptionParameterLowerBoundAnnotations}, should override {@link
    * #getThrowUpperBoundAnnotations()}.
    *
-   * @param node ThrowTree to check
+   * @param tree ThrowTree to check
    */
-  protected void checkThrownExpression(ThrowTree node) {
-    AnnotatedTypeMirror throwType = atypeFactory.getAnnotatedType(node.getExpression());
+  protected void checkThrownExpression(ThrowTree tree) {
+    AnnotatedTypeMirror throwType = atypeFactory.getAnnotatedType(tree.getExpression());
     Set<? extends AnnotationMirror> required = getThrowUpperBoundAnnotations();
     switch (throwType.getKind()) {
       case NULL:
       case DECLARED:
         Set<AnnotationMirror> found = throwType.getAnnotations();
         if (!atypeFactory.getQualifierHierarchy().isSubtype(found, required)) {
-          checker.reportError(node.getExpression(), "throw", found, required);
+          checker.reportError(tree.getExpression(), "throw", found, required);
         }
         break;
       case TYPEVAR:
@@ -2707,18 +2707,18 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // TODO: this code might change after the type var changes.
         Set<AnnotationMirror> foundEffective = throwType.getEffectiveAnnotations();
         if (!atypeFactory.getQualifierHierarchy().isSubtype(foundEffective, required)) {
-          checker.reportError(node.getExpression(), "throw", foundEffective, required);
+          checker.reportError(tree.getExpression(), "throw", foundEffective, required);
         }
         break;
       case UNION:
         AnnotatedUnionType unionType = (AnnotatedUnionType) throwType;
         Set<AnnotationMirror> foundPrimary = unionType.getAnnotations();
         if (!atypeFactory.getQualifierHierarchy().isSubtype(foundPrimary, required)) {
-          checker.reportError(node.getExpression(), "throw", foundPrimary, required);
+          checker.reportError(tree.getExpression(), "throw", foundPrimary, required);
         }
         for (AnnotatedTypeMirror altern : unionType.getAlternatives()) {
           if (!atypeFactory.getQualifierHierarchy().isSubtype(altern.getAnnotations(), required)) {
-            checker.reportError(node.getExpression(), "throw", altern.getAnnotations(), required);
+            checker.reportError(tree.getExpression(), "throw", altern.getAnnotations(), required);
           }
         }
         break;
@@ -3173,30 +3173,30 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * visitor may, for example, allow a method to be invoked even if the receivers are siblings in a
    * hierarchy, provided that some other condition (implemented by the visitor) is satisfied.
    *
-   * @param node the method invocation node
+   * @param tree the method invocation tree
    * @param methodDefinitionReceiver the ATM of the receiver of the method definition
    * @param methodCallReceiver the ATM of the receiver of the method call
    * @return whether to skip subtype checks on the receiver
    */
   protected boolean skipReceiverSubtypeCheck(
-      MethodInvocationTree node,
+      MethodInvocationTree tree,
       AnnotatedTypeMirror methodDefinitionReceiver,
       AnnotatedTypeMirror methodCallReceiver) {
     return false;
   }
 
   /**
-   * Tests whether the method can be invoked using the receiver of the 'node' method invocation, and
+   * Tests whether the method can be invoked using the receiver of the 'tree' method invocation, and
    * issues a "method.invocation" if the invocation is invalid.
    *
    * <p>This implementation tests whether the receiver in the method invocation is a subtype of the
    * method receiver type. This behavior can be specialized by overriding skipReceiverSubtypeCheck.
    *
    * @param method the type of the invoked method
-   * @param node the method invocation node
+   * @param tree the method invocation tree
    */
   protected void checkMethodInvocability(
-      AnnotatedExecutableType method, MethodInvocationTree node) {
+      AnnotatedExecutableType method, MethodInvocationTree tree) {
     if (method.getReceiverType() == null) {
       // Static methods don't have a receiver to check.
       return;
@@ -3206,24 +3206,24 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
       // from the enclosing constructor. We must not use the self type, but
       // instead should find a way to determine the receiver of the enclosing constructor.
       // rcv =
-      // ((AnnotatedExecutableType)atypeFactory.getAnnotatedType(atypeFactory.getEnclosingMethod(node))).getReceiverType();
+      // ((AnnotatedExecutableType)atypeFactory.getAnnotatedType(atypeFactory.getEnclosingMethod(tree))).getReceiverType();
       return;
     }
 
     AnnotatedTypeMirror methodReceiver = method.getReceiverType().getErased();
     AnnotatedTypeMirror treeReceiver = methodReceiver.shallowCopy(false);
-    AnnotatedTypeMirror rcv = atypeFactory.getReceiverType(node);
+    AnnotatedTypeMirror rcv = atypeFactory.getReceiverType(tree);
 
     treeReceiver.addAnnotations(rcv.getEffectiveAnnotations());
 
-    if (!skipReceiverSubtypeCheck(node, methodReceiver, rcv)) {
+    if (!skipReceiverSubtypeCheck(tree, methodReceiver, rcv)) {
       // The diagnostic can be a bit misleading because the check is of the receiver but
-      // `node` is the entire method invocation (where the receiver might be implicit).
-      commonAssignmentCheckStartDiagnostic(methodReceiver, treeReceiver, node);
+      // `tree` is the entire method invocation (where the receiver might be implicit).
+      commonAssignmentCheckStartDiagnostic(methodReceiver, treeReceiver, tree);
       boolean success = atypeFactory.getTypeHierarchy().isSubtype(treeReceiver, methodReceiver);
-      commonAssignmentCheckEndDiagnostic(success, null, methodReceiver, treeReceiver, node);
+      commonAssignmentCheckEndDiagnostic(success, null, methodReceiver, treeReceiver, tree);
       if (!success) {
-        reportMethodInvocabilityError(node, treeReceiver, methodReceiver);
+        reportMethodInvocabilityError(tree, treeReceiver, methodReceiver);
       }
     }
   }
@@ -3231,16 +3231,16 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   /**
    * Report a method invocability error. Allows checkers to change how the message is output.
    *
-   * @param node the AST node at which to report the error
+   * @param tree the AST node at which to report the error
    * @param found the actual type of the receiver
    * @param expected the expected type of the receiver
    */
   protected void reportMethodInvocabilityError(
-      MethodInvocationTree node, AnnotatedTypeMirror found, AnnotatedTypeMirror expected) {
+      MethodInvocationTree tree, AnnotatedTypeMirror found, AnnotatedTypeMirror expected) {
     checker.reportError(
-        node,
+        tree,
         "method.invocation",
-        TreeUtils.elementFromUse(node),
+        TreeUtils.elementFromUse(tree),
         found.toString(),
         expected.toString());
   }
@@ -4342,19 +4342,19 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   }
 
   @Override
-  public Void visitIdentifier(IdentifierTree node, Void p) {
-    checkAccess(node, p);
-    return super.visitIdentifier(node, p);
+  public Void visitIdentifier(IdentifierTree tree, Void p) {
+    checkAccess(tree, p);
+    return super.visitIdentifier(tree, p);
   }
 
-  protected void checkAccess(IdentifierTree node, Void p) {
+  protected void checkAccess(IdentifierTree identifierTree, Void p) {
     MemberSelectTree memberSel = enclosingMemberSelect();
     ExpressionTree tree;
     Element elem;
 
     if (memberSel == null) {
-      tree = node;
-      elem = TreeUtils.elementFromUse(node);
+      tree = identifierTree;
+      elem = TreeUtils.elementFromUse(identifierTree);
     } else {
       tree = memberSel;
       elem = TreeUtils.elementFromUse(memberSel);
@@ -4561,11 +4561,11 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
 
   /** Override Compilation Unit so we won't visit package names or imports. */
   @Override
-  public Void visitCompilationUnit(CompilationUnitTree node, Void p) {
-    Void r = scan(node.getPackageAnnotations(), p);
-    // r = reduce(scan(node.getPackageName(), p), r);
-    // r = reduce(scan(node.getImports(), p), r);
-    r = reduce(scan(node.getTypeDecls(), p), r);
+  public Void visitCompilationUnit(CompilationUnitTree identifierTree, Void p) {
+    Void r = scan(identifierTree.getPackageAnnotations(), p);
+    // r = reduce(scan(identifierTree.getPackageName(), p), r);
+    // r = reduce(scan(identifierTree.getImports(), p), r);
+    r = reduce(scan(identifierTree.getTypeDecls(), p), r);
     return r;
   }
 }

--- a/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
+++ b/framework/src/main/java/org/checkerframework/common/reflection/DefaultReflectionResolver.java
@@ -319,7 +319,7 @@ public class DefaultReflectionResolver implements ReflectionResolver {
   /**
    * Resolves a reflective method call and returns all possible corresponding method calls.
    *
-   * @param tree the MethodInvocationTree node that is to be resolved (Method.invoke)
+   * @param tree the MethodInvocationTree AST node that is to be resolved (Method.invoke)
    * @return a (potentially empty) list of all resolved MethodInvocationTrees
    */
   private List<MethodInvocationTree> resolveReflectiveMethod(
@@ -421,7 +421,7 @@ public class DefaultReflectionResolver implements ReflectionResolver {
    * Resolves a reflective constructor call and returns all possible corresponding constructor
    * calls.
    *
-   * @param tree the MethodInvocationTree node that is to be resolved (Constructor.newInstance)
+   * @param tree the MethodInvocationTree AST node that is to be resolved (Constructor.newInstance)
    * @return a (potentially empty) list of all resolved MethodInvocationTrees
    */
   private List<JCNewClass> resolveReflectiveConstructor(

--- a/framework/src/main/java/org/checkerframework/common/returnsreceiver/ReturnsReceiverVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/returnsreceiver/ReturnsReceiverVisitor.java
@@ -27,8 +27,8 @@ public class ReturnsReceiverVisitor extends BaseTypeVisitor<ReturnsReceiverAnnot
   }
 
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
-    AnnotationMirror annot = TreeUtils.annotationFromAnnotationTree(node);
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
+    AnnotationMirror annot = TreeUtils.annotationFromAnnotationTree(tree);
     // Warn if a @This annotation is in an illegal location.
     if (AnnotationUtils.areSame(annot, getTypeFactory().THIS_ANNOTATION)) {
       TreePath parentPath = getCurrentPath().getParentPath();
@@ -47,13 +47,13 @@ public class ReturnsReceiverVisitor extends BaseTypeVisitor<ReturnsReceiverAnnot
           grandparent instanceof TypeCastTree
               && parent.equals(((TypeCastTree) grandparent).getType());
       if (!(isReturnAnnot || isReceiverAnnot || isCastAnnot)) {
-        checker.reportError(node, "this.location");
+        checker.reportError(tree, "this.location");
       }
       if (isReturnAnnot
           && ElementUtils.isStatic(TreeUtils.elementFromDeclaration((MethodTree) grandparent))) {
-        checker.reportError(node, "this.location");
+        checker.reportError(tree, "this.location");
       }
     }
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 }

--- a/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
+++ b/framework/src/main/java/org/checkerframework/common/util/count/JavaCodeStatistics.java
@@ -98,8 +98,8 @@ public class JavaCodeStatistics extends SourceChecker {
     }
 
     @Override
-    public Void visitAnnotation(AnnotationTree node, Void aVoid) {
-      AnnotationMirror annotationMirror = TreeUtils.annotationFromAnnotationTree(node);
+    public Void visitAnnotation(AnnotationTree tree, Void aVoid) {
+      AnnotationMirror annotationMirror = TreeUtils.annotationFromAnnotationTree(tree);
       if (AnnotationUtils.annotationName(annotationMirror)
           .equals(SuppressWarnings.class.getCanonicalName())) {
         List<String> keys =
@@ -109,12 +109,12 @@ public class JavaCodeStatistics extends SourceChecker {
           for (String indexKey : warningKeys) {
             if (foundKey.startsWith(indexKey)) {
               numberOfIndexWarningSuppressions++;
-              return super.visitAnnotation(node, aVoid);
+              return super.visitAnnotation(tree, aVoid);
             }
           }
         }
       }
-      return super.visitAnnotation(node, aVoid);
+      return super.visitAnnotation(tree, aVoid);
     }
 
     @Override
@@ -145,31 +145,31 @@ public class JavaCodeStatistics extends SourceChecker {
     }
 
     @Override
-    public Void visitNewArray(NewArrayTree node, Void aVoid) {
-      arrayAccesses += node.getDimensions().size();
+    public Void visitNewArray(NewArrayTree tree, Void aVoid) {
+      arrayAccesses += tree.getDimensions().size();
 
-      return super.visitNewArray(node, aVoid);
+      return super.visitNewArray(tree, aVoid);
     }
 
     @Override
-    public Void visitNewClass(NewClassTree node, Void aVoid) {
-      if (TreeUtils.isDiamondTree(node)) {
+    public Void visitNewClass(NewClassTree tree, Void aVoid) {
+      if (TreeUtils.isDiamondTree(tree)) {
         generics++;
       }
-      generics += node.getTypeArguments().size();
-      return super.visitNewClass(node, aVoid);
+      generics += tree.getTypeArguments().size();
+      return super.visitNewClass(tree, aVoid);
     }
 
     @Override
-    public Void visitMethodInvocation(MethodInvocationTree node, Void aVoid) {
-      generics += node.getTypeArguments().size();
-      return super.visitMethodInvocation(node, aVoid);
+    public Void visitMethodInvocation(MethodInvocationTree tree, Void aVoid) {
+      generics += tree.getTypeArguments().size();
+      return super.visitMethodInvocation(tree, aVoid);
     }
 
     @Override
-    public Void visitMethod(MethodTree node, Void aVoid) {
-      generics += node.getTypeParameters().size();
-      return super.visitMethod(node, aVoid);
+    public Void visitMethod(MethodTree tree, Void aVoid) {
+      generics += tree.getTypeParameters().size();
+      return super.visitMethod(tree, aVoid);
     }
 
     @Override
@@ -179,15 +179,15 @@ public class JavaCodeStatistics extends SourceChecker {
     }
 
     @Override
-    public Void visitArrayAccess(ArrayAccessTree node, Void aVoid) {
+    public Void visitArrayAccess(ArrayAccessTree tree, Void aVoid) {
       arrayAccesses++;
-      return super.visitArrayAccess(node, aVoid);
+      return super.visitArrayAccess(tree, aVoid);
     }
 
     @Override
-    public Void visitTypeCast(TypeCastTree node, Void aVoid) {
+    public Void visitTypeCast(TypeCastTree tree, Void aVoid) {
       typecasts++;
-      return super.visitTypeCast(node, aVoid);
+      return super.visitTypeCast(tree, aVoid);
     }
   }
 

--- a/framework/src/main/java/org/checkerframework/common/util/debug/TreeDebug.java
+++ b/framework/src/main/java/org/checkerframework/common/util/debug/TreeDebug.java
@@ -53,7 +53,7 @@ public class TreeDebug extends AbstractProcessor {
     }
 
     @Override
-    public Void scan(Tree node, Void p) {
+    public Void scan(Tree tree, Void p) {
 
       // Indent according to subtrees.
       if (getCurrentPath() != null) {
@@ -62,16 +62,16 @@ public class TreeDebug extends AbstractProcessor {
         }
       }
 
-      // Add node kind to the buffer.
-      if (node == null) {
+      // Add tree kind to the buffer.
+      if (tree == null) {
         buf.append("null");
       } else {
-        buf.append(node.getKind());
+        buf.append(tree.getKind());
       }
       buf.append(LINE_SEPARATOR);
 
       // Visit subtrees.
-      super.scan(node, p);
+      super.scan(tree, p);
 
       // Display and clear the buffer.
       System.out.print(buf.toString());
@@ -81,9 +81,9 @@ public class TreeDebug extends AbstractProcessor {
     }
 
     /**
-     * Splices additional information for a node into the buffer.
+     * Splices additional information for an AST node into the buffer.
      *
-     * @param text additional information for the node
+     * @param text additional information for the AST node
      */
     private final void insert(Object text) {
       buf.insert(buf.length() - 1, " ");
@@ -91,29 +91,29 @@ public class TreeDebug extends AbstractProcessor {
     }
 
     @Override
-    public Void visitIdentifier(IdentifierTree node, Void p) {
-      insert(node);
-      return super.visitIdentifier(node, p);
+    public Void visitIdentifier(IdentifierTree tree, Void p) {
+      insert(tree);
+      return super.visitIdentifier(tree, p);
     }
 
     @Override
-    public Void visitMemberSelect(MemberSelectTree node, Void p) {
-      insert(node.getExpression() + "." + node.getIdentifier());
-      return super.visitMemberSelect(node, p);
+    public Void visitMemberSelect(MemberSelectTree tree, Void p) {
+      insert(tree.getExpression() + "." + tree.getIdentifier());
+      return super.visitMemberSelect(tree, p);
     }
 
     @Override
-    public Void visitNewArray(NewArrayTree node, Void p) {
-      insert(((JCNewArray) node).annotations);
+    public Void visitNewArray(NewArrayTree tree, Void p) {
+      insert(((JCNewArray) tree).annotations);
       insert("|");
-      insert(((JCNewArray) node).dimAnnotations);
-      return super.visitNewArray(node, p);
+      insert(((JCNewArray) tree).dimAnnotations);
+      return super.visitNewArray(tree, p);
     }
 
     @Override
-    public Void visitLiteral(LiteralTree node, Void p) {
-      insert(node.getValue());
-      return super.visitLiteral(node, p);
+    public Void visitLiteral(LiteralTree tree, Void p) {
+      insert(tree.getValue());
+      return super.visitLiteral(tree, p);
     }
   }
 

--- a/framework/src/main/java/org/checkerframework/common/util/debug/TypeOutputtingChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/util/debug/TypeOutputtingChecker.java
@@ -64,31 +64,31 @@ public class TypeOutputtingChecker extends BaseTypeChecker {
 
     // Print types of classes, methods, and fields
     @Override
-    public void processClassTree(ClassTree node) {
-      TypeElement element = TreeUtils.elementFromDeclaration(node);
+    public void processClassTree(ClassTree tree) {
+      TypeElement element = TreeUtils.elementFromDeclaration(tree);
       currentClass = element.getSimpleName().toString();
 
-      AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(node);
-      System.out.println(node.getSimpleName() + "\t" + type + "\t" + type.directSupertypes());
+      AnnotatedDeclaredType type = atypeFactory.getAnnotatedType(tree);
+      System.out.println(tree.getSimpleName() + "\t" + type + "\t" + type.directSupertypes());
 
-      super.processClassTree(node);
+      super.processClassTree(tree);
     }
 
     @Override
-    public Void visitMethod(MethodTree node, Void p) {
-      ExecutableElement elem = TreeUtils.elementFromDeclaration(node);
+    public Void visitMethod(MethodTree tree, Void p) {
+      ExecutableElement elem = TreeUtils.elementFromDeclaration(tree);
 
-      AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(node);
+      AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(tree);
       System.out.println(currentClass + "." + elem + "\t\t" + type);
       // Don't dig deeper
       return null;
     }
 
     @Override
-    public Void visitVariable(VariableTree node, Void p) {
-      VariableElement elem = TreeUtils.elementFromDeclaration(node);
+    public Void visitVariable(VariableTree tree, Void p) {
+      VariableElement elem = TreeUtils.elementFromDeclaration(tree);
       if (elem.getKind().isField()) {
-        AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(node);
+        AnnotatedTypeMirror type = atypeFactory.getAnnotatedType(tree);
         System.out.println(currentClass + "." + elem + "\t\t" + type);
       }
 

--- a/framework/src/main/java/org/checkerframework/common/util/report/ReportVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/util/report/ReportVisitor.java
@@ -85,18 +85,18 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
    * Check for uses of the {@link ReportUse} annotation. This method has to be called for every
    * explicit or implicit use of a type, most cases are simply covered by the type validator.
    *
-   * @param node the tree for error reporting only
+   * @param tree the tree for error reporting only
    * @param member the element from which to start looking
    */
-  private void checkReportUse(Tree node, Element member) {
+  private void checkReportUse(Tree tree, Element member) {
     Element loop = member;
     while (loop != null) {
       boolean report = this.atypeFactory.getDeclAnnotation(loop, ReportUse.class) != null;
       if (report) {
         checker.reportError(
-            node,
+            tree,
             "usage",
-            node,
+            tree,
             ElementUtils.getQualifiedName(loop),
             loop.getKind(),
             ElementUtils.getQualifiedName(member),
@@ -116,14 +116,14 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
   /* Would we want this? Seems redundant, as all uses of the imported
    * package should already be reported.
    * Also, how do we get an element for the import?
-  public Void visitImport(ImportTree node, Void p) {
-      checkReportUse(node, elem);
+  public Void visitImport(ImportTree tree, Void p) {
+      checkReportUse(tree, elem);
   }
   */
 
   @Override
-  public void processClassTree(ClassTree node) {
-    TypeElement member = TreeUtils.elementFromDeclaration(node);
+  public void processClassTree(ClassTree tree) {
+    TypeElement member = TreeUtils.elementFromDeclaration(tree);
     boolean report = false;
     // No need to check on the declaring class itself
     // this.atypeFactory.getDeclAnnotation(member, ReportInherit.class) != null;
@@ -133,15 +133,15 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
     for (TypeElement sup : suptypes) {
       report = this.atypeFactory.getDeclAnnotation(sup, ReportInherit.class) != null;
       if (report) {
-        checker.reportError(node, "inherit", node, ElementUtils.getQualifiedName(sup));
+        checker.reportError(tree, "inherit", tree, ElementUtils.getQualifiedName(sup));
       }
     }
-    super.processClassTree(node);
+    super.processClassTree(tree);
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    ExecutableElement method = TreeUtils.elementFromDeclaration(node);
+  public Void visitMethod(MethodTree tree, Void p) {
+    ExecutableElement method = TreeUtils.elementFromDeclaration(tree);
     boolean report = false;
 
     // Check all overridden methods.
@@ -159,15 +159,15 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
     }
 
     if (report) {
-      checker.reportError(node, "override", node, ElementUtils.getQualifiedName(method));
+      checker.reportError(tree, "override", tree, ElementUtils.getQualifiedName(method));
     }
-    return super.visitMethod(node, p);
+    return super.visitMethod(tree, p);
   }
 
   @Override
-  public Void visitMethodInvocation(MethodInvocationTree node, Void p) {
-    ExecutableElement method = TreeUtils.elementFromUse(node);
-    checkReportUse(node, method);
+  public Void visitMethodInvocation(MethodInvocationTree tree, Void p) {
+    ExecutableElement method = TreeUtils.elementFromUse(tree);
+    checkReportUse(tree, method);
     boolean report = this.atypeFactory.getDeclAnnotation(method, ReportCall.class) != null;
 
     if (!report) {
@@ -189,54 +189,54 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
     }
 
     if (report) {
-      checker.reportError(node, "methodcall", node, ElementUtils.getQualifiedName(method));
+      checker.reportError(tree, "methodcall", tree, ElementUtils.getQualifiedName(method));
     }
-    return super.visitMethodInvocation(node, p);
+    return super.visitMethodInvocation(tree, p);
   }
 
   @Override
-  public Void visitMemberSelect(MemberSelectTree node, Void p) {
-    Element member = TreeUtils.elementFromUse(node);
-    checkReportUse(node, member);
+  public Void visitMemberSelect(MemberSelectTree tree, Void p) {
+    Element member = TreeUtils.elementFromUse(tree);
+    checkReportUse(tree, member);
     boolean report = this.atypeFactory.getDeclAnnotation(member, ReportReadWrite.class) != null;
 
     if (report) {
-      checker.reportError(node, "fieldreadwrite", node, ElementUtils.getQualifiedName(member));
+      checker.reportError(tree, "fieldreadwrite", tree, ElementUtils.getQualifiedName(member));
     }
-    return super.visitMemberSelect(node, p);
+    return super.visitMemberSelect(tree, p);
   }
 
   @Override
-  public Void visitIdentifier(IdentifierTree node, Void p) {
-    Element member = TreeUtils.elementFromUse(node);
+  public Void visitIdentifier(IdentifierTree tree, Void p) {
+    Element member = TreeUtils.elementFromUse(tree);
     boolean report = this.atypeFactory.getDeclAnnotation(member, ReportReadWrite.class) != null;
 
     if (report) {
-      checker.reportError(node, "fieldreadwrite", node, ElementUtils.getQualifiedName(member));
+      checker.reportError(tree, "fieldreadwrite", tree, ElementUtils.getQualifiedName(member));
     }
-    return super.visitIdentifier(node, p);
+    return super.visitIdentifier(tree, p);
   }
 
   @Override
-  public Void visitAssignment(AssignmentTree node, Void p) {
-    VariableElement member = (VariableElement) TreeUtils.elementFromUse(node.getVariable());
+  public Void visitAssignment(AssignmentTree tree, Void p) {
+    VariableElement member = (VariableElement) TreeUtils.elementFromUse(tree.getVariable());
     boolean report = this.atypeFactory.getDeclAnnotation(member, ReportWrite.class) != null;
 
     if (report) {
-      checker.reportError(node, "fieldwrite", node, ElementUtils.getQualifiedName(member));
+      checker.reportError(tree, "fieldwrite", tree, ElementUtils.getQualifiedName(member));
     }
-    return super.visitAssignment(node, p);
+    return super.visitAssignment(tree, p);
   }
 
   @Override
-  public Void visitArrayAccess(ArrayAccessTree node, Void p) {
+  public Void visitArrayAccess(ArrayAccessTree tree, Void p) {
     // TODO: should we introduce an annotation for this?
-    return super.visitArrayAccess(node, p);
+    return super.visitArrayAccess(tree, p);
   }
 
   @Override
-  public Void visitNewClass(NewClassTree node, Void p) {
-    Element member = TreeUtils.elementFromUse(node);
+  public Void visitNewClass(NewClassTree tree, Void p) {
+    Element member = TreeUtils.elementFromUse(tree);
     boolean report = this.atypeFactory.getDeclAnnotation(member, ReportCreation.class) != null;
     if (!report) {
       // If the constructor is not annotated, check whether the class is.
@@ -257,40 +257,40 @@ public class ReportVisitor extends BaseTypeVisitor<BaseAnnotatedTypeFactory> {
     }
 
     if (report) {
-      checker.reportError(node, "creation", node, ElementUtils.getQualifiedName(member));
+      checker.reportError(tree, "creation", tree, ElementUtils.getQualifiedName(member));
     }
-    return super.visitNewClass(node, p);
+    return super.visitNewClass(tree, p);
   }
 
   @Override
-  public Void visitNewArray(NewArrayTree node, Void p) {
+  public Void visitNewArray(NewArrayTree tree, Void p) {
     // TODO Should we report this if the array type is @ReportCreation?
-    return super.visitNewArray(node, p);
+    return super.visitNewArray(tree, p);
   }
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, Void p) {
+  public Void visitTypeCast(TypeCastTree tree, Void p) {
     // TODO Is it worth adding a separate annotation for this?
-    return super.visitTypeCast(node, p);
+    return super.visitTypeCast(tree, p);
   }
 
   @Override
-  public Void visitInstanceOf(InstanceOfTree node, Void p) {
+  public Void visitInstanceOf(InstanceOfTree tree, Void p) {
     // TODO Is it worth adding a separate annotation for this?
-    return super.visitInstanceOf(node, p);
+    return super.visitInstanceOf(tree, p);
   }
 
   @SuppressWarnings("compilermessages") // These warnings are not translated.
   @Override
-  public Void visitModifiers(ModifiersTree node, Void p) {
-    if (node != null && modifiers != null) {
-      for (Modifier mod : node.getFlags()) {
+  public Void visitModifiers(ModifiersTree tree, Void p) {
+    if (tree != null && modifiers != null) {
+      for (Modifier mod : tree.getFlags()) {
         if (modifiers.contains(mod)) {
-          checker.reportError(node, "Modifier." + mod);
+          checker.reportError(tree, "Modifier." + mod);
         }
       }
     }
-    return super.visitModifiers(node, p);
+    return super.visitModifiers(tree, p);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueAnnotatedTypeFactory.java
@@ -567,8 +567,8 @@ public class ValueAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
               new PropagationTreeAnnotator(atypeFactory);
 
           @Override
-          public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror mirror) {
-            return propagationTreeAnnotator.visitNewArray(node, mirror);
+          public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror mirror) {
+            return propagationTreeAnnotator.visitNewArray(tree, mirror);
           }
         };
     return new ListTreeAnnotator(

--- a/framework/src/main/java/org/checkerframework/common/value/ValueTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueTreeAnnotator.java
@@ -591,7 +591,7 @@ class ValueTreeAnnotator extends TreeAnnotator {
 
   @Override
   public Void visitConditionalExpression(
-      ConditionalExpressionTree node, AnnotatedTypeMirror annotatedTypeMirror) {
+      ConditionalExpressionTree tree, AnnotatedTypeMirror annotatedTypeMirror) {
     // Work around for https://github.com/typetools/checker-framework/issues/602.
     annotatedTypeMirror.replaceAnnotation(atypeFactory.UNKNOWNVAL);
     return null;

--- a/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueVisitor.java
@@ -173,15 +173,15 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
    * Therefore, some validation is still done in #validateType below.
    */
   @Override
-  public Void visitAnnotation(AnnotationTree node, Void p) {
-    List<? extends ExpressionTree> args = node.getArguments();
+  public Void visitAnnotation(AnnotationTree tree, Void p) {
+    List<? extends ExpressionTree> args = tree.getArguments();
 
     if (args.isEmpty()) {
       // Nothing to do if there are no annotation arguments.
-      return super.visitAnnotation(node, p);
+      return super.visitAnnotation(tree, p);
     }
 
-    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(node);
+    AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(tree);
     switch (AnnotationUtils.annotationName(anno)) {
       case ValueAnnotatedTypeFactory.INTRANGE_NAME:
         // If there are 2 arguments, issue an error if from.greater.than.to.
@@ -192,7 +192,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
           long from = getTypeFactory().getIntRangeFromValue(anno);
           long to = getTypeFactory().getIntRangeToValue(anno);
           if (from > to) {
-            checker.reportError(node, "from.greater.than.to");
+            checker.reportError(tree, "from.greater.than.to");
             return null;
           }
         }
@@ -207,11 +207,11 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
             AnnotationUtils.getElementValueArray(anno, "value", Object.class, false);
 
         if (values.isEmpty()) {
-          checker.reportWarning(node, "no.values.given");
+          checker.reportWarning(tree, "no.values.given");
           return null;
         } else if (values.size() > ValueAnnotatedTypeFactory.MAX_VALUES) {
           checker.reportWarning(
-              node,
+              tree,
               (AnnotationUtils.areSameByName(anno, ValueAnnotatedTypeFactory.INTVAL_NAME)
                   ? "too.many.values.given.int"
                   : "too.many.values.given"),
@@ -220,7 +220,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         } else if (AnnotationUtils.areSameByName(anno, ValueAnnotatedTypeFactory.ARRAYLEN_NAME)) {
           List<Integer> arrayLens = getTypeFactory().getArrayLength(anno);
           if (Collections.min(arrayLens) < 0) {
-            checker.reportWarning(node, "negative.arraylen", Collections.min(arrayLens));
+            checker.reportWarning(tree, "negative.arraylen", Collections.min(arrayLens));
             return null;
           }
         }
@@ -229,10 +229,10 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         long from = getTypeFactory().getArrayLenRangeFromValue(anno);
         long to = getTypeFactory().getArrayLenRangeToValue(anno);
         if (from > to) {
-          checker.reportError(node, "from.greater.than.to");
+          checker.reportError(tree, "from.greater.than.to");
           return null;
         } else if (from < 0) {
-          checker.reportWarning(node, "negative.arraylen", from);
+          checker.reportWarning(tree, "negative.arraylen", from);
           return null;
         }
         break;
@@ -244,7 +244,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
           try {
             Pattern.compile(regex);
           } catch (PatternSyntaxException pse) {
-            checker.reportWarning(node, "invalid.matches.regex", pse.getMessage());
+            checker.reportWarning(tree, "invalid.matches.regex", pse.getMessage());
           }
         }
         break;
@@ -256,7 +256,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
           try {
             Pattern.compile(regex);
           } catch (PatternSyntaxException pse) {
-            checker.reportWarning(node, "invalid.doesnotmatch.regex", pse.getMessage());
+            checker.reportWarning(tree, "invalid.doesnotmatch.regex", pse.getMessage());
           }
         }
         break;
@@ -264,20 +264,20 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         // Do nothing.
     }
 
-    return super.visitAnnotation(node, p);
+    return super.visitAnnotation(tree, p);
   }
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, Void p) {
-    if (node.getExpression().getKind() == Tree.Kind.NULL_LITERAL) {
+  public Void visitTypeCast(TypeCastTree tree, Void p) {
+    if (tree.getExpression().getKind() == Tree.Kind.NULL_LITERAL) {
       return null;
     }
 
-    AnnotatedTypeMirror castType = atypeFactory.getAnnotatedType(node);
+    AnnotatedTypeMirror castType = atypeFactory.getAnnotatedType(tree);
     AnnotationMirror castAnno = castType.getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
     AnnotationMirror exprAnno =
         atypeFactory
-            .getAnnotatedType(node.getExpression())
+            .getAnnotatedType(tree.getExpression())
             .getAnnotationInHierarchy(atypeFactory.UNKNOWNVAL);
 
     // It is always legal to cast to an IntRange type that includes all values
@@ -321,7 +321,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         }
       }
     }
-    return super.visitTypeCast(node, p);
+    return super.visitTypeCast(tree, p);
   }
 
   /**
@@ -388,25 +388,25 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
   }
 
   @Override
-  public Void visitMethod(MethodTree node, Void p) {
-    super.visitMethod(node, p);
+  public Void visitMethod(MethodTree tree, Void p) {
+    super.visitMethod(tree, p);
 
-    ExecutableElement method = TreeUtils.elementFromDeclaration(node);
+    ExecutableElement method = TreeUtils.elementFromDeclaration(tree);
     if (atypeFactory.getDeclAnnotation(method, StaticallyExecutable.class) != null) {
       // The method is annotated as @StaticallyExecutable.
       if (atypeFactory.getDeclAnnotation(method, Pure.class) == null) {
-        checker.reportWarning(node, "statically.executable.not.pure");
+        checker.reportWarning(tree, "statically.executable.not.pure");
       }
       TypeMirror returnType = method.getReturnType();
       if (returnType.getKind() != TypeKind.VOID && !canBeConstant(returnType)) {
-        checker.reportError(node, "statically.executable.nonconstant.return.type", returnType);
+        checker.reportError(tree, "statically.executable.nonconstant.return.type", returnType);
       }
 
       // Ways to determine the receiver type.
       // 1. This definition of receiverType is null when receiver is implicit and method has
       //    class com.sun.tools.javac.code.Symbol$MethodSymbol.  WHY?
       //        TypeMirror receiverType = method.getReceiverType();
-      //    The same is true of TreeUtils.elementFromDeclaration(node).getReceiverType()
+      //    The same is true of TreeUtils.elementFromDeclaration(tree).getReceiverType()
       //    which seems to conflict with ExecutableType's documentation.
       // 2. Can't use the tree, because the receiver might not be explicit.
       // 3. Check whether method is static and use the declaring class.  Doesn't handle all
@@ -421,7 +421,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
           && receiverType.getKind() != TypeKind.NONE
           && !canBeConstant(receiverType)) {
         checker.reportError(
-            node,
+            tree,
             "statically.executable.nonconstant.parameter.type",
             "this (the receiver)",
             returnType);
@@ -431,7 +431,7 @@ public class ValueVisitor extends BaseTypeVisitor<ValueAnnotatedTypeFactory> {
         TypeMirror paramType = param.asType();
         if (paramType.getKind() != TypeKind.NONE && !canBeConstant(paramType)) {
           checker.reportError(
-              node,
+              tree,
               "statically.executable.nonconstant.parameter.type",
               param.getSimpleName().toString(),
               returnType);

--- a/framework/src/main/java/org/checkerframework/framework/ajava/ExpectedTreesVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/ajava/ExpectedTreesVisitor.java
@@ -126,13 +126,13 @@ public class ExpectedTreesVisitor extends TreeScannerWithDefaults {
       //      private final String myField;
       //   }
       // So the constructor and the field declarations have no matching trees in the
-      // JavaParser node, and we must remove those trees (and their subtrees) from the
+      // JavaParser AST node, and we must remove those trees (and their subtrees) from the
       // `trees` field.
       TreeScannerWithDefaults removeAllVisitor =
           new TreeScannerWithDefaults() {
             @Override
-            public void defaultAction(Tree node) {
-              trees.remove(node);
+            public void defaultAction(Tree tree) {
+              trees.remove(tree);
             }
           };
       for (Tree member : tree.getMembers()) {
@@ -262,7 +262,7 @@ public class ExpectedTreesVisitor extends TreeScannerWithDefaults {
 
     Void result = super.visitMethod(tree, p);
     // A varargs parameter like String... is converted to String[], where the array type doesn't
-    // have a corresponding JavaParser node. Conservatively skip the array type (but not the
+    // have a corresponding JavaParser AST node. Conservatively skip the array type (but not the
     // component type) if it's the last argument.
     if (!tree.getParameters().isEmpty()) {
       VariableTree last = tree.getParameters().get(tree.getParameters().size() - 1);

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2462,13 +2462,13 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
    * Tests whether the class definition should not be checked because it matches the {@code
    * checker.skipDefs} property.
    *
-   * @param node class to potentially skip
-   * @return true if checker should not test node
+   * @param tree class to potentially skip
+   * @return true if checker should not test {@code tree}
    */
-  public final boolean shouldSkipDefs(ClassTree node) {
-    String qualifiedName = TreeUtils.typeOf(node).toString();
+  public final boolean shouldSkipDefs(ClassTree tree) {
+    String qualifiedName = TreeUtils.typeOf(tree).toString();
     // System.out.printf("shouldSkipDefs(%s) %s%nskipDefs %s%nonlyDefs %s%nresult %s%n%n",
-    //                   node,
+    //                   tree,
     //                   qualifiedName,
     //                   skipDefsPattern.matcher(qualifiedName).find(),
     //                   onlyDefsPattern.matcher(qualifiedName).find(),
@@ -2493,7 +2493,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
    *
    * @param cls class to potentially skip
    * @param meth method to potentially skip
-   * @return true if checker should not test node
+   * @return true if checker should not test {@code meth}
    */
   public final boolean shouldSkipDefs(ClassTree cls, MethodTree meth) {
     return shouldSkipDefs(cls);

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceVisitor.java
@@ -105,9 +105,9 @@ public abstract class SourceVisitor<R, P> extends TreePathScanner<R, P> {
   }
 
   @Override
-  public R visitMethod(MethodTree node, P p) {
-    storeSuppressWarningsAnno(node);
-    return super.visitMethod(node, p);
+  public R visitMethod(MethodTree tree, P p) {
+    storeSuppressWarningsAnno(tree);
+    return super.visitMethod(tree, p);
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromClassVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromClassVisitor.java
@@ -12,8 +12,8 @@ import org.checkerframework.javacutil.TreeUtils;
 class TypeFromClassVisitor extends TypeFromTreeVisitor {
 
   @Override
-  public AnnotatedTypeMirror visitClass(ClassTree node, AnnotatedTypeFactory f) {
-    TypeElement elt = TreeUtils.elementFromDeclaration(node);
+  public AnnotatedTypeMirror visitClass(ClassTree tree, AnnotatedTypeFactory f) {
+    TypeElement elt = TreeUtils.elementFromDeclaration(tree);
     AnnotatedTypeMirror result = f.toAnnotatedType(elt.asType(), true);
 
     ElementAnnotationApplier.apply(result, elt, f);

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -81,102 +81,102 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitAnnotation(AnnotationTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitAnnotation(AnnotationTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitBinary(BinaryTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitBinary(BinaryTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
   public AnnotatedTypeMirror visitCompoundAssignment(
-      CompoundAssignmentTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+      CompoundAssignmentTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitInstanceOf(InstanceOfTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitInstanceOf(InstanceOfTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitLiteral(LiteralTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitLiteral(LiteralTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitUnary(UnaryTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitUnary(UnaryTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitAnnotatedType(AnnotatedTypeTree node, AnnotatedTypeFactory f) {
-    return f.fromTypeTree(node);
+  public AnnotatedTypeMirror visitAnnotatedType(AnnotatedTypeTree tree, AnnotatedTypeFactory f) {
+    return f.fromTypeTree(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitTypeCast(TypeCastTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitTypeCast(TypeCastTree tree, AnnotatedTypeFactory f) {
 
     // Use the annotated type of the type in the cast.
-    return f.fromTypeTree(node.getType());
+    return f.fromTypeTree(tree.getType());
   }
 
   @Override
-  public AnnotatedTypeMirror visitPrimitiveType(PrimitiveTypeTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitPrimitiveType(PrimitiveTypeTree tree, AnnotatedTypeFactory f) {
     // for e.g. "int.class"
-    return f.fromTypeTree(node);
+    return f.fromTypeTree(tree);
   }
 
   @Override
-  public AnnotatedTypeMirror visitArrayType(ArrayTypeTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitArrayType(ArrayTypeTree tree, AnnotatedTypeFactory f) {
     // for e.g. "int[].class"
-    return f.fromTypeTree(node);
+    return f.fromTypeTree(tree);
   }
 
   @Override
   public AnnotatedTypeMirror visitParameterizedType(
-      ParameterizedTypeTree node, AnnotatedTypeFactory f) {
-    return f.fromTypeTree(node);
+      ParameterizedTypeTree tree, AnnotatedTypeFactory f) {
+    return f.fromTypeTree(tree);
   }
 
   @Override
   public AnnotatedTypeMirror visitIntersectionType(
-      IntersectionTypeTree node, AnnotatedTypeFactory f) {
-    return f.fromTypeTree(node);
+      IntersectionTypeTree tree, AnnotatedTypeFactory f) {
+    return f.fromTypeTree(tree);
   }
 
   @Override
   public AnnotatedTypeMirror visitMemberReference(
-      MemberReferenceTree node, AnnotatedTypeFactory f) {
-    return f.toAnnotatedType(TreeUtils.typeOf(node), false);
+      MemberReferenceTree tree, AnnotatedTypeFactory f) {
+    return f.toAnnotatedType(TreeUtils.typeOf(tree), false);
   }
 
   @Override
   public AnnotatedTypeMirror visitLambdaExpression(
-      LambdaExpressionTree node, AnnotatedTypeFactory f) {
-    return f.toAnnotatedType(TreeUtils.typeOf(node), false);
+      LambdaExpressionTree tree, AnnotatedTypeFactory f) {
+    return f.toAnnotatedType(TreeUtils.typeOf(tree), false);
   }
 
   @Override
-  public AnnotatedTypeMirror visitAssignment(AssignmentTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitAssignment(AssignmentTree tree, AnnotatedTypeFactory f) {
 
     // Recurse on the type of the variable.
-    return visit(node.getVariable(), f);
+    return visit(tree.getVariable(), f);
   }
 
   @Override
   public AnnotatedTypeMirror visitConditionalExpression(
-      ConditionalExpressionTree node, AnnotatedTypeFactory f) {
+      ConditionalExpressionTree tree, AnnotatedTypeFactory f) {
     // The Java type of a conditional expression is generally the LUB of the boxed types
     // of the true and false expressions, but with a few exceptions. See JLS 15.25.
     // So, use the type of the ConditionalExpressionTree instead of
     // InternalUtils#leastUpperBound
-    TypeMirror alub = TreeUtils.typeOf(node);
+    TypeMirror alub = TreeUtils.typeOf(tree);
 
-    AnnotatedTypeMirror trueType = f.getAnnotatedType(node.getTrueExpression());
-    AnnotatedTypeMirror falseType = f.getAnnotatedType(node.getFalseExpression());
+    AnnotatedTypeMirror trueType = f.getAnnotatedType(tree.getTrueExpression());
+    AnnotatedTypeMirror falseType = f.getAnnotatedType(tree.getFalseExpression());
 
     return AnnotatedTypes.leastUpperBound(f, trueType, falseType, alub);
   }
@@ -218,29 +218,29 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitIdentifier(IdentifierTree node, AnnotatedTypeFactory f) {
-    if (node.getName().contentEquals("this") || node.getName().contentEquals("super")) {
-      AnnotatedDeclaredType res = f.getSelfType(node);
+  public AnnotatedTypeMirror visitIdentifier(IdentifierTree tree, AnnotatedTypeFactory f) {
+    if (tree.getName().contentEquals("this") || tree.getName().contentEquals("super")) {
+      AnnotatedDeclaredType res = f.getSelfType(tree);
       return res;
     }
 
-    Element elt = TreeUtils.elementFromUse(node);
-    AnnotatedTypeMirror selfType = f.getImplicitReceiverType(node);
+    Element elt = TreeUtils.elementFromUse(tree);
+    AnnotatedTypeMirror selfType = f.getImplicitReceiverType(tree);
     if (selfType != null) {
       AnnotatedTypeMirror type = AnnotatedTypes.asMemberOf(f.types, f, selfType, elt).asUse();
-      return f.applyCaptureConversion(type, TreeUtils.typeOf(node));
+      return f.applyCaptureConversion(type, TreeUtils.typeOf(tree));
     }
 
     AnnotatedTypeMirror type = f.getAnnotatedType(elt);
 
-    return f.applyCaptureConversion(type, TreeUtils.typeOf(node));
+    return f.applyCaptureConversion(type, TreeUtils.typeOf(tree));
   }
 
   @Override
-  public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree node, AnnotatedTypeFactory f) {
-    Element elt = TreeUtils.elementFromUse(node);
+  public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree tree, AnnotatedTypeFactory f) {
+    Element elt = TreeUtils.elementFromUse(tree);
 
-    if (TreeUtils.isClassLiteral(node)) {
+    if (TreeUtils.isClassLiteral(tree)) {
       // the type of a class literal is the type of the "class" element.
       return f.getAnnotatedType(elt);
     }
@@ -256,22 +256,22 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
         // Fall-through.
     }
 
-    if (node.getIdentifier().contentEquals("this")) {
-      // Node is "MyClass.this", where "MyClass" may be the innermost enclosing type or any
+    if (tree.getIdentifier().contentEquals("this")) {
+      // Tree is "MyClass.this", where "MyClass" may be the innermost enclosing type or any
       // outer type.
-      return f.getEnclosingType(TypesUtils.getTypeElement(TreeUtils.typeOf(node)), node);
+      return f.getEnclosingType(TypesUtils.getTypeElement(TreeUtils.typeOf(tree)), tree);
     } else {
-      // node must be a field access, so get the type of the expression, and then call
+      // tree must be a field access, so get the type of the expression, and then call
       // asMemberOf.
-      AnnotatedTypeMirror t = f.getAnnotatedType(node.getExpression());
+      AnnotatedTypeMirror t = f.getAnnotatedType(tree.getExpression());
       t = f.applyCaptureConversion(t);
       return AnnotatedTypes.asMemberOf(f.types, f, t, elt).asUse();
     }
   }
 
   @Override
-  public AnnotatedTypeMirror visitArrayAccess(ArrayAccessTree node, AnnotatedTypeFactory f) {
-    AnnotatedTypeMirror type = f.getAnnotatedType(node.getExpression());
+  public AnnotatedTypeMirror visitArrayAccess(ArrayAccessTree tree, AnnotatedTypeFactory f) {
+    AnnotatedTypeMirror type = f.getAnnotatedType(tree.getExpression());
     if (type.getKind() == TypeKind.ARRAY) {
       return ((AnnotatedArrayType) type).getComponentType();
     } else if (type.getKind() == TypeKind.WILDCARD
@@ -286,16 +286,16 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitNewArray(NewArrayTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitNewArray(NewArrayTree tree, AnnotatedTypeFactory f) {
 
-    // Don't use fromTypeTree here, because node.getType() is not an array type!
-    AnnotatedArrayType result = (AnnotatedArrayType) f.type(node);
+    // Don't use fromTypeTree here, because tree.getType() is not an array type!
+    AnnotatedArrayType result = (AnnotatedArrayType) f.type(tree);
 
-    if (node.getType() == null) { // e.g., byte[] b = {(byte)1, (byte)2};
+    if (tree.getType() == null) { // e.g., byte[] b = {(byte)1, (byte)2};
       return result;
     }
 
-    annotateArrayAsArray(result, node, f);
+    annotateArrayAsArray(result, tree, f);
 
     return result;
   }
@@ -310,11 +310,11 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   }
 
   private void annotateArrayAsArray(
-      AnnotatedArrayType result, NewArrayTree node, AnnotatedTypeFactory f) {
+      AnnotatedArrayType result, NewArrayTree tree, AnnotatedTypeFactory f) {
     // Copy annotations from the type.
-    AnnotatedTypeMirror treeElem = f.fromTypeTree(node.getType());
-    boolean hasInit = node.getInitializers() != null;
-    AnnotatedTypeMirror typeElem = descendBy(result, hasInit ? 1 : node.getDimensions().size());
+    AnnotatedTypeMirror treeElem = f.fromTypeTree(tree.getType());
+    boolean hasInit = tree.getInitializers() != null;
+    AnnotatedTypeMirror typeElem = descendBy(result, hasInit ? 1 : tree.getDimensions().size());
     while (true) {
       typeElem.addAnnotations(treeElem.getAnnotations());
       if (!(treeElem instanceof AnnotatedArrayType)) {
@@ -329,13 +329,13 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     AnnotatedTypeMirror level = result;
     while (level.getKind() == TypeKind.ARRAY) {
       AnnotatedArrayType array = (AnnotatedArrayType) level;
-      List<? extends AnnotationMirror> annos = TreeUtils.annotationsFromArrayCreation(node, idx++);
+      List<? extends AnnotationMirror> annos = TreeUtils.annotationsFromArrayCreation(tree, idx++);
       array.addAnnotations(annos);
       level = array.getComponentType();
     }
 
     // Add top-level annotations.
-    result.addAnnotations(TreeUtils.annotationsFromArrayCreation(node, -1));
+    result.addAnnotations(TreeUtils.annotationsFromArrayCreation(tree, -1));
   }
 
   /**
@@ -349,31 +349,31 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
    *       public MyClass() {}}).
    * </ul>
    *
-   * @param node NewClassTree
+   * @param tree NewClassTree
    * @param f the type factory
-   * @return AnnotatedDeclaredType of {@code node}
+   * @return AnnotatedDeclaredType of {@code tree}
    */
   @Override
-  public AnnotatedTypeMirror visitNewClass(NewClassTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitNewClass(NewClassTree tree, AnnotatedTypeFactory f) {
     // Add annotations that are on the constructor declaration.
     AnnotatedDeclaredType returnType =
-        (AnnotatedDeclaredType) f.constructorFromUse(node).executableType.getReturnType();
+        (AnnotatedDeclaredType) f.constructorFromUse(tree).executableType.getReturnType();
     // Clear the annotations on the return type, so that the explicit annotations can be added
     // first, then the annotations from the return type are added as needed.
     Set<AnnotationMirror> fromReturn = new AnnotationMirrorSet(returnType.getAnnotations());
     returnType.clearPrimaryAnnotations();
-    returnType.addAnnotations(f.getExplicitNewClassAnnos(node));
+    returnType.addAnnotations(f.getExplicitNewClassAnnos(tree));
     returnType.addMissingAnnotations(fromReturn);
     return returnType;
   }
 
   @Override
   public AnnotatedTypeMirror visitMethodInvocation(
-      MethodInvocationTree node, AnnotatedTypeFactory f) {
-    AnnotatedExecutableType ex = f.methodFromUse(node).executableType;
+      MethodInvocationTree tree, AnnotatedTypeFactory f) {
+    AnnotatedExecutableType ex = f.methodFromUse(tree).executableType;
     AnnotatedTypeMirror returnT = ex.getReturnType().asUse();
     if (TypesUtils.isCapturedTypeVariable(returnT.getUnderlyingType())
-        && !TypesUtils.isCapturedTypeVariable(TreeUtils.typeOf(node))) {
+        && !TypesUtils.isCapturedTypeVariable(TreeUtils.typeOf(tree))) {
       // Sometimes javac types an expression as the upper bound of a captured type variable
       // instead of the captured type variable itself. This seems to be a bug in javac. Detect
       // this case and match the annotated type to the Java type.
@@ -383,27 +383,27 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitParenthesized(ParenthesizedTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitParenthesized(ParenthesizedTree tree, AnnotatedTypeFactory f) {
 
     // Recurse on the expression inside the parens.
-    return visit(node.getExpression(), f);
+    return visit(tree.getExpression(), f);
   }
 
   @Override
-  public AnnotatedTypeMirror visitWildcard(WildcardTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitWildcard(WildcardTree tree, AnnotatedTypeFactory f) {
 
-    AnnotatedTypeMirror bound = visit(node.getBound(), f);
+    AnnotatedTypeMirror bound = visit(tree.getBound(), f);
 
-    AnnotatedTypeMirror result = f.type(node);
+    AnnotatedTypeMirror result = f.type(tree);
     assert result instanceof AnnotatedWildcardType;
 
     // Instead of directly overwriting the bound, replace each annotation
     // to ensure that the structure of the wildcard will match that created by
     // BoundsInitializer/createType.
-    if (node.getKind() == Tree.Kind.SUPER_WILDCARD) {
+    if (tree.getKind() == Tree.Kind.SUPER_WILDCARD) {
       f.replaceAnnotations(bound, ((AnnotatedWildcardType) result).getSuperBound());
 
-    } else if (node.getKind() == Tree.Kind.EXTENDS_WILDCARD) {
+    } else if (tree.getKind() == Tree.Kind.EXTENDS_WILDCARD) {
       f.replaceAnnotations(bound, ((AnnotatedWildcardType) result).getExtendsBound());
     }
     return result;

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -309,6 +309,13 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
     return result;
   }
 
+  /**
+   * Add annotations to an array type.
+   *
+   * @param result an array type; is side-effected by this method
+   * @param tree an array construction expression from which to obtain annotations
+   * @param f the type factory
+   */
   private void annotateArrayAsArray(
       AnnotatedArrayType result, NewArrayTree tree, AnnotatedTypeFactory f) {
     // Copy annotations from the type.

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -101,8 +101,8 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitMethod(MethodTree node, AnnotatedTypeFactory f) {
-    ExecutableElement elt = TreeUtils.elementFromDeclaration(node);
+  public AnnotatedTypeMirror visitMethod(MethodTree tree, AnnotatedTypeFactory f) {
+    ExecutableElement elt = TreeUtils.elementFromDeclaration(tree);
 
     AnnotatedExecutableType result =
         (AnnotatedExecutableType) f.toAnnotatedType(elt.asType(), false);

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTreeVisitor.java
@@ -22,13 +22,13 @@ abstract class TypeFromTreeVisitor
   TypeFromTreeVisitor() {}
 
   @Override
-  public AnnotatedTypeMirror defaultAction(Tree node, AnnotatedTypeFactory f) {
-    if (node == null) {
+  public AnnotatedTypeMirror defaultAction(Tree tree, AnnotatedTypeFactory f) {
+    if (tree == null) {
       throw new BugInCF("TypeFromTree.defaultAction: null tree");
     }
     throw new BugInCF(
         this.getClass().getCanonicalName()
             + ": conversion undefined for tree type "
-            + node.getKind());
+            + tree.getKind());
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromTypeTreeVisitor.java
@@ -52,28 +52,28 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   private final Map<Tree, AnnotatedTypeMirror> visitedBounds = new HashMap<>();
 
   @Override
-  public AnnotatedTypeMirror visitAnnotatedType(AnnotatedTypeTree node, AnnotatedTypeFactory f) {
-    AnnotatedTypeMirror type = visit(node.getUnderlyingType(), f);
+  public AnnotatedTypeMirror visitAnnotatedType(AnnotatedTypeTree tree, AnnotatedTypeFactory f) {
+    AnnotatedTypeMirror type = visit(tree.getUnderlyingType(), f);
     if (type == null) { // e.g., for receiver type
       type = f.toAnnotatedType(f.types.getNoType(TypeKind.NONE), false);
     }
     assert AnnotatedTypeFactory.validAnnotatedType(type);
-    List<? extends AnnotationMirror> annos = TreeUtils.annotationsFromTree(node);
+    List<? extends AnnotationMirror> annos = TreeUtils.annotationsFromTree(tree);
 
     if (type.getKind() == TypeKind.WILDCARD) {
       // Work-around for https://github.com/eisop/checker-framework/issues/17
-      // For an annotated wildcard tree node, the type attached to the
-      // node is a WildcardType with a correct bound (set to the type
+      // For an annotated wildcard tree tree, the type attached to the
+      // tree is a WildcardType with a correct bound (set to the type
       // variable which the wildcard instantiates). The underlying type is
       // also a WildcardType but with a bound of null. Here we update the
       // bound of the underlying WildcardType to be consistent.
-      WildcardType wildcardAttachedToNode = (WildcardType) TreeUtils.typeOf(node);
+      WildcardType wildcardAttachedToNode = (WildcardType) TreeUtils.typeOf(tree);
       WildcardType underlyingWildcard = (WildcardType) type.getUnderlyingType();
       underlyingWildcard.withTypeVar(wildcardAttachedToNode.bound);
       // End of work-around
 
       final AnnotatedWildcardType wctype = ((AnnotatedWildcardType) type);
-      final ExpressionTree underlyingTree = node.getUnderlyingType();
+      final ExpressionTree underlyingTree = tree.getUnderlyingType();
 
       if (underlyingTree.getKind() == Tree.Kind.UNBOUNDED_WILDCARD) {
         // primary annotations on unbounded wildcard types apply to both bounds
@@ -85,8 +85,8 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
         wctype.getExtendsBound().addAnnotations(annos);
       } else {
         throw new BugInCF(
-            "Unexpected kind for type.  node="
-                + node
+            "Unexpected kind for type.  tree="
+                + tree
                 + " type="
                 + type
                 + " kind="
@@ -100,10 +100,10 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitArrayType(ArrayTypeTree node, AnnotatedTypeFactory f) {
-    AnnotatedTypeMirror component = visit(node.getType(), f);
+  public AnnotatedTypeMirror visitArrayType(ArrayTypeTree tree, AnnotatedTypeFactory f) {
+    AnnotatedTypeMirror component = visit(tree.getType(), f);
 
-    AnnotatedTypeMirror result = f.type(node);
+    AnnotatedTypeMirror result = f.type(tree);
     assert result instanceof AnnotatedArrayType;
     ((AnnotatedArrayType) result).setComponentType(component);
     return result;
@@ -111,23 +111,23 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
 
   @Override
   public AnnotatedTypeMirror visitParameterizedType(
-      ParameterizedTypeTree node, AnnotatedTypeFactory f) {
+      ParameterizedTypeTree tree, AnnotatedTypeFactory f) {
 
-    ClassSymbol baseType = (ClassSymbol) TreeUtils.elementFromTree(node.getType());
-    updateWildcardBounds(node.getTypeArguments(), baseType.getTypeParameters());
+    ClassSymbol baseType = (ClassSymbol) TreeUtils.elementFromTree(tree.getType());
+    updateWildcardBounds(tree.getTypeArguments(), baseType.getTypeParameters());
 
     List<AnnotatedTypeMirror> args =
-        CollectionsPlume.mapList((Tree t) -> visit(t, f), node.getTypeArguments());
+        CollectionsPlume.mapList((Tree t) -> visit(t, f), tree.getTypeArguments());
 
-    AnnotatedTypeMirror result = f.type(node); // use creator?
-    AnnotatedTypeMirror atype = visit(node.getType(), f);
+    AnnotatedTypeMirror result = f.type(tree); // use creator?
+    AnnotatedTypeMirror atype = visit(tree.getType(), f);
     result.addAnnotations(atype.getAnnotations());
     // new ArrayList<>() type is AnnotatedExecutableType for some reason
 
     // Don't initialize the type arguments if they are empty. The type arguments might be a
     // diamond which should be inferred.
     if (result instanceof AnnotatedDeclaredType && !args.isEmpty()) {
-      assert result instanceof AnnotatedDeclaredType : node + " --> " + result;
+      assert result instanceof AnnotatedDeclaredType : tree + " --> " + result;
       ((AnnotatedDeclaredType) result).setTypeArguments(args);
     }
     return result;
@@ -183,16 +183,16 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitPrimitiveType(PrimitiveTypeTree node, AnnotatedTypeFactory f) {
-    return f.type(node);
+  public AnnotatedTypeMirror visitPrimitiveType(PrimitiveTypeTree tree, AnnotatedTypeFactory f) {
+    return f.type(tree);
   }
 
   @Override
   public AnnotatedTypeVariable visitTypeParameter(
-      TypeParameterTree node, @FindDistinct AnnotatedTypeFactory f) {
+      TypeParameterTree tree, @FindDistinct AnnotatedTypeFactory f) {
 
-    List<AnnotatedTypeMirror> bounds = new ArrayList<>(node.getBounds().size());
-    for (Tree t : node.getBounds()) {
+    List<AnnotatedTypeMirror> bounds = new ArrayList<>(tree.getBounds().size());
+    for (Tree t : tree.getBounds()) {
       AnnotatedTypeMirror bound;
       if (visitedBounds.containsKey(t) && f == visitedBounds.get(t).atypeFactory) {
         bound = visitedBounds.get(t);
@@ -204,8 +204,8 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
       bounds.add(bound);
     }
 
-    AnnotatedTypeVariable result = (AnnotatedTypeVariable) f.type(node);
-    List<? extends AnnotationMirror> annotations = TreeUtils.annotationsFromTree(node);
+    AnnotatedTypeVariable result = (AnnotatedTypeVariable) f.type(tree);
+    List<? extends AnnotationMirror> annotations = TreeUtils.annotationsFromTree(tree);
     result.getLowerBound().addAnnotations(annotations);
 
     switch (bounds.size()) {
@@ -224,20 +224,20 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitWildcard(WildcardTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitWildcard(WildcardTree tree, AnnotatedTypeFactory f) {
 
-    AnnotatedTypeMirror bound = visit(node.getBound(), f);
+    AnnotatedTypeMirror bound = visit(tree.getBound(), f);
 
-    AnnotatedTypeMirror result = f.type(node);
+    AnnotatedTypeMirror result = f.type(tree);
     assert result instanceof AnnotatedWildcardType;
 
     // for wildcards unlike type variables there are bounds that differ in type from
     // result.  These occur for RAW types.  In this case, use the newly created bound
     // rather than merging into result
-    if (node.getKind() == Tree.Kind.SUPER_WILDCARD) {
+    if (tree.getKind() == Tree.Kind.SUPER_WILDCARD) {
       ((AnnotatedWildcardType) result).setSuperBound(bound);
 
-    } else if (node.getKind() == Tree.Kind.EXTENDS_WILDCARD) {
+    } else if (tree.getKind() == Tree.Kind.EXTENDS_WILDCARD) {
       ((AnnotatedWildcardType) result).setExtendsBound(bound);
     }
     return result;
@@ -298,21 +298,9 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitIdentifier(IdentifierTree node, AnnotatedTypeFactory f) {
+  public AnnotatedTypeMirror visitIdentifier(IdentifierTree tree, AnnotatedTypeFactory f) {
 
-    AnnotatedTypeMirror type = f.type(node);
-
-    if (type.getKind() == TypeKind.TYPEVAR) {
-      return getTypeVariableFromDeclaration((AnnotatedTypeVariable) type, f);
-    }
-
-    return type;
-  }
-
-  @Override
-  public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree node, AnnotatedTypeFactory f) {
-
-    AnnotatedTypeMirror type = f.type(node);
+    AnnotatedTypeMirror type = f.type(tree);
 
     if (type.getKind() == TypeKind.TYPEVAR) {
       return getTypeVariableFromDeclaration((AnnotatedTypeVariable) type, f);
@@ -322,8 +310,20 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
   }
 
   @Override
-  public AnnotatedTypeMirror visitUnionType(UnionTypeTree node, AnnotatedTypeFactory f) {
-    AnnotatedTypeMirror type = f.type(node);
+  public AnnotatedTypeMirror visitMemberSelect(MemberSelectTree tree, AnnotatedTypeFactory f) {
+
+    AnnotatedTypeMirror type = f.type(tree);
+
+    if (type.getKind() == TypeKind.TYPEVAR) {
+      return getTypeVariableFromDeclaration((AnnotatedTypeVariable) type, f);
+    }
+
+    return type;
+  }
+
+  @Override
+  public AnnotatedTypeMirror visitUnionType(UnionTypeTree tree, AnnotatedTypeFactory f) {
+    AnnotatedTypeMirror type = f.type(tree);
 
     if (type.getKind() == TypeKind.TYPEVAR) {
       return getTypeVariableFromDeclaration((AnnotatedTypeVariable) type, f);
@@ -334,13 +334,13 @@ class TypeFromTypeTreeVisitor extends TypeFromTreeVisitor {
 
   @Override
   public AnnotatedTypeMirror visitIntersectionType(
-      IntersectionTypeTree node, AnnotatedTypeFactory f) {
+      IntersectionTypeTree tree, AnnotatedTypeFactory f) {
     // This method is only called for IntersectionTypes in casts.  There is no
     // IntersectionTypeTree
     // for a type variable bound that is an intersection.  See #visitTypeParameter.
-    AnnotatedIntersectionType type = (AnnotatedIntersectionType) f.type(node);
+    AnnotatedIntersectionType type = (AnnotatedIntersectionType) f.type(tree);
     List<AnnotatedTypeMirror> bounds =
-        CollectionsPlume.mapList((Tree boundTree) -> visit(boundTree, f), node.getBounds());
+        CollectionsPlume.mapList((Tree boundTree) -> visit(boundTree, f), tree.getBounds());
     type.setBounds(bounds);
     type.copyIntersectionBoundAnnotations();
     return type;

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/DebugListTreeAnnotator.java
@@ -34,17 +34,17 @@ public class DebugListTreeAnnotator extends ListTreeAnnotator {
   }
 
   @Override
-  public Void defaultAction(Tree node, AnnotatedTypeMirror type) {
-    if (kinds.contains(node.getKind())) {
-      System.out.println("DebugListTreeAnnotator input tree: " + node);
+  public Void defaultAction(Tree tree, AnnotatedTypeMirror type) {
+    if (kinds.contains(tree.getKind())) {
+      System.out.println("DebugListTreeAnnotator input tree: " + tree);
       System.out.println("    Initial type: " + type);
       for (TreeAnnotator annotator : annotators) {
         System.out.println("    Running annotator: " + annotator.getClass());
-        annotator.visit(node, type);
+        annotator.visit(tree, type);
         System.out.println("    Current type: " + type);
       }
     } else {
-      super.defaultAction(node, type);
+      super.defaultAction(tree, type);
     }
 
     return null;

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/ListTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/ListTreeAnnotator.java
@@ -47,9 +47,9 @@ public class ListTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void defaultAction(Tree node, AnnotatedTypeMirror type) {
+  public Void defaultAction(Tree tree, AnnotatedTypeMirror type) {
     for (TreeAnnotator annotator : annotators) {
-      annotator.visit(node, type);
+      annotator.visit(tree, type);
     }
 
     return null;

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/PropagationTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/PropagationTreeAnnotator.java
@@ -182,14 +182,14 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void visitCompoundAssignment(CompoundAssignmentTree node, AnnotatedTypeMirror type) {
+  public Void visitCompoundAssignment(CompoundAssignmentTree tree, AnnotatedTypeMirror type) {
     if (hasPrimaryAnnotationInAllHierarchies(type)) {
       // If the type already has a primary annotation in all hierarchies, then the
       // propagated annotations won't be applied.  So don't compute them.
       return null;
     }
-    AnnotatedTypeMirror rhs = atypeFactory.getAnnotatedType(node.getExpression());
-    AnnotatedTypeMirror lhs = atypeFactory.getAnnotatedType(node.getVariable());
+    AnnotatedTypeMirror rhs = atypeFactory.getAnnotatedType(tree.getExpression());
+    AnnotatedTypeMirror lhs = atypeFactory.getAnnotatedType(tree.getVariable());
     Set<? extends AnnotationMirror> lubs =
         qualHierarchy.leastUpperBounds(
             rhs.getEffectiveAnnotations(), lhs.getEffectiveAnnotations());
@@ -198,7 +198,7 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void visitBinary(BinaryTree node, AnnotatedTypeMirror type) {
+  public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror type) {
     if (hasPrimaryAnnotationInAllHierarchies(type)) {
       // If the type already has a primary annotation in all hierarchies, then the
       // propagated annotations won't be applied.  So don't compute them.
@@ -207,7 +207,7 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
       return null;
     }
 
-    Pair<AnnotatedTypeMirror, AnnotatedTypeMirror> argTypes = atypeFactory.binaryTreeArgTypes(node);
+    Pair<AnnotatedTypeMirror, AnnotatedTypeMirror> argTypes = atypeFactory.binaryTreeArgTypes(tree);
     Set<? extends AnnotationMirror> lubs =
         qualHierarchy.leastUpperBounds(
             argTypes.first.getEffectiveAnnotations(), argTypes.second.getEffectiveAnnotations());
@@ -217,14 +217,14 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void visitUnary(UnaryTree node, AnnotatedTypeMirror type) {
+  public Void visitUnary(UnaryTree tree, AnnotatedTypeMirror type) {
     if (hasPrimaryAnnotationInAllHierarchies(type)) {
       // If the type already has a primary annotation in all hierarchies, then the
       // propagated annotations won't be applied.  So don't compute them.
       return null;
     }
 
-    AnnotatedTypeMirror exp = atypeFactory.getAnnotatedType(node.getExpression());
+    AnnotatedTypeMirror exp = atypeFactory.getAnnotatedType(tree.getExpression());
     type.addMissingAnnotations(exp.getAnnotations());
     return null;
   }
@@ -232,25 +232,25 @@ public class PropagationTreeAnnotator extends TreeAnnotator {
   /*
    * TODO: would this make sense in general?
   @Override
-  public Void visitConditionalExpression(ConditionalExpressionTree node, AnnotatedTypeMirror type) {
+  public Void visitConditionalExpression(ConditionalExpressionTree tree, AnnotatedTypeMirror type) {
       if (!type.isAnnotated()) {
-          AnnotatedTypeMirror a = typeFactory.getAnnotatedType(node.getTrueExpression());
-          AnnotatedTypeMirror b = typeFactory.getAnnotatedType(node.getFalseExpression());
+          AnnotatedTypeMirror a = typeFactory.getAnnotatedType(tree.getTrueExpression());
+          AnnotatedTypeMirror b = typeFactory.getAnnotatedType(tree.getFalseExpression());
           Set<AnnotationMirror> lubs = qualHierarchy.leastUpperBounds(a.getEffectiveAnnotations(), b.getEffectiveAnnotations());
           type.replaceAnnotations(lubs);
       }
-      return super.visitConditionalExpression(node, type);
+      return super.visitConditionalExpression(tree, type);
   }*/
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, AnnotatedTypeMirror type) {
+  public Void visitTypeCast(TypeCastTree tree, AnnotatedTypeMirror type) {
     if (hasPrimaryAnnotationInAllHierarchies(type)) {
       // If the type is already has a primary annotation in all hierarchies, then the
       // propagated annotations won't be applied.  So don't compute them.
       return null;
     }
 
-    AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(node.getExpression());
+    AnnotatedTypeMirror exprType = atypeFactory.getAnnotatedType(tree.getExpression());
     if (type.getKind() == TypeKind.TYPEVAR) {
       if (exprType.getKind() == TypeKind.TYPEVAR) {
         // If both types are type variables, take the direct annotations.

--- a/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/treeannotator/TreeAnnotator.java
@@ -41,8 +41,8 @@ public abstract class TreeAnnotator extends SimpleTreeVisitor<Void, AnnotatedTyp
    * @see org.checkerframework.framework.type.typeannotator.TypeAnnotator
    */
   @Override
-  public Void visitMethod(MethodTree node, AnnotatedTypeMirror p) {
-    return super.visitMethod(node, p);
+  public Void visitMethod(MethodTree tree, AnnotatedTypeMirror p) {
+    return super.visitMethod(tree, p);
   }
 
   /**
@@ -57,7 +57,7 @@ public abstract class TreeAnnotator extends SimpleTreeVisitor<Void, AnnotatedTyp
    * a subtype of the type the AnnotatedTypeFactory computes.
    */
   @Override
-  public Void visitBinary(BinaryTree node, AnnotatedTypeMirror mirror) {
-    return super.visitBinary(node, mirror);
+  public Void visitBinary(BinaryTree tree, AnnotatedTypeMirror mirror) {
+    return super.visitBinary(tree, mirror);
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/Heuristics.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/Heuristics.java
@@ -68,13 +68,13 @@ public class Heuristics {
   public static class Matcher extends SimpleTreeVisitor<Boolean, Void> {
 
     @Override
-    protected Boolean defaultAction(Tree node, Void p) {
+    protected Boolean defaultAction(Tree tree, Void p) {
       return false;
     }
 
     @Override
-    public Boolean visitParenthesized(ParenthesizedTree node, Void p) {
-      return visit(node.getExpression(), p);
+    public Boolean visitParenthesized(ParenthesizedTree tree, Void p) {
+      return visit(tree.getExpression(), p);
     }
 
     /**

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesHelper.java
@@ -1126,22 +1126,22 @@ public class DependentTypesHelper {
    * Reports an expression.unparsable error for each Java expression in the given type variables
    * that is an expression error string.
    *
-   * @param node a method declaration
+   * @param tree a method declaration
    * @param methodType annotated type of the method
    */
   private void checkTypeVariablesForErrorExpressions(
-      MethodTree node, AnnotatedExecutableType methodType) {
+      MethodTree tree, AnnotatedExecutableType methodType) {
     for (int i = 0; i < methodType.getTypeVariables().size(); i++) {
       AnnotatedTypeMirror atm = methodType.getTypeVariables().get(i);
       StringToJavaExpression stringToJavaExpr =
-          stringExpr -> StringToJavaExpression.atMethodBody(stringExpr, node, factory.getChecker());
+          stringExpr -> StringToJavaExpression.atMethodBody(stringExpr, tree, factory.getChecker());
       if (debugStringToJavaExpression) {
         System.out.printf(
             "checkTypeVariablesForErrorExpressions(%s, %s) created %s%n",
-            node, methodType, stringToJavaExpr);
+            tree, methodType, stringToJavaExpr);
       }
       convertAnnotatedTypeMirror(stringToJavaExpr, atm);
-      checkTypeForErrorExpressions(atm, node.getTypeParameters().get(i));
+      checkTypeForErrorExpressions(atm, tree.getTypeParameters().get(i));
     }
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesTreeAnnotator.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/dependenttypes/DependentTypesTreeAnnotator.java
@@ -29,46 +29,46 @@ public class DependentTypesTreeAnnotator extends TreeAnnotator {
   }
 
   @Override
-  public Void visitClass(ClassTree node, AnnotatedTypeMirror annotatedTypeMirror) {
-    TypeElement ele = TreeUtils.elementFromDeclaration(node);
+  public Void visitClass(ClassTree tree, AnnotatedTypeMirror annotatedTypeMirror) {
+    TypeElement ele = TreeUtils.elementFromDeclaration(tree);
     helper.atTypeDecl(annotatedTypeMirror, ele);
-    return super.visitClass(node, annotatedTypeMirror);
+    return super.visitClass(tree, annotatedTypeMirror);
   }
 
   @Override
-  public Void visitNewArray(NewArrayTree node, AnnotatedTypeMirror annotatedType) {
-    helper.atExpression(annotatedType, node);
-    return super.visitNewArray(node, annotatedType);
+  public Void visitNewArray(NewArrayTree tree, AnnotatedTypeMirror annotatedType) {
+    helper.atExpression(annotatedType, tree);
+    return super.visitNewArray(tree, annotatedType);
   }
 
   @Override
-  public Void visitTypeCast(TypeCastTree node, AnnotatedTypeMirror annotatedType) {
-    helper.atExpression(annotatedType, node);
-    return super.visitTypeCast(node, annotatedType);
+  public Void visitTypeCast(TypeCastTree tree, AnnotatedTypeMirror annotatedType) {
+    helper.atExpression(annotatedType, tree);
+    return super.visitTypeCast(tree, annotatedType);
   }
 
   @Override
-  public Void visitVariable(VariableTree node, AnnotatedTypeMirror annotatedTypeMirror) {
-    VariableElement ele = TreeUtils.elementFromDeclaration(node);
-    helper.atVariableDeclaration(annotatedTypeMirror, node, ele);
-    return super.visitVariable(node, annotatedTypeMirror);
+  public Void visitVariable(VariableTree tree, AnnotatedTypeMirror annotatedTypeMirror) {
+    VariableElement ele = TreeUtils.elementFromDeclaration(tree);
+    helper.atVariableDeclaration(annotatedTypeMirror, tree, ele);
+    return super.visitVariable(tree, annotatedTypeMirror);
   }
 
   @Override
-  public Void visitIdentifier(IdentifierTree node, AnnotatedTypeMirror annotatedTypeMirror) {
-    Element ele = TreeUtils.elementFromUse(node);
+  public Void visitIdentifier(IdentifierTree tree, AnnotatedTypeMirror annotatedTypeMirror) {
+    Element ele = TreeUtils.elementFromUse(tree);
     if (ele.getKind() == ElementKind.FIELD || ele.getKind() == ElementKind.ENUM_CONSTANT) {
-      helper.atVariableDeclaration(annotatedTypeMirror, node, (VariableElement) ele);
+      helper.atVariableDeclaration(annotatedTypeMirror, tree, (VariableElement) ele);
     }
-    return super.visitIdentifier(node, annotatedTypeMirror);
+    return super.visitIdentifier(tree, annotatedTypeMirror);
   }
 
   @Override
-  public Void visitMemberSelect(MemberSelectTree node, AnnotatedTypeMirror type) {
-    Element ele = TreeUtils.elementFromUse(node);
+  public Void visitMemberSelect(MemberSelectTree tree, AnnotatedTypeMirror type) {
+    Element ele = TreeUtils.elementFromUse(tree);
     if (ele.getKind() == ElementKind.FIELD || ele.getKind() == ElementKind.ENUM_CONSTANT) {
-      helper.atFieldAccess(type, node);
+      helper.atFieldAccess(type, tree);
     }
-    return super.visitMemberSelect(node, type);
+    return super.visitMemberSelect(tree, type);
   }
 }

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/compound/AnotherCompoundCheckerAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/compound/AnotherCompoundCheckerAnnotatedTypeFactory.java
@@ -34,18 +34,18 @@ public class AnotherCompoundCheckerAnnotatedTypeFactory extends BaseAnnotatedTyp
         super.createTreeAnnotator(),
         new TreeAnnotator(this) {
           @Override
-          protected Void defaultAction(Tree node, AnnotatedTypeMirror p) {
+          protected Void defaultAction(Tree tree, AnnotatedTypeMirror p) {
             // Just access the subchecker type factories to make
             // sure they were created properly
             GenericAnnotatedTypeFactory<?, ?, ?, ?> aliasingATF =
                 getTypeFactoryOfSubchecker(AliasingChecker.class);
             @SuppressWarnings("unused")
-            AnnotatedTypeMirror aliasing = aliasingATF.getAnnotatedType(node);
+            AnnotatedTypeMirror aliasing = aliasingATF.getAnnotatedType(tree);
             GenericAnnotatedTypeFactory<?, ?, ?, ?> valueATF =
                 getTypeFactoryOfSubchecker(ValueChecker.class);
             @SuppressWarnings("unused")
-            AnnotatedTypeMirror value = valueATF.getAnnotatedType(node);
-            return super.defaultAction(node, p);
+            AnnotatedTypeMirror value = valueATF.getAnnotatedType(tree);
+            return super.defaultAction(tree, p);
           }
         });
   }

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/compound/CompoundCheckerAnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/compound/CompoundCheckerAnnotatedTypeFactory.java
@@ -34,21 +34,21 @@ public class CompoundCheckerAnnotatedTypeFactory extends BaseAnnotatedTypeFactor
         super.createTreeAnnotator(),
         new TreeAnnotator(this) {
           @Override
-          protected Void defaultAction(Tree node, AnnotatedTypeMirror p) {
+          protected Void defaultAction(Tree tree, AnnotatedTypeMirror p) {
             // Just access the subchecker type factories to make
             // sure they were created properly
             GenericAnnotatedTypeFactory<?, ?, ?, ?> accATF =
                 getTypeFactoryOfSubchecker(AnotherCompoundChecker.class);
             @SuppressWarnings("unused")
-            AnnotatedTypeMirror another = accATF.getAnnotatedType(node);
+            AnnotatedTypeMirror another = accATF.getAnnotatedType(tree);
             GenericAnnotatedTypeFactory<?, ?, ?, ?> aliasingATF =
                 getTypeFactoryOfSubchecker(AliasingChecker.class);
             @SuppressWarnings("unused")
-            AnnotatedTypeMirror aliasing = aliasingATF.getAnnotatedType(node);
+            AnnotatedTypeMirror aliasing = aliasingATF.getAnnotatedType(tree);
             GenericAnnotatedTypeFactory<?, ?, ?, ?> valueATF =
                 getTypeFactoryOfSubchecker(ValueChecker.class);
             assert valueATF == null : "Should not be able to access the ValueChecker annotations.";
-            return super.defaultAction(node, p);
+            return super.defaultAction(tree, p);
           }
         });
   }


### PR DESCRIPTION
Most of the codebase already followed this convention.