### PR TITLE
Change `optional.collection` error to warning

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/optional/OptionalVisitor.java
@@ -398,7 +398,7 @@ public class OptionalVisitor
         if (typeArgs.size() == 1) {
           TypeMirror typeArg = typeArgs.get(0);
           if (isCollectionType(typeArg)) {
-            checker.reportError(tree, "optional.collection");
+            checker.reportWarning(tree, "optional.collection");
           }
         }
       }

--- a/checker/tests/optional/Marks7.java
+++ b/checker/tests/optional/Marks7.java
@@ -11,9 +11,9 @@ import java.util.Set;
 public class Marks7 {
 
   void illegalInstantiations() {
-    // :: error: (optional.collection)
+    // :: warning: (optional.collection)
     Optional<List<String>> ols = Optional.of(new ArrayList<String>());
-    // :: error: (optional.collection)
+    // :: warning: (optional.collection)
     Optional<Set<String>> oss = Optional.of(new HashSet<String>());
   }
 }


### PR DESCRIPTION
After a discussion in a research meeting with @mernst, the `optional.collection` compile-time error should instead be a compile-time warning.

The reason for this change is that using an `Optional` to wrap a collection is a matter of style and not necessarily one of correctness.