### PR TITLE
Don't use `var` declarations as assignment context

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -1646,8 +1646,8 @@ public abstract class GenericAnnotatedTypeFactory<
    * this default is too conservative. So this method is used instead of {@link
    * GenericAnnotatedTypeFactory#getAnnotatedTypeLhs(Tree)}.
    *
-   * <p>{@link TypeArgInferenceUtil#assignedToVariable(AnnotatedTypeFactory, Tree)} explains why a
-   * different type is used.
+   * <p>{@link TypeArgInferenceUtil#assignedToVariable(AnnotatedTypeFactory, VariableTree)} explains
+   * why a different type is used.
    *
    * @param lhsTree left-hand side of an assignment
    * @return AnnotatedTypeMirror of {@code lhsTree}

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference/TypeArgInferenceUtil.java
@@ -211,7 +211,7 @@ public class TypeArgInferenceUtil {
       }
 
     } else if (assignmentContext instanceof VariableTree) {
-      res = assignedToVariable(atypeFactory, assignmentContext);
+      res = assignedToVariable(atypeFactory, (VariableTree) assignmentContext);
     } else {
       throw new BugInCF("AnnotatedTypes.assignedTo: shouldn't be here");
     }
@@ -331,7 +331,10 @@ public class TypeArgInferenceUtil {
    * @return AnnotatedTypeMirror of Assignment context
    */
   public static AnnotatedTypeMirror assignedToVariable(
-      AnnotatedTypeFactory atypeFactory, Tree assignmentContext) {
+      AnnotatedTypeFactory atypeFactory, VariableTree assignmentContext) {
+    if (TreeUtils.isVariableTreeDeclaredUsingVar(assignmentContext)) {
+      return null;
+    }
     if (atypeFactory instanceof GenericAnnotatedTypeFactory<?, ?, ?, ?>) {
       GenericAnnotatedTypeFactory<?, ?, ?, ?> gatf =
           ((GenericAnnotatedTypeFactory<?, ?, ?, ?>) atypeFactory);

--- a/framework/tests/all-systems/Issue6098.java
+++ b/framework/tests/all-systems/Issue6098.java
@@ -1,0 +1,9 @@
+public class Issue6098 {
+  <T> T method(T t) {
+    return t;
+  }
+
+  void use() {
+    var c = method("");
+  }
+}


### PR DESCRIPTION
Fixes #6098.