### PR TITLE
Correctly merge adjacent CFG blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ dataflow/tests/busy-expression/Out.txt
 dataflow/tests/busy-expression/*.class
 dataflow/tests/busyexpr/Out.txt
 dataflow/tests/busyexpr/*.class
+dataflow/tests/cfgconstruction/*.class
 dataflow/tests/constant-propagation/Out.txt
 dataflow/tests/constant-propagation/*.class
 dataflow/tests/issue3447/Out.txt

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -147,6 +147,7 @@ def testDataflowAnalysis(taskName, dirName, className, diff) {
 }
 
 // When adding a new test case, don't forget to add the temporary files to `../.gitignore`.
+testDataflowAnalysis("cfgConstructionTest", "cfgconstruction", "cfgconstruction.CFGConstruction", false)
 testDataflowAnalysis("busyExpressionTest", "busyexpr", "busyexpr.BusyExpression", true)
 testDataflowAnalysis("constantPropagationTest", "constant-propagation", "constantpropagation.ConstantPropagation", true)
 testDataflowAnalysis("issue3447Test", "issue3447", "livevar.LiveVariable", false)

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -136,6 +137,54 @@ public class ControlFlowGraph implements UniqueId {
   }
 
   /**
+   * Verify that this is a complete and well-formed CFG, i.e. that all internal invariants hold.
+   *
+   * @throws IllegalStateException if some internal invariant is violated
+   */
+  public void checkInvariants() {
+    // TODO: this is a big data structure with many more invariants...
+    for (Block b : getAllBlocks()) {
+
+      // Each node in the block should have this block as its parent.
+      for (Node n : b.getNodes()) {
+        if (n.getBlock() != b) {
+          throw new IllegalStateException(
+              "Node "
+                  + n
+                  + " in block "
+                  + b
+                  + " incorrectly believes it belongs to "
+                  + n.getBlock());
+        }
+      }
+
+      // Each successor should have this block in its predecessors.
+      for (Block succ : b.getSuccessors()) {
+        if (!succ.getPredecessors().contains(b)) {
+          throw new IllegalStateException(
+              "Block "
+                  + b
+                  + " has successor "
+                  + succ
+                  + " but does not appear in that successor's predecessors");
+        }
+      }
+
+      // Each predecessor should have this block in its successors.
+      for (Block pred : b.getPredecessors()) {
+        if (!pred.getSuccessors().contains(b)) {
+          throw new IllegalStateException(
+              "Block "
+                  + b
+                  + " has predecessor "
+                  + pred
+                  + " but does not appear in that predecessor's successors");
+        }
+      }
+    }
+  }
+
+  /**
    * Returns the set of {@link Node}s to which the {@link Tree} {@code t} corresponds, or null for
    * trees that don't produce a value.
    *
@@ -188,7 +237,7 @@ public class ControlFlowGraph implements UniqueId {
    */
   public Set<Block> getAllBlocks(
       @UnknownInitialization(ControlFlowGraph.class) ControlFlowGraph this) {
-    Set<Block> visited = new HashSet<>();
+    Set<Block> visited = new LinkedHashSet<>();
     // worklist is always a subset of visited; any block in worklist is also in visited.
     Queue<Block> worklist = new ArrayDeque<>();
     Block cur = entryBlock;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/ControlFlowGraph.java
@@ -15,6 +15,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -147,7 +148,7 @@ public class ControlFlowGraph implements UniqueId {
 
       // Each node in the block should have this block as its parent.
       for (Node n : b.getNodes()) {
-        if (n.getBlock() != b) {
+        if (!Objects.equals(n.getBlock(), b)) {
           throw new IllegalStateException(
               "Node "
                   + n

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseThree.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseThree.java
@@ -132,6 +132,7 @@ public class CFGTranslationPhaseThree {
    *
    * @param cfg the control flow graph
    */
+  @SuppressWarnings("nullness") // TODO: successors
   protected static void mergeConsecutiveBlocks(ControlFlowGraph cfg) {
     Set<Block> worklist = cfg.getAllBlocks();
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseThree.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseThree.java
@@ -123,23 +123,57 @@ public class CFGTranslationPhaseThree {
     }
     */
 
-    // merge consecutive basic blocks if possible
-    worklist = cfg.getAllBlocks();
+    mergeConsecutiveBlocks(cfg);
+    return cfg;
+  }
+
+  /**
+   * Simplify the CFG by merging consecutive single-successor blocks.
+   *
+   * @param cfg the control flow graph
+   */
+  protected static void mergeConsecutiveBlocks(ControlFlowGraph cfg) {
+    Set<Block> worklist = cfg.getAllBlocks();
+
+    // This transformation removes blocks from the CFG.  If those blocks appear in `worklist`
+    // then we might visit a block AFTER it has been removed and its nodes have been moved
+    // somewhere else.  When this happens the correct behavior is to just skip the removed
+    // block; to do so, we need to remember which blocks have been removed.
+    Set<Block> removedBlocks = new HashSet<>();
+
     for (Block cur : worklist) {
-      if (cur.getType() == BlockType.REGULAR_BLOCK) {
-        RegularBlockImpl b = (RegularBlockImpl) cur;
-        Block succ = b.getRegularSuccessor();
-        if (succ.getType() == BlockType.REGULAR_BLOCK) {
-          RegularBlockImpl rs = (RegularBlockImpl) succ;
-          if (rs.getPredecessors().size() == 1) {
-            b.setSuccessor(rs.getRegularSuccessor());
-            b.addNodes(rs.getNodes());
-            rs.getRegularSuccessor().removePredecessor(rs);
+
+      // Skip this block if it was already merged into another.
+      if (removedBlocks.contains(cur)) {
+        continue;
+      }
+
+      // There may be many blocks to merge in series.
+      //
+      // ... \                   /> ...
+      // ... --> cur -> b2 -> b3 -> ...
+      // ... /                   \> ...
+      //
+      // This loop merges the successor into `cur` until it can't do so anymore.
+      boolean didMerge;
+      do {
+        didMerge = false;
+        if (cur.getType() == BlockType.REGULAR_BLOCK) {
+          RegularBlockImpl b = (RegularBlockImpl) cur;
+          Block succ = b.getRegularSuccessor();
+          if (succ.getType() == BlockType.REGULAR_BLOCK) {
+            RegularBlockImpl rs = (RegularBlockImpl) succ;
+            if (rs.getPredecessors().size() == 1) {
+              b.setSuccessor(rs.getRegularSuccessor());
+              b.addNodes(rs.getNodes());
+              rs.getRegularSuccessor().removePredecessor(rs);
+              removedBlocks.add(rs);
+              didMerge = true;
+            }
           }
         }
-      }
+      } while (didMerge);
     }
-    return cfg;
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -214,7 +214,7 @@ public final class CFGVisualizeLauncher {
    * @param method name of the method to generate the CFG for
    * @return control flow graph of the specified method
    */
-  private static ControlFlowGraph generateMethodCFG(String file, String clas, String method) {
+  public static ControlFlowGraph generateMethodCFG(String file, String clas, String method) {
 
     CFGProcessor cfgProcessor = new CFGProcessor(clas, method);
 

--- a/dataflow/src/test/java/cfgconstruction/CFGConstruction.java
+++ b/dataflow/src/test/java/cfgconstruction/CFGConstruction.java
@@ -1,0 +1,17 @@
+package cfgconstruction;
+
+import org.checkerframework.dataflow.cfg.ControlFlowGraph;
+import org.checkerframework.dataflow.cfg.visualize.CFGVisualizeLauncher;
+
+public class CFGConstruction {
+
+  public static void main(String[] args) {
+
+    String inputFile = "Test.java";
+    String clazz = "Test";
+    String method = "manyNestedTryFinallyBlocks";
+
+    ControlFlowGraph cfg = CFGVisualizeLauncher.generateMethodCFG(inputFile, clazz, method);
+    cfg.checkInvariants();
+  }
+}

--- a/dataflow/tests/cfgconstruction/Test.java
+++ b/dataflow/tests/cfgconstruction/Test.java
@@ -1,0 +1,26 @@
+public class Test {
+
+  public void manyNestedTryFinallyBlocks() {
+    try {
+      System.out.println("!");
+    } finally {
+      try {
+        System.out.println("!");
+      } finally {
+        try {
+          System.out.println("!");
+        } finally {
+          try {
+            System.out.println("!");
+          } finally {
+            try {
+              System.out.println("!");
+            } finally {
+              System.out.println("!");
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I observed some nondeterministic behavior from the Resource Leak Checker on a real project.  The root cause appears to be a defect in the code that merges adjacent blocks in CFGTranslationPhaseThree.  The original code did not correctly handle the case where there are three or more adjacent blocks that can be merged.

For instance, suppose the CFG contains:

    ... \                        /> ...
    ... --> b1 -> b2 -> b3 -> b4 -> ...
    ... /                        \> ...

When the original loop visited b1, it would move all of b2's nodes into b1 and update the successor/predecessor pointers:

    ... \                        /> ...
    ... --> b1 -------> b3 -> b4 -> ...
    ... /               ^        \> ...
                       b2

However, b2 remains in the worklist of blocks to visit.  If b2 were the next visited block, the original code would blindly move all of b3's nodes into b2.  This is clearly wrong, since b2 has been disconnected from the CFG.  The result is a graph that is "mostly" well-formed, but has some nodes that reference the wrong parent block.  This, in turn, causes strange results in downstream consumers of the CFG.

To make matters worse, `cfg.getAllBlocks()` does not promise a deterministic iteration order, even though every caller of this method iterates over the returned set.  Finding this bug was a nightmare because the behavior changed depending on seemingly irrelevant factors like what print statements appeared in the code and whether a debugger was attached.  I have changed `getAllBlocks` to return a `LinkedHashSet` to help make debugging similar problems easier in the future.

To fix the problem, this commit reworks the merging algorithm so that

 - Long chains of blocks are completely merged
 - Removed blocks are skipped over

I have also added a simple test case to verify the fix.  Without this fix, the test case fails.