### PR TITLE
Don't print `INFERENCE FAILED for:` when printing raw types.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultAnnotatedTypeFormatter.java
@@ -155,6 +155,13 @@ public class DefaultAnnotatedTypeFormatter implements AnnotatedTypeFormatter {
     /** Whether the visitor is currently printing a raw type. */
     protected boolean currentPrintingRaw;
 
+    /**
+     * Creates the visitor.
+     *
+     * @param annoFormatter formatter used for {@code AnnotationMirror}s
+     * @param printVerboseGenerics whether to verbosely print type variables and wildcards
+     * @param defaultInvisiblesSetting whether to print invisible qualifiers
+     */
     public FormattingVisitor(
         AnnotationFormatter annoFormatter,
         boolean printVerboseGenerics,


### PR DESCRIPTION
For example:
```java
import java.util.List;
import org.checkerframework.checker.nullness.qual.NonNull;

public class RawTypePrinting<T,S extends List,Q extends CharSequence>{
    void method(){
      @NonNull RawTypePrinting myClass = null;
    }
}
```

```
javacheck -processor nullness ../testcases/src/RawTypePrinting.java
../testcases/src/RawTypePrinting.java:7: error: [assignment] incompatible types in assignment.
      @NonNull MyClass myClass = null;
                                 ^
  found   : null (NullType)
  required: @UnknownInitialization @NonNull MyClass</*RAW*/>
1 error
```
With ` -AprintVerboseGenerics`
```
javacheck -processor nullness ../testcases/src/RawTypePrinting.java  -AprintVerboseGenerics
../testcases/src/RawTypePrinting.java:6: error: [assignment] incompatible types in assignment.
      @NonNull RawTypePrinting myClass = null;
                                         ^
  found   : @FBCBottom @Nullable NullType
  required: @UnknownInitialization @NonNull RawTypePrinting</*RAW TYPE ARGUMENT:*/ ?[ extends @Initialized @NonNull Object super @Initialized @NonNull Void], /*RAW TYPE ARGUMENT:*/ ?[ extends @Initialized @NonNull List</*RAW TYPE ARGUMENT:*/ ?[ extends @Initialized @NonNull Object super @Initialized @NonNull Void]> super @Initialized @NonNull Void], /*RAW TYPE ARGUMENT:*/ ?[ extends @Initialized @NonNull CharSequence super @Initialized @NonNull Void]>
1 error
```
