### PR TITLE
Don't print test summary.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -936,20 +936,6 @@ subprojects {
         // Don't show the uninteresting stack traces from the exceptions.
         showStackTraces = false
       }
-
-      // After each test, print a summary.
-      afterSuite { desc, result ->
-        if (desc.getClassName() != null) {
-          long mils = result.getEndTime() - result.getStartTime()
-          double seconds = mils / 1000.0
-
-          println "Testsuite: ${desc.getClassName()}\n" +
-              "Tests run: ${result.testCount}, " +
-              "Failures: ${result.failedTestCount}, " +
-              "Skipped: ${result.skippedTestCount}, " +
-              "Time elapsed: ${seconds} sec\n"
-        }
-      }
     }
 
     // Create a nonJunitTests task per project


### PR DESCRIPTION
This makes the logs shorter and easier to see which test failed.  
Here's an example log with test failures: 
https://dev.azure.com/smillst/checker-framework/_build/results?buildId=2836&view=logs&j=b53dbc13-46ec-5e04-a8ed-e1947e1a55a7&t=ae6fdf58-1b39-5626-fe20-47bffdcb43fc

