### PR TITLE
The receiver type of `Object.hashCode()` is now `@UnknownSignedness`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,12 @@ spotlessPredeclare {
 }
 
 allprojects {
+  // Increment the minor version (second number) rather than just the patch
+  // level (third number) if:
+  //   * any new checkers have been added, or
+  //   * backward-incompatible changes have been made to APIs or elsewhere.
+  version '3.34.1-SNAPSHOT'
+
   tasks.withType(JavaCompile).configureEach {
     options.fork = true
   }
@@ -113,12 +119,6 @@ allprojects {
   apply plugin: 'net.ltgt.errorprone'
 
   group 'org.checkerframework'
-
-  // Increment the minor version (second number) rather than just the patch
-  // level (third number) if:
-  //   * any new checkers have been added, or
-  //   * backward-incompatible changes have been made to APIs or elsewhere.
-  version '3.34.1-SNAPSHOT'
 
   // Keep in sync with "repositories { ... }" block above.
   repositories {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,9 @@ Version 3.34.1 (June 1, 2023)
 
 **User-visible changes:**
 
+Signedness Checker:
+ * The receiver type of `Object.hashCode()` is now `@UnknownSignedness`.
+
 **Implementation details:**
 
 **Closed issues:**


### PR DESCRIPTION
Merge together:
https://github.com/typetools/jdk/pull/173
https://github.com/codespecs/daikon/pull/474
https://github.com/plume-lib/multi-version-control/pull/221
https://github.com/plume-lib/plume-util/pull/295
