### PR TITLE
Default variable names ".*OrNull" to `@Nullable`

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/nullness/qual/Nullable.java
@@ -31,5 +31,5 @@ import org.checkerframework.framework.qual.SubtypeOf;
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @SubtypeOf({})
 @QualifierForLiterals(LiteralKind.NULL)
-@DefaultFor(types = Void.class)
+@DefaultFor(types = Void.class, names = ".*OrNull$")
 public @interface Nullable {}


### PR DESCRIPTION
Is this a good choice to reduce annotation effort?  Or a bad choice because it might surprise users?

(If we accept this change, I'll add documentation to the pull request.)