### PR TITLE
Don't advertise assembleForJavac task, which is a hack for Checker Framework developers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1035,10 +1035,11 @@ subprojects {
   }
 }
 
+// The `assembleForJavac` task is faster than the `assemble` task, if you only
+// care about running `javac`.
 // The assemble task also produces Javadoc jars, because its purpose is to build
 // all artifacts produced by the Gradle project:
 // https://docs.gradle.org/current/userguide/base_plugin.html#sec:base_tasks
-
 assemble.dependsOn(':checker:assembleForJavac')
 
 assemble.mustRunAfter(clean)

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -93,6 +93,8 @@ jar {
   }
 }
 
+// This task differs from the `assemble` task in that it does not build Javadoc.
+// It is useful for those who only want to run `javac`.
 // checker.jar is copied to checker/dist/ when it is built by the shadowJar task.
 task assembleForJavac(dependsOn: shadowJar, group: 'Build') {
   description 'Builds or downloads jars required by CheckerMain and puts them in checker/dist/.'

--- a/docs/developer/developer-manual.html
+++ b/docs/developer/developer-manual.html
@@ -138,7 +138,7 @@ Frequently-used tasks:
 </p>
 <ul>
   <li> <code>assemble</code>: builds all artifacts, including jars and Javadoc jars.
-  <li> <code>assembleForJavac</code>: builds only the jars required to use checker/bin/javac; faster than assemble.
+  <li> <code>assembleForJavac</code>: builds only the jars required to use <code>checker/bin/javac</code>; faster than <code>assemble</code>.
   <li> <code>build</code>: <code>assemble</code>, plus runs all JUnit tests.
   <li> <code>allTests</code>: runs all tests.
   <li> <code>spotlessApply</code>: reformats Java files.

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -793,7 +793,7 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-17.jdk/Contents/
 
 
 \item[Windows]
-  To build on Windows 10,
+  To build on Windows 10 or later,
   run \<bash> to obtain a version of
   Ubuntu (provided by the Windows Subsystem for Linux) and follow the Ubuntu
   instructions.

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -834,11 +834,11 @@ You might want to add an \<export CHECKERFRAMEWORK=...> line to your
 \begin{enumerate}
 
 \item
-Run \code{./gradlew assembleForJavac} to build the Checker Framework for \<javac>:
+Run \code{./gradlew assemble} to build the Checker Framework for \<javac>:
 
 \begin{Verbatim}
   cd $CHECKERFRAMEWORK
-  ./gradlew assembleForJavac
+  ./gradlew assemble
 \end{Verbatim}
 % $ to unconfuse Emacs LaTeX mode
 


### PR DESCRIPTION
The `assemble` task is more standard, and it also works.