### PR TITLE
Make `ExtendedNode` and `Label` public (really)

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/ExtendedNode.java
@@ -23,7 +23,7 @@ import org.checkerframework.javacutil.BugInCF;
  * CFG construction.
  */
 @SuppressWarnings("nullness") // TODO
-abstract class ExtendedNode {
+public abstract class ExtendedNode {
 
   /** The basic block this extended node belongs to (as determined in phase two). */
   protected BlockImpl block;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/Label.java
@@ -8,7 +8,7 @@ package org.checkerframework.dataflow.cfg.builder;
  * <p>Note that this class is deliberately public, to enable users of the dataflow library to
  * customize CFG construction.
  */
-class Label {
+public class Label {
 
   /** Unique id counter that incremented in {@code #uniqueName}. */
   private static int uid = 0;


### PR DESCRIPTION
No idea how this happened, but it seems in #6130 I neglected to add `public` keywords to the relevant classes.  