### PR TITLE
Add Signature annotations instead of suppressing warnings.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -750,13 +750,13 @@ public class WholeProgramInferenceJavaParserStorage
               className = ElementUtils.getBinaryName(classElt);
               for (TypeElement supertypeElement : ElementUtils.getSuperTypes(classElt, elements)) {
                 String supertypeName = ElementUtils.getBinaryName(supertypeElement);
-                @SuppressWarnings("signature:return") // #97
                 Set<@BinaryName String> supertypeSet =
-                    supertypesMap.computeIfAbsent(className, k -> new TreeSet<>());
+                    supertypesMap.computeIfAbsent(
+                        className, k -> new TreeSet<@BinaryName String>());
                 supertypeSet.add(supertypeName);
-                @SuppressWarnings("signature:return") // #97
                 Set<@BinaryName String> subtypeSet =
-                    subtypesMap.computeIfAbsent(supertypeName, k -> new TreeSet<>());
+                    subtypesMap.computeIfAbsent(
+                        supertypeName, k -> new TreeSet<@BinaryName String>());
                 subtypeSet.add(className);
               }
             }

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -750,12 +750,12 @@ public class WholeProgramInferenceJavaParserStorage
               className = ElementUtils.getBinaryName(classElt);
               for (TypeElement supertypeElement : ElementUtils.getSuperTypes(classElt, elements)) {
                 String supertypeName = ElementUtils.getBinaryName(supertypeElement);
-                @SuppressWarnings({"signature:assignment", "signature:return"}) // #979?
-                Set<String> supertypeSet =
+                @SuppressWarnings("signature:return") // #97
+                Set<@BinaryName String> supertypeSet =
                     supertypesMap.computeIfAbsent(className, k -> new TreeSet<>());
                 supertypeSet.add(supertypeName);
-                @SuppressWarnings({"signature:assignment", "signature:return"}) // #979?
-                Set<String> subtypeSet =
+                @SuppressWarnings("signature:return") // #97
+                Set<@BinaryName String> subtypeSet =
                     subtypesMap.computeIfAbsent(supertypeName, k -> new TreeSet<>());
                 subtypeSet.add(className);
               }


### PR DESCRIPTION
The annotation in `k -> new TreeSet<@BinaryName String>()` isn't needed when type argument inference is implemented.