### PR TITLE
RLC: when computing the must-call type of an obligation, don't use the local element type if it is top and instead fall back to the class' type (if it exists)

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -340,11 +340,11 @@ class MustCallConsistencyAnalyzer {
           mcAtf
               .getAnnotatedType(reference.getElement())
               .getEffectiveAnnotationInHierarchy(mcAtf.TOP);
-      if (result != null) {
+      if (result != null && !AnnotationUtils.areSame(result, mcAtf.TOP)) {
         return result;
       }
-      // There wasn't an @MustCall annotation for it in the store, so fall back to the default
-      // must-call type for the class.
+      // There wasn't an @MustCall annotation for it in the store and the type factory has no
+      // information, so fall back to the default must-call type for the class.
       // TODO: we currently end up in this case when checking a call to the return type
       // of a returns-receiver method on something with a MustCall type; for example,
       // see tests/socket/ZookeeperReport6.java. We should instead use a poly type if we can.

--- a/checker/tests/resourceleak/IndexMode.java
+++ b/checker/tests/resourceleak/IndexMode.java
@@ -2,6 +2,7 @@
 // Reported as part of https://github.com/typetools/checker-framework/issues/6077.
 
 import java.util.Map;
+import org.checkerframework.checker.mustcall.qual.MustCall;
 
 public class IndexMode {
   public static Object getMode(Map<String, String> indexOptions) {
@@ -13,5 +14,31 @@ public class IndexMode {
 
     // Actual return type rather than void is needed, otherwise no FP.
     return null;
+  }
+
+  // This copy of getMode() adds an explicit `@MustCall` annotation to the String.
+  public static Object getMode2(Map<String, @MustCall("hashCode") String> indexOptions) {
+    try {
+      // :: error: required.method.not.called
+      String literalOption = indexOptions.get("is_literal");
+    } catch (Exception e) {
+    }
+
+    return null;
+  }
+
+  // This copy of getMode() adds an explicit `@MustCall` annotation to the String and removes
+  // the try-catch.
+  public static Object getMode3(Map<String, @MustCall("hashCode") String> indexOptions) {
+    // :: error: required.method.not.called
+    String literalOption = indexOptions.get("is_literal");
+    return null;
+  }
+
+  // This copy of getMode() adds an explicit `@MustCall` annotation to the String, removes
+  // the try-catch, and makes the return type void.
+  public static void getMode4(Map<String, @MustCall("hashCode") String> indexOptions) {
+    // :: error: required.method.not.called
+    String literalOption = indexOptions.get("is_literal");
   }
 }

--- a/checker/tests/resourceleak/IndexMode.java
+++ b/checker/tests/resourceleak/IndexMode.java
@@ -1,0 +1,127 @@
+// A test for a new false positive issued in release 3.36.0 but not 3.35.0.
+// Reported as part of https://github.com/typetools/checker-framework/issues/6077.
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class IndexMode
+{
+  public static final IndexMode NOT_INDEXED = new IndexMode(Mode.PREFIX, true, false, NonTokenizingAnalyzer.class, 0);
+
+  private static class NonTokenizingAnalyzer {
+
+  }
+
+  private static final String INDEX_MODE_OPTION = "mode";
+  private static final String INDEX_ANALYZED_OPTION = "analyzed";
+  private static final String INDEX_ANALYZER_CLASS_OPTION = "analyzer_class";
+  private static final String INDEX_IS_LITERAL_OPTION = "is_literal";
+  private static final String INDEX_MAX_FLUSH_MEMORY_OPTION = "max_compaction_flush_memory_in_mb";
+  private static final double INDEX_MAX_FLUSH_DEFAULT_MULTIPLIER = 0.15;
+  private static final long DEFAULT_MAX_MEM_BYTES = (long) (1073741824 * INDEX_MAX_FLUSH_DEFAULT_MULTIPLIER); // 1G default for memtable
+
+  public final Mode mode;
+  public final boolean isAnalyzed, isLiteral;
+  public final Class analyzerClass;
+  public final long maxCompactionFlushMemoryInBytes;
+
+  private IndexMode(Mode mode, boolean isLiteral, boolean isAnalyzed, Class analyzerClass, long maxMemBytes)
+  {
+    this.mode = mode;
+    this.isLiteral = isLiteral;
+    this.isAnalyzed = isAnalyzed;
+    this.analyzerClass = analyzerClass;
+    this.maxCompactionFlushMemoryInBytes = maxMemBytes;
+  }
+
+  public static class ColumnMetadata {
+    public AbstractType<?> cellValueType() { return null; }
+  }
+
+  public static class AbstractType<T> {
+
+  }
+
+  public static class UTF8Type extends AbstractType<UTF8Type> {
+
+  }
+
+  public static class AsciiType extends AbstractType<AsciiType> {
+
+  }
+
+  public static IndexMode getMode(ColumnMetadata column, Map<String, String> indexOptions) throws ConfigurationException
+  {
+    if (indexOptions == null || indexOptions.isEmpty())
+      return IndexMode.NOT_INDEXED;
+
+    Mode mode;
+
+    try
+    {
+      mode = indexOptions.get(INDEX_MODE_OPTION) == null
+          ? Mode.PREFIX
+          : Mode.mode(indexOptions.get(INDEX_MODE_OPTION));
+    }
+    catch (IllegalArgumentException e)
+    {
+      throw new ConfigurationException("Incorrect index mode: " + indexOptions.get(INDEX_MODE_OPTION));
+    }
+
+    boolean isAnalyzed = false;
+    Class analyzerClass = null;
+    try
+    {
+      if (indexOptions.get(INDEX_ANALYZER_CLASS_OPTION) != null)
+      {
+        analyzerClass = Class.forName(indexOptions.get(INDEX_ANALYZER_CLASS_OPTION));
+        isAnalyzed = indexOptions.get(INDEX_ANALYZED_OPTION) == null
+            ? true : Boolean.parseBoolean(indexOptions.get(INDEX_ANALYZED_OPTION));
+      }
+      else if (indexOptions.get(INDEX_ANALYZED_OPTION) != null)
+      {
+        isAnalyzed = Boolean.parseBoolean(indexOptions.get(INDEX_ANALYZED_OPTION));
+      }
+    }
+    catch (ClassNotFoundException e)
+    { }
+
+    boolean isLiteral = false;
+    try
+    {
+      String literalOption = indexOptions.get(INDEX_IS_LITERAL_OPTION);
+      AbstractType<?> validator = column.cellValueType();
+
+      isLiteral = literalOption == null
+          ? (validator instanceof UTF8Type || validator instanceof AsciiType)
+          : Boolean.parseBoolean(literalOption);
+    }
+    catch (Exception e)
+    {
+    }
+
+    long maxMemBytes = indexOptions.get(INDEX_MAX_FLUSH_MEMORY_OPTION) == null
+        ? DEFAULT_MAX_MEM_BYTES
+        : 1048576L * Long.parseLong(indexOptions.get(INDEX_MAX_FLUSH_MEMORY_OPTION));
+
+    if (maxMemBytes > 100L * 1073741824)
+    {
+      maxMemBytes = DEFAULT_MAX_MEM_BYTES;
+    }
+    return new IndexMode(mode, isLiteral, isAnalyzed, analyzerClass, maxMemBytes);
+  }
+
+  public enum Mode {
+    PREFIX, OTHER;
+
+    static Mode mode(String s) { return OTHER; }
+  }
+
+  public static class ConfigurationException extends Exception {
+    public ConfigurationException(String s) {
+
+    }
+  }
+}

--- a/checker/tests/resourceleak/IndexMode.java
+++ b/checker/tests/resourceleak/IndexMode.java
@@ -27,6 +27,18 @@ public class IndexMode {
     return null;
   }
 
+  // This copy of getMode() adds an explicit `@MustCall` annotation to the String and to
+  // the local variable. This version currently works as expected, unlike getMode2().
+  public static Object getMode2a(Map<String, @MustCall("hashCode") String> indexOptions) {
+    try {
+      // :: error: required.method.not.called
+      @MustCall("hashCode") String literalOption = indexOptions.get("is_literal");
+    } catch (Exception e) {
+    }
+
+    return null;
+  }
+
   // This copy of getMode() adds an explicit `@MustCall` annotation to the String and removes
   // the try-catch.
   public static Object getMode3(Map<String, @MustCall("hashCode") String> indexOptions) {

--- a/checker/tests/resourceleak/IndexMode.java
+++ b/checker/tests/resourceleak/IndexMode.java
@@ -1,127 +1,17 @@
 // A test for a new false positive issued in release 3.36.0 but not 3.35.0.
 // Reported as part of https://github.com/typetools/checker-framework/issues/6077.
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
-public class IndexMode
-{
-  public static final IndexMode NOT_INDEXED = new IndexMode(Mode.PREFIX, true, false, NonTokenizingAnalyzer.class, 0);
-
-  private static class NonTokenizingAnalyzer {
-
-  }
-
-  private static final String INDEX_MODE_OPTION = "mode";
-  private static final String INDEX_ANALYZED_OPTION = "analyzed";
-  private static final String INDEX_ANALYZER_CLASS_OPTION = "analyzer_class";
-  private static final String INDEX_IS_LITERAL_OPTION = "is_literal";
-  private static final String INDEX_MAX_FLUSH_MEMORY_OPTION = "max_compaction_flush_memory_in_mb";
-  private static final double INDEX_MAX_FLUSH_DEFAULT_MULTIPLIER = 0.15;
-  private static final long DEFAULT_MAX_MEM_BYTES = (long) (1073741824 * INDEX_MAX_FLUSH_DEFAULT_MULTIPLIER); // 1G default for memtable
-
-  public final Mode mode;
-  public final boolean isAnalyzed, isLiteral;
-  public final Class analyzerClass;
-  public final long maxCompactionFlushMemoryInBytes;
-
-  private IndexMode(Mode mode, boolean isLiteral, boolean isAnalyzed, Class analyzerClass, long maxMemBytes)
-  {
-    this.mode = mode;
-    this.isLiteral = isLiteral;
-    this.isAnalyzed = isAnalyzed;
-    this.analyzerClass = analyzerClass;
-    this.maxCompactionFlushMemoryInBytes = maxMemBytes;
-  }
-
-  public static class ColumnMetadata {
-    public AbstractType<?> cellValueType() { return null; }
-  }
-
-  public static class AbstractType<T> {
-
-  }
-
-  public static class UTF8Type extends AbstractType<UTF8Type> {
-
-  }
-
-  public static class AsciiType extends AbstractType<AsciiType> {
-
-  }
-
-  public static IndexMode getMode(ColumnMetadata column, Map<String, String> indexOptions) throws ConfigurationException
-  {
-    if (indexOptions == null || indexOptions.isEmpty())
-      return IndexMode.NOT_INDEXED;
-
-    Mode mode;
-
-    try
-    {
-      mode = indexOptions.get(INDEX_MODE_OPTION) == null
-          ? Mode.PREFIX
-          : Mode.mode(indexOptions.get(INDEX_MODE_OPTION));
-    }
-    catch (IllegalArgumentException e)
-    {
-      throw new ConfigurationException("Incorrect index mode: " + indexOptions.get(INDEX_MODE_OPTION));
+public class IndexMode {
+  public static Object getMode(Map<String, String> indexOptions) {
+    // Try-catch is needed, otherwise no FP.
+    try {
+      String literalOption = indexOptions.get("is_literal");
+    } catch (Exception e) {
     }
 
-    boolean isAnalyzed = false;
-    Class analyzerClass = null;
-    try
-    {
-      if (indexOptions.get(INDEX_ANALYZER_CLASS_OPTION) != null)
-      {
-        analyzerClass = Class.forName(indexOptions.get(INDEX_ANALYZER_CLASS_OPTION));
-        isAnalyzed = indexOptions.get(INDEX_ANALYZED_OPTION) == null
-            ? true : Boolean.parseBoolean(indexOptions.get(INDEX_ANALYZED_OPTION));
-      }
-      else if (indexOptions.get(INDEX_ANALYZED_OPTION) != null)
-      {
-        isAnalyzed = Boolean.parseBoolean(indexOptions.get(INDEX_ANALYZED_OPTION));
-      }
-    }
-    catch (ClassNotFoundException e)
-    { }
-
-    boolean isLiteral = false;
-    try
-    {
-      String literalOption = indexOptions.get(INDEX_IS_LITERAL_OPTION);
-      AbstractType<?> validator = column.cellValueType();
-
-      isLiteral = literalOption == null
-          ? (validator instanceof UTF8Type || validator instanceof AsciiType)
-          : Boolean.parseBoolean(literalOption);
-    }
-    catch (Exception e)
-    {
-    }
-
-    long maxMemBytes = indexOptions.get(INDEX_MAX_FLUSH_MEMORY_OPTION) == null
-        ? DEFAULT_MAX_MEM_BYTES
-        : 1048576L * Long.parseLong(indexOptions.get(INDEX_MAX_FLUSH_MEMORY_OPTION));
-
-    if (maxMemBytes > 100L * 1073741824)
-    {
-      maxMemBytes = DEFAULT_MAX_MEM_BYTES;
-    }
-    return new IndexMode(mode, isLiteral, isAnalyzed, analyzerClass, maxMemBytes);
-  }
-
-  public enum Mode {
-    PREFIX, OTHER;
-
-    static Mode mode(String s) { return OTHER; }
-  }
-
-  public static class ConfigurationException extends Exception {
-    public ConfigurationException(String s) {
-
-    }
+    // Actual return type rather than void is needed, otherwise no FP.
+    return null;
   }
 }

--- a/checker/tests/resourceleak/IndexMode.java
+++ b/checker/tests/resourceleak/IndexMode.java
@@ -1,6 +1,7 @@
 // A test for a new false positive issued in release 3.36.0 but not 3.35.0.
 // Reported as part of https://github.com/typetools/checker-framework/issues/6077.
 
+import java.io.InputStream;
 import java.util.Map;
 import org.checkerframework.checker.mustcall.qual.MustCall;
 
@@ -19,7 +20,15 @@ public class IndexMode {
   // This copy of getMode() adds an explicit `@MustCall` annotation to the String.
   public static Object getMode2(Map<String, @MustCall("hashCode") String> indexOptions) {
     try {
-      // :: error: required.method.not.called
+      // TODO: a required.method.not.called error should be issued on this line, but currently
+      // it is not. The reason is an interaction between type variable defaulting,
+      // local dataflow, and the rules that the RLC uses for choosing a variable's must-call
+      // obligations: local inference defaults literalOption to @MustCallUnknown (i.e., the
+      // top MustCall type) even though the RHS expression's type is @MustCall("hashCode").
+      // Then, the rule for obligations says that if a variable has the top must-call type,
+      // use the type's default must-call type instead. For String, this is @MustCall({}),
+      // so no error is issued. This rule is important to avoid false positives in realistic
+      // code (such as the first getMode() method in this class).
       String literalOption = indexOptions.get("is_literal");
     } catch (Exception e) {
     }
@@ -52,5 +61,23 @@ public class IndexMode {
   public static void getMode4(Map<String, @MustCall("hashCode") String> indexOptions) {
     // :: error: required.method.not.called
     String literalOption = indexOptions.get("is_literal");
+  }
+
+  // This copy of getMode() removes the try-catch and makes the return type void.
+  public static void getMode5(Map<String, String> indexOptions) {
+    String literalOption = indexOptions.get("is_literal");
+  }
+
+  // This variant uses an InputStream (which has a MustCall type by default) as the
+  // value type in the map.
+  // :: error: type.argument
+  public static Object getModeIS(Map<String, InputStream> indexOptions) {
+    try {
+      // :: error: required.method.not.called
+      InputStream literalOption = indexOptions.get("is_literal");
+    } catch (Exception e) {
+    }
+
+    return null;
   }
 }

--- a/checker/tests/resourceleak/SocketIntoList.java
+++ b/checker/tests/resourceleak/SocketIntoList.java
@@ -1,0 +1,45 @@
+// This test case demonstrates that the checker does issue a warning when
+// a socket with an obligation is stored into a List<Socket> (which cannot be
+// owning).
+
+import java.net.*;
+import java.util.List;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class SocketIntoList {
+  public void test1(List<@MustCall({}) Socket> l) {
+    // s is unconnected, so no error is expected when it's stored into a list
+    Socket s = new Socket();
+    l.add(s);
+  }
+
+  // :: error: type.argument
+  public void test2(List<Socket> l) {
+    // s is unconnected, so no error is expected when it's stored into the list.
+    // But, if the list is unannotated, we do get an error at its declaration site
+    // (as expected, due to #5912).
+    Socket s = new Socket();
+    l.add(s);
+  }
+
+  public void test3(List<@MustCall({}) Socket> l) throws Exception {
+    // :: error: required.method.not.called
+    Socket s = new Socket();
+    s.bind(new InetSocketAddress("192.168.0.1", 0));
+    l.add(s);
+  }
+
+  // This input list might have been produced by e.g., test1()
+  public void test4(List<@MustCall({}) Socket> l) throws Exception {
+    // :: error: required.method.not.called
+    Socket s = l.get(0);
+    s.bind(new InetSocketAddress("192.168.0.1", 0));
+  }
+
+  // This input list might have been produced by e.g., test1()
+  public void test5(List<@MustCall({}) Socket> l) throws Exception {
+    // No error is expected here, because the socket should be @MustCall({}) when
+    // it is retrieved from the list. (Equivalently, the list is not owning).
+    Socket s = l.get(0);
+  }
+}


### PR DESCRIPTION
This fixes at least one of the false positives reported in #6077, but I'm a bit unsure of how safe this change is. @msridhar, I'd appreciate it if you can look over the whole method in which I made this change: the approach for pulling the `@MustCall` type here seems a bit sketchy in general.

Merge with https://github.com/codespecs/daikon/pull/498.