### PR TITLE
Deprecate `checker/bin-devel/build.sh`

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -40,7 +40,7 @@ SCRIPTDIR=$ROOTDIR/checker/bin-devel/
 "${SCRIPTDIR}/plume-scripts/ci-info" typetools
 eval $("${SCRIPTDIR}/plume-scripts/ci-info" typetools)
 
-source "$SCRIPTDIR/build.sh"
+source "$SCRIPTDIR/clone-related"
 
 ###
 ### Run the test

--- a/build.gradle
+++ b/build.gradle
@@ -437,7 +437,7 @@ allprojects {
 
 task cloneAndBuildDependencies(type: Exec, group: 'Build') {
   description 'Clones (or updates) and builds all dependencies'
-  executable 'checker/bin-devel/build.sh'
+  executable 'checker/bin-devel/clone-related.sh'
 }
 
 task version(group: 'Documentation') {

--- a/build.gradle
+++ b/build.gradle
@@ -435,11 +435,6 @@ allprojects {
   } // end afterEvaluate
 } // end allProjects
 
-task cloneAndBuildDependencies(type: Exec, group: 'Build') {
-  description 'Clones (or updates) and builds all dependencies'
-  executable 'checker/bin-devel/clone-related.sh'
-}
-
 task version(group: 'Documentation') {
   description 'Print Checker Framework version'
   doLast {

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -1,86 +1,10 @@
 #!/bin/bash
 
+echo Deprecated: use ./gradlew assemble instead.
 echo Entering checker/bin-devel/build.sh in "$(pwd)"
 
 # Fail the whole script if any command fails
 set -e
-
-DEBUG=0
-# To enable debugging, uncomment the following line.
-# DEBUG=1
-
-if [ $DEBUG -eq 0 ] ; then
-  DEBUG_FLAG=
-else
-  DEBUG_FLAG=--debug
-fi
-
-echo "initial CHECKERFRAMEWORK=$CHECKERFRAMEWORK"
-export CHECKERFRAMEWORK="${CHECKERFRAMEWORK:-$(pwd -P)}"
-echo "CHECKERFRAMEWORK=$CHECKERFRAMEWORK"
-
-export SHELLOPTS
-echo "SHELLOPTS=${SHELLOPTS}"
-
-echo "initial JAVA_HOME=${JAVA_HOME}"
-if [ "$(uname)" == "Darwin" ] ; then
-  export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}
-else
-  # shellcheck disable=SC2230
-  export JAVA_HOME=${JAVA_HOME:-$(dirname "$(dirname "$(readlink -f "$(which javac)")")")}
-fi
-echo "JAVA_HOME=${JAVA_HOME}"
-
-# Using `(cd "$CHECKERFRAMEWORK" && ./gradlew getPlumeScripts -q)` leads to infinite regress.
-PLUME_SCRIPTS="$CHECKERFRAMEWORK/checker/bin-devel/.plume-scripts"
-if [ -d "$PLUME_SCRIPTS" ] ; then
-  (cd "$PLUME_SCRIPTS" && (git pull -q || true))
-else
-  (cd "$CHECKERFRAMEWORK/checker/bin-devel" && \
-      (git clone --depth 1 -q https://github.com/plume-lib/plume-scripts.git .plume-scripts || \
-       (sleep 1m && git clone --depth 1 -q https://github.com/plume-lib/plume-scripts.git .plume-scripts)))
-fi
-
-# Clone the annotated JDK into ../jdk .
-"$PLUME_SCRIPTS/git-clone-related" ${DEBUG_FLAG} typetools jdk
-
-AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
-# Don't use `AT=${AFU}/..` which causes a git failure.
-AT=$(dirname "${AFU}")
-
-## Build annotation-tools (Annotation File Utilities)
-"$PLUME_SCRIPTS/git-clone-related" ${DEBUG_FLAG} typetools annotation-tools "${AT}"
-if [ ! -d ../annotation-tools ] ; then
-  ln -s "${AT}" ../annotation-tools
-fi
-
-echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
-(cd "${AT}" && ./.build-without-test.sh)
-echo "... done: (cd ${AT} && ./.build-without-test.sh)"
-
-
-### Commented temporarily because JSpecify build is failing under JDK 17.
-### (I guess they don't use continuous integration.)
-# ## Build JSpecify, only for the purpose of using its tests.
-# "$PLUME_SCRIPTS/git-clone-related" jspecify jspecify
-# if type -p java; then
-#   _java=java
-# elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
-#   _java="$JAVA_HOME/bin/java"
-# else
-#   echo "Can't find java"
-#   exit 1
-# fi
-# version=$("$_java" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
-# if [[ "$version" -ge 9 ]]; then
-#   echo "Running:  (cd ../jspecify/ && ./gradlew build)"
-#   # If failure, retry in case the failure was due to network lossage.
-#   (cd ../jspecify/ && export JDK_JAVA_OPTIONS='--add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' && (./gradlew build || (sleep 60s && ./gradlew build)))
-#   echo "... done: (cd ../jspecify/ && ./gradlew build)"
-# fi
-
-
-## Compile
 
 # Download dependencies, trying a second time if there is a failure.
 (TERM=dumb timeout 300 ./gradlew --write-verification-metadata sha256 help --dry-run || \

--- a/checker/bin-devel/build.sh
+++ b/checker/bin-devel/build.sh
@@ -6,10 +6,11 @@ echo Entering checker/bin-devel/build.sh in "$(pwd)"
 # Fail the whole script if any command fails
 set -e
 
+source "$SCRIPTDIR"/clone-related.sh
 # Download dependencies, trying a second time if there is a failure.
 (TERM=dumb timeout 300 ./gradlew --write-verification-metadata sha256 help --dry-run || \
      (sleep 1m && ./gradlew --write-verification-metadata sha256 help --dry-run))
 echo "running \"./gradlew assemble\" for checker-framework"
-./gradlew assemble --console=plain --warning-mode=all -s -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 echo Exiting checker/bin-devel/build.sh in "$(pwd)"

--- a/checker/bin-devel/clone-related.sh
+++ b/checker/bin-devel/clone-related.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo Entering checker/bin-devel/build.sh in "$(pwd)"
+echo Entering checker/bin-devel/clone-related.sh in "$(pwd)"
 
 # Fail the whole script if any command fails
 set -e

--- a/checker/bin-devel/clone-related.sh
+++ b/checker/bin-devel/clone-related.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+echo Entering checker/bin-devel/build.sh in "$(pwd)"
+
+# Fail the whole script if any command fails
+set -e
+
+DEBUG=0
+# To enable debugging, uncomment the following line.
+# DEBUG=1
+
+if [ $DEBUG -eq 0 ] ; then
+  DEBUG_FLAG=
+else
+  DEBUG_FLAG=--debug
+fi
+
+echo "initial CHECKERFRAMEWORK=$CHECKERFRAMEWORK"
+export CHECKERFRAMEWORK="${CHECKERFRAMEWORK:-$(pwd -P)}"
+echo "CHECKERFRAMEWORK=$CHECKERFRAMEWORK"
+
+export SHELLOPTS
+echo "SHELLOPTS=${SHELLOPTS}"
+
+echo "initial JAVA_HOME=${JAVA_HOME}"
+if [ "$(uname)" == "Darwin" ] ; then
+  export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}
+else
+  # shellcheck disable=SC2230
+  export JAVA_HOME=${JAVA_HOME:-$(dirname "$(dirname "$(readlink -f "$(which javac)")")")}
+fi
+echo "JAVA_HOME=${JAVA_HOME}"
+
+# Using `(cd "$CHECKERFRAMEWORK" && ./gradlew getPlumeScripts -q)` leads to infinite regress.
+PLUME_SCRIPTS="$CHECKERFRAMEWORK/checker/bin-devel/.plume-scripts"
+if [ -d "$PLUME_SCRIPTS" ] ; then
+  (cd "$PLUME_SCRIPTS" && (git pull -q || true))
+else
+  (cd "$CHECKERFRAMEWORK/checker/bin-devel" && \
+      (git clone --depth 1 -q https://github.com/plume-lib/plume-scripts.git .plume-scripts || \
+       (sleep 1m && git clone --depth 1 -q https://github.com/plume-lib/plume-scripts.git .plume-scripts)))
+fi
+
+# Clone the annotated JDK into ../jdk .
+"$PLUME_SCRIPTS/git-clone-related" ${DEBUG_FLAG} typetools jdk
+
+AFU="${AFU:-../annotation-tools/annotation-file-utilities}"
+# Don't use `AT=${AFU}/..` which causes a git failure.
+AT=$(dirname "${AFU}")
+
+## Build annotation-tools (Annotation File Utilities)
+"$PLUME_SCRIPTS/git-clone-related" ${DEBUG_FLAG} typetools annotation-tools "${AT}"
+if [ ! -d ../annotation-tools ] ; then
+  ln -s "${AT}" ../annotation-tools
+fi
+
+echo "Running:  (cd ${AT} && ./.build-without-test.sh)"
+(cd "${AT}" && ./.build-without-test.sh)
+echo "... done: (cd ${AT} && ./.build-without-test.sh)"
+
+
+### Commented temporarily because JSpecify build is failing under JDK 17.
+### (I guess they don't use continuous integration.)
+# ## Build JSpecify, only for the purpose of using its tests.
+# "$PLUME_SCRIPTS/git-clone-related" jspecify jspecify
+# if type -p java; then
+#   _java=java
+# elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+#   _java="$JAVA_HOME/bin/java"
+# else
+#   echo "Can't find java"
+#   exit 1
+# fi
+# version=$("$_java" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 | sed 's/-ea//')
+# if [[ "$version" -ge 9 ]]; then
+#   echo "Running:  (cd ../jspecify/ && ./gradlew build)"
+#   # If failure, retry in case the failure was due to network lossage.
+#   (cd ../jspecify/ && export JDK_JAVA_OPTIONS='--add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' && (./gradlew build || (sleep 60s && ./gradlew build)))
+#   echo "... done: (cd ../jspecify/ && ./gradlew build)"
+# fi
+
+
+## Compile
+
+# Download dependencies, trying a second time if there is a failure.
+(TERM=dumb timeout 300 ./gradlew --write-verification-metadata sha256 help --dry-run || \
+     (sleep 1m && ./gradlew --write-verification-metadata sha256 help --dry-run))
+
+echo Exiting checker/bin-devel/clone-related.sh in "$(pwd)"

--- a/checker/bin-devel/test-cftests-all.sh
+++ b/checker/bin-devel/test-cftests-all.sh
@@ -12,7 +12,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-cftests-inference-part1.sh
+++ b/checker/bin-devel/test-cftests-inference-part1.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-cftests-inference-part2.sh
+++ b/checker/bin-devel/test-cftests-inference-part2.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-cftests-inference.sh
+++ b/checker/bin-devel/test-cftests-inference.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090# In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-cftests-nonjunit.sh
+++ b/checker/bin-devel/test-cftests-nonjunit.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090# In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 

--- a/checker/bin-devel/test-daikon-part1.sh
+++ b/checker/bin-devel/test-daikon-part1.sh
@@ -11,6 +11,9 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
+echo "running \"./gradlew assemble\" for checker-framework"
+./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+
 
 # daikon-typecheck: 15 minutes
 "$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon

--- a/checker/bin-devel/test-daikon-part1.sh
+++ b/checker/bin-devel/test-daikon-part1.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090# In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # daikon-typecheck: 15 minutes

--- a/checker/bin-devel/test-daikon-part1.sh
+++ b/checker/bin-devel/test-daikon-part1.sh
@@ -11,8 +11,9 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
-echo "running \"./gradlew assemble\" for checker-framework"
-./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+# Run assembleForJavac because it does not build the javadoc, so it is faster than assemble.
+echo "running \"./gradlew assembleForJavac\" for checker-framework"
+./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 
 # daikon-typecheck: 15 minutes

--- a/checker/bin-devel/test-daikon-part2.sh
+++ b/checker/bin-devel/test-daikon-part2.sh
@@ -11,8 +11,9 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
-echo "running \"./gradlew assemble\" for checker-framework"
-./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+# Run assembleForJavac because it does not build the javadoc, so it is faster than assemble.
+echo "running \"./gradlew assembleForJavac\" for checker-framework"
+./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 # daikon-typecheck: 15 minutes
 "$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon

--- a/checker/bin-devel/test-daikon-part2.sh
+++ b/checker/bin-devel/test-daikon-part2.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # daikon-typecheck: 15 minutes

--- a/checker/bin-devel/test-daikon-part2.sh
+++ b/checker/bin-devel/test-daikon-part2.sh
@@ -11,6 +11,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
+echo "running \"./gradlew assemble\" for checker-framework"
+./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 # daikon-typecheck: 15 minutes
 "$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -11,8 +11,9 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
-echo "running \"./gradlew assemble\" for checker-framework"
-./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
+# Run assembleForJavac because it does not build the javadoc, so it is faster than assemble.
+echo "running \"./gradlew assembleForJavac\" for checker-framework"
+./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 # daikon-typecheck: 15 minutes
 "$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # daikon-typecheck: 15 minutes

--- a/checker/bin-devel/test-daikon.sh
+++ b/checker/bin-devel/test-daikon.sh
@@ -11,6 +11,8 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
 
+echo "running \"./gradlew assemble\" for checker-framework"
+./gradlew assemble --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 # daikon-typecheck: 15 minutes
 "$SCRIPTDIR/.plume-scripts/git-clone-related" codespecs daikon

--- a/checker/bin-devel/test-downstream.sh
+++ b/checker/bin-devel/test-downstream.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 ## downstream tests:  projects that depend on the Checker Framework.

--- a/checker/bin-devel/test-guava-formatter.sh
+++ b/checker/bin-devel/test-guava-formatter.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-index.sh
+++ b/checker/bin-devel/test-guava-index.sh
@@ -10,7 +10,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-interning.sh
+++ b/checker/bin-devel/test-guava-interning.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-lock.sh
+++ b/checker/bin-devel/test-guava-lock.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-nullness.sh
+++ b/checker/bin-devel/test-guava-nullness.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-regex.sh
+++ b/checker/bin-devel/test-guava-regex.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava-signature.sh
+++ b/checker/bin-devel/test-guava-signature.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 "$SCRIPTDIR/.plume-scripts/git-clone-related" typetools guava

--- a/checker/bin-devel/test-guava.sh
+++ b/checker/bin-devel/test-guava.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 # TODO: Maybe I should move this into the CI job, and do it for all CI jobs.
 cp "$SCRIPTDIR"/mvn-settings.xml ~/settings.xml

--- a/checker/bin-devel/test-guava.sh
+++ b/checker/bin-devel/test-guava.sh
@@ -10,6 +10,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
+./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 # TODO: Maybe I should move this into the CI job, and do it for all CI jobs.
 cp "$SCRIPTDIR"/mvn-settings.xml ~/settings.xml

--- a/checker/bin-devel/test-misc.sh
+++ b/checker/bin-devel/test-misc.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 PLUME_SCRIPTS="$SCRIPTDIR/.plume-scripts"
 

--- a/checker/bin-devel/test-plume-lib.sh
+++ b/checker/bin-devel/test-plume-lib.sh
@@ -35,6 +35,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
 source "$SCRIPTDIR"/clone-related.sh
+./gradlew assembleForJavac --console=plain -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
 
 failing_packages=""

--- a/checker/bin-devel/test-plume-lib.sh
+++ b/checker/bin-devel/test-plume-lib.sh
@@ -34,7 +34,7 @@ echo "PACKAGES=" "${PACKAGES[@]}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 failing_packages=""

--- a/checker/bin-devel/test-typecheck-part1.sh
+++ b/checker/bin-devel/test-typecheck-part1.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # Pluggable type-checking:  run the Checker Framework on itself

--- a/checker/bin-devel/test-typecheck-part2.sh
+++ b/checker/bin-devel/test-typecheck-part2.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # Pluggable type-checking:  run the Checker Framework on itself

--- a/checker/bin-devel/test-typecheck.sh
+++ b/checker/bin-devel/test-typecheck.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # shellcheck disable=SC1090 # In newer shellcheck than 0.6.0, pass: "-P SCRIPTDIR" (literally)
 export ORG_GRADLE_PROJECT_useJdk17Compiler=true
-source "$SCRIPTDIR"/build.sh
+source "$SCRIPTDIR"/clone-related.sh
 
 
 # Pluggable type-checking:  run the Checker Framework on itself

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -748,7 +748,7 @@ pipx ensurepath
 In a startup file, write:
 % Can someone give a simpler command?
 % Command taken from:
-%   https://github.com/typetools/checker-framework/blob/master/checker/bin-devel/build.sh#L19
+%   https://github.com/typetools/checker-framework/blob/master/checker/bin-devel/clone-related.sh#L19
 %BEGIN LATEX
 \begin{smaller}
 %END LATEX

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -945,14 +945,14 @@ Building the Checker Framework depends on other repositories, such as
 You need to have compatible versions of each.
 
 After you \<git pull> in one of the repositories, you should do so in the
-others as well.  The script \<checker/bin-devel/build.sh> pulls all the
+others as well.  The script \<checker/bin-devel/clone-related.sh> pulls all the
 related repositories, so to build the latest development version of the
 Checker Framework you can do
 
 \begin{Verbatim}
 cd $CHECKERFRAMEWORK
 git pull
-checker/bin-devel/build.sh
+checker/bin-devel/clone-related.sh
 \end{Verbatim}
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ include 'framework-test'
 includeBuild ('../annotation-tools/annotation-file-utilities') {
   if (!file('../annotation-tools/annotation-file-utilities').exists()) {
     exec {
-      executable 'checker/bin-devel/build.sh'
+      executable 'checker/bin-devel/clone-related.sh'
     }
   }
 }


### PR DESCRIPTION
`./gradlew assemble` is sufficient to build the Checker Framework. (It runs `checker/bin-devel/clone-related.sh` to clone annotation-tools and jdk.) 

 Adds a new scripts `checker/bin-devel/clone-related.sh` has the same contents as the old `build.sh`, but doen't call `./gradlew assemble`.