### PR TITLE
RLC: @MustCallAlias contract only needs to be fulfilled on regular method exits

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1800,10 +1800,16 @@ class MustCallConsistencyAnalyzer {
           // immediately issued, because such a parameter should not go out of scope
           // without its obligation being resolved some other way.
           if (obligation.derivedFromMustCallAlias()) {
-            checker.reportError(
-                obligation.resourceAliases.asList().get(0).tree,
-                "mustcallalias.out.of.scope",
-                exitReasonForErrorMessage);
+            // MustCallAlias annotations only have meaning if the method returns normally,
+            // so issue an error if and only if this exit is happening on a normal exit path.
+            if (exceptionType == null) {
+              checker.reportError(
+                  obligation.resourceAliases.asList().get(0).tree,
+                  "mustcallalias.out.of.scope",
+                  exitReasonForErrorMessage);
+            }
+            // Whether or not an error is issued, the check is now complete - there is no further
+            // checking to do on a must-call-alias-derived obligation along an exceptional path.
             continue;
           }
 

--- a/checker/tests/resourceleak/MustCallAliasNormalExit.java
+++ b/checker/tests/resourceleak/MustCallAliasNormalExit.java
@@ -1,0 +1,73 @@
+// Test case for https://github.com/typetools/checker-framework/issues/5597
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+@InheritableMustCall("close")
+public class MustCallAliasNormalExit {
+
+  final @Owning InputStream is;
+
+  @MustCallAlias MustCallAliasNormalExit(@MustCallAlias InputStream p, boolean b) throws Exception {
+    if (b) {
+      throw new Exception("an exception!");
+    }
+    this.is = p;
+  }
+
+  @EnsuresCalledMethods(value = "this.is", methods = "close")
+  public void close() throws IOException {
+    this.is.close();
+  }
+
+  public static @MustCallAlias MustCallAliasNormalExit mcaneFactory(InputStream is)
+      throws Exception {
+    return new MustCallAliasNormalExit(is, false);
+  }
+
+  // :: error: required.method.not.called
+  public static void testUse1(@Owning InputStream inputStream) throws IOException {
+    MustCallAliasNormalExit mcane = null;
+    try {
+      mcane = new MustCallAliasNormalExit(inputStream, true); // at run time, this WILL throw
+    } catch (Exception e) {
+      // At run time would fail (NPE), but for illustrative purposes this is fine.
+      // This absolutely must not cause inputStream to be considered closed because of the
+      // MustCallAlias
+      // relationship.
+      mcane.close();
+    }
+  }
+
+  // :: error: required.method.not.called
+  public static void testUse2(@Owning InputStream inputStream) throws IOException {
+    MustCallAliasNormalExit mcane = null;
+    try {
+      mcane = mcaneFactory(inputStream);
+    } catch (Exception e) {
+      mcane.close();
+    }
+  }
+
+  // :: error: required.method.not.called
+  public static void testUse3(@Owning InputStream inputStream) throws Exception {
+    // if mcaneFactory throws, then inputStream goes out of scope w/o being closed
+    MustCallAliasNormalExit mcane = mcaneFactory(inputStream);
+    mcane.close();
+  }
+
+  // TODO: this appears to be a false positive, but the RLC doesn't handle it correctly because
+  // close() is called on different aliases on different branches.
+  // :: error: required.method.not.called
+  public static void testUse4(@Owning InputStream inputStream) throws Exception {
+    MustCallAliasNormalExit mcane = null;
+    try {
+      mcane = mcaneFactory(inputStream);
+    } catch (Exception e) {
+      // this makes it safe
+      inputStream.close();
+    }
+    mcane.close();
+  }
+}


### PR DESCRIPTION
fixes #5597 

@msridhar this fix seems suspiciously simple - much simpler than our discussions about this problem had led me to expect. I tried to write a test case that demonstrated an unsoundness in this implementation, but I wasn't able to find one. It would be great if you could take a few minutes to try to figure out a way to take advantage of the fact that I haven't actually changed how call-sites of methods annotated with `@MustCallAlias` annotations are treated.