### PR TITLE
Update Optional Checker manual

### DIFF
--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -1306,7 +1306,7 @@ crash due to use of a non-present Optional value.  Therefore, the receiver
 of
 \<orElseThrow> is annotated as
 \refqualclass{checker/optional/qual}{Present},
-and the Optional Checker issues a warning if the client calls
+and the Optional Checker issues an error if the client calls
 \<orElseThrow> on a \refqualclass{checker/optional/qual}{MaybePresent} value.
 
 

--- a/docs/manual/optional-checker.tex
+++ b/docs/manual/optional-checker.tex
@@ -100,7 +100,7 @@ Figure~\ref{fig-optional-hierarchy}.
 
 The Optional Checker guarantees that your code will not throw an exception
 due to use of an absent \<Optional> where a present \<Optional> is needed.
-More specifically, the Optional Checker will issue a warning if you call
+More specifically, the Optional Checker will issue an error if you call
 \sunjavadoc{java.base/java/util/Optional.html\#get()
 }{get}
 or


### PR DESCRIPTION
The Optional Checker currently issues errors and not warnings in cases where `.get()` or `.orElseThrow(...)` is called on a `MaybePresent`

e.g.,
```txt
 /scratch/jmsy/outdir/21-points-9942264aa97089e646fd2beef968bf49adc627e9/21-points/src/main/java/org/jhipster/health/security/DomainUserDetailsService.java:42: error: [method.invocation]
                .orElseThrow(() -> new UsernameNotFoundException("User with email " + login + " was not found in the database"));
                            ^
  found   : @MaybePresent Optional</*RAW*/>
  required: @Present Optional</*RAW*/>
```