### PR TITLE
RLC: Resource variables are @Owning for the purposes of issuing reset.not.owning errors

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -184,16 +184,6 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
     }
   }
 
-  /**
-   * Returns true iff the given element is a resource variable.
-   *
-   * @param elt an element; may be null, in which case this method always returns false
-   * @return true iff the given element represents a resource variable
-   */
-  /*package-private*/ boolean isResourceVariable(@Nullable Element elt) {
-    return elt != null && elt.getKind() == ElementKind.RESOURCE_VARIABLE;
-  }
-
   /** Treat non-owning method parameters as @MustCallUnknown (top) when the method is called. */
   @Override
   public void methodFromUsePreSubstitution(ExpressionTree tree, AnnotatedExecutableType type) {
@@ -425,7 +415,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
           && (noLightweightOwnership || getDeclAnnotation(elt, Owning.class) == null)) {
         type.replaceAnnotation(BOTTOM);
       }
-      if (isResourceVariable(elt)) {
+      if (ElementUtils.isResourceVariable(elt)) {
         type.replaceAnnotation(withoutClose(type.getAnnotationInHierarchy(TOP)));
       }
       return super.visitIdentifier(tree, type);

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -29,6 +29,7 @@ import org.checkerframework.framework.flow.CFAnalysis;
 import org.checkerframework.framework.flow.CFStore;
 import org.checkerframework.framework.flow.CFTransfer;
 import org.checkerframework.framework.flow.CFValue;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreePathUtil;
 import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
@@ -110,7 +111,7 @@ public class MustCallTransfer extends CFTransfer {
     // Remove "close" from the type in the store for resource variables.
     // The Resource Leak Checker relies on this code to avoid checking that
     // resource variables are closed.
-    if (atypeFactory.isResourceVariable(TreeUtils.elementFromTree(n.getTarget().getTree()))) {
+    if (ElementUtils.isResourceVariable(TreeUtils.elementFromTree(n.getTarget().getTree()))) {
       CFStore store = result.getRegularStore();
       JavaExpression expr = JavaExpression.fromNode(n.getTarget());
       CFValue value = store.getValue(expr);

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -641,7 +641,8 @@ class MustCallConsistencyAnalyzer {
    *   <li>2) the expression already has a tracked Obligation (i.e. there is already a resource
    *       alias in some Obligation's resource alias set that refers to the expression), or
    *   <li>3) the method in which the invocation occurs also has an @CreatesMustCallFor annotation,
-   *       with the same expression.
+   *       with the same expression, or
+   *   <li>4) the expression is a resource variable.
    * </ul>
    *
    * @param obligations the currently-tracked Obligations; this value is side-effected if there is
@@ -667,6 +668,10 @@ class MustCallConsistencyAnalyzer {
         // the @Owning annotation can only be written on methods, parameters, and fields;
         // formal parameters are also represented by LocalVariable in the bodies of methods.
         // This satisfies case 1.
+        return true;
+      } else if (ElementUtils.isResourceVariable(elt)) {
+        // The expression is a resource variable, and therefore will be closed, so we can
+        // treat it as owning (case 4).
         return true;
       } else {
         Obligation toRemove = null;

--- a/checker/tests/resourceleak/ConnectingSockets2.java
+++ b/checker/tests/resourceleak/ConnectingSockets2.java
@@ -1,7 +1,5 @@
 // Test case for https://github.com/typetools/checker-framework/issues/5739 .
 
-// @skip-test until the bug is fixed
-
 import java.io.IOException;
 import java.net.*;
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -1083,4 +1083,14 @@ public class ElementUtils {
     return elt.getKind() == ElementKind.CONSTRUCTOR
         && (((Symbol) elt).flags() & TreeUtils.Flags_COMPACT_RECORD_CONSTRUCTOR) != 0;
   }
+
+  /**
+   * Returns true iff the given element is a resource variable.
+   *
+   * @param elt an element; may be null, in which case this method always returns false
+   * @return true iff the given element represents a resource variable
+   */
+  public static boolean isResourceVariable(@Nullable Element elt) {
+    return elt != null && elt.getKind() == ElementKind.RESOURCE_VARIABLE;
+  }
 }


### PR DESCRIPTION
Fixes #5739 