### PR TITLE
Switch to Temurin from AdoptOpenJDK in build instructions

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -766,8 +766,8 @@ In a startup file, write:
 \begin{Verbatim}
 brew update
 brew install git ant hevea maven mercurial librsvg unzip make
-brew tap AdoptOpenJDK/openjdk
-brew install --cask adoptopenjdk17
+brew tap homebrew/cask-versions
+brew install --cask temurin17
 brew install --cask mactex
 \end{Verbatim}
 


### PR DESCRIPTION
AdoptOpenJDK is now the Eclipse Adoptium project:

https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/

The JDK that they distribute is called Temurin.