### PR TITLE
WPI: Avoid crashing in asSuper when inferring annotations on fields with typevar types

### DIFF
--- a/checker/tests/ainfer-testchecker/non-annotated/EnumMapCrash.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/EnumMapCrash.java
@@ -2,6 +2,7 @@
 
 import java.util.EnumMap;
 
+@SuppressWarnings("all") // only check for crashes
 public class EnumMapCrash {
   private class Holder<T> {
     public T held;

--- a/checker/tests/ainfer-testchecker/non-annotated/EnumMapCrash.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/EnumMapCrash.java
@@ -1,0 +1,25 @@
+// Based on a crash encountered when running WPI with the RLC on Apache Hadoop.
+
+import java.util.EnumMap;
+
+public class EnumMapCrash {
+  private class Holder<T> {
+    public T held;
+
+    public Holder(T held) {
+      this.held = held;
+    }
+
+    @Override
+    public String toString() {
+      return String.valueOf(held);
+    }
+  }
+
+  private enum FSEditLogOpCodes {}
+
+  void callHolder(FSEditLogOpCodes f, EnumMap<FSEditLogOpCodes, Holder<Integer>> opCounts) {
+    Holder<Integer> holder = opCounts.get(f);
+    holder.held++;
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -398,7 +398,18 @@ public class WholeProgramInferenceJavaParserStorage
   @Override
   public AnnotatedTypeMirror atmFromStorageLocation(
       TypeMirror typeMirror, AnnotatedTypeMirror storageLocation) {
-    return storageLocation;
+    if (typeMirror.getKind() == TypeKind.TYPEVAR) {
+      // Only copy the primary annotation, because we don't currently have
+      // support for inferring type bounds. This avoids accidentally substituting the
+      // use of the type variable for its declaration when inferring annotations on
+      // fields with a type variable as their type.
+      AnnotatedTypeMirror asExpectedType =
+          AnnotatedTypeMirror.createType(typeMirror, atypeFactory, false);
+      asExpectedType.replaceAnnotations(storageLocation.getAnnotations());
+      return asExpectedType;
+    } else {
+      return storageLocation;
+    }
   }
 
   @Override


### PR DESCRIPTION
This bug was exposed by #5590, which enabled this capability. Without this change, ajava-based WPI stores inferred types using the LHS' type, which might be an instantiation of a type variable (instead of the type variable itself).

This fix assumes that no annotations are inferred on type variable bounds. This is true right now, but it would require a change here in the future.