### PR TITLE
Methods that return "void" cannot be pure, so -AsuggestPurity should not suggest that they are

### DIFF
--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaValidationTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ainferrunners/AinferTestCheckerAjavaValidationTest.java
@@ -26,6 +26,7 @@ public class AinferTestCheckerAjavaValidationTest extends AinferValidatePerDirec
         "ainfer-testchecker/annotated",
         AinferTestCheckerAjavaTest.class,
         ajavaArgFromFiles(testFiles, "testchecker"),
+        "-AcheckPurityAnnotations",
         "-Awarns");
   }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1023,7 +1023,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     if (isDeterministic) {
       if (TreeUtils.isConstructor(tree)) {
         checker.reportWarning(tree, "purity.deterministic.constructor");
-      } else if (TreeUtils.typeOf(tree.getReturnType()).getKind() == TypeKind.VOID) {
+      } else if (TreeUtils.isVoidReturn(tree)) {
         checker.reportWarning(tree, "purity.deterministic.void.method");
       }
     }
@@ -1047,7 +1047,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         // present (because they were inferred in a previous WPI round).
         additionalKinds.removeAll(kinds);
       }
-      if (TreeUtils.isConstructor(tree)) {
+      if (TreeUtils.isConstructor(tree) || TreeUtils.isVoidReturn(tree)) {
         additionalKinds.remove(Pure.Kind.DETERMINISTIC);
       }
       if (!additionalKinds.isEmpty()) {

--- a/framework/tests/purity-suggestions/PuritySuggestionsClass.java
+++ b/framework/tests/purity-suggestions/PuritySuggestionsClass.java
@@ -24,7 +24,7 @@ public class PuritySuggestionsClass {
     public PureClass() {}
   }
 
-  // :: warning: (purity.more.pure)
+  // :: warning: (purity.more.sideeffectfree)
   void nonpure() {}
 
   @Pure

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -960,6 +960,16 @@ public final class TreeUtils {
   }
 
   /**
+   * Is this method's declared return type "void"?
+   *
+   * @param tree a method declaration
+   * @return true iff method's declared return type is "void"
+   */
+  public static boolean isVoidReturn(MethodTree tree) {
+    return typeOf(tree.getReturnType()).getKind() == TypeKind.VOID;
+  }
+
+  /**
    * Returns true if the tree is a constant-time expression.
    *
    * <p>A tree is a constant-time expression if it is:


### PR DESCRIPTION
This issue was causing a large number of spurious warnings in WPI. This PR also fixes the WPI tests so that they actually check the purity suggestions that WPI produces. (In real WPI runs, this problem is easy to observe, because -Ainfer implies purity checking, but WPI validation tests don't actually run with -Ainfer, which is why we didn't notice the problem before.)