### PR TITLE
At (pseudo) assignments, use the existing strength of any obligations

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1438,7 +1438,7 @@ class MustCallConsistencyAnalyzer {
         replacements.put(obligation, null);
       } else {
         replacements.put(
-            obligation, new Obligation(newResourceAliasesForObligation, MethodExitKind.ALL));
+            obligation, new Obligation(newResourceAliasesForObligation, obligation.whenToEnforce));
       }
     }
 

--- a/checker/tests/resourceleak/MustCallAliasInitializeWithOwningParameter.java
+++ b/checker/tests/resourceleak/MustCallAliasInitializeWithOwningParameter.java
@@ -1,0 +1,32 @@
+// Test that methods like `allocateAndInitializeService` are accepted by
+// the resource leak checker.
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class MustCallAliasInitializeWithOwningParameter {
+
+  public Service allocateAndInitializeService(@Owning Closeable resource) throws IOException {
+    Service service = new Service(resource);
+    service.initialize();
+    return service;
+  }
+
+  private static class Service implements Closeable {
+
+    private final @Owning Closeable wrappedResource;
+
+    public @MustCallAlias Service(@MustCallAlias Closeable resource) {
+      this.wrappedResource = resource;
+    }
+
+    public void initialize() throws IOException {}
+
+    @Override
+    @EnsuresCalledMethods(value = "wrappedResource", methods = "close")
+    public void close() throws IOException {
+      wrappedResource.close();
+    }
+  }
+}


### PR DESCRIPTION
In PR #6241 (commit 5b5c9e53) I was very cautious about the value of the `whenToEnforce` field on obligations.  It is always safe to use `MethodExitKind.ALL`, and so in most cases that's what I used.

However, having had some time to code with the new change, it's clear that `MethodExitKind.ALL` is too strong for (pseudo) assignments.  The left hand side should have the same `whenToEnforce` as the right-hand side.

See the new test case `MustCallAliasInitializeWithOwningParameter`. The pattern there is (in my experience) relatively common, but it does not verify with the latest Checker Framework release.

This change alters the behavior of a few of the `InputOutputStreams` test cases, since those tests take `@Owning` arguments instead of allocating new objects.  I have added copies of the changed tests to retain their intended behavior; the copies allocate sockets instead of using `@Owning` parameters.