### PR TITLE
Fix Gradle deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import de.undercouch.gradle.tasks.download.Download
 
 plugins {
   // https://plugins.gradle.org/plugin/com.github.johnrengelman.shadow
-  id 'com.github.johnrengelman.shadow' version '8.1.0'
+  id 'com.github.johnrengelman.shadow' version '8.1.1'
   // https://plugins.gradle.org/plugin/de.undercouch.download
   id 'de.undercouch.download' version '5.4.0'
   id 'java'

--- a/checker-qual/build.gradle
+++ b/checker-qual/build.gradle
@@ -1,19 +1,8 @@
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    // Create OSGI bundles
-    classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:6.4.0'
-    // Don't add implementation dependencies; checker-qual.jar should have no dependencies.
-  }
-}
-
 plugins {
   id 'java-library'
+  id("biz.aQute.bnd.builder") version "6.4.0"
 }
 
-apply plugin: 'biz.aQute.bnd.builder'
 
 jar {
   manifest {

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -164,7 +164,6 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 task checkerJar(type: ShadowJar, dependsOn: compileJava, group: 'Build') {
   description "Builds checker-${project.version}.jar with all dependencies except checker-qual and checker-util."
   includeEmptyDirs = false
-  archivesBaseName = 'checker'
 
   from shadowJar.source
   configurations = shadowJar.configurations

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -165,7 +165,6 @@ task checkerJar(type: ShadowJar, dependsOn: compileJava, group: 'Build') {
   description "Builds checker-${project.version}.jar with all dependencies except checker-qual and checker-util."
   includeEmptyDirs = false
   archivesBaseName = 'checker'
-  archiveClassifier = ''
 
   from shadowJar.source
   configurations = shadowJar.configurations
@@ -190,7 +189,7 @@ shadowJar {
   description 'Creates checker-VERSION-all.jar and copies it to dist/checker.jar.'
   // To see what files are incorporated into the shadow jar file:
   // doFirst { println sourceSets.main.runtimeClasspath.asPath }
-
+  archiveClassifier = 'all'
   doLast{
     copy {
       from archiveFile.get()
@@ -1056,6 +1055,10 @@ publishing {
   publications {
     checker(MavenPublication) {
       project.shadow.component it
+      // reset the artifacts because of project.shadow.component changes
+      // the classifier from 'all' to '' because of
+      // https://github.com/johnrengelman/shadow/issues/860
+      artifacts = [shadowJar]
       checkerPom it
       artifact checkerJar
       artifact allSourcesJar

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -28,7 +28,7 @@ def createDataflowShaded(shadedPkgName) {
   tasks.create(name: "dataflow${shadedPkgName}Jar", type: ShadowJar, dependsOn: compileJava, group: 'Build') {
     description "Builds dataflow-${shadedPkgName}.jar."
     includeEmptyDirs = false
-    archivesBaseName = "dataflow-${shadedPkgName}"
+    archiveBaseName.set("dataflow-${shadedPkgName}")
     // Without this line, the Maven artifact will have the classifier "all".
     archiveClassifier.set('')
 


### PR DESCRIPTION
One warning remains:
```
> Configure project :checker-qual
The AbstractTask.getConvention() method has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.2/userguide/upgrading_version_8.html#deprecated_access_to_conventions
```
It's from the biz.aQute.bnd plugin: see https://github.com/bndtools/bnd/issues/5714.