### PR TITLE
Add missing meta-annotations to Called Methods Checker

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethods.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethods.java
@@ -44,6 +44,7 @@ import org.checkerframework.framework.qual.QualifierArgument;
 @PostconditionAnnotation(qualifier = CalledMethods.class)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 @Repeatable(EnsuresCalledMethods.List.class)
+@InheritedAnnotation
 public @interface EnsuresCalledMethods {
   /**
    * The Java expressions that will have methods called on them.
@@ -72,6 +73,7 @@ public @interface EnsuresCalledMethods {
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
   @InheritedAnnotation
+  @PostconditionAnnotation(qualifier = CalledMethods.class)
   public static @interface List {
     /**
      * Return the repeatable annotations.

--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/RequiresCalledMethods.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/RequiresCalledMethods.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.calledmethods.qual;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -22,6 +23,7 @@ import org.checkerframework.framework.qual.QualifierArgument;
 @Retention(RetentionPolicy.RUNTIME)
 @PreconditionAnnotation(qualifier = CalledMethods.class)
 @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Repeatable(RequiresCalledMethods.List.class)
 public @interface RequiresCalledMethods {
   /**
    * The Java expressions that must have had methods called on them.
@@ -48,6 +50,7 @@ public @interface RequiresCalledMethods {
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
+  @PreconditionAnnotation(qualifier = CalledMethods.class)
   @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
   public static @interface List {
     /**

--- a/checker/tests/calledmethods/EnsuresCalledMethodsIfRepeatable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsIfRepeatable.java
@@ -1,0 +1,53 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsIf;
+
+public class EnsuresCalledMethodsIfRepeatable {
+
+  @EnsuresCalledMethodsIf(expression = "#1", result = true, methods = "close")
+  @EnsuresCalledMethodsIf(expression = "#2", result = true, methods = "close")
+  public boolean close2MissingFirst(Closeable r1, Closeable r2) throws IOException {
+    r1.close();
+    // ::error: (contracts.conditional.postcondition)
+    return true;
+  }
+
+  @EnsuresCalledMethodsIf(expression = "#1", result = true, methods = "close")
+  @EnsuresCalledMethodsIf(expression = "#2", result = true, methods = "close")
+  public boolean close2MissingSecond(Closeable r1, Closeable r2) throws IOException {
+    r2.close();
+    // ::error: (contracts.conditional.postcondition)
+    return true;
+  }
+
+  @EnsuresCalledMethodsIf(expression = "#1", result = true, methods = "close")
+  @EnsuresCalledMethodsIf(expression = "#2", result = true, methods = "close")
+  public boolean close2Correct(Closeable r1, Closeable r2) throws IOException {
+    try {
+      r1.close();
+    } finally {
+      r2.close();
+    }
+    return true;
+  }
+
+  @EnsuresCalledMethodsIf(expression = "#1", result = true, methods = "close")
+  @EnsuresCalledMethodsIf(expression = "#2", result = true, methods = "close")
+  public boolean close2CorrectViaCall(Closeable r1, Closeable r2) throws IOException {
+    return close2Correct(r1, r2);
+  }
+
+  public static class SubclassWrong extends EnsuresCalledMethodsIfRepeatable {
+    @Override
+    public boolean close2Correct(Closeable r1, Closeable r2) throws IOException {
+      // ::error: (contracts.conditional.postcondition)
+      return true;
+    }
+  }
+
+  public static class SubclassRight extends EnsuresCalledMethodsIfRepeatable {
+    @Override
+    public boolean close2Correct(Closeable r1, Closeable r2) throws IOException {
+      return false;
+    }
+  }
+}

--- a/checker/tests/calledmethods/EnsuresCalledMethodsIfSubclass.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsIfSubclass.java
@@ -1,0 +1,28 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsIf;
+
+public class EnsuresCalledMethodsIfSubclass {
+
+  public static class Parent {
+    @EnsuresCalledMethodsIf(expression = "#1", result = true, methods = "close")
+    public boolean method(Closeable x) throws IOException {
+      x.close();
+      return true;
+    }
+  }
+
+  public static class SubclassWrong extends Parent {
+    @Override
+    public boolean method(Closeable x) throws IOException {
+      // ::error: (contracts.conditional.postcondition)
+      return true;
+    }
+  }
+
+  public static class SubclassRight extends Parent {
+    @Override
+    public boolean method(Closeable x) throws IOException {
+      return false;
+    }
+  }
+}

--- a/checker/tests/calledmethods/EnsuresCalledMethodsRepeatable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsRepeatable.java
@@ -1,3 +1,4 @@
+import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 
 class EnsuresCalledMethodsRepeatable {
@@ -11,5 +12,41 @@ class EnsuresCalledMethodsRepeatable {
   void test(Object obj) {
     obj.toString();
     obj.hashCode();
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "close")
+  @EnsuresCalledMethods(value = "#2", methods = "close")
+  // ::error: (contracts.postcondition)
+  public void close2MissingFirst(Closeable r1, Closeable r2) throws IOException {
+    r1.close();
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "close")
+  @EnsuresCalledMethods(value = "#2", methods = "close")
+  // ::error: (contracts.postcondition)
+  public void close2MissingSecond(Closeable r1, Closeable r2) throws IOException {
+    r2.close();
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "close")
+  @EnsuresCalledMethods(value = "#2", methods = "close")
+  public void close2Correct(Closeable r1, Closeable r2) throws IOException {
+    try {
+      r1.close();
+    } finally {
+      r2.close();
+    }
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "close")
+  @EnsuresCalledMethods(value = "#2", methods = "close")
+  public void close2CorrectViaCall(Closeable r1, Closeable r2) throws IOException {
+    close2Correct(r1, r2);
+  }
+
+  public static class Subclass extends EnsuresCalledMethodsRepeatable {
+    @Override
+    // ::error: (contracts.postcondition)
+    public void close2Correct(Closeable r1, Closeable r2) throws IOException {}
   }
 }

--- a/checker/tests/calledmethods/EnsuresCalledMethodsSubclass.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsSubclass.java
@@ -1,0 +1,18 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+
+public class EnsuresCalledMethodsSubclass {
+
+  public static class Parent {
+    @EnsuresCalledMethods(value = "#1", methods = "close")
+    public void method(Closeable x) throws IOException {
+      x.close();
+    }
+  }
+
+  public static class Subclass extends Parent {
+    @Override
+    // ::error: (contracts.postcondition)
+    public void method(Closeable x) throws IOException {}
+  }
+}

--- a/checker/tests/calledmethods/RequiresCalledMethodsRepeatable.java
+++ b/checker/tests/calledmethods/RequiresCalledMethodsRepeatable.java
@@ -1,0 +1,32 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+public class RequiresCalledMethodsRepeatable {
+
+  @RequiresCalledMethods(value = "#1", methods = "close")
+  @RequiresCalledMethods(value = "#2", methods = "close")
+  public void requires2(Closeable r1, Closeable r2) {
+    @CalledMethods("close") Closeable r3 = r1;
+    @CalledMethods("close") Closeable r4 = r2;
+  }
+
+  public void requires2Wrong(Closeable r1, Closeable r2) {
+    // ::error: (contracts.precondition)
+    requires2(r1, r2);
+  }
+
+  @RequiresCalledMethods(value = "#1", methods = "close")
+  @RequiresCalledMethods(value = "#2", methods = "close")
+  public void requires2Correct(Closeable r1, Closeable r2) {
+    requires2(r1, r2);
+  }
+
+  public static class Subclass extends RequiresCalledMethodsRepeatable {
+    @Override
+    public void requires2Correct(Closeable r1, Closeable r2) {}
+
+    public void caller(Closeable r1, Closeable r2) {
+      requires2Correct(r1, r2); // OK: we override requires2Correct() with a weaker precondition
+    }
+  }
+}

--- a/checker/tests/calledmethods/RequiresCalledMethodsSubclass.java
+++ b/checker/tests/calledmethods/RequiresCalledMethodsSubclass.java
@@ -1,0 +1,24 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.RequiresCalledMethods;
+
+public class RequiresCalledMethodsSubclass {
+
+  public static class Parent {
+    @RequiresCalledMethods(value = "#1", methods = "close")
+    public void method(Closeable x) throws IOException {}
+
+    public void caller(Closeable x) throws IOException {
+      // ::error: (contracts.precondition)
+      method(x);
+    }
+  }
+
+  public static class Subclass extends Parent {
+    @Override
+    public void method(Closeable x) throws IOException {}
+
+    public void caller(Closeable x) throws IOException {
+      method(x); // OK: we override method() with a weaker precondition
+    }
+  }
+}


### PR DESCRIPTION
The Called Methods Checker pre- and postcondition annotations were missing some meta-annotations to make them properly repeatable and correctly inherited.  This commit adds the missing annotations along with a fairly complete set of tests.