### PR TITLE
Fix copy-paste error in OptionalVisitor causing incorrect warning

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -238,7 +238,7 @@ public class OptionalVisitor
    */
   private boolean sameExpression(ExpressionTree tree1, ExpressionTree tree2) {
     JavaExpression r1 = JavaExpression.fromTree(tree1);
-    JavaExpression r2 = JavaExpression.fromTree(tree1);
+    JavaExpression r2 = JavaExpression.fromTree(tree2);
     if (r1 != null && !r1.containsUnknown() && r2 != null && !r2.containsUnknown()) {
       return r1.equals(r2);
     } else {


### PR DESCRIPTION
OptionalVisitor uses pattern matching, to find patterns such as `VAR.isPresent() ? VAR.get().METHOD() : VALUE`.

However, it currently also matches this pattern:
```java
VAR.isPresent() ? TOTALLY_DIFFERENT.get().toString() : "foo"
```
causing this warning:
```
Warning: [prefer.map.and.orelse] It is better style to use map and orElse.
   Consider changing to:
   VAR.map(CONTAININGCLASS::toString).orElse("foo")
```

However, it is wrong to change the above code to 
```java
VAR.map(String::toString().orElse("foo");
```
(`VAR` and `TOTALLY_DIFFERENT` are totally different variables)

This is caused by the `sameExpression` method that has a copy-paste error.
(Using `JavaExpression.fromTree(tree1)` twice)

Online example:
http://eisop.uwaterloo.ca/live/#mode=display&code=import+java.util.Optional%3B%0A%0Aclass+OptionalExampleWithWarnings+%7B++++%0A++++String+foo()+%7B%0A++++++++Optional%3CString%3E+VAR+%3D+Optional.empty()%3B%0A++++++++Optional%3CString%3E+TOTALLY_DIFFERENT+%3D+Optional.of(%22%22)%3B%0A++++++++return+VAR.isPresent()+%3F+TOTALLY_DIFFERENT.get().toString()+%3A+%22foo%22%3B%0A++++%7D%0A%7D&typeSystem=optional
