### PR TITLE
Suggest use of maven-compiler-plugin 3.11.0

### DIFF
--- a/docs/examples/MavenExample/pom.xml
+++ b/docs/examples/MavenExample/pom.xml
@@ -68,7 +68,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.1</version>
+            <version>3.11.0</version>
             <configuration>
               <fork>true</fork> <!-- Must fork or else JVM arguments are ignored. -->
               <annotationProcessorPaths>

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -1032,7 +1032,7 @@ latest bug fixes and new features:
         <plugins>
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.1</version>
+            <version>3.11.0</version>
             <configuration>
               <fork>true</fork> <!-- Must fork or else JVM arguments are ignored. -->
               <annotationProcessorPaths>


### PR DESCRIPTION
I've found that with maven-compiler-plugin 3.10.1, many Error Prone and NullAway warnings are not printed; see https://github.com/google/error-prone/pull/4162.  This may affect Checker Framework warnings as well.