### PR TITLE
Enable accumulation checkers to accumulate facts on type variables for fields

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1472,12 +1472,16 @@ class MustCallConsistencyAnalyzer {
     AccumulationStore cmStoreBefore = typeFactory.getStoreBefore(rhs);
     AccumulationValue cmValue = cmStoreBefore == null ? null : cmStoreBefore.getValue(lhs);
     AnnotationMirror cmAnno = null;
-    if (cmValue != null) {
-      for (AnnotationMirror anno : cmValue.getAnnotations()) {
-        if (AnnotationUtils.areSameByName(
-            anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods")) {
-          cmAnno = anno;
-          break;
+    if (cmValue != null) { // When store contains the lhs
+      Set<String> accumulatedValues = cmValue.getAccumulatedValues();
+      if (accumulatedValues != null) { // type variable or wildcard type
+        cmAnno = typeFactory.createCalledMethods(accumulatedValues.toArray(new String[0]));
+      } else {
+        for (AnnotationMirror anno : cmValue.getAnnotations()) {
+          if (AnnotationUtils.areSameByName(
+              anno, "org.checkerframework.checker.calledmethods.qual.CalledMethods")) {
+            cmAnno = anno;
+          }
         }
       }
     }

--- a/checker/tests/resourceleak/AccumulationValueFieldTest.java
+++ b/checker/tests/resourceleak/AccumulationValueFieldTest.java
@@ -1,0 +1,40 @@
+// This test checks the accumulation value for a field with a wildcard type.
+
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class AccumulationValueFieldTest {
+
+  @InheritableMustCall({"a"})
+  class MCAB {
+    void a() {}
+
+    void b() {}
+  }
+
+  @InheritableMustCall({"a"})
+  class FieldTest<T extends MCAB> {
+
+    @Owning
+    @MustCall({"a"}) T m = null;
+
+    FieldTest(@Owning @MustCall({"a"}) T mcab) {
+      m = mcab;
+    }
+
+    @RequiresCalledMethods(
+        value = {"this.m"},
+        methods = {"a"})
+    @CreatesMustCallFor("this")
+    void overwriteMCorrect(@Owning @MustCall({"a"}) T mcab) {
+      this.m = mcab;
+    }
+
+    @EnsuresCalledMethods(
+        value = {"this.m"},
+        methods = {"a"})
+    void a() {
+      m.a();
+    }
+  }
+}


### PR DESCRIPTION
This PR checks AccumulationValue to support fields with type variable in RLC.