### PR TITLE
Don't use source 8 when building Javadoc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -300,7 +300,19 @@ allprojects {
         // This file is looked for by Javadoc.
         file("${destinationDir}/resources/fonts/").mkdirs()
         ant.touch(file: "${destinationDir}/resources/fonts/dejavu.css")
-        options.addStringOption('source', '8')
+
+        if(!isJava8) {
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED', true)
+          options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED', true)
+        }
+
         // "-Xwerror" requires Javadoc everywhere.  Currently, CI jobs require Javadoc only
         // on changed lines.  Enable -Xwerror in the future when all Javadoc exists.
         // options.addBooleanOption('Xwerror', true)
@@ -560,50 +572,6 @@ task allJavadoc(type: Javadoc, group: 'Documentation') {
     classpath += configurations.javacJar
   }
   doLast {
-    // The next 5 `exec` blocks correct Javadoc links.
-    // This is gross and inefficient, but it does work for methods with up to 11 formal parameters.
-    // (An alternative would be to use a single regex with Perl's `s///e` operator.)
-    exec {
-      workingDir "${rootDir}/docs/api"
-      executable "${plumeScriptsHome}/preplace"
-      args += [
-        '(/8/[^ "]*)#([a-zA-Z0-9_]+)\\(([^)"]*),([^)"]*),([^)"]*),([^)"]*),([^)"]*)\\)"',
-        '\\1#\\2(\\3-\\4-\\5-\\6-\\7)"'
-      ]
-    }
-    exec {
-      workingDir "${rootDir}/docs/api"
-      executable "${plumeScriptsHome}/preplace"
-      args += [
-        '(/8/[^ "]*)#([a-zA-Z0-9_]+)\\(([^)"]*),([^)"]*),([^)"]*),([^)"]*)\\)"',
-        '\\1#\\2(\\3-\\4-\\5-\\6)"'
-      ]
-    }
-    exec {
-      workingDir "${rootDir}/docs/api"
-      executable "${plumeScriptsHome}/preplace"
-      args += [
-        '(/8/[^ "]*)#([a-zA-Z0-9_]+)\\(([^)"]*),([^)"]*),([^)"]*)\\)"',
-        '\\1#\\2(\\3-\\4-\\5)"'
-      ]
-    }
-    exec {
-      workingDir "${rootDir}/docs/api"
-      executable "${plumeScriptsHome}/preplace"
-      args += [
-        '(/8/[^ "]*)#([a-zA-Z0-9_]+)\\(([^)"]*),([^)"]*)\\)"',
-        '\\1#\\2(\\3-\\4)"'
-      ]
-    }
-    exec {
-      workingDir "${rootDir}/docs/api"
-      executable "${plumeScriptsHome}/preplace"
-      args += [
-        '(/8/[^ "]*)#([a-zA-Z0-9_]+)\\(([^)"]*)\\)"',
-        '\\1#\\2-\\3-"'
-      ]
-    }
-
     copy {
       from 'docs/logo/Checkmark/CFCheckmark_favicon.png'
       rename('CFCheckmark_favicon.png', 'favicon-checkerframework.png')

--- a/build.gradle
+++ b/build.gradle
@@ -301,7 +301,7 @@ allprojects {
         file("${destinationDir}/resources/fonts/").mkdirs()
         ant.touch(file: "${destinationDir}/resources/fonts/dejavu.css")
 
-        if(!isJava8) {
+        if (!isJava8) {
           options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED', true)
           options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED', true)
           options.addBooleanOption('-add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED', true)


### PR DESCRIPTION
This is so that when build Javadocs with JDK 17 the links to Java API link to the Java 17 docs and are not broken.