### PR TITLE
Fix soundness issue when checking that an @MustCallAlias parameter is correctly assigned to an owning field

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -413,7 +413,9 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
       Element elt = TreeUtils.elementFromUse(tree);
       if (elt.getKind() == ElementKind.PARAMETER
           && (noLightweightOwnership || getDeclAnnotation(elt, Owning.class) == null)) {
-        type.replaceAnnotation(BOTTOM);
+        if (!type.hasAnnotation(POLY)) {
+          type.replaceAnnotation(BOTTOM);
+        }
       }
       if (ElementUtils.isResourceVariable(elt)) {
         type.replaceAnnotation(withoutClose(type.getAnnotationInHierarchy(TOP)));

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -414,6 +414,10 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
       if (elt.getKind() == ElementKind.PARAMETER
           && (noLightweightOwnership || getDeclAnnotation(elt, Owning.class) == null)) {
         if (!type.hasAnnotation(POLY)) {
+          // Parameters that are not annotated with @Owning should be treated as bottom
+          // (to suppress warnings about them). An exception is polymorphic parameters, which
+          // might be @MustCallAlias (and so wouldn't be annotated with @Owning): these are not
+          // modified, to support verification of @MustCallAlias annotations.
           type.replaceAnnotation(BOTTOM);
         }
       }

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -77,7 +77,7 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
 
   @Override
   public Void visitAssignment(AssignmentTree tree, Void p) {
-    // The following code implements the following rule:
+    // This code implements the following rule:
     //  * It is always safe to assign a MustCallAlias parameter of a constructor
     //    to an owning field of the containing class.
     // It is necessary to special case this because MustCallAlias is translated
@@ -96,9 +96,8 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
       // * if the field is not final, then it cannot be assigned to in a constructor at all: the
       //   @CreatesMustCallFor annotation cannot be written on a constructor (it has
       //   @Target({ElementType.METHOD})), so this code relies on the standard rules for non-final
-      // owning
-      //   field reassignment, which prevent it without an @CreatesMustCallFor annotation except
-      //   in the constructor of the object containing the field.
+      //   owning field reassignment, which prevent it without an @CreatesMustCallFor annotation
+      //   except in the constructor of the object containing the field.
       boolean lhsIsOwningField =
           lhs.getKind() == Tree.Kind.MEMBER_SELECT
               && atypeFactory.getDeclAnnotation(lhsElt, Owning.class) != null;

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -1,6 +1,7 @@
 package org.checkerframework.checker.mustcall;
 
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.AssignmentTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -21,6 +22,7 @@ import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.checker.mustcall.qual.NotOwning;
+import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.basetype.BaseTypeVisitor;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
@@ -71,6 +73,35 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
       }
     }
     return super.visitReturn(tree, p);
+  }
+
+  @Override
+  public Void visitAssignment(AssignmentTree tree, Void p) {
+    // The following code implements the following rule:
+    //  * It is always safe to assign a MustCallAlias parameter of a constructor
+    //    to an owning field of the containing class.
+    // It is necessary to special case this because MustCallAlias is translated
+    // into @PolyMustCall.
+    ExpressionTree lhs = tree.getVariable();
+    ExpressionTree rhs = tree.getExpression();
+    Element lhsElt = TreeUtils.elementFromTree(lhs);
+    Element rhsElt = TreeUtils.elementFromTree(rhs);
+    if (lhsElt != null && rhsElt != null) {
+      boolean lhsIsOwningField =
+          lhs.getKind() == Tree.Kind.MEMBER_SELECT
+              && atypeFactory.getDeclAnnotation(lhsElt, Owning.class) != null;
+      boolean rhsIsMCA =
+          AnnotationUtils.containsSameByClass(rhsElt.getAnnotationMirrors(), MustCallAlias.class);
+      boolean rhsIsConstructorParam =
+          rhsElt.getKind() == ElementKind.PARAMETER
+              && rhsElt.getEnclosingElement().getKind() == ElementKind.CONSTRUCTOR;
+      if (lhsIsOwningField && rhsIsMCA && rhsIsConstructorParam) {
+        // Do not execute common assignment check.
+        return null;
+      }
+    }
+
+    return super.visitAssignment(tree, p);
   }
 
   /** An empty string list. */

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallVisitor.java
@@ -81,12 +81,24 @@ public class MustCallVisitor extends BaseTypeVisitor<MustCallAnnotatedTypeFactor
     //  * It is always safe to assign a MustCallAlias parameter of a constructor
     //    to an owning field of the containing class.
     // It is necessary to special case this because MustCallAlias is translated
-    // into @PolyMustCall.
+    // into @PolyMustCall, so the common assignment check will fail when assigning
+    // an @MustCallAlias parameter to an owning field: the parameter is polymorphic,
+    // but the field is not.
     ExpressionTree lhs = tree.getVariable();
     ExpressionTree rhs = tree.getExpression();
     Element lhsElt = TreeUtils.elementFromTree(lhs);
     Element rhsElt = TreeUtils.elementFromTree(rhs);
     if (lhsElt != null && rhsElt != null) {
+      // Note that it is not necessary to check that the assignment is to a field of this, because
+      // that is implied by the other conditions:
+      // * if the field is final, then the only place it can be assigned to is in the constructor
+      //   of the proper object (enforced by javac).
+      // * if the field is not final, then it cannot be assigned to in a constructor at all: the
+      //   @CreatesMustCallFor annotation cannot be written on a constructor (it has
+      //   @Target({ElementType.METHOD})), so this code relies on the standard rules for non-final
+      // owning
+      //   field reassignment, which prevent it without an @CreatesMustCallFor annotation except
+      //   in the constructor of the object containing the field.
       boolean lhsIsOwningField =
           lhs.getKind() == Tree.Kind.MEMBER_SELECT
               && atypeFactory.getDeclAnnotation(lhsElt, Owning.class) != null;

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1390,12 +1390,13 @@ class MustCallConsistencyAnalyzer {
     // that. Otherwise, use the declared type of the field
     CFStore mcStore = mcTypeFactory.getStoreBefore(lhs);
     CFValue mcValue = mcStore.getValue(lhs);
-    AnnotationMirror mcAnno;
-    if (mcValue == null) {
-      // No store value, so use the declared type.
-      mcAnno = mcTypeFactory.getAnnotatedType(lhs.getElement()).getAnnotation(MustCall.class);
-    } else {
+    AnnotationMirror mcAnno = null;
+    if (mcValue != null) {
       mcAnno = AnnotationUtils.getAnnotationByClass(mcValue.getAnnotations(), MustCall.class);
+    }
+    if (mcAnno == null) {
+      // No stored value (or the stored value is Poly/top), so use the declared type.
+      mcAnno = mcTypeFactory.getAnnotatedType(lhs.getElement()).getAnnotation(MustCall.class);
     }
     List<String> mcValues =
         AnnotationUtils.getElementValueArray(

--- a/checker/tests/resourceleak/MustCallAliasImplWrong2.java
+++ b/checker/tests/resourceleak/MustCallAliasImplWrong2.java
@@ -12,6 +12,10 @@ public class MustCallAliasImplWrong2 implements Closeable {
 
   // :: error: (mustcallalias.out.of.scope)
   public @MustCallAlias MustCallAliasImplWrong2(@MustCallAlias Closeable foo) {
+    // The following error isn't really desirable, but occurs because the special case
+    // in the Must Call Checker for assigning @MustCallAlias parameters to @Owning fields
+    // is not triggered.
+    // :: error: (assignment)
     this.foo = foo;
   }
 

--- a/checker/tests/resourceleak/MustCallAliasLocal.java
+++ b/checker/tests/resourceleak/MustCallAliasLocal.java
@@ -1,0 +1,26 @@
+// Test case for a set of false positives caused by the Must Call Checker's handling
+// of assigning @MustCallAlias parameters to @Owning fields as a special case.
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class MustCallAliasLocal implements Closeable {
+
+  final @Owning Closeable foo;
+
+  public @MustCallAlias MustCallAliasLocal(@MustCallAlias Closeable foo) {
+    Closeable local = foo;
+    // The error on the following line is a false positive:
+    // :: error: assignment
+    this.foo = local;
+  }
+
+  @Override
+  @EnsuresCalledMethods(
+      value = {"this.foo"},
+      methods = {"close"})
+  public void close() throws IOException {
+    this.foo.close();
+  }
+}

--- a/checker/tests/resourceleak/MustCallAliasNotThis.java
+++ b/checker/tests/resourceleak/MustCallAliasNotThis.java
@@ -1,0 +1,54 @@
+// A test case with examples of code that shouldn't pass the checker where an @MustCallAlias
+// parameter is passed to an owning field, but not an owning field of this.
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class MustCallAliasNotThis implements Closeable {
+
+  @Owning Closeable foo;
+
+  // Both of these constructors are wrong: the first assigns to the owning field of another
+  // object of the same class, but not the "this" object; the second assigns to another class'
+  // owning field entirely. Both of these assignments would require @CreatesMustCallFor annotations
+  // to verify, so it's okay that the @MustCallAlias annotations are verified here (because it
+  // is impossible to write the required @CreatesMustCallFor annotations, since they can only be
+  // written on methods, not on constructors). If we ever permit @CreatesMustCallFor annotations
+  // on constructors, this test should be revisited: it might be necessary to make a corresponding
+  // change in the rules for verifying @MustCallAlias.
+
+  // :: error: missing.creates.mustcall.for
+  public @MustCallAlias MustCallAliasNotThis(
+      @MustCallAlias Closeable foo, MustCallAliasNotThis other) throws IOException {
+    other.close();
+    other.foo = foo;
+  }
+
+  // :: error: missing.creates.mustcall.for
+  public @MustCallAlias MustCallAliasNotThis(@MustCallAlias Closeable foo, Bar other)
+      throws IOException {
+    other.close();
+    other.baz = foo;
+  }
+
+  @Override
+  @EnsuresCalledMethods(
+      value = {"this.foo"},
+      methods = {"close"})
+  public void close() throws IOException {
+    this.foo.close();
+  }
+
+  class Bar implements Closeable {
+    @Owning Closeable baz;
+
+    @Override
+    @EnsuresCalledMethods(
+        value = {"this.baz"},
+        methods = {"close"})
+    public void close() throws IOException {
+      this.baz.close();
+    }
+  }
+}

--- a/checker/tests/resourceleak/MustCallAliasNullConstructor.java
+++ b/checker/tests/resourceleak/MustCallAliasNullConstructor.java
@@ -1,0 +1,26 @@
+// test for https://github.com/typetools/checker-framework/issues/5777
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.Socket;
+
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+public class MustCallAliasNullConstructor implements Closeable {
+  @Owning Socket socket;
+
+  @MustCallAlias
+  MustCallAliasNullConstructor(@MustCallAlias Socket s) throws IOException {
+    if (this.socket != null) { this.socket.close(); }
+    this.socket = s;
+    // :: error: required.method.not.called
+    this.socket = null;
+  }
+
+  @Override
+  @EnsuresCalledMethods(value="this.socket", methods="close")
+  public void close() throws IOException {
+    this.socket.close();
+  }
+}

--- a/checker/tests/resourceleak/MustCallAliasNullConstructor.java
+++ b/checker/tests/resourceleak/MustCallAliasNullConstructor.java
@@ -3,23 +3,23 @@
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.Socket;
-
-import org.checkerframework.checker.mustcall.qual.*;
 import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
 
 public class MustCallAliasNullConstructor implements Closeable {
   @Owning Socket socket;
 
-  @MustCallAlias
-  MustCallAliasNullConstructor(@MustCallAlias Socket s) throws IOException {
-    if (this.socket != null) { this.socket.close(); }
+  @MustCallAlias MustCallAliasNullConstructor(@MustCallAlias Socket s) throws IOException {
+    if (this.socket != null) {
+      this.socket.close();
+    }
     this.socket = s;
     // :: error: required.method.not.called
     this.socket = null;
   }
 
   @Override
-  @EnsuresCalledMethods(value="this.socket", methods="close")
+  @EnsuresCalledMethods(value = "this.socket", methods = "close")
   public void close() throws IOException {
     this.socket.close();
   }

--- a/checker/tests/resourceleak/MustCallAliasPassthroughWrong2.java
+++ b/checker/tests/resourceleak/MustCallAliasPassthroughWrong2.java
@@ -13,6 +13,10 @@ class MustCallAliasPassthroughWrong2 extends FilterInputStream {
   // :: error: (mustcallalias.out.of.scope)
   @MustCallAlias MustCallAliasPassthroughWrong2(@MustCallAlias InputStream is) throws Exception {
     super(null);
+    // The following error isn't really desirable, but occurs because the special case
+    // in the Must Call Checker for assigning @MustCallAlias parameters to @Owning fields
+    // is not triggered, and @MustCallAlias is treated as @PolyMustCall otherwise.
+    // :: error: argument
     closeIS(is);
   }
 

--- a/checker/tests/resourceleak/MustCallAliasPassthroughWrong3.java
+++ b/checker/tests/resourceleak/MustCallAliasPassthroughWrong3.java
@@ -5,9 +5,9 @@ import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
 
 class MustCallAliasPassthroughWrong3 {
-  // Both of these verify - it's okay to leave off the MCA param, because the return type is
-  // owning - but the first one leads to imprecision at call sites.
+
   static InputStream missingMCA(@MustCallAlias InputStream is) {
+    // :: error: (return)
     return is;
   }
 


### PR DESCRIPTION
fixes #5777 

This implementation does introduce some false positives (see the test cases), but I think they'll only occur in very unusual code. I'm open to suggestions on how to prevent them; long-term, I think the solution is to decouple `@MustCallAlias` checking from `@PolyMustCall`.