### PR TITLE
Erase types in `super()` signature when the super type is raw

### DIFF
--- a/checker/tests/tainting/CaptureSubtype.java
+++ b/checker/tests/tainting/CaptureSubtype.java
@@ -19,6 +19,7 @@ public class CaptureSubtype {
               QInterface<
                   ? extends MInterface<DInterface>, ? extends MInterface<DInterface>, DInterface>>
           r) {
+    // :: error: (assignment)
     this.r = r;
   }
 }

--- a/checker/tests/tainting/CaptureSubtype.java
+++ b/checker/tests/tainting/CaptureSubtype.java
@@ -1,25 +1,16 @@
-import java.util.function.Function;
+import org.checkerframework.checker.tainting.qual.Tainted;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 public class CaptureSubtype {
 
-  interface FFunction<T, R> extends Function<T, R> {}
+  class MyGeneric<T extends @Tainted Number> {}
 
-  interface DInterface {}
+  class SubGeneric<T extends @Untainted Number> extends MyGeneric<T> {}
 
-  interface MInterface<P> {}
+  class UseMyGeneric {
+    SubGeneric<? extends @Tainted Object> wildcardUnbounded = new SubGeneric<@Untainted Number>();
 
-  interface QInterface<K extends MInterface<P>, V extends MInterface<P>, P> {}
-
-  FFunction<String, QInterface<?, @Untainted ?, DInterface>> r;
-
-  CaptureSubtype(
-      FFunction<
-              String,
-              QInterface<
-                  ? extends MInterface<DInterface>, ? extends MInterface<DInterface>, DInterface>>
-          r) {
-    // :: error: (assignment)
-    this.r = r;
+    MyGeneric<?> wildcardOutsideUB = wildcardUnbounded;
+    MyGeneric<? extends @Untainted Number> wildcardInsideUB2 = wildcardUnbounded;
   }
 }

--- a/checker/tests/tainting/CaptureSubtype.java
+++ b/checker/tests/tainting/CaptureSubtype.java
@@ -1,16 +1,24 @@
-import org.checkerframework.checker.tainting.qual.Tainted;
+import java.util.function.Function;
 import org.checkerframework.checker.tainting.qual.Untainted;
 
 public class CaptureSubtype {
 
-  class MyGeneric<T extends @Tainted Number> {}
+  interface FFunction<T, R> extends Function<T, R> {}
 
-  class SubGeneric<T extends @Untainted Number> extends MyGeneric<T> {}
+  interface DInterface {}
 
-  class UseMyGeneric {
-    SubGeneric<? extends @Tainted Object> wildcardUnbounded = new SubGeneric<@Untainted Number>();
+  interface MInterface<P> {}
 
-    MyGeneric<?> wildcardOutsideUB = wildcardUnbounded;
-    MyGeneric<? extends @Untainted Number> wildcardInsideUB2 = wildcardUnbounded;
+  interface QInterface<K extends MInterface<P>, V extends MInterface<P>, P> {}
+
+  FFunction<String, QInterface<?, @Untainted ?, DInterface>> r;
+
+  CaptureSubtype(
+      FFunction<
+              String,
+              QInterface<
+                  ? extends MInterface<DInterface>, ? extends MInterface<DInterface>, DInterface>>
+          r) {
+    this.r = r;
   }
 }

--- a/checker/tests/tainting/CaptureSubtype2.java
+++ b/checker/tests/tainting/CaptureSubtype2.java
@@ -1,0 +1,25 @@
+import java.util.function.Function;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+public class CaptureSubtype2 {
+
+  interface FFunction<T, R> extends Function<T, R> {}
+
+  interface DInterface {}
+
+  interface MInterface<P> {}
+
+  interface QInterface<K extends MInterface<P>, V extends MInterface<P>, P> {}
+
+  FFunction<String, QInterface<?, @Untainted ?, DInterface>> r;
+
+  CaptureSubtype(
+      FFunction<
+              String,
+              QInterface<
+                  ? extends MInterface<DInterface>, ? extends MInterface<DInterface>, DInterface>>
+          r) {
+    // :: error: (assignment)
+    this.r = r;
+  }
+}

--- a/checker/tests/tainting/CaptureSubtype2.java
+++ b/checker/tests/tainting/CaptureSubtype2.java
@@ -13,7 +13,7 @@ public class CaptureSubtype2 {
 
   FFunction<String, QInterface<?, @Untainted ?, DInterface>> r;
 
-  CaptureSubtype(
+  CaptureSubtype2(
       FFunction<
               String,
               QInterface<

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -508,6 +508,10 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       }
     } catch (Exception e) {
       // Some types need to be captured first, so ignore crashes.
+      for (int i = 0; i < supertypeTypeArgs.size(); i++) {
+        areEqualVisitHistory.remove(
+            subtypeAsSuper.getTypeArguments().get(i), supertypeTypeArgs.get(i), currentTop);
+      }
     }
     // 5th paragraph:
     // Instead of calling isSubtype with the captured type, just check for containment.

--- a/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
@@ -74,6 +74,15 @@ public class StructuralEqualityVisitHistory {
     return null;
   }
 
+  /**
+   * Remove the result of comparing {@code type1} and {@code type2} for structural equality for the
+   * given hierarchy.
+   *
+   * @param type1 the first type
+   * @param type2 the second type
+   * @param hierarchy the top of the relevant type hierarchy; only annotations from that hierarchy
+   *     are considered
+   */
   public void remove(
       AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, AnnotationMirror hierarchy) {
     falseHistory.remove(type1, type2, hierarchy);

--- a/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/StructuralEqualityVisitHistory.java
@@ -73,4 +73,10 @@ public class StructuralEqualityVisitHistory {
     }
     return null;
   }
+
+  public void remove(
+      AnnotatedTypeMirror type1, AnnotatedTypeMirror type2, AnnotationMirror hierarchy) {
+    falseHistory.remove(type1, type2, hierarchy);
+    trueHistory.remove(type1, type2, hierarchy);
+  }
 }

--- a/framework/tests/all-systems/RawSuper.java
+++ b/framework/tests/all-systems/RawSuper.java
@@ -1,0 +1,17 @@
+import java.util.ArrayList;
+import java.util.List;
+
+public class RawSuper {
+  static class MySuper<T> {
+    public MySuper(List<Integer> p) {}
+
+    void method(List<Integer> o) {}
+  }
+
+  @SuppressWarnings("unchecked") // raw extends
+  static class SubRaw extends MySuper {
+    public SubRaw() {
+      super(new ArrayList<List<?>>());
+    }
+  }
+}


### PR DESCRIPTION
Also, clears the `areEqualVisitHistory` when `isSubtype` crashes.  