### PR TITLE
Updating inference.tex (wpi-many.sh docs)

### DIFF
--- a/docs/manual/inference.tex
+++ b/docs/manual/inference.tex
@@ -281,8 +281,9 @@ not want to use GitHub, construct a file yourself that matches the format of
 the file \<securerandom.list>.
 
 \item Use \<wpi-many.sh> to run whole-program inference on every
-Ant, Gradle, or Maven project in a list of (GitHub repository URL, git hash)
-pairs.
+Ant, Gradle, or Maven project in a list of GitHub repository URL and git hash
+pairs (GitHub-repository-URL git-hash)
+The GitHub repository URL and git hash should be whitespace-separated.
 \begin{itemize}
 \item If you are using a checker that is distributed with the Checker
 Framework, use \<wpi-many.sh> directly.

--- a/docs/manual/inference.tex
+++ b/docs/manual/inference.tex
@@ -280,10 +280,10 @@ created by running \<query-github.sh securerandom.query 100>. If you do
 not want to use GitHub, construct a file yourself that matches the format of
 the file \<securerandom.list>.
 
-\item Use \<wpi-many.sh> to run whole-program inference on every
-Ant, Gradle, or Maven project in a list of GitHub repository URL and git hash
-pairs (GitHub-repository-URL git-hash)
-The GitHub repository URL and git hash should be whitespace-separated.
+\item Use \<wpi-many.sh> to run whole-program inference on multiple
+Ant, Gradle, or Maven projects.  You provide it a file in which each line
+is ``GitHub repository URL'' ``git hash'' (with no quotes, and with
+whitespace between them).
 \begin{itemize}
 \item If you are using a checker that is distributed with the Checker
 Framework, use \<wpi-many.sh> directly.


### PR DESCRIPTION
The format of the GitHub repository URL and git hash pairs provided as input to `wpi-many.sh` is not clear. The current documentation, i.e.,

> Use wpi-many.sh to run whole-program inference on every Ant, Gradle, or Maven project in a list of (GitHub repository URL, git hash) pairs.

Available [here](https://checkerframework.org/manual/#wpi-many) suggests that the the elements of the pairs should be comma-separated, when it in fact should be whitespace-separated.