### PR TITLE
Only add `dirty=true` if the version is a snapshot snapshot or the branch isn't master.

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2749,7 +2749,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
     // git.dirty indicates modified tracked files and staged changes.  Untracked content doesn't
     // count, so not being dirty doesn't mean that exactly the printed commit is being run.
     String dirty = gitProperties.getProperty("git.dirty");
-    if (version.endsWith("-SNAPSHOT") || !branch.equals("master") || dirty.equals("true")) {
+    if (version.endsWith("-SNAPSHOT") || !branch.equals("master")) {
       // Sometimes the branch is HEAD, which is not informative.
       // How does that happen, and how can I fix it?
       version += ", branch " + branch;


### PR DESCRIPTION
@mernst This seem to be the cleanest way to do this, since we were already checking for the version for SNAPSHOT.