### PR TITLE
Updating `wpi.sh` to support execution from binary distribution

### DIFF
--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -312,9 +312,14 @@ if [ "${DLJC}" = "" ]; then
   # The user did not set the DLJC environment variable.
   if [ ! -f "${CHECKERFRAMEWORK}/gradlew" ]; then
       # The user is likely executing wpi.sh from a binary distribution of the
-      # Checker Framework. 
-      echo "Fix me: clone do-like-javac"
+      # Checker Framework.
+      if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
+        (cd "${SCRIPTDIR}" && (git clone -b master -q --single-branch --depth 1 "https://github.com/plume-lib/plume-scripts.git"))
+        "${SCRIPTDIR}"/plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
+      fi
   else
+      # Otherwise, assume the user is executing wpi.sh from a locally-built
+      # version of the Checker Framework.
       (cd "${SCRIPTDIR}"/../.. && (./gradlew --stacktrace getPlumeScripts || (sleep 60s && ./gradlew --stacktrace getPlumeScripts)))
       "${SCRIPTDIR}"/../bin-devel/.plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
       if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -324,10 +324,10 @@ if [ "${DLJC}" = "" ]; then
       # version of the Checker Framework.
       (cd "${SCRIPTDIR}"/../.. && (./gradlew --stacktrace getPlumeScripts || (sleep 60s && ./gradlew --stacktrace getPlumeScripts)))
       "${SCRIPTDIR}"/../bin-devel/.plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
-      if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
-          echo "Failed to clone do-like-javac"
-          exit 1
-      fi
+  fi
+  if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
+      echo "Failed to clone do-like-javac"
+      exit 1
   fi
   DLJC="${SCRIPTDIR}/.do-like-javac/dljc"
 else

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -316,6 +316,8 @@ if [ "${DLJC}" = "" ]; then
       if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
         (cd "${SCRIPTDIR}" && (git clone -b master -q --single-branch --depth 1 "https://github.com/plume-lib/plume-scripts.git"))
         "${SCRIPTDIR}"/plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
+      else
+        (cd "${SCRIPTDIR}/.do-like-javac" && (git pull -q))
       fi
   else
       # Otherwise, assume the user is executing wpi.sh from a locally-built

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -307,6 +307,11 @@ stdout is in      $dljc_stdout"
 
 #### Check and setup dependencies
 
+# Proposed changes
+# - If the DLJC environment variable is not set:
+#   - Check if the script is being executed from the binary distribution
+#   - If so, means there isn't going to be gradle or the getPlumeScripts deps.
+
 # Clone or update DLJC
 if [ "${DLJC}" = "" ]; then
   # The user did not set the DLJC environment variable.

--- a/checker/bin/wpi.sh
+++ b/checker/bin/wpi.sh
@@ -307,19 +307,20 @@ stdout is in      $dljc_stdout"
 
 #### Check and setup dependencies
 
-# Proposed changes
-# - If the DLJC environment variable is not set:
-#   - Check if the script is being executed from the binary distribution
-#   - If so, means there isn't going to be gradle or the getPlumeScripts deps.
-
 # Clone or update DLJC
 if [ "${DLJC}" = "" ]; then
   # The user did not set the DLJC environment variable.
-  (cd "${SCRIPTDIR}"/../.. && (./gradlew --stacktrace getPlumeScripts || (sleep 60s && ./gradlew --stacktrace getPlumeScripts)))
-  "${SCRIPTDIR}"/../bin-devel/.plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
-  if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
-      echo "Failed to clone do-like-javac"
-      exit 1
+  if [ ! -f "${CHECKERFRAMEWORK}/gradlew" ]; then
+      # The user is likely executing wpi.sh from a binary distribution of the
+      # Checker Framework. 
+      echo "Fix me: clone do-like-javac"
+  else
+      (cd "${SCRIPTDIR}"/../.. && (./gradlew --stacktrace getPlumeScripts || (sleep 60s && ./gradlew --stacktrace getPlumeScripts)))
+      "${SCRIPTDIR}"/../bin-devel/.plume-scripts/git-clone-related kelloggm do-like-javac "${SCRIPTDIR}"/.do-like-javac
+      if [ ! -d "${SCRIPTDIR}/.do-like-javac" ]; then
+          echo "Failed to clone do-like-javac"
+          exit 1
+      fi
   fi
   DLJC="${SCRIPTDIR}/.do-like-javac/dljc"
 else


### PR DESCRIPTION
This PR proposes a change to `wpi.sh` to enable its execution from a binary distribution of the CF. See #6155 for more details.

At a high level, the proposed changes are:

* Check if the `gradlew` wrapper exists In the user-set `CHECKERFRAMEWORK` env variable.
  * If it exists, then resume the same behaviour as before
  * If it does not exist, it's likely the user is executing `wpi.sh` from a binary distribution. In this case, the relevant scripts from `plume-scripts` should be cloned and used to download the `do-like-javac` dependency.

I'm not super experienced with bash, so I'd love any feedback on best practices and such.