### PR TITLE
Correct reflective invocation of Analysis constructors.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -627,7 +627,7 @@ public abstract class GenericAnnotatedTypeFactory<
       FlowAnalysis result =
           BaseTypeChecker.invokeConstructorFor(
               BaseTypeChecker.getRelatedClassName(checkerClass, "Analysis"),
-              new Class<?>[] {BaseTypeChecker.class, this.getClass(), List.class},
+              new Class<?>[] {BaseTypeChecker.class, this.getClass()},
               new Object[] {checker, this});
       if (result != null) {
         return result;


### PR DESCRIPTION
This has been broken for 2 years.  It also does not work if the constructor is protected.  Should we just remove the reflective code?