### PR TITLE
Correct treatment of methods whose receiver is raw.

### DIFF
--- a/checker/tests/nullness/Issue3929.java
+++ b/checker/tests/nullness/Issue3929.java
@@ -12,7 +12,6 @@ public class Issue3929 {
 
   public void endElement(NullableMyClass3929 arg) {
     for (Object o : arg.getKeys()) {
-      // :: error: (dereference.of.nullable)
       o.toString();
     }
   }

--- a/checker/tests/nullness/MisuseProperties.java
+++ b/checker/tests/nullness/MisuseProperties.java
@@ -16,8 +16,7 @@ public class MisuseProperties {
     p.put("line.separator", null);
     Hashtable h = p;
     // Error, because HashTable value has NonNull bound.
-    //// :: error: (argument) :: warning: [unchecked] unchecked call to
-    //// put(K,V) as a member of the raw type java.util.Hashtable
+    // put(K,V) as a member of the raw type java.util.Hashtable
     // :: warning: [unchecked] unchecked call to put(K,V) as a member of the raw type
     // java.util.Hashtable
     // :: error: (argument)

--- a/checker/tests/nullness/MisuseProperties.java
+++ b/checker/tests/nullness/MisuseProperties.java
@@ -16,11 +16,11 @@ public class MisuseProperties {
     p.put("line.separator", null);
     Hashtable h = p;
     // Error, because HashTable value has NonNull bound.
-    // TODO: false negative. See #365.
     //// :: error: (argument) :: warning: [unchecked] unchecked call to
     //// put(K,V) as a member of the raw type java.util.Hashtable
     // :: warning: [unchecked] unchecked call to put(K,V) as a member of the raw type
     // java.util.Hashtable
+    // :: error: (argument)
     h.put("line.separator", null);
     // :: error: (argument)
     System.setProperty("line.separator", null);

--- a/checker/tests/nullness/RawTypesUses.java
+++ b/checker/tests/nullness/RawTypesUses.java
@@ -14,8 +14,7 @@ public abstract class RawTypesUses {
     @NonNull Object o1 = notRawNullable.foo();
 
     Generic rawNullable = new Generic<@Nullable String>();
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o2 = rawNullable.foo();
 
     Generic<@NonNull String> notRawNonNull = new Generic<>();
@@ -23,11 +22,9 @@ public abstract class RawTypesUses {
 
     Generic rawNonNull = new Generic<@NonNull String>();
     Generic rawNonNullAlais = rawNonNull;
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o4 = rawNonNull.foo();
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o5 = rawNonNullAlais.foo();
   }
 
@@ -40,18 +37,15 @@ public abstract class RawTypesUses {
     @NonNull Object o1 = notRawNullable.foo();
 
     Generic rawNullable = rawReturn();
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o2 = rawNullable.foo();
 
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o3 = rawReturn().foo();
 
     Generic local = rawReturn();
     Generic localAlias = local;
-    // TODO: false negative. See #635.
-    //// :: error: (assignment)
+    // :: error: (assignment)
     @NonNull Object o4 = local.foo();
   }
 }

--- a/checker/tests/nullness/generics/Issue269.java
+++ b/checker/tests/nullness/generics/Issue269.java
@@ -20,8 +20,7 @@ class Issue269 {
 
   void method2(CallbackNN callback) {
     // Forbid this call, because the bound is not respected.
-    // TODO: false negative. See #635.
-    //// :: error: (argument)
+    // :: error: (argument)
     // :: warning: [unchecked] unchecked call to handler(H) as a member of the raw type
     // Issue269.CallbackNN
     callback.handler(null);

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3735,7 +3735,9 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             || memberReferenceTree.getTypeArguments().isEmpty())) {
       // Method type args
       requiresInference = true;
-    } else if (memberReferenceTree.getMode() == ReferenceMode.NEW) {
+    } else if (memberReferenceTree.getMode() == ReferenceMode.NEW
+        || ((JCTree.JCMemberReference) memberReferenceTree)
+            .hasKind(JCTree.JCMemberReference.ReferenceKind.UNBOUND)) {
       if (type.getKind() == TypeKind.DECLARED
           && ((AnnotatedDeclaredType) type).isUnderlyingTypeRaw()) {
         // Class type args

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -440,6 +440,7 @@ public class AnnotatedTypes {
         }
         return result;
       case UNION:
+        return substituteTypeVariables(types, atypeFactory, receiverType, member, memberType);
       case DECLARED:
         AnnotatedDeclaredType receiverTypeDT = (AnnotatedDeclaredType) receiverType;
         if (receiverTypeDT.isUnderlyingTypeRaw()

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -441,7 +441,19 @@ public class AnnotatedTypes {
         return result;
       case UNION:
       case DECLARED:
-        if (((AnnotatedDeclaredType) receiverType).isUnderlyingTypeRaw()) {
+        AnnotatedDeclaredType receiverTypeDT = (AnnotatedDeclaredType) receiverType;
+        if (receiverTypeDT.isUnderlyingTypeRaw()
+            && member
+                .getEnclosingElement()
+                .equals(receiverTypeDT.getUnderlyingType().asElement())) {
+          // Section 4.8, "Raw Types".
+          // (https://docs.oracle.com/javase/specs/jls/se11/html/jls-4.html#jls-4.8)
+          //
+          // The type of a constructor (§8.8), instance method (8.4, 9.4), or non-static field
+          // (8.3) of a raw type C that is not inherited from its superclasses or superinterfaces
+          // is the raw type that corresponds to the erasure of its type in the generic declaration
+          // corresponding to C.
+
           return memberType.getErased();
         }
         return substituteTypeVariables(types, atypeFactory, receiverType, member, memberType);

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -441,6 +441,9 @@ public class AnnotatedTypes {
         return result;
       case UNION:
       case DECLARED:
+        if (((AnnotatedDeclaredType) receiverType).isUnderlyingTypeRaw()) {
+          return memberType.getErased();
+        }
         return substituteTypeVariables(types, atypeFactory, receiverType, member, memberType);
       default:
         throw new BugInCF("asMemberOf called on unexpected type.%nt: %s", receiverType);
@@ -696,6 +699,10 @@ public class AnnotatedTypes {
     // Has the user supplied type arguments?
     if (!targs.isEmpty()) {
       List<? extends AnnotatedTypeVariable> tvars = preType.getTypeVariables();
+      if (tvars.isEmpty()) {
+        // This happens when the method is invoked with a raw receiver.
+        return Collections.emptyMap();
+      }
 
       Map<TypeVariable, AnnotatedTypeMirror> typeArguments = new HashMap<>();
       for (int i = 0; i < elt.getTypeParameters().size(); ++i) {

--- a/framework/tests/all-systems/Issue3785.java
+++ b/framework/tests/all-systems/Issue3785.java
@@ -1,0 +1,39 @@
+import java.util.List;
+
+public class Issue3785<T> {
+  public Issue3785(List<T> l) {}
+
+  <L> void method(L l) {}
+
+  @SuppressWarnings("unchecked")
+  void use(Issue3785 p, Object o, List<String> list) {
+    // This type-checks in Java, but probably shouldn't.
+    p.<Void>method(o);
+    p.method(o);
+    new Issue3785(list);
+  }
+
+  /*
+  <L> L method2(L l) { return l;}
+
+  @SuppressWarnings("unchecked")
+  void use2(Issue3785<String> p, Object o) {
+      // javac issues: "error: incompatible types: Object cannot be converted to Void"
+      p.<Void>method(o);
+      // javac issues: "error: incompatible types: Object cannot be converted to Void"
+      Void s = p.<Void>method2(o);
+  }
+  */
+}
+
+/*
+class Issue3785NonParameterized {
+    <L> void method(L l) {}
+
+    @SuppressWarnings("unchecked")
+    void use(Issue3785NonParameterized p, Object o) {
+        // javac issues: "error: incompatible types: Object cannot be converted to Void"
+        p.<Void>method(o);
+    }
+}
+*/

--- a/framework/tests/all-systems/Issue5436.java
+++ b/framework/tests/all-systems/Issue5436.java
@@ -1,0 +1,26 @@
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+@SuppressWarnings("unchecked")
+public class Issue5436 {
+  static class BoundedWindow {}
+
+  static class Accessor<K> {
+    public Accessor(Supplier<BoundedWindow> s) {}
+
+    Accessor() {}
+  }
+
+  private final Accessor<?> stateAccessor;
+  private List<BoundedWindow> currentWindows;
+
+  Issue5436() {
+    currentWindows = new ArrayList<>();
+    stateAccessor = new Accessor(() -> currentWindows);
+  }
+
+  private Object getCurrentKey() {
+    return new Object();
+  }
+}

--- a/framework/tests/framework/BridgeMethods.java
+++ b/framework/tests/framework/BridgeMethods.java
@@ -20,8 +20,7 @@ class Usage {
     c.id(new @Odd Object());
 
     // Oddness is wrong! Would also fail with ClassCastException.
-    // TODO: false negative. See #635.
-    //// :: error: (argument)
+    // :: error: (argument)
     // :: warning: [unchecked] unchecked call to id(T) as a member of the raw type C
     // :: warning: (cast.unsafe.constructor.invocation)
     c.id(new @Even Object());


### PR DESCRIPTION
Basically if a method is invoke with a raw receiver method, all types of the method signature are erased.  (This doesn't fix #635 because there are other places where raw types are ignored besides and the type of a receiver expression.)

Fixes #5436 and #3785.