### PR TITLE
Optional Checker detects calls to `Optional.of` with null literals

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/optional/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/optional/messages.properties
@@ -2,6 +2,7 @@
 prefer.map.and.orelse=It is better style to use map and orElse.%nConsider changing to:%n%s.map(CONTAININGCLASS::%s).orElse(%s)
 prefer.ifpresent=It is better style to use ifPresent.%nConsider changing to:%n%s.ifPresent(%s)
 introduce.eliminate=It is bad style to create an Optional just to chain methods to get a value.
+optional.of.null=Don't use Optional to wrap a null value.
 optional.as.element.type=Don't use Optional as the element type in a collection.
 optional.collection=Don't use Optional to wrap a collection type.%nUse an empty collection to represent the absence of values.
 optional.field=Don't use Optional as the type of a field.

--- a/checker/tests/optional/OptionalOfNullTest.java
+++ b/checker/tests/optional/OptionalOfNullTest.java
@@ -1,0 +1,9 @@
+import java.util.Optional;
+
+public class OptionalOfNullTest {
+
+  void test_optional_of_null_literal() {
+    // :: error: (optional.of.null)
+    Optional<String> somevar = Optional.of(null);
+  }
+}


### PR DESCRIPTION
Currently, the Optional Checker admits expressions like:

```java
Optional<String> name = Optional.of(null);
```

That is, calls to `Optional.of` with null literals. This is at odds with what the Java SDK specifies in the [JDK documentation](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#of-T-) for `Optional.of`:

> [Optional.of(value)] returns an Optional with the specified present non-null value.

This is not enforced by the Java compiler, as well.

I think we could expand this new check further by looking at the data-flow into calls to `Optional.of` and checking for null values. This is a rudimentary change that introduces the check initially.