### PR TITLE
Enable Gradle build cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+org.gradle.caching=true


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/build_cache.html

This can reduce local build times, e.g., when you are switching locally between multiple branches, since the task outputs for all branches are stored in the build cache.  For custom tasks, a bit of care is required to ensure all task inputs are properly declared before making the task cacheable.  But, since tasks need to opt-in to caching, I don't think this is too risky.

Note that if we land this, running `./gradlew clean` may not be sufficient to force a task to run; you may also need to add the `--no-build-cache` argument.