### PR TITLE
Document 0-indexing

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -1499,7 +1499,7 @@ public class WholeProgramInferenceJavaParserStorage
      * Adds a declaration annotation to this parameter and returns whether it was a new annotation.
      *
      * @param annotation the declaration annotation to add
-     * @param index index of the parameter
+     * @param index index of the parameter (0-indexed)
      * @return true if {@code annotation} wasn't previously stored for this parameter
      */
     public boolean addDeclarationAnnotationToFormalParameter(


### PR DESCRIPTION
Most parts of the Checker Framework use 1-indexing for formal parameters, to emphasize that the receiver is a formal parameter.  I wonder whether WPI should use that convention, too.