### PR TITLE
RLC: allow wrapper types to have a differently-named @MustCall method from wrapped type

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
@@ -42,7 +42,9 @@ import java.lang.annotation.Target;
  *   <li>In all other cases, the return type has the same {@code @MustCall} type as {@code p}.
  * </ul>
  *
- * {@link PolyMustCall} has an identical type system semantics.
+ * {@link PolyMustCall} has an identical type system semantics. This special treatment is required
+ * to allow for a wrapper object to have a must-call method with a different name than the must-call
+ * method name for the wrapped object.
  *
  * <h2>Verifying {@code @MustCallAlias} annotations</h2>
  *

--- a/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/MustCallAlias.java
@@ -11,7 +11,9 @@ import java.lang.annotation.Target;
  * always be used in pairs. On a method, it is written on some formal parameter type and on the
  * method return type. On a constructor, it is written on some formal parameter type and on the
  * result type. Fulfilling the must-call obligation of one is equivalent to fulfilling the must-call
- * obligation of the other.
+ * obligation of the other. Beyond its impact as a polymorphic annotation on {@code MustCall} types,
+ * the Resource Leak Checker uses {@link MustCallAlias} annotations to more precisely determine when
+ * a must-call obligation has been satisfied.
  *
  * <p>This annotation is useful for wrapper objects. For example, consider the declaration of {@code
  * java.net.Socket#getOutputStream}:
@@ -24,6 +26,23 @@ import java.lang.annotation.Target;
  *
  * Calling {@code close()} on the returned {@code OutputStream} will close the underlying socket,
  * but the Socket may also be closed directly, which has the same effect.
+ *
+ * <h2>Type system semantics</h2>
+ *
+ * Within the Must Call Checker's type system, {@code @MustCallAlias} annotations have a semantics
+ * different from a standard polymorphic annotation, in that the relevant actual parameter type and
+ * return type at a call site are not equated in all cases. Given an actual parameter {@code p}
+ * passed in a {@code @MustCallAlias} position at a call site, the return type of the call is
+ * defined as follows:
+ *
+ * <ul>
+ *   <li>If the base return type has a non-empty {@code @InheritableMustCall("m")} annotation on its
+ *       declaration, and {@code p} has a non-empty {@code @MustCall} type, then the return type is
+ *       {@code @MustCall("m")}.
+ *   <li>In all other cases, the return type has the same {@code @MustCall} type as {@code p}.
+ * </ul>
+ *
+ * {@link PolyMustCall} has an identical type system semantics.
  *
  * <h2>Verifying {@code @MustCallAlias} annotations</h2>
  *
@@ -47,7 +66,10 @@ import java.lang.annotation.Target;
  * </ul>
  *
  * When the -AnoResourceAliases command-line argument is passed to the checker, this annotation is
- * treated identically to {@link PolyMustCall}.
+ * treated identically to {@link PolyMustCall}. That is, the annotation still impacts {@link
+ * MustCall} types as a polymorphic annotation (see "Type system semantics" above), but it is not
+ * used by the Resource Leak Checker to more precisely reason about when obligations have been
+ * satisfied.
  *
  * @checker_framework.manual #resource-leak-checker Resource Leak Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism

--- a/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/PolyMustCall.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/mustcall/qual/PolyMustCall.java
@@ -8,7 +8,9 @@ import java.lang.annotation.Target;
 import org.checkerframework.framework.qual.PolymorphicQualifier;
 
 /**
- * The polymorphic qualifier for the Must Call type system.
+ * The polymorphic qualifier for the Must Call type system. The semantics of this qualifier differ
+ * from that of a standard polymorphic qualifier; see {@link MustCallAlias} for documentation of its
+ * semantics.
  *
  * @checker_framework.manual #must-call-checker Must Call Checker
  * @checker_framework.manual #qualifier-polymorphism Qualifier polymorphism

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -245,7 +245,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
       if (typeElement != null) {
         if (replacements.size() == 1 && replacements.containsKey(POLY)) {
           other = replacements.get(POLY);
-          if (AnnotationUtils.annotationName(other).equals(MustCall.class.getCanonicalName())) {
+          if (AnnotationUtils.areSameByName(other, MustCall.class.getCanonicalName())) {
             List<String> otherVals =
                 AnnotationUtils.getElementValueArray(
                     other, getMustCallValueElement(), String.class);

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -248,7 +248,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
       TypeElement typeElement = TypesUtils.getTypeElement(type.getUnderlyingType());
       // only customize replacement for type elements
       if (typeElement != null) {
-        assert replacements.size() == 1;
+        assert replacements.size() == 1 && replacements.containsKey(POLY);
         extantPolyAnnoReplacement = replacements.get(POLY);
         if (AnnotationUtils.areSameByName(
             extantPolyAnnoReplacement, MustCall.class.getCanonicalName())) {

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -26,7 +26,6 @@ import javax.lang.model.type.TypeMirror;
 import org.checkerframework.checker.mustcall.qual.CreatesMustCallFor;
 import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.MustCall;
-import org.checkerframework.checker.mustcall.qual.MustCallAlias;
 import org.checkerframework.checker.mustcall.qual.MustCallUnknown;
 import org.checkerframework.checker.mustcall.qual.Owning;
 import org.checkerframework.checker.mustcall.qual.PolyMustCall;
@@ -136,7 +135,7 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
     addAliasedTypeAnnotation(InheritableMustCall.class, MustCall.class, true);
     if (!checker.hasOption(MustCallChecker.NO_RESOURCE_ALIASES)) {
       // In NO_RESOURCE_ALIASES mode, all @MustCallAlias annotations are ignored.
-      addAliasedTypeAnnotation(MustCallAlias.class, POLY);
+      // addAliasedTypeAnnotation(MustCallAlias.class, POLY);
     }
     noLightweightOwnership = checker.hasOption(MustCallChecker.NO_LIGHTWEIGHT_OWNERSHIP);
     enableWpiForRlc = checker.hasOption(ResourceLeakChecker.ENABLE_WPI_FOR_RLC);

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -255,7 +255,10 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
               extantPolyAnnoReplacement, MustCall.class.getCanonicalName())) {
             List<String> extentReplacementVals =
                 AnnotationUtils.getElementValueArray(
-                    extantPolyAnnoReplacement, getMustCallValueElement(), String.class);
+                    extantPolyAnnoReplacement,
+                    getMustCallValueElement(),
+                    String.class,
+                    Collections.emptyList());
             // replacement only customized when parameter type has a non-empty must-call obligation
             if (!extentReplacementVals.isEmpty()) {
               AnnotationMirror inheritableMustCall =

--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallAnnotatedTypeFactory.java
@@ -266,7 +266,10 @@ public class MustCallAnnotatedTypeFactory extends BaseAnnotatedTypeFactory
               if (inheritableMustCall != null) {
                 List<String> inheritableMustCallVals =
                     AnnotationUtils.getElementValueArray(
-                        inheritableMustCall, inheritableMustCallValueElement, String.class);
+                        inheritableMustCall,
+                        inheritableMustCallValueElement,
+                        String.class,
+                        Collections.emptyList());
                 if (!inheritableMustCallVals.equals(extentReplacementVals)) {
                   // Use the must call values from the @InheritableMustCall annotation instead.
                   // This allows for wrapper types to have a must-call method with a different

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -324,13 +324,14 @@ class MustCallConsistencyAnalyzer {
 
     /**
      * Gets the must-call methods (i.e. the list of methods that must be called to satisfy the
-     * must-call obligation) of the resource represented by this Obligation.
+     * must-call obligation) of each resource alias represented by this Obligation.
      *
      * @param rlAtf a Resource Leak Annotated Type Factory
      * @param mcStore a CFStore produced by the MustCall checker's dataflow analysis. If this is
      *     null, then the default MustCall type of each variable's class will be used.
-     * @return the list of must-call method names, or null if the resource's must-call obligations
-     *     are unsatisfiable (i.e. its value in the Must Call store is MustCallUnknown)
+     * @return a map from each resource alias of this to a list of its must-call method names, or
+     *     null if the must-call obligations are unsatisfiable (i.e. the value of some tracked
+     *     resource alias of this in the Must Call store is MustCallUnknown)
      */
     public @Nullable Map<ResourceAlias, List<String>> getMustCallMethods(
         ResourceLeakAnnotatedTypeFactory rlAtf, @Nullable CFStore mcStore) {

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -2329,6 +2329,7 @@ class MustCallConsistencyAnalyzer {
   private void checkMustCall(
       Obligation obligation, AccumulationStore cmStore, CFStore mcStore, String outOfScopeReason) {
 
+    // TODO this is broken, as different aliases may have different @MustCall requirements
     List<String> mustCallValue = obligation.getMustCallMethods(typeFactory, mcStore);
 
     // optimization: if mustCallValue is null, always issue a warning (there is no way to satisfy

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -206,7 +206,7 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
    * Returns the {@link MustCall#value} element/argument of the @MustCall annotation on the class
    * type of {@code element}. If there is no such annotation, returns the empty list.
    *
-   * <p>Do not use this method to get the MustCall value of an {@link
+   * <p>Do not use this method to get the MustCall values of an {@link
    * org.checkerframework.checker.resourceleak.MustCallConsistencyAnalyzer.Obligation}. Instead, use
    * {@link
    * org.checkerframework.checker.resourceleak.MustCallConsistencyAnalyzer.Obligation#getMustCallMethods(ResourceLeakAnnotatedTypeFactory,

--- a/checker/tests/mustcall/PolyMustCallDifferentNames.java
+++ b/checker/tests/mustcall/PolyMustCallDifferentNames.java
@@ -1,0 +1,76 @@
+// Tests for @PolyMustCall and @MustCallAlias where the must-call method of the return type has
+// a different name than the must-call method of the parameter type.
+
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.*;
+
+class PolyMustCallDifferentNames {
+
+  @InheritableMustCall("a")
+  static class Wrapped {
+    void a() {}
+  }
+
+  @InheritableMustCall("b")
+  static class Wrapper1 {
+    private final @Owning Wrapped field;
+
+    public @PolyMustCall Wrapper1(@PolyMustCall Wrapped w) {
+      // we get this error since we only have a field-assignment special case for @MustCallAlias,
+      // not @PolyMustCall
+      // :: error: (assignment)
+      this.field = w;
+    }
+
+    @EnsuresCalledMethods(
+        value = {"this.field"},
+        methods = {"a"})
+    void b() {
+      this.field.a();
+    }
+  }
+
+  static @PolyMustCall Wrapper1 getWrapper1(@PolyMustCall Wrapped w) {
+    return new Wrapper1(w);
+  }
+
+  @InheritableMustCall("c")
+  static class Wrapper2 {
+    private final @Owning Wrapped field;
+
+    public @MustCallAlias Wrapper2(@MustCallAlias Wrapped w) {
+      this.field = w;
+    }
+
+    @EnsuresCalledMethods(
+        value = {"this.field"},
+        methods = {"a"})
+    void c() {
+      this.field.a();
+    }
+  }
+
+  static @MustCallAlias Wrapper2 getWrapper2(@MustCallAlias Wrapped w) {
+    return new Wrapper2(w);
+  }
+
+  static void test1() {
+    @MustCall("a") Wrapped x = new Wrapped();
+    @MustCall("b") Wrapper1 w1 = new Wrapper1(x);
+    @MustCall("b") Wrapper1 w2 = getWrapper1(x);
+    // :: error: (assignment)
+    @MustCall("a") Wrapper1 w3 = new Wrapper1(x);
+    // :: error: (assignment)
+    @MustCall("a") Wrapper1 w4 = getWrapper1(x);
+  }
+
+  static void test2() {
+    @MustCall("a") Wrapped x = new Wrapped();
+    @MustCall("c") Wrapper2 w1 = new Wrapper2(x);
+    @MustCall("c") Wrapper2 w2 = getWrapper2(x);
+    // :: error: (assignment)
+    @MustCall("a") Wrapper2 w3 = new Wrapper2(x);
+    // :: error: (assignment)
+    @MustCall("a") Wrapper2 w4 = getWrapper2(x);
+  }
+}

--- a/checker/tests/resourceleak/CreatesMustCallForTwoAliases.java
+++ b/checker/tests/resourceleak/CreatesMustCallForTwoAliases.java
@@ -1,0 +1,52 @@
+// Test case for taking the least upper bound of obligations.
+
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class CreatesMustCallForTwoAliases {
+  @InheritableMustCall("a")
+  static class Foo {
+
+    @SuppressWarnings("mustcall")
+    @MustCall() Foo() {
+      // unconnected socket like
+    }
+
+    @CreatesMustCallFor("this")
+    void reset() {}
+
+    void a() {}
+  }
+
+  public static void test1() {
+    Foo a = new Foo();
+    // :: error: required.method.not.called
+    Foo b = a;
+    b.reset();
+  }
+
+  @CreatesMustCallFor("#1")
+  public static void sneakyReset(Foo f) {
+    f.reset();
+  }
+
+  public static void test2() {
+    Foo a = new Foo();
+    // :: error: required.method.not.called
+    Foo b = a;
+    sneakyReset(b);
+  }
+
+  public static void test3(Foo b) {
+    Foo a = new Foo();
+    // :: error: required.method.not.called
+    b = a;
+    sneakyReset(b);
+  }
+
+  public static void test4(Foo b) {
+    // :: error: required.method.not.called
+    Foo a = new Foo();
+    b = a;
+    sneakyReset(a);
+  }
+}

--- a/checker/tests/resourceleak/MustCallAliasDifferentMethodNames.java
+++ b/checker/tests/resourceleak/MustCallAliasDifferentMethodNames.java
@@ -1,0 +1,34 @@
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
+import org.checkerframework.checker.mustcall.qual.MustCallAlias;
+import org.checkerframework.checker.mustcall.qual.Owning;
+
+class MustCallAliasDifferentMethodNames {
+
+  @InheritableMustCall("a")
+  static class Foo {
+    void a() {}
+  }
+
+  @InheritableMustCall("b")
+  static class FooField {
+    private final @Owning Foo finalOwningFoo;
+
+    public @MustCallAlias FooField(@MustCallAlias Foo f) {
+      this.finalOwningFoo = f;
+    }
+
+    @EnsuresCalledMethods(
+        value = {"this.finalOwningFoo"},
+        methods = {"a"})
+    void b() {
+      this.finalOwningFoo.a();
+    }
+  }
+
+  void testField() {
+    Foo f = new Foo(); // False Positive for this line
+    FooField fooField12345 = new FooField(f);
+    fooField12345.b();
+  }
+}

--- a/checker/tests/resourceleak/MustCallAliasDifferentMethodNames.java
+++ b/checker/tests/resourceleak/MustCallAliasDifferentMethodNames.java
@@ -1,3 +1,7 @@
+// Test case to check that a wrapper type can have a @MustCall method with a different name than
+// the @MustCall method of the type it wraps.
+// See https://github.com/typetools/checker-framework/issues/4947
+
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
 import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import org.checkerframework.checker.mustcall.qual.MustCallAlias;
@@ -26,9 +30,17 @@ class MustCallAliasDifferentMethodNames {
     }
   }
 
-  void testField() {
-    Foo f = new Foo(); // False Positive for this line
-    FooField fooField12345 = new FooField(f);
-    fooField12345.b();
+  void testField1() {
+    Foo f = new Foo();
+    FooField fooFieldWrapper = new FooField(f);
+    // Either calling f.a() or fooFieldWrapper.b() satisfies the obligation
+    fooFieldWrapper.b();
+  }
+
+  void testField2() {
+    Foo f = new Foo();
+    FooField fooFieldWrapper = new FooField(f);
+    // Either calling f.a() or fooFieldWrapper.b() satisfies the obligation
+    f.a();
   }
 }


### PR DESCRIPTION
Fixes #4947 

The fix works by customizing how polymorphic types are instantiated at call sites for the Must Call Checker, along with some adjustments in `MustCallConsistencyAnalyzer` to account for different resource aliases in the same `Obligation` having different `@MustCall` methods.  See the code and docs for further details.