### PR TITLE
Add `-AresourceLeakIgnoredExceptions` option

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnalysis.java
@@ -2,9 +2,9 @@ package org.checkerframework.checker.calledmethods;
 
 import com.google.common.collect.ImmutableSet;
 import com.sun.tools.javac.code.Type;
-import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.type.TypeMirror;
+import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.common.accumulation.AccumulationAnalysis;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
@@ -18,17 +18,16 @@ public class CalledMethodsAnalysis extends AccumulationAnalysis {
    * The fully-qualified names of the exception types that are ignored by this checker when
    * computing dataflow stores.
    */
-  protected static final Set<String> ignoredExceptionTypes =
-      new HashSet<>(
-          ImmutableSet.of(
-              // Use the Nullness Checker instead.
-              NullPointerException.class.getCanonicalName(),
-              // Ignore run-time errors, which cannot be predicted statically. Doing
-              // so is unsound in the sense that they could still occur - e.g., the
-              // program could run out of memory - but if they did, the checker's
-              // results would be useless anyway.
-              Error.class.getCanonicalName(),
-              RuntimeException.class.getCanonicalName()));
+  protected static final Set<@CanonicalName String> ignoredExceptionTypes =
+      ImmutableSet.of(
+          // Use the Nullness Checker instead.
+          NullPointerException.class.getCanonicalName(),
+          // Ignore run-time errors, which cannot be predicted statically. Doing
+          // so is unsound in the sense that they could still occur - e.g., the
+          // program could run out of memory - but if they did, the checker's
+          // results would be useless anyway.
+          Error.class.getCanonicalName(),
+          RuntimeException.class.getCanonicalName());
 
   /**
    * Creates a new {@code CalledMethodsAnalysis}.

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -46,6 +46,7 @@ import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.checker.mustcall.qual.NotOwning;
 import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.checker.signature.qual.FullyQualifiedName;
 import org.checkerframework.common.accumulation.AccumulationAnalysis;
 import org.checkerframework.common.accumulation.AccumulationStore;
@@ -2481,34 +2482,33 @@ class MustCallConsistencyAnalyzer {
    *
    * <p>Package-private to permit access from {@link ResourceLeakAnalysis}.
    */
-  /*package-private*/ static final Set<String> ignoredExceptionTypes =
-      new HashSet<>(
-          ImmutableSet.of(
-              // Any method call has a CFG edge for Throwable/RuntimeException/Error
-              // to represent run-time misbehavior. Ignore it.
-              Throwable.class.getCanonicalName(),
-              Error.class.getCanonicalName(),
-              RuntimeException.class.getCanonicalName(),
-              // Use the Nullness Checker to prove this won't happen.
-              NullPointerException.class.getCanonicalName(),
-              // These errors can't be predicted statically, so ignore them and assume
-              // they won't happen.
-              ClassCircularityError.class.getCanonicalName(),
-              ClassFormatError.class.getCanonicalName(),
-              NoClassDefFoundError.class.getCanonicalName(),
-              OutOfMemoryError.class.getCanonicalName(),
-              // It's not our problem if the Java type system is wrong.
-              ClassCastException.class.getCanonicalName(),
-              // It's not our problem if the code is going to divide by zero.
-              ArithmeticException.class.getCanonicalName(),
-              // Use the Index Checker to prevent these errors.
-              ArrayIndexOutOfBoundsException.class.getCanonicalName(),
-              NegativeArraySizeException.class.getCanonicalName(),
-              // Most of the time, this exception is infeasible, as the charset used
-              // is guaranteed to be present by the Java spec (e.g., "UTF-8").
-              // Eventually, this exclusion could be refined by looking at the charset
-              // being requested.
-              UnsupportedEncodingException.class.getCanonicalName()));
+  /*package-private*/ static final Set<@CanonicalName String> ignoredExceptionTypes =
+      ImmutableSet.of(
+          // Any method call has a CFG edge for Throwable/RuntimeException/Error
+          // to represent run-time misbehavior. Ignore it.
+          Throwable.class.getCanonicalName(),
+          Error.class.getCanonicalName(),
+          RuntimeException.class.getCanonicalName(),
+          // Use the Nullness Checker to prove this won't happen.
+          NullPointerException.class.getCanonicalName(),
+          // These errors can't be predicted statically, so ignore them and assume
+          // they won't happen.
+          ClassCircularityError.class.getCanonicalName(),
+          ClassFormatError.class.getCanonicalName(),
+          NoClassDefFoundError.class.getCanonicalName(),
+          OutOfMemoryError.class.getCanonicalName(),
+          // It's not our problem if the Java type system is wrong.
+          ClassCastException.class.getCanonicalName(),
+          // It's not our problem if the code is going to divide by zero.
+          ArithmeticException.class.getCanonicalName(),
+          // Use the Index Checker to prevent these errors.
+          ArrayIndexOutOfBoundsException.class.getCanonicalName(),
+          NegativeArraySizeException.class.getCanonicalName(),
+          // Most of the time, this exception is infeasible, as the charset used
+          // is guaranteed to be present by the Java spec (e.g., "UTF-8").
+          // Eventually, this exclusion could be refined by looking at the charset
+          // being requested.
+          UnsupportedEncodingException.class.getCanonicalName());
 
   /**
    * Is {@code exceptionClassName} an exception type the checker ignores, to avoid excessive false

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
@@ -1,5 +1,7 @@
 package org.checkerframework.checker.resourceleak;
 
+import com.sun.tools.javac.code.Type;
+import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnalysis;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
 import org.checkerframework.common.basetype.BaseTypeChecker;
@@ -19,6 +21,12 @@ public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
   protected ResourceLeakAnalysis(
       BaseTypeChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
     super(checker, factory);
-    ignoredExceptionTypes.addAll(MustCallConsistencyAnalyzer.ignoredExceptionTypes);
+  }
+
+  @Override
+  protected boolean isIgnoredExceptionType(TypeMirror exceptionType) {
+    return super.isIgnoredExceptionType(exceptionType)
+        || MustCallConsistencyAnalyzer.ignoredExceptionTypes.contains(
+            ((Type) exceptionType).tsym.getQualifiedName().toString());
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
@@ -2,56 +2,20 @@ package org.checkerframework.checker.resourceleak;
 
 import com.google.common.collect.ImmutableSet;
 import com.sun.tools.javac.code.Type;
-import java.io.UnsupportedEncodingException;
 import java.util.Set;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnalysis;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
 import org.checkerframework.checker.signature.qual.CanonicalName;
-import org.checkerframework.common.basetype.BaseTypeChecker;
 
 /**
- * This variant of CFAnalysis extends the set of ignored exception types to include all those
- * ignored by the {@link MustCallConsistencyAnalyzer}. See {@link
- * MustCallConsistencyAnalyzer#ignoredExceptionTypes}.
+ * This variant of CFAnalysis extends the set of ignored exception types.
+ *
+ * @see ResourceLeakChecker#getIgnoredExceptions()
  */
 public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
 
-  /**
-   * The exception types in this set are ignored in the CFG when determining if a resource leaks
-   * along an exceptional path. These kinds of errors fall into a few categories: runtime errors,
-   * errors that the JVM can issue on any statement, and errors that can be prevented by running
-   * some other CF checker.
-   *
-   * <p>Package-private to permit access from {@link ResourceLeakAnalysis}.
-   */
-  /*package-private*/ static final Set<@CanonicalName String> ignoredExceptionTypes =
-      ImmutableSet.of(
-          // Any method call has a CFG edge for Throwable/RuntimeException/Error
-          // to represent run-time misbehavior. Ignore it.
-          Throwable.class.getCanonicalName(),
-          Error.class.getCanonicalName(),
-          RuntimeException.class.getCanonicalName(),
-          // Use the Nullness Checker to prove this won't happen.
-          NullPointerException.class.getCanonicalName(),
-          // These errors can't be predicted statically, so ignore them and assume
-          // they won't happen.
-          ClassCircularityError.class.getCanonicalName(),
-          ClassFormatError.class.getCanonicalName(),
-          NoClassDefFoundError.class.getCanonicalName(),
-          OutOfMemoryError.class.getCanonicalName(),
-          // It's not our problem if the Java type system is wrong.
-          ClassCastException.class.getCanonicalName(),
-          // It's not our problem if the code is going to divide by zero.
-          ArithmeticException.class.getCanonicalName(),
-          // Use the Index Checker to prevent these errors.
-          ArrayIndexOutOfBoundsException.class.getCanonicalName(),
-          NegativeArraySizeException.class.getCanonicalName(),
-          // Most of the time, this exception is infeasible, as the charset used
-          // is guaranteed to be present by the Java spec (e.g., "UTF-8").
-          // Eventually, this exclusion could be refined by looking at the charset
-          // being requested.
-          UnsupportedEncodingException.class.getCanonicalName());
+  private final Set<@CanonicalName String> ignoredExceptions;
 
   /**
    * Creates a new {@code CalledMethodsAnalysis}.
@@ -60,14 +24,13 @@ public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
    * @param factory the factory
    */
   protected ResourceLeakAnalysis(
-      BaseTypeChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
+      ResourceLeakChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
     super(checker, factory);
+    this.ignoredExceptions = ImmutableSet.copyOf(checker.getIgnoredExceptions());
   }
 
   @Override
   public boolean isIgnoredExceptionType(TypeMirror exceptionType) {
-    return super.isIgnoredExceptionType(exceptionType)
-        || ignoredExceptionTypes.contains(
-            ((Type) exceptionType).tsym.getQualifiedName().toString());
+    return ignoredExceptions.contains(((Type) exceptionType).tsym.getQualifiedName().toString());
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
@@ -1,9 +1,13 @@
 package org.checkerframework.checker.resourceleak;
 
+import com.google.common.collect.ImmutableSet;
 import com.sun.tools.javac.code.Type;
+import java.io.UnsupportedEncodingException;
+import java.util.Set;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnalysis;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
+import org.checkerframework.checker.signature.qual.CanonicalName;
 import org.checkerframework.common.basetype.BaseTypeChecker;
 
 /**
@@ -12,6 +16,43 @@ import org.checkerframework.common.basetype.BaseTypeChecker;
  * MustCallConsistencyAnalyzer#ignoredExceptionTypes}.
  */
 public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
+
+  /**
+   * The exception types in this set are ignored in the CFG when determining if a resource leaks
+   * along an exceptional path. These kinds of errors fall into a few categories: runtime errors,
+   * errors that the JVM can issue on any statement, and errors that can be prevented by running
+   * some other CF checker.
+   *
+   * <p>Package-private to permit access from {@link ResourceLeakAnalysis}.
+   */
+  /*package-private*/ static final Set<@CanonicalName String> ignoredExceptionTypes =
+      ImmutableSet.of(
+          // Any method call has a CFG edge for Throwable/RuntimeException/Error
+          // to represent run-time misbehavior. Ignore it.
+          Throwable.class.getCanonicalName(),
+          Error.class.getCanonicalName(),
+          RuntimeException.class.getCanonicalName(),
+          // Use the Nullness Checker to prove this won't happen.
+          NullPointerException.class.getCanonicalName(),
+          // These errors can't be predicted statically, so ignore them and assume
+          // they won't happen.
+          ClassCircularityError.class.getCanonicalName(),
+          ClassFormatError.class.getCanonicalName(),
+          NoClassDefFoundError.class.getCanonicalName(),
+          OutOfMemoryError.class.getCanonicalName(),
+          // It's not our problem if the Java type system is wrong.
+          ClassCastException.class.getCanonicalName(),
+          // It's not our problem if the code is going to divide by zero.
+          ArithmeticException.class.getCanonicalName(),
+          // Use the Index Checker to prevent these errors.
+          ArrayIndexOutOfBoundsException.class.getCanonicalName(),
+          NegativeArraySizeException.class.getCanonicalName(),
+          // Most of the time, this exception is infeasible, as the charset used
+          // is guaranteed to be present by the Java spec (e.g., "UTF-8").
+          // Eventually, this exclusion could be refined by looking at the charset
+          // being requested.
+          UnsupportedEncodingException.class.getCanonicalName());
+
   /**
    * Creates a new {@code CalledMethodsAnalysis}.
    *
@@ -24,9 +65,9 @@ public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
   }
 
   @Override
-  protected boolean isIgnoredExceptionType(TypeMirror exceptionType) {
+  public boolean isIgnoredExceptionType(TypeMirror exceptionType) {
     return super.isIgnoredExceptionType(exceptionType)
-        || MustCallConsistencyAnalyzer.ignoredExceptionTypes.contains(
+        || ignoredExceptionTypes.contains(
             ((Type) exceptionType).tsym.getQualifiedName().toString());
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
@@ -1,12 +1,8 @@
 package org.checkerframework.checker.resourceleak;
 
-import com.google.common.collect.ImmutableSet;
-import com.sun.tools.javac.code.Type;
-import java.util.Set;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnalysis;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
-import org.checkerframework.checker.signature.qual.CanonicalName;
 
 /**
  * This variant of CFAnalysis extends the set of ignored exception types.
@@ -15,7 +11,7 @@ import org.checkerframework.checker.signature.qual.CanonicalName;
  */
 public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
 
-  private final Set<@CanonicalName String> ignoredExceptions;
+  private final SetOfTypes ignoredExceptions;
 
   /**
    * Creates a new {@code CalledMethodsAnalysis}.
@@ -26,11 +22,11 @@ public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
   protected ResourceLeakAnalysis(
       ResourceLeakChecker checker, CalledMethodsAnnotatedTypeFactory factory) {
     super(checker, factory);
-    this.ignoredExceptions = ImmutableSet.copyOf(checker.getIgnoredExceptions());
+    this.ignoredExceptions = checker.getIgnoredExceptions();
   }
 
   @Override
   public boolean isIgnoredExceptionType(TypeMirror exceptionType) {
-    return ignoredExceptions.contains(((Type) exceptionType).tsym.getQualifiedName().toString());
+    return ignoredExceptions.contains(getTypes(), exceptionType);
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnalysis.java
@@ -11,6 +11,10 @@ import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFact
  */
 public class ResourceLeakAnalysis extends CalledMethodsAnalysis {
 
+  /**
+   * The set of exceptions to ignore, cached from {@link
+   * ResourceLeakChecker#getIgnoredExceptions()}.
+   */
   private final SetOfTypes ignoredExceptions;
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -134,7 +134,7 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
   @Override
   public void postAnalyze(ControlFlowGraph cfg) {
     MustCallConsistencyAnalyzer mustCallConsistencyAnalyzer =
-        new MustCallConsistencyAnalyzer(this, this.analysis);
+        new MustCallConsistencyAnalyzer(this, (ResourceLeakAnalysis) this.analysis);
     mustCallConsistencyAnalyzer.analyze(cfg);
 
     // Inferring owning annotations for final owning fields

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -151,7 +151,7 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
 
   @Override
   protected ResourceLeakAnalysis createFlowAnalysis() {
-    return new ResourceLeakAnalysis(checker, this);
+    return new ResourceLeakAnalysis((ResourceLeakChecker) checker, this);
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/SetOfTypes.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/SetOfTypes.java
@@ -1,0 +1,97 @@
+package org.checkerframework.checker.resourceleak;
+
+import com.google.common.collect.ImmutableSet;
+import com.sun.tools.javac.code.Type;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
+import org.checkerframework.checker.signature.qual.CanonicalName;
+import org.checkerframework.dataflow.qual.Pure;
+
+/**
+ * A set of types.
+ *
+ * <p>Important properties of this class:
+ *
+ * <ul>
+ *   <li>No defined equality: in general, equality between these sets is prohibitively difficult to
+ *       compute, and therefore this class uses <i>reference equality</i>.
+ *   <li>Unknown size: it is not possible to know the true size of a set like {@link
+ *       #allSubtypes(TypeMirror)}. By extension, it is not possible to iterate over a {@code
+ *       SetOfTypes}.
+ *   <li>Immutable: instances of this class can be created but not modified.
+ * </ul>
+ */
+public interface SetOfTypes {
+
+  /**
+   * Test whether this set contains the given type.
+   *
+   * @param typeUtils a {@code Types} object for computing the relationships between types
+   * @param type the type in question
+   * @return true if this set contains {@code type}, or false otherwise
+   */
+  @Pure
+  boolean contains(Types typeUtils, TypeMirror type);
+
+  /** An empty set of types. */
+  SetOfTypes EMPTY = (typeUtils, type) -> false;
+
+  /**
+   * Create a set containing exactly the given type, but not its subtypes.
+   *
+   * @param t the type
+   * @return a set containing only {@code t}
+   */
+  @Pure
+  static SetOfTypes singleton(TypeMirror t) {
+    return (typeUtils, u) -> typeUtils.isSameType(t, u);
+  }
+
+  /**
+   * Create a set containing the given type and all of its subtypes.
+   *
+   * @param t the type
+   * @return a set containing {@code t} and its subtypes
+   */
+  @Pure
+  static SetOfTypes allSubtypes(TypeMirror t) {
+    return (typeUtils, u) -> typeUtils.isSubtype(u, t);
+  }
+
+  /**
+   * Create a set containing exactly the types with the given names, but not their subtypes.
+   *
+   * @param names the type names
+   * @return a set containing only the named types
+   */
+  @Pure
+  static SetOfTypes anyOfTheseNames(ImmutableSet<@CanonicalName String> names) {
+    return (typeUtils, u) ->
+        u instanceof Type && names.contains(((Type) u).tsym.getQualifiedName().toString());
+  }
+
+  /**
+   * Create a set representing the union of all the given sets.
+   *
+   * @param typeSets an array of sets
+   * @return the union of the given sets
+   */
+  @Pure
+  static SetOfTypes union(SetOfTypes... typeSets) {
+    switch (typeSets.length) {
+      case 0:
+        return EMPTY;
+      case 1:
+        return typeSets[0];
+      default:
+        return (typeUtils, type) -> {
+          for (SetOfTypes set : typeSets) {
+            if (set.contains(typeUtils, type)) {
+              return true;
+            }
+          }
+          return false;
+        };
+    }
+  }
+}

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.checker.test.junit;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.resourceleak.ResourceLeakChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized;
+
+public class ResourceLeakCustomIgnoredExceptionsTest extends CheckerFrameworkPerDirectoryTest {
+  public ResourceLeakCustomIgnoredExceptionsTest(List<File> testFiles) {
+    super(
+        testFiles,
+        ResourceLeakChecker.class,
+        "resourceleak-customignoredexceptions",
+        "-AresourceLeakIgnoredExceptions=java.lang.Error,java.lang.ClassCircularityError,java.lang.ClassFormatError,java.lang.NoClassDefFoundError,java.lang.OutOfMemoryError,java.lang.NullPointerException",
+        "-AwarnUnneededSuppressions",
+        "-encoding",
+        "UTF-8");
+  }
+
+  @Parameterized.Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"resourceleak-customignoredexceptions"};
+  }
+}

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
@@ -12,7 +12,7 @@ public class ResourceLeakCustomIgnoredExceptionsTest extends CheckerFrameworkPer
         testFiles,
         ResourceLeakChecker.class,
         "resourceleak-customignoredexceptions",
-        "-AresourceLeakIgnoredExceptions=java.lang.Error,java.lang.ClassCircularityError,java.lang.ClassFormatError,java.lang.NoClassDefFoundError,java.lang.OutOfMemoryError,java.lang.NullPointerException",
+        "-AresourceLeakIgnoredExceptions=? extends java.lang.Error, java.lang.NullPointerException",
         "-AwarnUnneededSuppressions",
         "-encoding",
         "UTF-8");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakCustomIgnoredExceptionsTest.java
@@ -12,7 +12,7 @@ public class ResourceLeakCustomIgnoredExceptionsTest extends CheckerFrameworkPer
         testFiles,
         ResourceLeakChecker.class,
         "resourceleak-customignoredexceptions",
-        "-AresourceLeakIgnoredExceptions=? extends java.lang.Error, java.lang.NullPointerException",
+        "-AresourceLeakIgnoredExceptions=java.lang.Error, =java.lang.NullPointerException",
         "-AwarnUnneededSuppressions",
         "-encoding",
         "UTF-8");

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakExtraIgnoredExceptionsTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakExtraIgnoredExceptionsTest.java
@@ -1,0 +1,25 @@
+package org.checkerframework.checker.test.junit;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.resourceleak.ResourceLeakChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized;
+
+public class ResourceLeakExtraIgnoredExceptionsTest extends CheckerFrameworkPerDirectoryTest {
+  public ResourceLeakExtraIgnoredExceptionsTest(List<File> testFiles) {
+    super(
+        testFiles,
+        ResourceLeakChecker.class,
+        "resourceleak-extraignoredexceptions",
+        "-AresourceLeakIgnoredExceptions=default,java.lang.IllegalStateException",
+        "-AwarnUnneededSuppressions",
+        "-encoding",
+        "UTF-8");
+  }
+
+  @Parameterized.Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"resourceleak-extraignoredexceptions"};
+  }
+}

--- a/checker/tests/resourceleak-customignoredexceptions/BasicTest.java
+++ b/checker/tests/resourceleak-customignoredexceptions/BasicTest.java
@@ -41,4 +41,19 @@ abstract class BasicTest {
     }
     r.close();
   }
+
+  static class CustomNPESubtype extends NullPointerException {
+    static final CustomNPESubtype INSTANCE = new CustomNPESubtype();
+  }
+
+  public void doNotIgnoreNPESubtype() throws IOException {
+    // Only NullPointerException should be ignored, not its subtypes, since the options
+    // specified "=java.lang.NullPointerException".
+    // ::error: (required.method.not.called)
+    Closeable r = alloc();
+    if (true) {
+      throw CustomNPESubtype.INSTANCE;
+    }
+    r.close();
+  }
 }

--- a/checker/tests/resourceleak-customignoredexceptions/BasicTest.java
+++ b/checker/tests/resourceleak-customignoredexceptions/BasicTest.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+abstract class BasicTest {
+
+  abstract Closeable alloc();
+
+  abstract void method();
+
+  public void runtimeExceptionManuallyThrown() throws IOException {
+    // this code is obviously wrong
+    // ::error: (required.method.not.called)
+    Closeable r = alloc();
+    if (true) {
+      throw new RuntimeException();
+    }
+    r.close();
+  }
+
+  public void runtimeExceptionFromMethod() throws IOException {
+    // method() may throw RuntimeException, so this code is not OK
+    // ::error: (required.method.not.called)
+    Closeable r = alloc();
+    method();
+    r.close();
+  }
+
+  // Note that even just constructing an instance of NullPointerException can throw all kinds
+  // of exceptions: ClassCircularityError, OutOfMemoryError, etc.  Even RuntimeException is
+  // possible in theory.  So, to really test what we're trying to test, we have to isolate
+  // the construction of the exception out here.
+  static final NullPointerException NPE = new NullPointerException();
+
+  public void ignoreNPE() throws IOException {
+    // this code is obviously wrong, but it is allowed because our ignored exceptions list
+    // includes NullPointerException
+    Closeable r = alloc();
+    if (true) {
+      throw NPE;
+    }
+    r.close();
+  }
+}

--- a/checker/tests/resourceleak-extraignoredexceptions/BasicTest.java
+++ b/checker/tests/resourceleak-extraignoredexceptions/BasicTest.java
@@ -1,0 +1,36 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+abstract class BasicTest {
+
+  abstract Closeable alloc();
+
+  abstract void method();
+
+  public void runtimeExceptionManuallyThrown() throws IOException {
+    // this code is obviously wrong, but RuntimeException is ignored by default
+    Closeable r = alloc();
+    if (true) {
+      throw new RuntimeException();
+    }
+    r.close();
+  }
+
+  public void runtimeExceptionFromMethod() throws IOException {
+    // method() may throw RuntimeException, but RuntimeException is ignored by default
+    Closeable r = alloc();
+    method();
+    r.close();
+  }
+
+  public void ignoreIllegalStateException() throws IOException {
+    // this code is obviously wrong, but it is allowed because our ignored exceptions list
+    // includes IllegalStateException
+    Closeable r = alloc();
+    if (true) {
+      throw new IllegalStateException();
+    }
+    r.close();
+  }
+}

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -514,15 +514,18 @@ verification tool.
 
 The set of ignored exception types can be controlled with the option
 \<-AresourceLeakIgnoredExceptions=...>.  The option takes a comma-separated list of
-fully-qualified exception types.  For example, a very pedantic set of ignored
-exceptions might be
+fully-qualified exception types.  It can also include \<? extends TYPE> to ignore all
+subtypes of an exception.  For example, for a very pedantic set of ignored exceptions use:
 
 \begin{verbatim}
-  -AresourceLeakIgnoredExceptions=java.lang.Error,java.lang.NullPointerException
+  -AresourceLeakIgnoredExceptions=? extends java.lang.Error, java.lang.NullPointerException
 \end{verbatim}
 
+which ignores \<java.lang.Error> (and all its subclasses) as well as
+\<java.lang.NullPointerException> (but not its subclasses).
+
 The keyword \<default> will expand to the default set of ignored exceptions.  So,
-to add an exception to the set of ignored exceptions, use e.g.
+to add an additional exception to the set of ignored exceptions, use:
 
 \begin{verbatim}
   -AresourceLeakIgnoredExceptions=default,package.MyCustomException

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -51,11 +51,13 @@ javac -processor org.checkerframework.checker.resourceleak.ResourceLeakChecker M
 
 The Resource Leak Checker supports all the command-line arguments
 listed in Section~\ref{called-methods-run-checker} for
-the Called Methods Checker, plus two others:
+the Called Methods Checker, plus three others:
 
 \begin{description}
 \item[\<-ApermitStaticOwning>]
   See Section~\ref{resource-leak-owning-fields}.
+\item[\<-AresourceLeakIgnoredExceptions=...>]
+  See Section~\ref{resource-leak-ignored-exceptions}.
 \item[\<-ApermitInitializationLeak>]
   See Section~\ref{resource-leak-field-initialization}.
 \end{description}
@@ -510,6 +512,14 @@ be ignored by filing an issue listing both the exception type and the
 verification tool.
 \end{itemize}
 
+The set of ignored exception types can be controlled with the option
+\<-AresourceLeakIgnoredExceptions=...>.  The option takes a comma-separated list of
+fully-qualified exception types.  For example, a very pedantic set of ignored
+exceptions might be
+
+\begin{verbatim}
+  -AresourceLeakIgnoredExceptions=java.lang.Error,java.lang.NullPointerException
+\end{verbatim}
 
 \sectionAndLabel{Errors about field initialization}{resource-leak-field-initialization}
 

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -491,6 +491,8 @@ an \<OutOfMemoryError> on any allocation.  Similarly,
 \<ClassCircularityError>, \<ClassFormatError>, and \<NoClassDefFoundError>
 may occur at any reference to a class.  Such exceptions usually terminate
 the program, and in that case unclosed resources do not matter.
+Furthermore, any method can throw \<RuntimeException>, and by default the
+Checker Framework pessimistically assumes one can be thrown by every call.
 Accounting for such exceptions would lead to vast numbers of
 false positive warnings, so the Resource Leak Checker assumes they are
 never thrown.  Strictly speaking, this is an unsoundness:  it can lead to

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -487,14 +487,14 @@ The Resource Leak Checker ignores control flow due to some exceptions.
 
 \begin{itemize}
 \item
-The Resource Leak Checker ignores run-time errors that can occur
+By default the Resource Leak Checker ignores run-time errors that can occur
 unpredictably at most points in the program. For example, the JVM can throw
 an \<OutOfMemoryError> on any allocation.  Similarly,
 \<ClassCircularityError>, \<ClassFormatError>, and \<NoClassDefFoundError>
 may occur at any reference to a class.  Such exceptions usually terminate
 the program, and in that case unclosed resources do not matter.
-Furthermore, any method can throw \<RuntimeException>, and by default the
-Checker Framework pessimistically assumes one can be thrown by every call.
+Furthermore, any method can throw \<RuntimeException>, and the Checker
+Framework pessimistically assumes one can be thrown at every call site.
 Accounting for such exceptions would lead to vast numbers of
 false positive warnings, so the Resource Leak Checker assumes they are
 never thrown.  Strictly speaking, this is an unsoundness:  it can lead to

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -521,6 +521,13 @@ exceptions might be
   -AresourceLeakIgnoredExceptions=java.lang.Error,java.lang.NullPointerException
 \end{verbatim}
 
+The keyword \<default> will expand to the default set of ignored exceptions.  So,
+to add an exception to the set of ignored exceptions, use e.g.
+
+\begin{verbatim}
+  -AresourceLeakIgnoredExceptions=default,package.MyCustomException
+\end{verbatim}
+
 \sectionAndLabel{Errors about field initialization}{resource-leak-field-initialization}
 
 % Arguably, this is working around a bug in the

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -514,11 +514,12 @@ verification tool.
 
 The set of ignored exception types can be controlled with the option
 \<-AresourceLeakIgnoredExceptions=...>.  The option takes a comma-separated list of
-fully-qualified exception types.  It can also include \<? extends TYPE> to ignore all
-subtypes of an exception.  For example, for a very pedantic set of ignored exceptions use:
+fully-qualified exception types.  A type can be prefixed with \<=> to ignore exactly
+that type and not its subclasses.  For example, for a very pedantic set of ignored
+exceptions use:
 
 \begin{verbatim}
-  -AresourceLeakIgnoredExceptions=? extends java.lang.Error, java.lang.NullPointerException
+  -AresourceLeakIgnoredExceptions=java.lang.Error, =java.lang.NullPointerException
 \end{verbatim}
 
 which ignores \<java.lang.Error> (and all its subclasses) as well as


### PR DESCRIPTION
Fixes #6218.

This change is admittedly overwrought, but
 - I want the ability to ignore all subtypes of an exception type and
 - I want to preserve the current behavior where subtypes of the default ignored exceptions are _not_ themselves ignored.

To meet those constraints I added a new data structure (`SetOfTypes`) and some funky syntax for specifying the set of ignored exceptions.

I'm not particularly attached to the syntax, and we should probably discuss improvements because it will be difficult to change later.

I picked the option name "resourceLeakIgnoredExceptions", but I'm happy to rename it if there is some sort of option naming pattern to follow.