### PR TITLE
Update to a SNAPSHOT version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ allprojects {
   //   * any new checkers have been added, or
   //   * backward-incompatible changes have been made to APIs or elsewhere.
   // To make a snapshot release: ./gradlew publish
-  version '3.41.0'
+  version '3.41.1-SNAPSHOT'
 
   tasks.withType(JavaCompile).configureEach {
     options.fork = true


### PR DESCRIPTION
I think the master branch should normally be on a SNAPSHOT version, and I think 3.41.1 will likely be the next release version.