### PR TITLE
Improve exception handling in `CalledMethodsTransfer.accumulate`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -115,7 +115,10 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
         }
       }
       AnnotationMirror newAnno = atypeFactory.createAccumulatorAnnotation(valuesAsList);
-      exceptionalStores.forEach((tm, s) -> s.insertValue(target, newAnno));
+      exceptionalStores.forEach(
+          (tm, s) ->
+              s.replaceValue(
+                  target, analysis.createSingleAnnotationValue(newAnno, target.getType())));
     }
   }
 

--- a/checker/tests/calledmethods/ExceptionalPath2.java
+++ b/checker/tests/calledmethods/ExceptionalPath2.java
@@ -1,0 +1,37 @@
+import java.io.IOException;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+class ExceptionalPath2 {
+
+  interface Resource {
+    void a();
+
+    void b() throws IOException;
+  }
+
+  Resource r;
+
+  // Regression test for an obscure bug: in some cases, the called
+  // methods transfer function would silently fail to update the
+  // set of known called methods along exceptional paths.  That
+  // would a spurious precondition error on this method.
+  @EnsuresCalledMethods(
+      value = "this.r",
+      methods = {"b"})
+  void test() {
+    try {
+      try {
+        r.a();
+      } finally {
+        r.b();
+      }
+    } catch (IOException ignored) {
+      // The only way to get here is if `r.b()` started running and
+      // threw an IOException.  We no longer know whether `r.a()`
+      // has been called, since `r.b()` might have overwritten `r`
+      // before throwing.
+      // ::error: (assignment)
+      @CalledMethods({"a"}) Resource x = r;
+    }
+  }
+}


### PR DESCRIPTION
The call to `s.insertValue` may silently do nothing if the new annotation is not a super- or sub-type of the existing one.  This can actually happen in some cases.

For example, in the new test case, at the call to `r.b()`:

 - The incoming transfer input lists {"a"} as the called methods.
 - The result of the transfer function for the regular path produces only {"b"} as the called methods (since the call to `b()` may modify `r`, invalidating the set of called methods).
 - The exceptional store handling begins with every exceptional store equal to the input store. When it tries to insert {"b"} over the input value {"a"}, nothing happens since neither value is more specific.

This change makes the accumulation completely overwrite the exceptional output with the regular output instead of allowing a silent no-op.