### PR TITLE
Correct test case name in Junit tests

### DIFF
--- a/framework-test/src/main/java/org/checkerframework/framework/test/PerDirectorySuite.java
+++ b/framework-test/src/main/java/org/checkerframework/framework/test/PerDirectorySuite.java
@@ -163,7 +163,7 @@ public class PerDirectorySuite extends Suite {
       if (file == null) {
         throw new Error("root was passed? " + javaFiles.get(0));
       }
-      return file.getPath().replace("tests" + File.separator, "");
+      return file.getPath();
     }
 
     @Override


### PR DESCRIPTION
This makes it so that the test case name is the full path to the directory of the test java files that are being checked. For example: 

`org.checkerframework.checker.test.junit.NullnessTest > run[/Users/smillst/jsr308/checker-framework/checker/tests/nullness/java8]`