### PR TITLE
WPI: place inferred field declaration annotations on fields with Outer.Inner-style types properly

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -599,6 +599,10 @@ task ainferTestCheckerGenerateJaifs(type: Test) {
     // TODO: fix this bug in the AFU, then reinstate this test.
     delete('tests/ainfer-testchecker/annotated/OverriddenMethodsTest.java')
 
+    // JAIF-based WPI fails this test, too, because the insertion of a declaration annotation
+    // onto a field with a multi-part type (e.g. Outer.Inner) doesn't appear to be supported by the AFU.
+    delete('tests/ainfer-testchecker/annotated/InnerClassFieldDeclAnno.java')
+
     // Inserting annotations from .jaif files in-place.
     String jaifsDir = 'tests/ainfer-testchecker/inference-output';
     List<File> jaifs = fileTree(jaifsDir).matching {

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.testchecker.ainfer;
 
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.VariableTree;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
@@ -121,6 +122,16 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         wpi.addClassDeclarationAnnotation(classElt, SIBLING1);
       }
       return super.visitClass(classTree, type);
+    }
+
+    @Override
+    public Void visitVariable(VariableTree variableTree, AnnotatedTypeMirror type) {
+      WholeProgramInference wpi = atypeFactory.getWholeProgramInference();
+      VariableElement varElt = TreeUtils.elementFromDeclaration(variableTree);
+      if (wpi != null && varElt.getSimpleName().contentEquals("iShouldBeTreatedAsSibling1")) {
+        wpi.addFieldDeclarationAnnotation(varElt, TREAT_AS_SIBLING1);
+      }
+      return super.visitVariable(variableTree, type);
     }
 
     @Override

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/AinferTestAnnotatedTypeFactory.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -71,8 +72,8 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
 
   public AinferTestAnnotatedTypeFactory(BaseTypeChecker checker) {
     super(checker);
-    // Support a declaration annotation that can be written on parameters, to test that the
-    // WPI feature allowing inference of declaration annotations on parameters works as intended.
+    // Support a declaration annotation that has the same meaning as @Sibling1, to test that the
+    // WPI feature allowing inference of declaration annotations works as intended.
     addAliasedTypeAnnotation(AinferTreatAsSibling1.class, SIBLING1);
     postInit();
   }
@@ -101,6 +102,19 @@ public class AinferTestAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         new PropagationTreeAnnotator(this),
         literalTreeAnnotator,
         new AinferTestTreeAnnotator(this));
+  }
+
+  @Override
+  public AnnotatedTypeMirror getAnnotatedType(Element elt) {
+    // By default, the CF does not look for declaration annotations
+    // that are aliases of type annotations in annotation files.
+    // For the test that the WPI places declaration annotations properly,
+    // adjust those rules for fields here. TODO: is that a bug in the CF or expected behavior?
+    AnnotatedTypeMirror result = super.getAnnotatedType(elt);
+    if (getDeclAnnotation(elt, AinferTreatAsSibling1.class) != null) {
+      result.replaceAnnotation(SIBLING1);
+    }
+    return result;
   }
 
   protected class AinferTestTreeAnnotator extends TreeAnnotator {

--- a/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
+++ b/checker/src/test/java/org/checkerframework/checker/testchecker/ainfer/qual/AinferTreatAsSibling1.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
  * treat the annotated element as if it were annotated as {@link AinferSibling1}.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER})
+@Target({ElementType.PARAMETER, ElementType.FIELD})
 public @interface AinferTreatAsSibling1 {}

--- a/checker/tests/ainfer-testchecker/non-annotated/InnerClassFieldDeclAnno.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/InnerClassFieldDeclAnno.java
@@ -1,0 +1,24 @@
+// Tests that ajava-based inference places declaration annotations on
+// inner class fields in the correct place. Declaration annotations (unlike
+// type annotations) need to be placed before the name of the outer class.
+// E.g., "@DeclAnno Outer.Inner field;" rather than "Outer.@DeclAnno Inner field;".
+
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferSibling1;
+import org.checkerframework.checker.testchecker.ainfer.qual.AinferTreatAsSibling1;
+
+public class InnerClassFieldDeclAnno {
+  static class Outer {
+    static class Inner {}
+  }
+
+  public Outer.Inner iShouldBeTreatedAsSibling1 = new Outer.Inner();
+
+  @AinferTreatAsSibling1 public Outer.Inner preAnnotated = null;
+
+  public static void test(InnerClassFieldDeclAnno a) {
+    // :: warning: assignment
+    @AinferSibling1 Object obj = a.iShouldBeTreatedAsSibling1;
+    // Test that the annotation works as expected.
+    @AinferSibling1 Object obj2 = a.preAnnotated;
+  }
+}

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -1989,7 +1989,7 @@ This does not work if you are using Maven, because it does not print
 the full output of the Java compiler (see \url{https://github.com/codehaus-plexus/plexus-compiler/issues/149}).
 % Also, with forked compilation,
 % the maven-compiler-plugin queues up all the output and then prints it at the end.
-(Also, maven-compiler-plugin versions before 3.10.1 are buggy: it sometimes
+(Also, maven-compiler-plugin is buggy: it sometimes
 doesn't print any output if it cannot parse it.)
 % Example of not producing output:
 % https://github.com/codehaus-plexus/plexus-compiler/issues/66

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -9,6 +9,7 @@ import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumConstantDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.Parameter;
 import com.github.javaparser.ast.body.ReceiverParameter;
@@ -1535,11 +1536,17 @@ public class WholeProgramInferenceJavaParserStorage
       }
 
       if (declarationAnnotations != null) {
-        ClassOrInterfaceType type = declaration.getType().asClassOrInterfaceType();
-        for (AnnotationMirror annotation : declarationAnnotations) {
-          type.addAnnotation(
-              AnnotationMirrorToAnnotationExprConversion.annotationMirrorToAnnotationExpr(
-                  annotation));
+        // Don't add directly to the type of the variable declarator,
+        // because declaration annotations need to be attached to the FieldDeclaration
+        // node instead.
+        Node declParent = declaration.getParentNode().orElse(null);
+        if (declParent instanceof FieldDeclaration) {
+          FieldDeclaration decl = (FieldDeclaration) declParent;
+          for (AnnotationMirror annotation : declarationAnnotations) {
+            decl.addAnnotation(
+                AnnotationMirrorToAnnotationExprConversion.annotationMirrorToAnnotationExpr(
+                    annotation));
+          }
         }
       }
 

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -163,6 +163,9 @@ public class WholeProgramInferenceScenesStorage
       case CLASS:
         className = ElementUtils.getBinaryName((TypeElement) elt);
         break;
+      case PARAMETER:
+        className = ElementUtils.getEnclosingClassName((VariableElement) elt);
+        break;
       default:
         throw new BugInCF("What element? %s %s", elt.getKind(), elt);
     }


### PR DESCRIPTION
correct:
```
@DeclAnno
public Outer.Inner foo;
```

incorrect (this is the behavior prior to this PR):
```
public Outer.@DeclAnno Inner foo;
```

The latter is right for type annotations, but declaration annotations need to be attached higher up in the AST.

The test infra for this PR is kind of involved, and I'm not that confident that it would catch all variants of this that are wrong. You can check the output in the generated `.ajava` file for the new test case to confirm that this does the right thing.