### PR TITLE
Fix crash in RLC

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1442,6 +1442,13 @@ class MustCallConsistencyAnalyzer {
       mcAnno =
           mcTypeFactory.getAnnotatedType(lhs.getElement()).getPrimaryAnnotation(MustCall.class);
     }
+    // if mcAnno is still null, then the declared type must be something other than
+    // @MustCall (probably @MustCallUnknown). Do nothing in this case: a warning
+    // about the field will be issued elsewhere (it will be impossible to satisfy its
+    // obligations!).
+    if (mcAnno == null) {
+      return;
+    }
     List<String> mcValues =
         AnnotationUtils.getElementValueArray(
             mcAnno, mcTypeFactory.getMustCallValueElement(), String.class);

--- a/checker/tests/resourceleak/Issue6030.java
+++ b/checker/tests/resourceleak/Issue6030.java
@@ -1,0 +1,29 @@
+// Test case for https://github.com/typetools/checker-framework/issues/6030
+
+import java.util.*;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+public class Issue6030 {
+
+  interface CloseableIterator<T> extends Iterator<T>, java.io.Closeable {}
+
+  static class MyScanner<T, I extends MyScanner<T, I>> implements CloseableIterator<T> {
+    @Owning I iterator;
+
+    // :: error: missing.creates.mustcall.for
+    public boolean hasNext() {
+      if (iterator == null) iterator = createIterator();
+      return iterator.hasNext();
+    }
+
+    public T next() {
+      return null;
+    }
+
+    private I createIterator() {
+      return null;
+    }
+
+    public void close() {}
+  }
+}

--- a/checker/tests/resourceleak/OwningMCU.java
+++ b/checker/tests/resourceleak/OwningMCU.java
@@ -1,0 +1,15 @@
+// a test case that @Owning @MustCallUnknown fields do not cause a crash. Of course,
+// such fields should never exist. But, better to be safe. Relevant GitHub issue with
+// discussion: https://github.com/typetools/checker-framework/issues/6030.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class OwningMCU {
+
+  @Owning @MustCallUnknown Object foo;
+
+  // :: error: missing.creates.mustcall.for
+  void test() {
+    foo = new Object();
+  }
+}


### PR DESCRIPTION
This PR only fixes the crash, not the fact that no warning is issued.

No warning is issued about the owning field because of #5908. #5912 will fix that issue, and will presumably also require a change in this test case.