### PR TITLE
Make `ExtendedNode` and `Label` public again

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
@@ -18,6 +18,9 @@ import org.checkerframework.javacutil.BugInCF;
  *   <li><em>TWO_TARGET_CONDITIONAL_JUMP</em>: {@link ConditionalJump}. A conditional jump with two
  *       targets for both the 'then' and 'else' branch.
  * </ul>
+ *
+ * Note that this class is deliberately public, to enable users of the dataflow library to customize
+ * CFG construction.
  */
 @SuppressWarnings("nullness") // TODO
 abstract class ExtendedNode {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
@@ -20,7 +20,7 @@ import org.checkerframework.javacutil.BugInCF;
  * </ul>
  */
 @SuppressWarnings("nullness") // TODO
-/*package-private*/ abstract class ExtendedNode {
+abstract class ExtendedNode {
 
   /** The basic block this extended node belongs to (as determined in phase two). */
   protected BlockImpl block;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -5,7 +5,7 @@ package org.checkerframework.dataflow.cfg.builder;
  * Labels get their names either from labeled statements in the source code or from internally
  * generated unique names.
  */
-/*package-private*/ class Label {
+class Label {
 
   /** Unique id counter that incremented in {@code #uniqueName}. */
   private static int uid = 0;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -4,6 +4,9 @@ package org.checkerframework.dataflow.cfg.builder;
  * A label is used to refer to other extended nodes using a mapping from labels to extended nodes.
  * Labels get their names either from labeled statements in the source code or from internally
  * generated unique names.
+ *
+ * <p>Note that this class is deliberately public, to enable users of the dataflow library to
+ * customize CFG construction.
  */
 class Label {
 


### PR DESCRIPTION
In #5955, the `ExtendedNode` and `Label` classes from the dataflow framework were changed from public to package-private.  However, NullAway relies on these classes being public (see https://github.com/typetools/checker-framework/pull/5156, https://github.com/typetools/checker-framework/pull/5152, and https://github.com/uber/NullAway/pull/608).  This PR makes the classes public again and adds an explanatory comment.