### PR TITLE
Use an artifact version of the stubparser.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ import org.ajoberstar.grgit.Grgit
 
 // There is another `repositories { ... }` block below; if you change this one, change that one as well.
 repositories {
+  maven { url 'https://oss.sonatype.org/content/repositories/snapshots/'}
   mavenCentral()
 }
 
@@ -40,10 +41,6 @@ ext {
 
   annotationTools = "${parentDir}/annotation-tools"
   afu = "${annotationTools}/annotation-file-utilities"
-
-  stubparser = "${parentDir}/stubparser"
-  stubparserVersion = "3.25.5"
-  stubparserJar = "${stubparser}/javaparser-core/target/stubparser-${stubparserVersion}.jar"
 
   plumeScriptsHome = "${project(':checker').projectDir}/bin-devel/.plume-scripts"
   htmlToolsHome = "${project(':checker').projectDir}/bin-devel/.html-tools"
@@ -131,6 +128,7 @@ allprojects {
 
   // Keep in sync with "repositories { ... }" block above.
   repositories {
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/'}
     mavenCentral()
   }
 
@@ -415,46 +413,6 @@ allprojects {
 task cloneAndBuildDependencies(type: Exec, group: 'Build') {
   description 'Clones (or updates) and builds all dependencies'
   executable 'checker/bin-devel/build.sh'
-}
-
-task maybeCloneAndBuildDependencies() {
-  // No group so it does not show up in the output of `gradlew tasks`
-  description 'Clones (or updates) and builds all dependencies if they are not present.'
-  onlyIf {
-    !file(stubparserJar).exists()
-    // The jdk repository is cloned via the copyAndMinimizeAnnotatedJdkFiles task that is run if
-    // the repository does not exist when building checker.jar.
-  }
-
-  doFirst {
-    if (file(stubparser).exists()) {
-      exec {
-        workingDir stubparser
-        executable 'git'
-        args = ['pull', '-q']
-        ignoreExitValue = true  // because of the doLast block below
-      }
-      exec {
-        workingDir stubparser
-        executable "${stubparser}/.build-without-test.sh"
-      }
-    } else {
-      exec {
-        executable 'checker/bin-devel/build.sh'
-      }
-    }
-  }
-  doLast {
-    if (!file(stubparserJar).exists()) {
-      println "The contents of ${stubparser}/javaparser-core/target (which does not contain stubparser-${stubparserVersion}.jar!) are:"
-      exec {
-        workingDir "${stubparser}/javaparser-core/target"
-        executable 'ls'
-        ignoreExitValue = true
-      }
-      throw new RuntimeException('Can\'t find stubparser jar: ' + stubparserJar + '; are you using an out-of-date Checker Framework or Stubparser?')
-    }
-  }
 }
 
 task version(group: 'Documentation') {

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -59,13 +59,6 @@ echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
 echo "... done: (cd ${AT} && ./.build-without-test.sh)"
 
 
-## Build stubparser
-"$PLUME_SCRIPTS/git-clone-related" ${DEBUG_FLAG} typetools stubparser
-echo "Running:  (cd ../stubparser/ && ./.build-without-test.sh)"
-(cd ../stubparser/ && ./.build-without-test.sh)
-echo "... done: (cd ../stubparser/ && ./.build-without-test.sh)"
-
-
 ### Commented temporarily because JSpecify build is failing under JDK 17.
 ### (I guess they don't use continuous integration.)
 # ## Build JSpecify, only for the purpose of using its tests.

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -31,7 +31,7 @@ configurations {
 dependencies {
   api project(':javacutil')
   api project(':dataflow')
-  api files("${stubparserJar}")
+  api 'org.checkerframework:stubparser:3.25.5-SNAPSHOT'
   // AFU is an "includedBuild" imported in checker-framework/settings.gradle, so the version number doesn't matter.
   // https://docs.gradle.org/current/userguide/composite_builds.html#settings_defined_composite
   api('org.checkerframework:annotation-file-utilities:*') {
@@ -132,16 +132,6 @@ task copyAndMinimizeAnnotatedJdkFiles(dependsOn: cloneTypetoolsJdk, group: 'Buil
 sourcesJar.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
 
 processResources.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
-
-task checkDependencies(dependsOn: ':maybeCloneAndBuildDependencies') {
-  doLast {
-    if (!file(stubparserJar).exists()) {
-      throw new GradleException("${stubparserJar} does not exist. Try running './gradlew cloneAndBuildDependencies'")
-    }
-  }
-}
-
-compileJava.dependsOn(checkDependencies)
 
 task allSourcesJar(type: Jar, group: 'Build') {
   description 'Creates a sources jar that includes sources for all Checker Framework classes in framework.jar'

--- a/framework/tests/annotationclassloader/Makefile
+++ b/framework/tests/annotationclassloader/Makefile
@@ -13,8 +13,6 @@ JAVAC = $(PROJECTDIR)/../../../checker/bin/javac
 
 FRAMEWORKJAR := $(PROJECTDIR)/../../dist/framework.jar
 
-STUBPARSERJAR := $(PROJECTDIR)/../../../../stubparser/javaparser-core/target/stubparser.jar
-
 CHECKERQUALJAR := $(PROJECTDIR)/../../../checker/dist/checker-qual.jar
 
 # build directories
@@ -32,7 +30,7 @@ all: load-from-dir-test load-from-jar-test
 demo1:
 	@echo "***** This command is expected to produce an error on line 7:"
 	$(JAVAC) \
-	  -processorpath $(DATAFLOWBUILD):$(JAVACUTILBUILD):$(FRAMEWORKBUILD):${STUBPARSERJAR} \
+	  -processorpath $(DATAFLOWBUILD):$(JAVACUTILBUILD):$(FRAMEWORKBUILD) \
 	  -classpath $(PROJECTDIR):${CHECKERQUALBUILD} \
 	  -processor org.checkerframework.common.aliasing.AliasingChecker \
 	  -Anomsgtext \
@@ -55,7 +53,7 @@ demo2:
 # loads from build directories
 load-from-dir-test:
 	-$(JAVAC) \
-	  -processorpath $(DATAFLOWBUILD):$(JAVACUTILBUILD):$(FRAMEWORKBUILD):${STUBPARSERJAR} \
+	  -processorpath $(DATAFLOWBUILD):$(JAVACUTILBUILD):$(FRAMEWORKBUILD) \
 	  -classpath $(PROJECTDIR):${CHECKERQUALBUILD} \
 	  -processor org.checkerframework.common.aliasing.AliasingChecker \
 	  -Anomsgtext \


### PR DESCRIPTION
I've released a snapshot version of the StubParser (See https://github.com/typetools/stubparser/pull/116).  This pull request uses the snapshot version instead of building a new one.   

The point of this is so that the CI jobs don't have to build StubParser and can therefore use JDK 21 as the default JDK. 
So, this branch plus mernst/jdk21-test (plus suppressing the new lint warnings) gets the tests to pass on JDK 21.  I've merges them together here:
https://github.com/smillst/checker-framework/tree/jdk21-test-use-stuparser-artifact