### PR TITLE
Handle EnsuresCalledMethods.List when checking field ownership

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -385,6 +385,11 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
     return super.getTypeFactoryOfSubcheckerOrNull(subCheckerClass);
   }
 
+  /**
+   * Returns the {@link EnsuresCalledMethods.List#value} element.
+   *
+   * @return the {@link EnsuresCalledMethods.List#value} element
+   */
   public ExecutableElement getEnsuresCalledMethodsListValueElement() {
     return ensuresCalledMethodsListValueElement;
   }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -60,6 +60,10 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
   /*package-private*/ final ExecutableElement ensuresCalledMethodsMethodsElement =
       TreeUtils.getMethod(EnsuresCalledMethods.class, "methods", 0, processingEnv);
 
+  /** The EnsuresCalledMethods.List.value element/field. */
+  private final ExecutableElement ensuresCalledMethodsListValueElement =
+      TreeUtils.getMethod(EnsuresCalledMethods.List.class, "value", 0, processingEnv);
+
   /** The CreatesMustCallFor.List.value element/field. */
   private final ExecutableElement createsMustCallForListValueElement =
       TreeUtils.getMethod(CreatesMustCallFor.List.class, "value", 0, processingEnv);
@@ -379,6 +383,10 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
       }
     }
     return super.getTypeFactoryOfSubcheckerOrNull(subCheckerClass);
+  }
+
+  public ExecutableElement getEnsuresCalledMethodsListValueElement() {
+    return ensuresCalledMethodsListValueElement;
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -323,21 +323,20 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
   @Pure
   private static AnnotationMirrorSet getEnsuresCalledMethodsAnnotations(
       ExecutableElement elt, ResourceLeakAnnotatedTypeFactory atypeFactory) {
-    AnnotationMirror createsMustCallForList =
+    AnnotationMirror ensuresCalledMethodsAnnos =
         atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethods.List.class);
     AnnotationMirrorSet result = new AnnotationMirrorSet();
-    if (createsMustCallForList != null) {
-      List<AnnotationMirror> createsMustCallFors =
+    if (ensuresCalledMethodsAnnos != null) {
+      result.addAll(
           AnnotationUtils.getElementValueArray(
-              createsMustCallForList,
+              ensuresCalledMethodsAnnos,
               atypeFactory.getEnsuresCalledMethodsListValueElement(),
-              AnnotationMirror.class);
-      result.addAll(createsMustCallFors);
+              AnnotationMirror.class));
     }
-    AnnotationMirror createsMustCallFor =
+    AnnotationMirror ensuresCalledMethod =
         atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethods.class);
-    if (createsMustCallFor != null) {
-      result.add(createsMustCallFor);
+    if (ensuresCalledMethod != null) {
+      result.add(ensuresCalledMethod);
     }
     return result;
   }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -21,6 +21,7 @@ import org.checkerframework.checker.mustcall.qual.NotOwning;
 import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.dataflow.expression.JavaExpression;
+import org.checkerframework.dataflow.qual.Pure;
 import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
@@ -312,6 +313,14 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
     return result;
   }
 
+  /**
+   * Get all {@link EnsuresCalledMethods} annotations on an element.
+   *
+   * @param elt an executable element that might have {@link EnsuresCalledMethods} annotations
+   * @param atypeFactory a <code>ResourceLeakAnnotatedTypeFactory</code>
+   * @return a set of {@link EnsuresCalledMethods} annotations
+   */
+  @Pure
   private static AnnotationMirrorSet getEnsuresCalledMethodsAnnotations(
       ExecutableElement elt, ResourceLeakAnnotatedTypeFactory atypeFactory) {
     AnnotationMirror createsMustCallForList =

--- a/checker/tests/resourceleak/MultipleOwnedResources.java
+++ b/checker/tests/resourceleak/MultipleOwnedResources.java
@@ -1,0 +1,28 @@
+// Test case for https://github.com/typetools/checker-framework/issues/5911
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+class MultipleOwnedResources implements Closeable {
+
+  private final @Owning Closeable r1;
+  private final @Owning Closeable r2;
+
+  public MultipleOwnedResources(@Owning Closeable r1, @Owning Closeable r2) {
+    this.r1 = r1;
+    this.r2 = r2;
+  }
+
+  @Override
+  @EnsuresCalledMethods(
+      value = {"r1", "r2"},
+      methods = {"close"})
+  public void close() throws IOException {
+    try {
+      r1.close();
+    } finally {
+      r2.close();
+    }
+  }
+}

--- a/checker/tests/resourceleak/MultipleOwnedResourcesOfDifferentTypes.java
+++ b/checker/tests/resourceleak/MultipleOwnedResourcesOfDifferentTypes.java
@@ -1,0 +1,44 @@
+// Test case for https://github.com/typetools/checker-framework/issues/5911
+
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+class MultipleOwnedResourcesOfDifferentTypes {
+
+  @InheritableMustCall("a")
+  static class Foo {
+    void a() {}
+  }
+
+  @InheritableMustCall("b")
+  static class Bar {
+    void b() {}
+  }
+
+  @InheritableMustCall("finalizer")
+  static class OwningField {
+
+    private final @Owning Foo owningFoo;
+
+    private final @Owning Bar owningBar;
+
+    public OwningField() {
+      this.owningFoo = new Foo();
+      this.owningBar = new Bar();
+    }
+
+    @EnsuresCalledMethods(
+        value = {"owningBar"},
+        methods = {"b"})
+    @EnsuresCalledMethods(
+        value = {"this.owningFoo"},
+        methods = {"a"})
+    void finalizer() {
+      try {
+        this.owningFoo.a();
+      } finally {
+        this.owningBar.b();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #5911.

Please let me know if there is a shorter or more canonical way to write `getEnsuresCalledMethodsAnnotations`; this seems like something a lot of checkers have to do, but I couldn't find an appropriate helper method.