### PR TITLE
Deprecate `ElementUtils.getSimpleNameOrDescription()` in favor of `getSimpleDescription()`

### DIFF
--- a/checker/bin-devel/wpi-plumelib/bcel-util.expected
+++ b/checker/bin-devel/wpi-plumelib/bcel-util.expected
@@ -1,4 +1,4 @@
-BcelUtil.java:778: error: [argument] incompatible argument for parameter typename of parseFqBinaryName.
+BcelUtil.java:778: error: [argument] incompatible argument for parameter typename of ClassnameAndDimensions.parseFqBinaryName.
         Signatures.ClassnameAndDimensions.parseFqBinaryName(classname);
                                                             ^
   found   : @SignatureUnknown String

--- a/checker/jtreg/sortwarnings/ErrorOrders.out
+++ b/checker/jtreg/sortwarnings/ErrorOrders.out
@@ -26,46 +26,46 @@ ErrorOrders.java:24:43: compiler.err.proc.messager: [expression.unparsable] Expr
 ErrorOrders.java:24:51: compiler.err.proc.messager: [assignment] incompatible types in assignment.
 found   : @LTLengthOf("p2") int
 required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because the expression did not parse. Error message: Encountered unexpected token: "isn" <IDENTIFIER>]") int
-ErrorOrders.java:29:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:29:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of ErrorOrders.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:29:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:29:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of ErrorOrders.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:29:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:29:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of ErrorOrders.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:29:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:29:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of ErrorOrders.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:29:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:29:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of ErrorOrders.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:29:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:29:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of ErrorOrders.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:29:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:29:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of ErrorOrders.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:29:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:29:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of ErrorOrders.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:29:29: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of test4.
+ErrorOrders.java:29:29: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of ErrorOrders.test4.
 found   : @UnknownVal int @UnknownVal []
 required: @UnknownVal int @BottomVal []
-ErrorOrders.java:29:33: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of test4.
+ErrorOrders.java:29:33: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of ErrorOrders.test4.
 found   : int @SameLen("p4") []
 required: int @SameLenBottom []
-ErrorOrders.java:29:37: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of test4.
+ErrorOrders.java:29:37: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of ErrorOrders.test4.
 found   : @UnknownVal int
 required: @BottomVal int
-ErrorOrders.java:29:42: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of test4.
+ErrorOrders.java:29:42: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of ErrorOrders.test4.
 found   : @UnknownVal int @UnknownVal []
 required: @UnknownVal int @BottomVal []
-ErrorOrders.java:29:46: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of test4.
+ErrorOrders.java:29:46: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of ErrorOrders.test4.
 found   : int @SameLen("p4") []
 required: int @SameLenBottom []
-ErrorOrders.java:29:50: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of test4.
+ErrorOrders.java:29:50: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of ErrorOrders.test4.
 found   : @UnknownVal int
 required: @BottomVal int
 ErrorOrders.java:33:43: compiler.err.proc.messager: [expression.unparsable] Expression invalid in dependent type annotation: [error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because the expression did not parse. Error message: Encountered unexpected token: "isn" <IDENTIFIER>]
@@ -95,46 +95,46 @@ ErrorOrders.java:56:43: compiler.err.proc.messager: [expression.unparsable] Expr
 ErrorOrders.java:56:51: compiler.err.proc.messager: [assignment] incompatible types in assignment.
 found   : @LTLengthOf("p2") int
 required: @LTLengthOf("[error for expression: This isn't an expression; error: Invalid 'This isn't an expression' because the expression did not parse. Error message: Encountered unexpected token: "isn" <IDENTIFIER>]") int
-ErrorOrders.java:61:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:61:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of InSameCompilationUnit.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:61:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:61:11: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of InSameCompilationUnit.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:61:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:61:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of InSameCompilationUnit.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:61:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:61:20: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of InSameCompilationUnit.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:61:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:61:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of InSameCompilationUnit.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:61:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of test4.
+ErrorOrders.java:61:21: compiler.err.proc.messager: [argument] incompatible argument for parameter p1 of InSameCompilationUnit.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:61:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:61:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of InSameCompilationUnit.test4.
 found   : int
 required: @GTENegativeOne int
-ErrorOrders.java:61:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of test4.
+ErrorOrders.java:61:25: compiler.err.proc.messager: [argument] incompatible argument for parameter p2 of InSameCompilationUnit.test4.
 found   : int
 required: @UpperBoundBottom int
-ErrorOrders.java:61:29: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of test4.
+ErrorOrders.java:61:29: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of InSameCompilationUnit.test4.
 found   : @UnknownVal int @UnknownVal []
 required: @UnknownVal int @BottomVal []
-ErrorOrders.java:61:33: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of test4.
+ErrorOrders.java:61:33: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of InSameCompilationUnit.test4.
 found   : int @SameLen("p4") []
 required: int @SameLenBottom []
-ErrorOrders.java:61:37: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of test4.
+ErrorOrders.java:61:37: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of InSameCompilationUnit.test4.
 found   : @UnknownVal int
 required: @BottomVal int
-ErrorOrders.java:61:42: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of test4.
+ErrorOrders.java:61:42: compiler.err.proc.messager: [argument] incompatible argument for parameter p3 of InSameCompilationUnit.test4.
 found   : @UnknownVal int @UnknownVal []
 required: @UnknownVal int @BottomVal []
-ErrorOrders.java:61:46: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of test4.
+ErrorOrders.java:61:46: compiler.err.proc.messager: [argument] incompatible argument for parameter p4 of InSameCompilationUnit.test4.
 found   : int @SameLen("p4") []
 required: int @SameLenBottom []
-ErrorOrders.java:61:50: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of test4.
+ErrorOrders.java:61:50: compiler.err.proc.messager: [argument] incompatible argument for parameter p5 of InSameCompilationUnit.test4.
 found   : @UnknownVal int
 required: @BottomVal int
 49 errors

--- a/checker/jtreg/stubs/issue2147/WithStub.out
+++ b/checker/jtreg/stubs/issue2147/WithStub.out
@@ -1,4 +1,4 @@
-EnumStubTest.java:16:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of requireEnum.
+EnumStubTest.java:16:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of EnumStubTest.requireEnum.
 found   : @Tainted SampleEnum
 required: @Untainted SampleEnum
 1 error

--- a/checker/jtreg/stubs/issue2147/WithoutStub.out
+++ b/checker/jtreg/stubs/issue2147/WithoutStub.out
@@ -1,7 +1,7 @@
-EnumStubTest.java:15:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of requireEnum.
+EnumStubTest.java:15:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of EnumStubTest.requireEnum.
 found   : @Tainted SampleEnum
 required: @Untainted SampleEnum
-EnumStubTest.java:16:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of requireEnum.
+EnumStubTest.java:16:27: compiler.err.proc.messager: [argument] incompatible argument for parameter sEnum of EnumStubTest.requireEnum.
 found   : @Tainted SampleEnum
 required: @Untainted SampleEnum
 2 errors

--- a/checker/jtreg/tainting/NewClass.out
+++ b/checker/jtreg/tainting/NewClass.out
@@ -1,4 +1,4 @@
-NewClass.java:18:45: compiler.err.proc.messager: [argument] incompatible argument for parameter o of get.
+NewClass.java:18:45: compiler.err.proc.messager: [argument] incompatible argument for parameter o of NewClass.get.
 found   : @Tainted Object
 required: @Untainted Object
 1 error

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
@@ -113,7 +113,7 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
                     if (!fc.isValidArgument(formatCat, argType)) {
                       // II.3
                       ExecutableElement method = TreeUtils.elementFromUse(tree);
-                      CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
+                      CharSequence methodName = ElementUtils.getSimpleDescription(method);
                       ftu.failure(
                           arg, "argument", "in varargs position", methodName, argType, formatCat);
                     }

--- a/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/guieffect/GuiEffectVisitor.java
@@ -504,7 +504,7 @@ public class GuiEffectVisitor extends BaseTypeVisitor<GuiEffectTypeFactory> {
         ParameterizedExecutableType mType = atypeFactory.methodFromUse(invocationTree);
         AnnotatedExecutableType invokedMethod = mType.executableType;
         ExecutableElement method = invokedMethod.getElement();
-        CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
+        CharSequence methodName = ElementUtils.getSimpleDescription(method);
         List<? extends VariableElement> methodParams = method.getParameters();
         List<AnnotatedTypeMirror> paramTypes =
             AnnotatedTypes.adaptParameters(

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -87,7 +87,7 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
                 default:
                   if (!fc.isValidParameter(formatCat, paramType)) {
                     ExecutableElement method = TreeUtils.elementFromUse(fc.getTree());
-                    CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
+                    CharSequence methodName = ElementUtils.getSimpleDescription(method);
                     tu.failure(
                         param,
                         "argument",

--- a/checker/tests/command-line/issue618/expected.txt
+++ b/checker/tests/command-line/issue618/expected.txt
@@ -1,4 +1,4 @@
-TwoCheckers.java:28: error: [argument] incompatible argument for parameter b of requiresUntainted.
+TwoCheckers.java:28: error: [argument] incompatible argument for parameter b of TwoCheckers.requiresUntainted.
     requiresUntainted(a);
                       ^
   found   : @Tainted String

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,15 @@
+Version 3.36.0 (July 5, 2023)
+-----------------------------
+
+**User-visible changes:**
+
+**Implementation details:**
+
+Deprecated `ElementUtils.getSimpleNameOrDescription()` in favor of `getSimpleDescription()`.
+
+**Closed issues:**
+
+
 Version 3.35.0 (June 1, 2023)
 ------------------------------
 

--- a/docs/examples/fenum-extension/Expected.txt
+++ b/docs/examples/fenum-extension/Expected.txt
@@ -43,12 +43,12 @@ FenumDemo.java:29: error: [assignment] incompatible types in assignment.
                        ^
   found   : @Fenum("B") int
   required: @Fenum("A") int
-FenumDemo.java:32: error: [argument] incompatible argument for parameter p of fenumArg.
+FenumDemo.java:32: error: [argument] incompatible argument for parameter p of FenumDemo.fenumArg.
     fenumArg(5); // Direct use of value forbidden!
              ^
   found   : @FenumUnqualified int
   required: @Fenum("A") int
-FenumDemo.java:33: error: [argument] incompatible argument for parameter p of fenumArg.
+FenumDemo.java:33: error: [argument] incompatible argument for parameter p of FenumDemo.fenumArg.
     fenumArg(TestStatic.BCONST1); // Incompatible fenums forbidden!
                        ^
   found   : @Fenum("B") int
@@ -63,12 +63,12 @@ FenumDemo.java:37: error: [assignment] incompatible types in assignment.
                        ^
   found   : @Fenum("A") int
   required: @MyFenum int
-FenumDemo.java:40: error: [argument] incompatible argument for parameter p of myFenumArg.
+FenumDemo.java:40: error: [argument] incompatible argument for parameter p of FenumDemo.myFenumArg.
     myFenumArg(8); // Direct use of value forbidden!
                ^
   found   : @FenumUnqualified int
   required: @MyFenum int
-FenumDemo.java:41: error: [argument] incompatible argument for parameter p of myFenumArg.
+FenumDemo.java:41: error: [argument] incompatible argument for parameter p of FenumDemo.myFenumArg.
     myFenumArg(TestStatic.BCONST2); // Incompatible fenums forbidden!
                          ^
   found   : @Fenum("B") int

--- a/docs/examples/lombok/Makefile
+++ b/docs/examples/lombok/Makefile
@@ -6,7 +6,7 @@ JAVA_VER := $(shell java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s/
 # So check for both the error message and make sure it is for the right assignment.
 all: clean
 	- ../../../gradlew build > Out.txt 2>&1
-	(grep -qF "User.java:9: error: [argument] incompatible argument for parameter y of y." Out.txt \
+	(grep -qF "User.java:9: error: [argument] incompatible argument for parameter y of FooBuilder.y." Out.txt \
 	  && grep -qF "Foo.java:12: error: [assignment] incompatible types in assignment." Out.txt \
 	  && grep -qF "y = null; // error" Out.txt) \
 	 || (echo "===== start of Out.txt =====" && cat Out.txt && echo "===== end of Out.txt =====" && false)

--- a/docs/examples/subtyping-extension/Expected.txt
+++ b/docs/examples/subtyping-extension/Expected.txt
@@ -1,7 +1,7 @@
 Demo.java:13: warning: [cast.unsafe] cast from "@PossiblyUnencrypted String" to "@Encrypted String" cannot be statically verified
     return (@Encrypted String) new String(b);
            ^
-Demo.java:36: error: [argument] incompatible argument for parameter msg of sendOverTheInternet.
+Demo.java:36: error: [argument] incompatible argument for parameter msg of EncryptionDemo.sendOverTheInternet.
     sendOverTheInternet(password); // invalid
                         ^
   found   : @PossiblyUnencrypted String

--- a/framework/jtreg/variablenamedefault/UseTest1.out
+++ b/framework/jtreg/variablenamedefault/UseTest1.out
@@ -1,4 +1,4 @@
-UseTest.java:8:17: compiler.err.proc.messager: [argument] incompatible argument for parameter middle of method.
+UseTest.java:8:17: compiler.err.proc.messager: [argument] incompatible argument for parameter middle of Test.method.
 found   : @VariableNameDefaultTop int
 required: @VariableNameDefaultMiddle int
 1 error

--- a/framework/jtreg/variablenamedefault/UseTest2.out
+++ b/framework/jtreg/variablenamedefault/UseTest2.out
@@ -1,4 +1,4 @@
-UseTest.java:8:17: compiler.err.proc.messager: [argument] incompatible argument for parameter arg0 of method.
+UseTest.java:8:17: compiler.err.proc.messager: [argument] incompatible argument for parameter arg0 of Test.method.
 found   : @VariableNameDefaultTop int
 required: @VariableNameDefaultMiddle int
 1 error

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1752,7 +1752,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             AnnotatedTypeVariable::getBounds, invokedMethod.getTypeVariables());
 
     ExecutableElement method = invokedMethod.getElement();
-    CharSequence methodName = ElementUtils.getSimpleNameOrDescription(method);
+    CharSequence methodName = ElementUtils.getSimpleDescription(method);
     try {
       checkTypeArguments(
           tree,
@@ -2066,7 +2066,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
         AnnotatedTypes.adaptParameters(atypeFactory, constructorType, passedArguments);
 
     ExecutableElement constructor = constructorType.getElement();
-    CharSequence constructorName = ElementUtils.getSimpleNameOrDescription(constructor);
+    CharSequence constructorName = ElementUtils.getSimpleDescription(constructor);
 
     checkArguments(params, passedArguments, constructorName, constructor.getParameters());
     checkVarargs(constructorType, tree);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -347,8 +347,9 @@ public class ElementUtils {
   }
 
   /**
-   * Returns a user-friendly name for the given method. Does not return {@code "<init>"} or {@code
-   * "<clinit>"} as ExecutableElement.getSimpleName() does.
+   * Returns a user-friendly name for the given method, which includes the name of the enclosing
+   * type. Does not return {@code "<init>"} or {@code "<clinit>"} as
+   * ExecutableElement.getSimpleName() does.
    *
    * @param element a method declaration
    * @return a user-friendly name for the method

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -354,7 +354,8 @@ public class ElementUtils {
    * @return a user-friendly name for the method
    */
   public static CharSequence getSimpleDescription(ExecutableElement element) {
-    TypeElement enclosingTypeName = (TypeElement) element.getEnclosingElement().getSimpleName();
+    String enclosingTypeName =
+        ((TypeElement) element.getEnclosingElement()).getSimpleName().toString();
     Name methodName = element.getSimpleName();
     switch (methodName.toString()) {
       case "<init>":

--- a/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/ElementUtils.java
@@ -331,7 +331,9 @@ public class ElementUtils {
    *
    * @param element a method declaration
    * @return a user-friendly name for the method
+   * @deprecated use {@link #getSimpleDescription}
    */
+  @Deprecated // 2023-06-01
   public static CharSequence getSimpleNameOrDescription(ExecutableElement element) {
     Name result = element.getSimpleName();
     switch (result.toString()) {
@@ -341,6 +343,26 @@ public class ElementUtils {
         return "class initializer";
       default:
         return result;
+    }
+  }
+
+  /**
+   * Returns a user-friendly name for the given method. Does not return {@code "<init>"} or {@code
+   * "<clinit>"} as ExecutableElement.getSimpleName() does.
+   *
+   * @param element a method declaration
+   * @return a user-friendly name for the method
+   */
+  public static CharSequence getSimpleDescription(ExecutableElement element) {
+    TypeElement enclosingTypeName = (TypeElement) element.getEnclosingElement().getSimpleName();
+    Name methodName = element.getSimpleName();
+    switch (methodName.toString()) {
+      case "<init>":
+        return enclosingTypeName + " constructor";
+      case "<clinit>":
+        return "class initializer for " + enclosingTypeName;
+      default:
+        return enclosingTypeName + "." + methodName;
     }
   }
 


### PR DESCRIPTION
If you want to merge this before the release, we need to edit the changelog (either in this pull request, or when making the release).