### PR TITLE
Add `@EnsuresCalledMethodsOnException`

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethods.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethods.java
@@ -39,6 +39,7 @@ import org.checkerframework.framework.qual.QualifierArgument;
  * </pre>
  *
  * @see EnsuresCalledMethodsIf
+ * @see EnsuresCalledMethodsOnException
  * @checker_framework.manual #called-methods-checker Called Methods Checker
  */
 @PostconditionAnnotation(qualifier = CalledMethods.class)

--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
@@ -1,0 +1,83 @@
+package org.checkerframework.checker.calledmethods.qual;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.InheritedAnnotation;
+
+/**
+ * Indicates that the method, if it terminates by throwing an exception, always invokes the given
+ * methods on the given expressions. This annotation is repeatable, which means that users can write
+ * more than one instance of it on the same method (users should NOT manually write an
+ * {@code @EnsuresCalledMethodsOnException.List} annotation, which the checker will create from
+ * multiple copies of this annotation automatically).
+ *
+ * <p>Consider the following method:
+ *
+ * <pre>
+ * &#64;EnsuresCalledMethodsOnException(value = "#1", methods = "m")
+ * public void callM(T t) { ... }
+ * </pre>
+ *
+ * <p>This method guarantees that {@code t.m()} is always called before the method throws an
+ * exception.
+ *
+ * @see EnsuresCalledMethods
+ * @checker_framework.manual #called-methods-checker Called Methods Checker
+ */
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Repeatable(EnsuresCalledMethodsOnException.List.class)
+@Retention(RetentionPolicy.RUNTIME)
+@InheritedAnnotation
+public @interface EnsuresCalledMethodsOnException {
+
+  /**
+   * Returns Java expressions that have had the given methods called on them after the method throws
+   * an exception.
+   *
+   * @return an array of Java expressions
+   * @checker_framework.manual #java-expressions-as-arguments Syntax of Java expressions
+   */
+  String[] value();
+
+  // NOTE 2023/10/6: There seems to be a fundamental limitation in the dataflow framework that
+  // prevent this feature.  Specifically, every method has a SINGLE exceptional exit block, meaning
+  // all information about what happens down different exception paths gets totally erased.
+  //  /**
+  //   * Returns the exception types under which the postcondition holds.
+  //   *
+  //   * @return the exception types under which the postcondition holds.
+  //   */
+  //  Class<? extends Throwable>[] exceptions();
+
+  /**
+   * The methods guaranteed to be invoked on the expressions if the result of the method throws an
+   * exception.
+   *
+   * @return the methods guaranteed to be invoked on the expressions if the method throws an
+   *     exception
+   */
+  String[] methods();
+
+  /**
+   * A wrapper annotation that makes the {@link EnsuresCalledMethodsOnException} annotation
+   * repeatable. This annotation is an implementation detail: programmers generally do not need to
+   * write this. It is created automatically by Java when a programmer writes more than one {@link
+   * EnsuresCalledMethodsOnException} annotation at the same location.
+   */
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+  @InheritedAnnotation
+  public static @interface List {
+    /**
+     * Return the repeatable annotations.
+     *
+     * @return the repeatable annotations
+     */
+    EnsuresCalledMethodsOnException[] value();
+  }
+}

--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
@@ -9,9 +9,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.InheritedAnnotation;
 
 /**
- * Indicates that the method, if it terminates by throwing an exception, always invokes the given
- * methods on the given expressions. This annotation is repeatable, which means that users can write
- * more than one instance of it on the same method (users should NOT manually write an
+ * Indicates that the method, if it terminates by throwing an {@link Exception}, always invokes the
+ * given methods on the given expressions. This annotation is repeatable, which means that users can
+ * write more than one instance of it on the same method (users should NOT manually write an
  * {@code @EnsuresCalledMethodsOnException.List} annotation, which the checker will create from
  * multiple copies of this annotation automatically).
  *
@@ -22,8 +22,12 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
  * public void callM(T t) { ... }
  * </pre>
  *
- * <p>This method guarantees that {@code t.m()} is always called before the method throws an
- * exception.
+ * <p>The <code>callM</code> method promises to always call {@code t.m()} before throwing any kind
+ * of {@link Exception}.
+ *
+ * <p>Note that {@code EnsuresCalledMethodsOnException} only describes behavior for {@link
+ * Exception} (and by extension {@link RuntimeException}, {@link NullPointerException}, etc.) but
+ * not {@link Error} or other throwables.
  *
  * @see EnsuresCalledMethods
  * @checker_framework.manual #called-methods-checker Called Methods Checker

--- a/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/calledmethods/qual/EnsuresCalledMethodsOnException.java
@@ -48,8 +48,18 @@ public @interface EnsuresCalledMethodsOnException {
   String[] value();
 
   // NOTE 2023/10/6: There seems to be a fundamental limitation in the dataflow framework that
-  // prevent this feature.  Specifically, every method has a SINGLE exceptional exit block, meaning
-  // all information about what happens down different exception paths gets totally erased.
+  // prevent us from supporting a custom set of exceptions.  Specifically, in the following code:
+  //
+  //     try {
+  //       m1();
+  //     } finally {
+  //       m2();
+  //     }
+  //
+  // all exceptional edges out of the `m1()` call will flow to the same place: the start of the
+  // `m2()` call in the finally block.  Any information about what `m1()` promised on specific
+  // exception types will be lost.
+  //
   //  /**
   //   * Returns the exception types under which the postcondition holds.
   //   *

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -482,9 +482,9 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    * @return the exceptional postconditions on the given method; the return value is newly-allocated
    *     and can be freely modified by callers
    */
-  public Set<EnsuredCalledMethodOnException> getExceptionalPostconditions(
+  public Set<EnsuresCalledMethodOnExceptionContract> getExceptionalPostconditions(
       ExecutableElement methodOrConstructor) {
-    Set<EnsuredCalledMethodOnException> result = new LinkedHashSet<>();
+    Set<EnsuresCalledMethodOnExceptionContract> result = new LinkedHashSet<>();
 
     parseEnsuresCalledMethodOnExceptionListAnnotation(
         getDeclAnnotation(methodOrConstructor, EnsuresCalledMethodsOnException.List.class), result);
@@ -503,7 +503,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    * @param out the output collection
    */
   private void parseEnsuresCalledMethodOnExceptionListAnnotation(
-      @Nullable AnnotationMirror annotation, Set<EnsuredCalledMethodOnException> out) {
+      @Nullable AnnotationMirror annotation, Set<EnsuresCalledMethodOnExceptionContract> out) {
     if (annotation == null) {
       return;
     }
@@ -528,7 +528,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    * @param out the output collection
    */
   private void parseEnsuresCalledMethodOnExceptionAnnotation(
-      @Nullable AnnotationMirror annotation, Set<EnsuredCalledMethodOnException> out) {
+      @Nullable AnnotationMirror annotation, Set<EnsuresCalledMethodOnExceptionContract> out) {
     if (annotation == null) {
       return;
     }
@@ -548,7 +548,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
 
     for (String expr : expressions) {
       for (String method : methods) {
-        out.add(new EnsuredCalledMethodOnException(expr, method));
+        out.add(new EnsuresCalledMethodOnExceptionContract(expr, method));
       }
     }
   }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -6,6 +6,7 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -408,7 +409,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    */
   protected List<String> getCalledMethods(AnnotationMirror calledMethodsAnnotation) {
     return AnnotationUtils.getElementValueArray(
-        calledMethodsAnnotation, calledMethodsValueElement, String.class);
+        calledMethodsAnnotation, calledMethodsValueElement, String.class, Collections.emptyList());
   }
 
   @Override
@@ -509,7 +510,10 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
 
     List<AnnotationMirror> annotations =
         AnnotationUtils.getElementValueArray(
-            annotation, ensuresCalledMethodsOnExceptionListValueElement, AnnotationMirror.class);
+            annotation,
+            ensuresCalledMethodsOnExceptionListValueElement,
+            AnnotationMirror.class,
+            Collections.emptyList());
 
     for (AnnotationMirror a : annotations) {
       parseEnsuresCalledMethodOnExceptionAnnotation(a, out);
@@ -531,10 +535,16 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
 
     List<String> expressions =
         AnnotationUtils.getElementValueArray(
-            annotation, ensuresCalledMethodsOnExceptionValueElement, String.class);
+            annotation,
+            ensuresCalledMethodsOnExceptionValueElement,
+            String.class,
+            Collections.emptyList());
     List<String> methods =
         AnnotationUtils.getElementValueArray(
-            annotation, ensuresCalledMethodsOnExceptionMethodsElement, String.class);
+            annotation,
+            ensuresCalledMethodsOnExceptionMethodsElement,
+            String.class,
+            Collections.emptyList());
 
     for (String expr : expressions) {
       for (String method : methods) {

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -400,6 +400,17 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
     return builderFrameworkSupports;
   }
 
+  /**
+   * Get the called methods specified by the given {@link CalledMethods} annotation.
+   *
+   * @param calledMethodsAnnotation the annotation
+   * @return the called methods
+   */
+  protected List<String> getCalledMethods(AnnotationMirror calledMethodsAnnotation) {
+    return AnnotationUtils.getElementValueArray(
+        calledMethodsAnnotation, calledMethodsValueElement, String.class);
+  }
+
   @Override
   protected @Nullable AnnotationMirror createRequiresOrEnsuresQualifier(
       String expression,
@@ -408,8 +419,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
       Analysis.BeforeOrAfter preOrPost,
       @Nullable List<AnnotationMirror> preconds) {
     if (preOrPost == BeforeOrAfter.AFTER && isAccumulatorAnnotation(qualifier)) {
-      List<String> calledMethods =
-          AnnotationUtils.getElementValueArray(qualifier, calledMethodsValueElement, String.class);
+      List<String> calledMethods = getCalledMethods(qualifier);
       if (!calledMethods.isEmpty()) {
         return ensuresCMAnno(expression, calledMethods);
       }
@@ -468,7 +478,8 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    * EnsuresCalledMethodsOnException} annotations on it.
    *
    * @param methodOrConstructor the method to examine
-   * @return the exceptional postconditions on the given method
+   * @return the exceptional postconditions on the given method; the return value is newly-allocated
+   *     and can be freely modified by callers
    */
   public Set<EnsuredCalledMethodOnException> getExceptionalPostconditions(
       ExecutableElement methodOrConstructor) {

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -6,7 +6,9 @@ import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.Tree;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -21,6 +23,7 @@ import org.checkerframework.checker.calledmethods.qual.CalledMethods;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsBottom;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsPredicate;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsVarArgs;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.accumulation.AccumulationAnnotatedTypeFactory;
@@ -73,6 +76,18 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
   /** The {@link EnsuresCalledMethodsVarArgs#value} element/argument. */
   /*package-private*/ final ExecutableElement ensuresCalledMethodsVarArgsValueElement =
       TreeUtils.getMethod(EnsuresCalledMethodsVarArgs.class, "value", 0, processingEnv);
+
+  /** The {@link EnsuresCalledMethodsOnException#value} element/argument. */
+  /*package-private*/ final ExecutableElement ensuresCalledMethodsOnExceptionValueElement =
+      TreeUtils.getMethod(EnsuresCalledMethodsOnException.class, "value", 0, processingEnv);
+
+  /** The {@link EnsuresCalledMethodsOnException#methods} element/argument. */
+  /*package-private*/ final ExecutableElement ensuresCalledMethodsOnExceptionMethodsElement =
+      TreeUtils.getMethod(EnsuresCalledMethodsOnException.class, "methods", 0, processingEnv);
+
+  /** The {@link EnsuresCalledMethodsOnException.List#value} element/argument. */
+  /*package-private*/ final ExecutableElement ensuresCalledMethodsOnExceptionListValueElement =
+      TreeUtils.getMethod(EnsuresCalledMethodsOnException.List.class, "value", 0, processingEnv);
 
   /**
    * Create a new CalledMethodsAnnotatedTypeFactory.
@@ -446,5 +461,74 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
           TypesUtils.getQualifiedName((DeclaredType) exceptionType));
     }
     return false;
+  }
+
+  /**
+   * Get the exceptional postconditions for the given method from the {@link
+   * EnsuresCalledMethodsOnException} annotations on it.
+   *
+   * @param methodOrConstructor the method to examine
+   * @return the exceptional postconditions on the given method
+   */
+  public Set<EnsuredCalledMethodOnException> getExceptionalPostconditions(
+      ExecutableElement methodOrConstructor) {
+    Set<EnsuredCalledMethodOnException> result = new LinkedHashSet<>();
+
+    parseEnsuresCalledMethodOnExceptionListAnnotation(
+        getDeclAnnotation(methodOrConstructor, EnsuresCalledMethodsOnException.List.class), result);
+
+    parseEnsuresCalledMethodOnExceptionAnnotation(
+        getDeclAnnotation(methodOrConstructor, EnsuresCalledMethodsOnException.class), result);
+
+    return result;
+  }
+
+  /**
+   * Helper for {@link #getExceptionalPostconditions(ExecutableElement)} that parses a {@link
+   * EnsuresCalledMethodsOnException.List} annotation and stores the results in <code>out</code>.
+   *
+   * @param annotation the annotation
+   * @param out the output collection
+   */
+  private void parseEnsuresCalledMethodOnExceptionListAnnotation(
+      @Nullable AnnotationMirror annotation, Set<EnsuredCalledMethodOnException> out) {
+    if (annotation == null) {
+      return;
+    }
+
+    List<AnnotationMirror> annotations =
+        AnnotationUtils.getElementValueArray(
+            annotation, ensuresCalledMethodsOnExceptionListValueElement, AnnotationMirror.class);
+
+    for (AnnotationMirror a : annotations) {
+      parseEnsuresCalledMethodOnExceptionAnnotation(a, out);
+    }
+  }
+
+  /**
+   * Helper for {@link #getExceptionalPostconditions(ExecutableElement)} that parses a {@link
+   * EnsuresCalledMethodsOnException} annotation and stores the results in <code>out</code>.
+   *
+   * @param annotation the annotation
+   * @param out the output collection
+   */
+  private void parseEnsuresCalledMethodOnExceptionAnnotation(
+      @Nullable AnnotationMirror annotation, Set<EnsuredCalledMethodOnException> out) {
+    if (annotation == null) {
+      return;
+    }
+
+    List<String> expressions =
+        AnnotationUtils.getElementValueArray(
+            annotation, ensuresCalledMethodsOnExceptionValueElement, String.class);
+    List<String> methods =
+        AnnotationUtils.getElementValueArray(
+            annotation, ensuresCalledMethodsOnExceptionMethodsElement, String.class);
+
+    for (String expr : expressions) {
+      for (String method : methods) {
+        out.add(new EnsuredCalledMethodOnException(expr, method));
+      }
+    }
   }
 }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -267,7 +267,7 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
       ExecutableElement method,
       Map<TypeMirror, AccumulationStore> exceptionalStores) {
     Types types = atypeFactory.getProcessingEnv().getTypeUtils();
-    for (EnsuredCalledMethodOnException postcond :
+    for (EnsuresCalledMethodOnExceptionContract postcond :
         ((CalledMethodsAnnotatedTypeFactory) atypeFactory).getExceptionalPostconditions(method)) {
       JavaExpression e;
       try {

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -279,6 +279,11 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
         // postcondition and move on to the others.
         continue;
       }
+
+      // NOTE: this code is a little inefficient; it creates a single-method annotation and calls
+      // `insertOrRefine` in a loop.  Even worse, this code appears within a loop.  For now we
+      // aren't too worried about it, since the number of EnsuresCalledMethodsOnException
+      // annotations should be small.
       AnnotationMirror calledMethod =
           atypeFactory.createAccumulatorAnnotation(postcond.getMethod());
       for (Map.Entry<TypeMirror, AccumulationStore> successor : exceptionalStores.entrySet()) {

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -6,10 +6,12 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsVarArgs;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.resourceleak.ResourceLeakChecker;
@@ -26,8 +28,11 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
+import org.checkerframework.framework.util.JavaExpressionParseUtil;
+import org.checkerframework.framework.util.StringToJavaExpression;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
 import org.plumelib.util.CollectionsPlume;
 
@@ -52,6 +57,9 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
    */
   private final ExecutableElement calledMethodsValueElement;
 
+  /** The type mirror for {@link Exception}. */
+  protected final TypeMirror javaLangExceptionType;
+
   /**
    * True if -AenableWpiForRlc was passed on the command line. See {@link
    * ResourceLeakChecker#ENABLE_WPI_FOR_RLC}.
@@ -68,6 +76,10 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
     calledMethodsValueElement =
         ((CalledMethodsAnnotatedTypeFactory) atypeFactory).calledMethodsValueElement;
     enableWpiForRlc = atypeFactory.getChecker().hasOption(ResourceLeakChecker.ENABLE_WPI_FOR_RLC);
+
+    ProcessingEnvironment env = atypeFactory.getProcessingEnv();
+    javaLangExceptionType =
+        env.getTypeUtils().getDeclaredType(ElementUtils.getTypeElement(env, Exception.class));
   }
 
   /**
@@ -109,7 +121,11 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
     exceptionalStores = makeExceptionalStores(node, input);
     TransferResult<AccumulationValue, AccumulationStore> superResult =
         super.visitMethodInvocation(node, input);
-    handleEnsuresCalledMethodsVarArgs(node, superResult);
+
+    ExecutableElement method = TreeUtils.elementFromUse(node.getTree());
+    handleEnsuresCalledMethodsVarArgs(node, method, superResult);
+    handleEnsuresCalledMethodsOnException(node, method, exceptionalStores);
+
     Node receiver = node.getTarget().getReceiver();
     if (receiver != null) {
       String methodName = node.getTarget().getMethod().getSimpleName().toString();
@@ -196,11 +212,13 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
    * present.
    *
    * @param node the method invocation node
+   * @param elt the method being invoked
    * @param result the current result
    */
   private void handleEnsuresCalledMethodsVarArgs(
-      MethodInvocationNode node, TransferResult<AccumulationValue, AccumulationStore> result) {
-    ExecutableElement elt = TreeUtils.elementFromUse(node.getTree());
+      MethodInvocationNode node,
+      ExecutableElement elt,
+      TransferResult<AccumulationValue, AccumulationStore> result) {
     AnnotationMirror annot = atypeFactory.getDeclAnnotation(elt, EnsuresCalledMethodsVarArgs.class);
     if (annot == null) {
       return;
@@ -231,6 +249,44 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
         JavaExpression receiverReceiver = JavaExpression.fromNode(arg);
         thenStore.insertValue(receiverReceiver, newType);
         elseStore.insertValue(receiverReceiver, newType);
+      }
+    }
+  }
+
+  /**
+   * Update the given <code>exceptionalStores</code> for the {@link
+   * org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException} annotations
+   * written on the given <code>method</code>.
+   *
+   * @param node a method invocation
+   * @param method the method being invoked
+   * @param exceptionalStores the stores to update
+   */
+  private void handleEnsuresCalledMethodsOnException(
+      MethodInvocationNode node,
+      ExecutableElement method,
+      Map<TypeMirror, AccumulationStore> exceptionalStores) {
+    Types types = atypeFactory.getProcessingEnv().getTypeUtils();
+    for (EnsuredCalledMethodOnException postcond :
+        ((CalledMethodsAnnotatedTypeFactory) atypeFactory).getExceptionalPostconditions(method)) {
+      JavaExpression e;
+      try {
+        e =
+            StringToJavaExpression.atMethodInvocation(
+                postcond.getExpression(), node.getTree(), atypeFactory.getChecker());
+      } catch (JavaExpressionParseUtil.JavaExpressionParseException ex) {
+        // This parse error will be reported later. For now, we'll skip this malformed
+        // postcondition and move on to the others.
+        continue;
+      }
+      AnnotationMirror calledMethod =
+          atypeFactory.createAccumulatorAnnotation(postcond.getMethod());
+      for (Map.Entry<TypeMirror, AccumulationStore> successor : exceptionalStores.entrySet()) {
+        TypeMirror caughtException = successor.getKey();
+        if (types.isSubtype(caughtException, javaLangExceptionType)) {
+          AccumulationStore resultStore = successor.getValue();
+          resultStore.insertOrRefine(e, calledMethod);
+        }
       }
     }
   }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
@@ -107,7 +107,7 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
     if (!checkContract(e, requiredAnno, inferredAnno, exitStore)) {
       checker.reportError(
           tree,
-          "contracts.postcondition",
+          "contracts.exceptional.postcondition",
           tree.getName(),
           contractExpressionAndType(postcond.getExpression(), inferredAnno),
           contractExpressionAndType(postcond.getExpression(), requiredAnno));

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
@@ -65,7 +65,7 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
         checker.report(tree, new DiagMessage(Diagnostic.Kind.ERROR, "ensuresvarargs.invalid"));
       }
     }
-    for (EnsuredCalledMethodOnException postcond :
+    for (EnsuresCalledMethodOnExceptionContract postcond :
         ((CalledMethodsAnnotatedTypeFactory) atypeFactory).getExceptionalPostconditions(elt)) {
       checkExceptionalPostcondition(postcond, tree);
     }
@@ -79,7 +79,7 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
    * @param tree the method
    */
   protected void checkExceptionalPostcondition(
-      EnsuredCalledMethodOnException postcond, MethodTree tree) {
+      EnsuresCalledMethodOnExceptionContract postcond, MethodTree tree) {
     CFAbstractStore<?, ?> exitStore = atypeFactory.getExceptionalExitStore(tree);
     if (exitStore == null) {
       // If there is no exceptional exitStore, then the method cannot throw exceptions and

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsVisitor.java
@@ -82,7 +82,7 @@ public class CalledMethodsVisitor extends AccumulationVisitor {
       EnsuredCalledMethodOnException postcond, MethodTree tree) {
     CFAbstractStore<?, ?> exitStore = atypeFactory.getExceptionalExitStore(tree);
     if (exitStore == null) {
-      // If there is no regular exitStore, then the method cannot throw exceptions and
+      // If there is no exceptional exitStore, then the method cannot throw exceptions and
       // there is no need to check anything.
       return;
     }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuredCalledMethodOnException.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuredCalledMethodOnException.java
@@ -6,8 +6,11 @@ import java.util.Objects;
  * A contract that a method calls the given method on the given expression when that method throws
  * an exception.
  *
+ * <p>Instances of this class are plain old immutable data with no interesting behavior.
+ *
  * @see org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException
  */
+// TODO: In the future, this class should be a record.
 public class EnsuredCalledMethodOnException {
 
   /** The expression described by this postcondition. */

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuredCalledMethodOnException.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuredCalledMethodOnException.java
@@ -1,0 +1,62 @@
+package org.checkerframework.checker.calledmethods;
+
+import java.util.Objects;
+
+/**
+ * A contract that a method calls the given method on the given expression when that method throws
+ * an exception.
+ *
+ * @see org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException
+ */
+public class EnsuredCalledMethodOnException {
+
+  /** The expression described by this postcondition. */
+  private final String expression;
+
+  /** The method this postcondition promises to call. */
+  private final String method;
+
+  /**
+   * Create a new <code>EnsuredCalledMethodOnException</code>. Usually this should be constructed
+   * from a {@link org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException}
+   * appearing in the source code.
+   *
+   * @param expression the expression described by this postcondition
+   * @param method the method this postcondition promises to call
+   */
+  public EnsuredCalledMethodOnException(String expression, String method) {
+    this.expression = expression;
+    this.method = method;
+  }
+
+  /**
+   * The expression described by this postcondition.
+   *
+   * @return the expression described by this postcondition
+   */
+  public String getExpression() {
+    return expression;
+  }
+
+  /**
+   * The method this postcondition promises to call.
+   *
+   * @return the method this postcondition promises to call
+   */
+  public String getMethod() {
+    return method;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof EnsuredCalledMethodOnException)) return false;
+    EnsuredCalledMethodOnException that = (EnsuredCalledMethodOnException) o;
+    return expression.equals(that.expression) && method.equals(that.method);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(expression, method);
+  }
+}

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuresCalledMethodOnExceptionContract.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/EnsuresCalledMethodOnExceptionContract.java
@@ -3,15 +3,15 @@ package org.checkerframework.checker.calledmethods;
 import java.util.Objects;
 
 /**
- * A contract that a method calls the given method on the given expression when that method throws
- * an exception.
+ * A postcondition contract that a method calls the given method on the given expression when that
+ * method throws an exception.
  *
  * <p>Instances of this class are plain old immutable data with no interesting behavior.
  *
  * @see org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException
  */
 // TODO: In the future, this class should be a record.
-public class EnsuredCalledMethodOnException {
+public class EnsuresCalledMethodOnExceptionContract {
 
   /** The expression described by this postcondition. */
   private final String expression;
@@ -27,7 +27,7 @@ public class EnsuredCalledMethodOnException {
    * @param expression the expression described by this postcondition
    * @param method the method this postcondition promises to call
    */
-  public EnsuredCalledMethodOnException(String expression, String method) {
+  public EnsuresCalledMethodOnExceptionContract(String expression, String method) {
     this.expression = expression;
     this.method = method;
   }
@@ -53,8 +53,8 @@ public class EnsuredCalledMethodOnException {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof EnsuredCalledMethodOnException)) return false;
-    EnsuredCalledMethodOnException that = (EnsuredCalledMethodOnException) o;
+    if (!(o instanceof EnsuresCalledMethodOnExceptionContract)) return false;
+    EnsuresCalledMethodOnExceptionContract that = (EnsuresCalledMethodOnExceptionContract) o;
     return expression.equals(that.expression) && method.equals(that.method);
   }
 

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/messages.properties
@@ -1,3 +1,4 @@
 finalizer.invocation=This finalizer cannot be invoked, because the following methods have not been called: %s
 ensuresvarargs.unverified=@EnsuresCalledMethodsVarArgs cannot be verified yet.  Please check that the implementation of the method actually does call the given methods on the varargs parameters by hand, and then suppress this warning.
 ensuresvarargs.invalid=@EnsuresCalledMethodsVarArgs cannot be written on a non-varargs method.
+contracts.exceptional.postcondition=on exception, postcondition of %s is not satisfied.%nfound   : %s%nrequired: %s

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/IOUtils.astub
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/IOUtils.astub
@@ -4,22 +4,38 @@ import org.checkerframework.checker.calledmethods.qual.*;
 
 class IOUtils {
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(Reader arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(Writer arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(InputStream arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(OutputStream arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(Closeable arg0);
+
     @SuppressWarnings("ensuresvarargs.unverified")
     @EnsuresCalledMethodsVarArgs("close")
     static void closeQuietly(Closeable... arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(Socket arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(Selector arg0);
+
     @EnsuresCalledMethods(value = "#1", methods = "close")
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
     static void closeQuietly(ServerSocket arg0);
 }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -13,7 +13,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import org.checkerframework.checker.calledmethods.CalledMethodsAnnotatedTypeFactory;
-import org.checkerframework.checker.calledmethods.EnsuredCalledMethodOnException;
+import org.checkerframework.checker.calledmethods.EnsuresCalledMethodOnExceptionContract;
 import org.checkerframework.checker.calledmethods.qual.CalledMethods;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsBottom;
 import org.checkerframework.checker.calledmethods.qual.CalledMethodsPredicate;
@@ -444,9 +444,9 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
   }
 
   @Override
-  public Set<EnsuredCalledMethodOnException> getExceptionalPostconditions(
+  public Set<EnsuresCalledMethodOnExceptionContract> getExceptionalPostconditions(
       ExecutableElement methodOrConstructor) {
-    Set<EnsuredCalledMethodOnException> result =
+    Set<EnsuresCalledMethodOnExceptionContract> result =
         super.getExceptionalPostconditions(methodOrConstructor);
 
     // This override is a sneaky way to satisfy a few subtle design constraints:
@@ -479,7 +479,8 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
       for (Contract.Postcondition normalPostcondition : normalPostconditions) {
         for (String method : getCalledMethods(normalPostcondition.annotation)) {
           result.add(
-              new EnsuredCalledMethodOnException(normalPostcondition.expressionString, method));
+              new EnsuresCalledMethodOnExceptionContract(
+                  normalPostcondition.expressionString, method));
         }
       }
     }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -466,6 +466,12 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
     //
     // It should be possible to remove this override entirely without sacrificing any soundness.
     // However, that is undesirable at this point because it would be a breaking change.
+    //
+    // TODO: gradually remove this override.
+    //   1. When this override adds an implicit annotation, the Checker Framework should issue
+    //      a warning along with a suggestion to add the right annotations.
+    //   2. After a few months we should remove this override and require proper annotations on
+    //      all destructors.
 
     if (isMustCallMethod(methodOrConstructor)) {
       Set<Contract.Postcondition> normalPostconditions =

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -3,7 +3,6 @@ package org.checkerframework.checker.resourceleak;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.VariableTree;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -366,20 +365,21 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
       }
     }
 
-    // This value is side-effected.
     List<String> mustCallObligationsOfOwningField = rlTypeFactory.getMustCallValues(field);
 
     if (mustCallObligationsOfOwningField.isEmpty()) {
       return;
     }
 
-    Set<DestructorObligation> unsatisfiedMustCallObligationsOfOwningField =
-        mustCallObligationsOfOwningField.stream()
-            .flatMap(
-                method ->
-                    Arrays.stream(MustCallConsistencyAnalyzer.MethodExitKind.values())
-                        .map(exitKind -> new DestructorObligation(method, exitKind)))
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+    // This value is side-effected.
+    Set<DestructorObligation> unsatisfiedMustCallObligationsOfOwningField = new LinkedHashSet<>();
+    for (String mustCallMethod : mustCallObligationsOfOwningField) {
+      for (MustCallConsistencyAnalyzer.MethodExitKind exitKind :
+          MustCallConsistencyAnalyzer.MethodExitKind.values()) {
+        unsatisfiedMustCallObligationsOfOwningField.add(
+            new DestructorObligation(mustCallMethod, exitKind));
+      }
+    }
 
     String error;
     Element enclosingElement = field.getEnclosingElement();

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -493,6 +493,7 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
   /**
    * Formats a list of must-call method post-conditions to be printed in an error message.
    *
+   * @param field the value whose methods must be called
    * @param mustCallVal the list of must-call strings
    * @return a formatted string
    */

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -307,6 +307,7 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
    * An obligation that must be satisfied by a destructor. Helper type for {@link
    * #checkOwningField(VariableElement)}.
    */
+  // TODO: In the future, this class should be a record.
   private static final class DestructorObligation {
     /** The method that must be called on the field. */
     final String mustCallMethod;

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakVisitor.java
@@ -15,7 +15,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.VariableElement;
 import org.checkerframework.checker.calledmethods.CalledMethodsVisitor;
-import org.checkerframework.checker.calledmethods.EnsuredCalledMethodOnException;
+import org.checkerframework.checker.calledmethods.EnsuresCalledMethodOnExceptionContract;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.CreatesMustCallForToJavaExpression;
 import org.checkerframework.checker.mustcall.MustCallAnnotatedTypeFactory;
@@ -428,9 +428,9 @@ public class ResourceLeakVisitor extends CalledMethodsVisitor {
               }
             }
 
-            Set<EnsuredCalledMethodOnException> exceptionalPostconds =
+            Set<EnsuresCalledMethodOnExceptionContract> exceptionalPostconds =
                 rlTypeFactory.getExceptionalPostconditions(siblingMethod);
-            for (EnsuredCalledMethodOnException postcond : exceptionalPostconds) {
+            for (EnsuresCalledMethodOnExceptionContract postcond : exceptionalPostconds) {
               if (expressionEqualsField(postcond.getExpression(), field)) {
                 unsatisfiedMustCallObligationsOfOwningField.remove(
                     new DestructorObligation(

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
@@ -1,3 +1,5 @@
+// Test that @EnsuresCalledMethodsOnException can be repeated.
+
 import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
 

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
+
+class EnsuresCalledMethodsOnExceptionRepeatable {
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
+  // ::error: (contracts.postcondition)
+  public void close2MissingFirst(Closeable r1, Closeable r2) throws IOException {
+    r1.close();
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
+  // ::error: (contracts.postcondition)
+  public void close2MissingSecond(Closeable r1, Closeable r2) throws IOException {
+    r2.close();
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
+  public void close2Correct(Closeable r1, Closeable r2) throws IOException {
+    try {
+      r1.close();
+    } finally {
+      r2.close();
+    }
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
+  public void close2CorrectViaCall(Closeable r1, Closeable r2) throws IOException {
+    close2Correct(r1, r2);
+  }
+
+  public static class Subclass extends EnsuresCalledMethodsOnExceptionRepeatable {
+    @Override
+    // ::error: (contracts.postcondition)
+    public void close2Correct(Closeable r1, Closeable r2) throws IOException {
+      throw new IOException();
+    }
+  }
+}

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionRepeatable.java
@@ -7,14 +7,14 @@ class EnsuresCalledMethodsOnExceptionRepeatable {
 
   @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
   @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
-  // ::error: (contracts.postcondition)
+  // ::error: (contracts.exceptional.postcondition)
   public void close2MissingFirst(Closeable r1, Closeable r2) throws IOException {
     r1.close();
   }
 
   @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
   @EnsuresCalledMethodsOnException(value = "#2", methods = "close")
-  // ::error: (contracts.postcondition)
+  // ::error: (contracts.exceptional.postcondition)
   public void close2MissingSecond(Closeable r1, Closeable r2) throws IOException {
     r2.close();
   }
@@ -37,7 +37,7 @@ class EnsuresCalledMethodsOnExceptionRepeatable {
 
   public static class Subclass extends EnsuresCalledMethodsOnExceptionRepeatable {
     @Override
-    // ::error: (contracts.postcondition)
+    // ::error: (contracts.exceptional.postcondition)
     public void close2Correct(Closeable r1, Closeable r2) throws IOException {
       throw new IOException();
     }

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
@@ -1,0 +1,27 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
+
+public class EnsuresCalledMethodsOnExceptionSubclass {
+
+  public static class Parent {
+    @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+    public void method(Closeable x) throws IOException {
+      x.close();
+    }
+  }
+
+  public static class SubclassWrong extends Parent {
+    @Override
+    // ::error: (contracts.postcondition)
+    public void method(Closeable x) throws IOException {
+      throw new IOException();
+    }
+  }
+
+  public static class SubclassCorrect extends Parent {
+    @Override
+    public void method(Closeable x) throws IOException {
+      // No exception thrown ==> no contract to satisfy!
+    }
+  }
+}

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
@@ -14,7 +14,7 @@ public class EnsuresCalledMethodsOnExceptionSubclass {
 
   public static class SubclassWrong extends Parent {
     @Override
-    // ::error: (contracts.postcondition)
+    // ::error: (contracts.exceptional.postcondition)
     public void method(Closeable x) throws IOException {
       throw new IOException();
     }

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionSubclass.java
@@ -1,3 +1,5 @@
+// Test that @EnsuresCalledMethodsOnException is inherited by overridden methods.
+
 import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
 

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
@@ -1,7 +1,8 @@
+// Test that @EnsuresCalledMethodsOnException behaves as expected.
+
 import java.io.IOException;
 import org.checkerframework.checker.calledmethods.qual.*;
 
-/** Test for postcondition support via @EnsureCalledMethodsOnException. */
 public abstract class EnsuresCalledMethodsOnExceptionTest {
 
   static class Resource {

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
@@ -27,7 +27,7 @@ public abstract class EnsuresCalledMethodsOnExceptionTest {
   }
 
   @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
-  // :: error: (contracts.postcondition)
+  // :: error: (contracts.exceptional.postcondition)
   void callAfterThrow(Resource r) throws Exception {
     if (arbitraryChoice()) {
       // Not OK: r.a() has not been called yet
@@ -62,7 +62,7 @@ public abstract class EnsuresCalledMethodsOnExceptionTest {
   }
 
   @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
-  // :: error: (contracts.postcondition)
+  // :: error: (contracts.exceptional.postcondition)
   void callInSpecificCatchBlock(Resource r) throws Exception {
     try {
       if (arbitraryChoice()) {

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionTest.java
@@ -1,0 +1,105 @@
+import java.io.IOException;
+import org.checkerframework.checker.calledmethods.qual.*;
+
+/** Test for postcondition support via @EnsureCalledMethodsOnException. */
+public abstract class EnsuresCalledMethodsOnExceptionTest {
+
+  static class Resource {
+    void a() {}
+
+    void b() throws IOException {}
+  }
+
+  abstract boolean arbitraryChoice();
+
+  abstract void throwArbitraryException() throws Exception;
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "b")
+  void blanketCase(Resource r) throws IOException {
+    // OK: r.b() counts as called even if it itself throws an exception.
+    r.b();
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  void noCall(Resource r) {
+    // OK: this method does not throw exceptions.
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  // :: error: (contracts.postcondition)
+  void callAfterThrow(Resource r) throws Exception {
+    if (arbitraryChoice()) {
+      // Not OK: r.a() has not been called yet
+      throwArbitraryException();
+    }
+    r.a();
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  void callInFinallyBlock(Resource r) throws Exception {
+    try {
+      if (arbitraryChoice()) {
+        // OK: r.a() will be called in the finally block
+        throwArbitraryException();
+      }
+    } finally {
+      r.a();
+    }
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  void callInCatchBlock(Resource r) throws Exception {
+    try {
+      if (arbitraryChoice()) {
+        // OK: r.a() will be called in the catch block
+        throwArbitraryException();
+      }
+    } catch (Exception e) {
+      r.a();
+      throw e;
+    }
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  // :: error: (contracts.postcondition)
+  void callInSpecificCatchBlock(Resource r) throws Exception {
+    try {
+      if (arbitraryChoice()) {
+        // Not OK: the catch block only catches IOException
+        throwArbitraryException();
+      }
+    } catch (IOException e) {
+      r.a();
+      throw e;
+    }
+  }
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  abstract void callMethodOnException(Resource r) throws Exception;
+
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "a")
+  void propagateSubtypeOfException(Resource r) throws Exception {
+    // OK: the call satisfies our contract
+    callMethodOnException(r);
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "a")
+  void exploitCalledMethodsOnException(Resource r) throws Exception {
+    try {
+      callMethodOnException(r);
+    } catch (Exception e) {
+      // OK: the other call ensured the contract
+      return;
+    }
+    // OK: although r.a() was not called, this method promises nothing on exceptional return
+    throw new Exception("Phooey");
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "a")
+  // :: error: (contracts.postcondition)
+  void exceptionalCallsDoNotSatisfyNormalPaths(Resource r) throws Exception {
+    // Not OK: this call is not enough to satisfy our contract, since it only promises something
+    // on exceptional return.
+    callMethodOnException(r);
+  }
+}

--- a/checker/tests/calledmethods/FinallyClose.java
+++ b/checker/tests/calledmethods/FinallyClose.java
@@ -1,6 +1,7 @@
+// Test case involving some complicated try-finally control flow.
+
 import java.io.*;
 import org.checkerframework.checker.calledmethods.qual.*;
-import org.checkerframework.checker.nullness.qual.*;
 
 abstract class FinallyClose {
 
@@ -52,7 +53,7 @@ abstract class FinallyClose {
   @EnsuresCalledMethodsOnException(
       value = "#1",
       methods = {"close"})
-  void closeResource(@Nullable Closeable resource) throws IOException {
+  void closeResource(Closeable resource) throws IOException {
     if (resource != null) {
       try {
         resource.close();

--- a/checker/tests/resourceleak/CloseSuper.java
+++ b/checker/tests/resourceleak/CloseSuper.java
@@ -1,0 +1,37 @@
+import java.io.Closeable;
+import java.io.IOException;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+public class CloseSuper {
+
+  public static class A implements Closeable {
+    private final @Owning Closeable resource;
+
+    public A(@Owning Closeable resource) {
+      this.resource = resource;
+    }
+
+    @Override
+    @EnsuresCalledMethods(
+        value = "resource",
+        methods = {"close"})
+    public void close() throws IOException {
+      resource.close();
+    }
+  }
+
+  public static class B extends A {
+    public B(@Owning Closeable resource) {
+      super(resource);
+    }
+
+    @Override
+    @EnsuresCalledMethods(
+        value = "resource",
+        methods = {"close"})
+    public void close() throws IOException {
+      super.close();
+    }
+  }
+}

--- a/checker/tests/resourceleak/CloseSuper.java
+++ b/checker/tests/resourceleak/CloseSuper.java
@@ -1,3 +1,5 @@
+// Test case for https://github.com/typetools/checker-framework/issues/6204
+
 import java.io.Closeable;
 import java.io.IOException;
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;

--- a/checker/tests/resourceleak/FinallyClose.java
+++ b/checker/tests/resourceleak/FinallyClose.java
@@ -1,0 +1,64 @@
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+abstract class FinallyClose {
+
+  abstract Closeable alloc() throws IOException;
+
+  abstract Closeable derive(Closeable r) throws IOException;
+
+  abstract String compute(Closeable resource) throws IOException;
+
+  abstract void makeNotes() throws IOException;
+
+  String run1() throws IOException {
+    Closeable resource = null;
+    try {
+      resource = alloc();
+      return compute(resource);
+    } finally {
+      try {
+        makeNotes();
+      } finally {
+        closeResource(resource);
+      }
+    }
+  }
+
+  String run2() throws IOException {
+    Closeable resource = null;
+    Closeable subresource = null;
+    try {
+      resource = alloc();
+      subresource = derive(resource);
+      return compute(subresource);
+    } finally {
+      try {
+        makeNotes();
+      } finally {
+        try {
+          closeResource(subresource);
+        } finally {
+          closeResource(resource);
+        }
+      }
+    }
+  }
+
+  @EnsuresCalledMethods(
+      value = "#1",
+      methods = {"close"})
+  @EnsuresCalledMethodsOnException(
+      value = "#1",
+      methods = {"close"})
+  void closeResource(@Nullable Closeable resource) throws IOException {
+    if (resource != null) {
+      try {
+        resource.close();
+      } catch (Exception e) {
+        System.out.println(e);
+      }
+    }
+  }
+}

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -82,7 +82,7 @@ class MultipleMethodParamsMustCallAliasTest {
     @EnsuresCalledMethods(
         value = {"this.in1", "this.in2"},
         methods = {"close"})
-    // :: error: (destructor.exceptional.postcondition)
+    // :: error: (contracts.postcondition)
     public void close() throws IOException {
       in1.close();
       in2.close();

--- a/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
+++ b/checker/tests/resourceleak/MultipleMethodParamsMustCallAliasTest.java
@@ -82,7 +82,7 @@ class MultipleMethodParamsMustCallAliasTest {
     @EnsuresCalledMethods(
         value = {"this.in1", "this.in2"},
         methods = {"close"})
-    // :: error: (contracts.postcondition)
+    // :: error: (contracts.exceptional.postcondition)
     public void close() throws IOException {
       in1.close();
       in2.close();

--- a/checker/tests/resourceleak/OwnershipWithExceptions.java
+++ b/checker/tests/resourceleak/OwnershipWithExceptions.java
@@ -154,7 +154,7 @@ abstract class OwnershipWithExceptions {
     @EnsuresCalledMethods(
         value = "this.resource",
         methods = {"close"})
-    // ::error: (contracts.postcondition)
+    // ::error: (contracts.exceptional.postcondition)
     public void close() throws IOException {
       throw new IOException();
     }
@@ -229,7 +229,7 @@ abstract class OwnershipWithExceptions {
     @EnsuresCalledMethods(
         value = {"this.resource", "this.unused"},
         methods = {"close"})
-    // ::error: (contracts.postcondition)
+    // ::error: (contracts.exceptional.postcondition)
     public void close() throws IOException {
       if (unused != null) unused.close();
       if (resource != null) resource.close();

--- a/checker/tests/resourceleak/OwnershipWithExceptions.java
+++ b/checker/tests/resourceleak/OwnershipWithExceptions.java
@@ -154,7 +154,7 @@ abstract class OwnershipWithExceptions {
     @EnsuresCalledMethods(
         value = "this.resource",
         methods = {"close"})
-    // ::error: (destructor.exceptional.postcondition)
+    // ::error: (contracts.postcondition)
     public void close() throws IOException {
       throw new IOException();
     }
@@ -229,7 +229,7 @@ abstract class OwnershipWithExceptions {
     @EnsuresCalledMethods(
         value = {"this.resource", "this.unused"},
         methods = {"close"})
-    // ::error: (destructor.exceptional.postcondition)
+    // ::error: (contracts.postcondition)
     public void close() throws IOException {
       if (unused != null) unused.close();
       if (resource != null) resource.close();

--- a/checker/tests/resourceleak/OwningAndEnsuresCalledMethodsOnException.java
+++ b/checker/tests/resourceleak/OwningAndEnsuresCalledMethodsOnException.java
@@ -1,0 +1,71 @@
+// Test case for a Resource Leak manual example that involves interaction
+// between @Owning and @EnsuresCalledMethodsOnException.
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+class OwningAndEnsuresCalledMethodsOnException implements Closeable {
+
+  private final @Owning Closeable resource;
+
+  // Good constructor, as illustrated in the manual.
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  public OwningAndEnsuresCalledMethodsOnException(@Owning Closeable resource) throws IOException {
+    this.resource = resource;
+    try {
+      initialize(resource);
+    } catch (Exception e) {
+      resource.close();
+      throw e;
+    }
+  }
+
+  // Alternative constructor with a weaker contract (specifically, the default
+  // contract for @Owning: only takes ownership on normal return)
+  public OwningAndEnsuresCalledMethodsOnException(@Owning Closeable resource, int ignored)
+      throws IOException {
+    this.resource = resource;
+    initialize(resource);
+  }
+
+  public OwningAndEnsuresCalledMethodsOnException() throws IOException {
+    // OK: the good delegate constructor will either take ownership or close the argument
+    // This will issue a false positive warning due to
+    // https://github.com/typetools/checker-framework/issues/6270
+    // ::error: (required.method.not.called)
+    this(new Resource());
+  }
+
+  public OwningAndEnsuresCalledMethodsOnException(int x) throws IOException {
+    // WRONG: the bad delegate constructor does not close the argument on exception
+    // ::error: (required.method.not.called)
+    this(new Resource(), x);
+  }
+
+  static void exampleUseInNormalMethod1() throws IOException {
+    // OK: the constructor will either take ownership or close the argument
+    // This will issue a false positive warning due to
+    // https://github.com/typetools/checker-framework/issues/6270
+    // ::error: (required.method.not.called)
+    new OwningAndEnsuresCalledMethodsOnException(new Resource());
+  }
+
+  static void exampleUseInNormalMethod2() throws IOException {
+    // WRONG: the bad constructor does not close the argument on exception
+    // ::error: (required.method.not.called)
+    new OwningAndEnsuresCalledMethodsOnException(new Resource(), 0);
+  }
+
+  static void initialize(Closeable resource) throws IOException {}
+
+  @EnsuresCalledMethods(value = "resource", methods = "close")
+  public void close() throws IOException {
+    resource.close();
+  }
+
+  private static class Resource implements Closeable {
+    @Override
+    public void close() throws IOException {}
+  }
+}

--- a/checker/tests/resourceleak/ReplicaInputStreams.java
+++ b/checker/tests/resourceleak/ReplicaInputStreams.java
@@ -20,7 +20,7 @@ class ReplicaInputStreams implements Closeable {
   @EnsuresCalledMethods(
       value = {"this.in1", "this.in2"},
       methods = {"close"})
-  // :: error: (contracts.postcondition)
+  // :: error: (contracts.exceptional.postcondition)
   public void close() throws IOException {
     in1.close();
     in2.close();

--- a/checker/tests/resourceleak/ReplicaInputStreams.java
+++ b/checker/tests/resourceleak/ReplicaInputStreams.java
@@ -20,7 +20,7 @@ class ReplicaInputStreams implements Closeable {
   @EnsuresCalledMethods(
       value = {"this.in1", "this.in2"},
       methods = {"close"})
-  // :: error: (destructor.exceptional.postcondition)
+  // :: error: (contracts.postcondition)
   public void close() throws IOException {
     in1.close();
     in2.close();

--- a/checker/tests/resourceleak/TwoResourcesECM.java
+++ b/checker/tests/resourceleak/TwoResourcesECM.java
@@ -17,10 +17,15 @@ class TwoResourcesECM {
   // even on the non-exceptional path. See ReplicaInputStreams.java for a variant
   // of this test where such an error is not issued. Because this method can leak
   // along both regular and exceptional exits, both errors are issued.
+  //
+  // The contracts.exceptional.postcondition error is thrown because destructors
+  // have to close their resources even on exception.  If s1.close() throws an
+  // exception, then s2.close() will not be called.
   @EnsuresCalledMethods(
       value = {"this.s1", "this.s2"},
       methods = {"close"})
   // :: error: (contracts.postcondition)
+  // :: error: (contracts.exceptional.postcondition)
   public void dispose() throws IOException {
     s1.close();
     s2.close();

--- a/checker/tests/resourceleak/TwoResourcesECM.java
+++ b/checker/tests/resourceleak/TwoResourcesECM.java
@@ -20,7 +20,7 @@ class TwoResourcesECM {
   @EnsuresCalledMethods(
       value = {"this.s1", "this.s2"},
       methods = {"close"})
-  // :: error: (contracts.postcondition) :: error: (destructor.exceptional.postcondition)
+  // :: error: (contracts.postcondition)
   public void dispose() throws IOException {
     s1.close();
     s2.close();

--- a/docs/manual/called-methods-checker.tex
+++ b/docs/manual/called-methods-checker.tex
@@ -255,6 +255,27 @@ There are also method annotations:
   that the named methods are actually called on every element of the varargs parameter via some
   other method (such as manual inspection) and then suppress the warning.
 
+\item[\refqualclass{checker/calledmethods/qual}{EnsuresCalledMethodsOnException}]
+  This declaration annotation specifies a post-condition on a method, indicating the methods it
+  guarantees to call when it throws an exception.  Like most post-condition annotations, the
+  other Called Methods post-condition annotations (\<@EnsuresCalledMethods>,
+  \<@EnsuresCalledMethodsIf>, and \<@EnsuresCalledMethodsVarArgs>) only specify behavior for
+  normal returns.  The annotation \<@EnsuresCalledMethodsOnException> allows you to write
+  stronger specifications indicating that a method \emph{always} calls the given methods:
+
+  \begin{Verbatim}
+    @EnsuresCalledMethods(expression = "#1", methods = {"close"})
+    @EnsuresCalledMethodsOnException(expression = "#1", methods = {"close"})
+    void closeIfNonNull(Closeable p) {
+      if (p != null) {
+        p.close();
+      }
+    }
+  \end{Verbatim}
+
+  \<@EnsuresCalledMethodsOnException> can also be used together with the Resource Leak Checker's
+  \<@Owning> annotation.  See~\ref{resource-leak-owning-parameters-and-exceptions}.
+
 \item[\refqualclass{checker/calledmethods/qual}{RequiresCalledMethods}]
   This declaration annotation specifies a pre-condition on a method, indicating that the expressions
   in its \<value> argument must have called-methods types that include all the methods named

--- a/docs/manual/resource-leak-checker.tex
+++ b/docs/manual/resource-leak-checker.tex
@@ -85,8 +85,9 @@ See Section~\ref{must-call-annotations}.
 \item[\refqualclasswithparams{checker/mustcall/qual}{InheritableMustCall}{String[] value}]
 on any classes defined in your program that have must-call obligations. See Section~\ref{must-call-on-class}.
 
-\item[\refqualclass{checker/calledmethods/qual}{EnsuresCalledMethods}] on a method in
-your code that fulfills a must-call obligation of one of its parameters or of a field.
+\item[\refqualclass{checker/calledmethods/qual}{EnsuresCalledMethods} and/or
+      \refqualclass{checker/calledmethods/qual}{EnsuresCalledMethodsOnException}]
+on a method in your code that fulfills a must-call obligation of one of its parameters or of a field.
 See Section~\ref{called-methods-ensurescalledmethods}.
 
 \end{description}
@@ -228,6 +229,8 @@ Writing \<@Owning> or \<@NotOwning> can never make the checker
 unsound:  a real warning can never be hidden by them.
 As with any annotation, incorrect or missing annotations can lead to false positive warnings.
 
+\subsectionAndLabel{Owning parameters and exceptions}{resource-leak-owning-parameters-and-exceptions}
+
 When \<@Owning> is written on a method parameter, the method only takes ownership of the
 parameter when it returns normally.  In this example, the Resource Leak Checker will report
 an error in the \<example> method and allow the definition of \<closeSocket>:
@@ -247,6 +250,23 @@ an error in the \<example> method and allow the definition of \<closeSocket>:
   }
 \end{verbatim}
 
+Sometimes a method really does promise to call some methods on an \<@Owning> parameter,
+even if it throws an exception.  The annotation \<@EnsuresCalledMethodsOnException> can
+overcome this limitation.  For example, a constructor that throws an exception might
+choose to close an \<@Owning> parameter instead of letting ownership remain with the caller:
+
+\begin{verbatim}
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  public Constructor(@Owning Closeable resource) {
+    this.resource = resource;
+    try {
+      initialize();
+    } catch (Exception e) {
+      resource.close();
+      throw e;
+    }
+  }
+\end{verbatim}
 
 \subsectionAndLabel{Owning fields}{resource-leak-owning-fields}
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1414,7 +1414,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
    * @param qualifier the expression's type, or null if no information is available
    * @return a string representation of the expression and type qualifier
    */
-  private String contractExpressionAndType(
+  protected String contractExpressionAndType(
       String expression, @Nullable AnnotationMirror qualifier) {
     if (qualifier == null) {
       return "no information about " + expression;


### PR DESCRIPTION
Fixes #6204 and adds a useful feature to the Called Methods Checker.

See also [this comment](https://github.com/typetools/checker-framework/issues/5734#issuecomment-1769708754).

**Motivation**

It is very common for resource-handling code to close owned resources even on exceptional return. The existing annotations like `@EnsuresCalledMethods` and `@Owning` only describe what happens on normal return, and there is no way to write a stronger contract that says a method _always_ closes a resource. (As far as I know, this limitation is common to all post-condition annotations in the Checker Framework.)

This PR adds `@EnsuresCalledMethodsOnException`, a new post-condition annotation that says what the method guarantees when it throws (subclasses of) `java.lang.Exception`.

**Why a new annotation instead of strengthening `@EnsuresCalledMethods`?**

I added an example in the manual for when you might want `@EnsuresCalledMethodsOnException` _without_ promising `@EnsuresCalledMethods`. In short, the new annotation interacts well with `@Owning`, enabling users to write a contract that says "this method either takes ownership of the resource or closes it immediately and throws an exception".

**Why only for `Exception` and not all `Throwable`s?**

I believe it is essentially impossible to guarantee no resource leaks in the presence of runtime errors: if `socket.close()` throws `StackOverflowError`, what can you possibly do?

We should discuss whether limiting `@EnsuresCalledMethodsOnException` to only `Exception` is right or not. There might be a good reason to generalize to all `Throwable`s, or to have some complex set of exceptions like "all subclasses of `Throwable` except these specific subclases of `Error`".

**Modified handling for destructors**

The Resource Leak Checker requires a stronger contract for "destructor-like" methods. They must close their resources even when they throw an exception. Previously, that was accomplished with a special-case check. Now it can be accomplished in terms of the new annotation.

To avoid a breaking change, I have made `@EnsuresCalledMethods` imply an identical `@EnsuresCalledMethodsOnException` when it appears on a destructor. In my opinion this is just as hacky as the previous approach, but it ensures backwards compatibility while unifying some related code. This is the change that fixes #6204, since callers of destructors now benefit from the implied exceptional post-condition.

**Misc notes**

We should discuss if the name `@EnsuresCalledMethodsOnException` is good or not. I don't know if there is a precedent for this kind of annotation.

In the future, we might want to add framework support for this kind of post-condition annotation, like how `@EnsuresCalledMethods` is mostly handled by existing machinery.

Originally I had hoped to have this done by the November release, but it took a while to put together. We should take the time to review it carefully, and I'll look forward to using it in December. :)