### PR TITLE
Instead of calling asSuper, box/unbox/narrow types in isSubtype 

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AsSuperVisitor.java
@@ -541,28 +541,12 @@ public class AsSuperVisitor extends AbstractAtmComboVisitor<AnnotatedTypeMirror,
     if (TypesUtils.isBoxedPrimitive(superType.getUnderlyingType())) {
       TypeMirror unboxedSuper = types.unboxedType(superType.getUnderlyingType());
       if (unboxedSuper.getKind() != type.getKind()
-          && canBeNarrowingPrimitiveConversion(unboxedSuper)) {
+          && TypesUtils.canBeNarrowingPrimitiveConversion(unboxedSuper, types)) {
         AnnotatedPrimitiveType narrowedType = atypeFactory.getNarrowedPrimitive(type, unboxedSuper);
         return visit(narrowedType, superType, p);
       }
     }
     return visitPrimitive_Other(type, superType, p);
-  }
-
-  /**
-   * Returns true if the type is byte, short, char, Byte, Short, or Character. All other narrowings
-   * require a cast. See JLS 5.1.3.
-   *
-   * @param type a type
-   * @return true if assignment to the type may be a narrowing
-   */
-  private boolean canBeNarrowingPrimitiveConversion(TypeMirror type) {
-    // See CFGBuilder.CFGTranslationPhaseOne#conversionRequiresNarrowing()
-    TypeMirror unboxedType = TypesUtils.isBoxedPrimitive(type) ? types.unboxedType(type) : type;
-    TypeKind unboxedKind = unboxedType.getKind();
-    return unboxedKind == TypeKind.BYTE
-        || unboxedKind == TypeKind.SHORT
-        || unboxedKind == TypeKind.CHAR;
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -177,7 +177,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
    * missing annotations.
    *
    * @param subtype a type that might be a subtype (with respect to primary annotations)
-   * @param supertype a type that might be a supertype (with respect to primary annotations)
+   * @param supertype a type that might be a supertype (with respect to primary annotations)x
    * @return true if the primary annotation on subtype {@literal <:} primary annotation on supertype
    *     for the current top.
    */
@@ -563,14 +563,15 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   @Override
   public Boolean visitDeclared_Primitive(
       AnnotatedDeclaredType subtype, AnnotatedPrimitiveType supertype, Void p) {
-    // We do an asSuper first because in some cases unboxing implies a more specific annotation
-    // e.g. @UnknownInterned Integer => @Interned int  because primitives are always interned
-    AnnotatedPrimitiveType subAsSuper =
-        AnnotatedTypes.castedAsSuper(subtype.atypeFactory, subtype, supertype);
-    if (subAsSuper == null) {
-      return isPrimarySubtype(subtype, supertype);
+    AnnotatedTypeMirror unboxedType;
+    try {
+      unboxedType = subtype.atypeFactory.getUnboxedType(subtype);
+    } catch (IllegalArgumentException ex) {
+      throw new BugInCF(
+          "DefaultTypeHierarchy: subtype isn't a boxed type: subtype: %s superType: %s",
+          subtype, supertype);
     }
-    return isPrimarySubtype(subAsSuper, supertype);
+    return isPrimarySubtype(unboxedType, supertype);
   }
 
   @Override
@@ -717,13 +718,19 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   @Override
   public Boolean visitPrimitive_Declared(
       AnnotatedPrimitiveType subtype, AnnotatedDeclaredType supertype, Void p) {
-    // see comment in visitDeclared_Primitive
-    AnnotatedDeclaredType subAsSuper =
-        AnnotatedTypes.castedAsSuper(subtype.atypeFactory, subtype, supertype);
-    if (subAsSuper == null) {
-      return isPrimarySubtype(subtype, supertype);
+    AnnotatedTypeFactory atypeFactory = subtype.atypeFactory;
+    Types types = atypeFactory.types;
+    AnnotatedPrimitiveType narrowedType = subtype;
+    if (TypesUtils.isBoxedPrimitive(supertype.getUnderlyingType())) {
+      TypeMirror unboxedSuper = types.unboxedType(supertype.getUnderlyingType());
+      if (unboxedSuper.getKind() != subtype.getKind()
+          && TypesUtils.canBeNarrowingPrimitiveConversion(unboxedSuper, types)) {
+        narrowedType = atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
+        return visit(narrowedType, supertype, p);
+      }
     }
-    return isPrimarySubtype(subAsSuper, supertype);
+    AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(narrowedType);
+    return isPrimarySubtype(boxedSubtype, supertype);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -726,7 +726,6 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       if (unboxedSuper.getKind() != subtype.getKind()
           && TypesUtils.canBeNarrowingPrimitiveConversion(unboxedSuper, types)) {
         narrowedType = atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
-        return visit(narrowedType, supertype, p);
       }
     }
     AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(narrowedType);

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -720,16 +720,16 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       AnnotatedPrimitiveType subtype, AnnotatedDeclaredType supertype, Void p) {
     AnnotatedTypeFactory atypeFactory = subtype.atypeFactory;
     Types types = atypeFactory.types;
-    AnnotatedPrimitiveType narrowedType = subtype;
     if (TypesUtils.isBoxedPrimitive(supertype.getUnderlyingType())) {
       TypeMirror unboxedSuper = types.unboxedType(supertype.getUnderlyingType());
       if (unboxedSuper.getKind() != subtype.getKind()
           && TypesUtils.canBeNarrowingPrimitiveConversion(unboxedSuper, types)) {
-        narrowedType = atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
+        AnnotatedPrimitiveType narrowedType =
+            atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
         return visit(narrowedType, supertype, p);
       }
     }
-    AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(narrowedType);
+    AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(subtype);
     return isPrimarySubtype(boxedSubtype, supertype);
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -177,7 +177,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
    * missing annotations.
    *
    * @param subtype a type that might be a subtype (with respect to primary annotations)
-   * @param supertype a type that might be a supertype (with respect to primary annotations)x
+   * @param supertype a type that might be a supertype (with respect to primary annotations)
    * @return true if the primary annotation on subtype {@literal <:} primary annotation on supertype
    *     for the current top.
    */

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -720,16 +720,16 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       AnnotatedPrimitiveType subtype, AnnotatedDeclaredType supertype, Void p) {
     AnnotatedTypeFactory atypeFactory = subtype.atypeFactory;
     Types types = atypeFactory.types;
+    AnnotatedPrimitiveType narrowedType = subtype;
     if (TypesUtils.isBoxedPrimitive(supertype.getUnderlyingType())) {
       TypeMirror unboxedSuper = types.unboxedType(supertype.getUnderlyingType());
       if (unboxedSuper.getKind() != subtype.getKind()
           && TypesUtils.canBeNarrowingPrimitiveConversion(unboxedSuper, types)) {
-        AnnotatedPrimitiveType narrowedType =
-            atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
+        narrowedType = atypeFactory.getNarrowedPrimitive(subtype, unboxedSuper);
         return visit(narrowedType, supertype, p);
       }
     }
-    AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(subtype);
+    AnnotatedTypeMirror boxedSubtype = atypeFactory.getBoxedType(narrowedType);
     return isPrimarySubtype(boxedSubtype, supertype);
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeHierarchy.java
@@ -28,12 +28,8 @@ public interface TypeHierarchy {
    * <p>3 categories are converted in isSubtype:
    *
    * <ul>
-   *   <li>Boxing conversions: isSubtype calls {@link AnnotatedTypes#asSuper( AnnotatedTypeFactory,
-   *       AnnotatedTypeMirror, AnnotatedTypeMirror)} which calls {@link
-   *       AnnotatedTypeFactory#getBoxedType}
-   *   <li>Unboxing conversions: isSubtype calls {@link AnnotatedTypes#asSuper(
-   *       AnnotatedTypeFactory, AnnotatedTypeMirror, AnnotatedTypeMirror)} which calls {@link
-   *       AnnotatedTypeFactory#getUnboxedType}
+   *   <li>Boxing conversions: isSubtype calls {@link AnnotatedTypeFactory#getBoxedType}
+   *   <li>Unboxing conversions: isSubtype calls {@link AnnotatedTypeFactory#getUnboxedType}
    *   <li>String conversions: Any type to String. isSubtype calls {@link AnnotatedTypes#asSuper}
    *       which calls {@link AnnotatedTypeFactory#getStringType(AnnotatedTypeMirror)}
    * </ul>

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -1249,4 +1249,21 @@ public final class TypesUtils {
     }
     throw new BugInCF("Not found: %s", StringsPlume.join(",", collection));
   }
+
+  /**
+   * Returns true if the type is byte, short, char, Byte, Short, or Character. All other narrowings
+   * require a cast. See JLS 5.1.3.
+   *
+   * @param type a type
+   * @param types the type utilities
+   * @return true if assignment to the type may be a narrowing
+   */
+  public static boolean canBeNarrowingPrimitiveConversion(TypeMirror type, Types types) {
+    // See CFGBuilder.CFGTranslationPhaseOne#conversionRequiresNarrowing()
+    TypeMirror unboxedType = isBoxedPrimitive(type) ? types.unboxedType(type) : type;
+    TypeKind unboxedKind = unboxedType.getKind();
+    return unboxedKind == TypeKind.BYTE
+        || unboxedKind == TypeKind.SHORT
+        || unboxedKind == TypeKind.CHAR;
+  }
 }


### PR DESCRIPTION
This fixes a problem in https://github.com/typetools/checker-framework/pull/5862.