### PR TITLE
Javadoc for `buildMethodContext()`

### DIFF
--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -397,6 +397,11 @@ public class Resolver {
    * Build an instance of {@code Resolve$MethodResolutionContext}.
    *
    * @return a MethodResolutionContext
+   * @throws ClassNotFoundException if there is trouble constructing the instance
+   * @throws InstantiationException if there is trouble constructing the instance
+   * @throws IllegalAccessException if there is trouble constructing the instance
+   * @throws InvocationTargetException if there is trouble constructing the instance
+   * @throws NoSuchFieldException if there is trouble constructing the instance
    */
   protected Object buildMethodContext()
       throws ClassNotFoundException,

--- a/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/Resolver.java
@@ -393,7 +393,11 @@ public class Resolver {
     }
   }
 
-  /** Build an instance of {@code Resolve$MethodResolutionContext}. */
+  /**
+   * Build an instance of {@code Resolve$MethodResolutionContext}.
+   *
+   * @return a MethodResolutionContext
+   */
   protected Object buildMethodContext()
       throws ClassNotFoundException,
           InstantiationException,


### PR DESCRIPTION
google-java-format recently changed formatting of throws clauses.  Adding this Javadoc prevents errors in other pull requests.