### PR TITLE
Speed up Spotless formatting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -257,28 +257,26 @@ allprojects { currentProj ->
       formatAnnotations()
     }
 
-    groovyGradle {
-      if (currentProj == currentProj.rootProject) {
-        target '*.gradle', 'docs/examples/**/*.gradle'
-      } else {
-        target '*.gradle'
+    if (currentProj == currentProj.rootProject) {
+      groovyGradle {
+        target '**/*.gradle'
+        targetExclude doNotFormat
+        greclipse()  // which formatter Spotless should use to format .gradle files.
+        indentWithSpaces(2)
+        trimTrailingWhitespace()
+        // endWithNewline() // Don't want to end empty files with a newline
       }
-      targetExclude doNotFormat
-      greclipse()  // which formatter Spotless should use to format .gradle files.
-      indentWithSpaces(2)
-      trimTrailingWhitespace()
-      // endWithNewline() // Don't want to end empty files with a newline
     }
-  }
 
-  tasks.register('printSpotlessTaskInputs') {
-    doLast {
-      project.tasks.forEach { task ->
-        if (task.name.contains('spotless')) {
-          println "Inputs for task '${task.name}':"
+    tasks.register('printSpotlessTaskInputs') {
+      doLast {
+        project.tasks.forEach { task ->
+          if (task.name.contains('spotless')) {
+            println "Inputs for task '${task.name}':"
 
-          task.inputs.files.each { inputFile ->
-            println "  Input: $inputFile"
+            task.inputs.files.each { inputFile ->
+              println "  Input: $inputFile"
+            }
           }
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -183,7 +183,8 @@ allprojects { currentProj ->
   }
 
   apply plugin: 'com.diffplug.spotless'
-  def doNotFormatMap = [
+  // patterns of files to skip for individual sub-projects
+  def perProjectDoNotFormat = [
     'checker': [
       'bin-devel/.plume-scripts/**',
       'tests/ainfer-*/annotated/*',
@@ -201,10 +202,12 @@ allprojects { currentProj ->
   spotless {
     // If you add any formatters to this block that require dependencies, then you must also
     // add them to the spotlessPredeclare block.
+
+    // Always skip formatting of files under build directory
     def doNotFormat = ['build/**']
     if (currentProj != project.rootProject) {
-      if (doNotFormatMap.containsKey(currentProj.name)) {
-        doNotFormat += doNotFormatMap[currentProj.name]
+      if (perProjectDoNotFormat.containsKey(currentProj.name)) {
+        doNotFormat += perProjectDoNotFormat[currentProj.name]
       }
 
       if (!isJava17orHigher) {
@@ -224,6 +227,7 @@ allprojects { currentProj ->
         doNotFormat += ['tests/**/java21/']
       }
     }
+
     format 'misc', {
       // define the files to apply `misc` to
       target '*.md', '*.tex', '.gitignore', 'Makefile'
@@ -236,6 +240,7 @@ allprojects { currentProj ->
 
     java {
       if (currentProj == currentProj.rootProject) {
+        // format .java files outside of Gradle sub-projects
         def targets = [
           'docs/examples',
           'docs/tutorial',
@@ -249,6 +254,7 @@ allprojects { currentProj ->
         }
         target targets
       } else {
+        // not the root project; format all .java files in the sub-project
         target '**/*.java'
       }
       targetExclude doNotFormat
@@ -257,6 +263,7 @@ allprojects { currentProj ->
       formatAnnotations()
     }
 
+    // Only define a groovyGradle task on the root project, for simplicity in setting the target pattern
     if (currentProj == currentProj.rootProject) {
       groovyGradle {
         target '**/*.gradle'
@@ -268,6 +275,7 @@ allprojects { currentProj ->
       }
     }
 
+    // a useful task for debugging; prints exactly which files are getting formatted by spotless
     tasks.register('printSpotlessTaskInputs') {
       doLast {
         project.tasks.forEach { task ->

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ spotlessPredeclare {
   }
 }
 
-allprojects {
+allprojects { currentProj ->
   // Increment the minor version (second number) rather than just the patch
   // level (third number) if:
   //   * any new checkers have been added, or
@@ -183,34 +183,47 @@ allprojects {
   }
 
   apply plugin: 'com.diffplug.spotless'
+  def doNotFormatMap = [
+    'checker': [
+      'bin-devel/.plume-scripts/**',
+      'tests/ainfer-*/annotated/*',
+      'tests/nullness-javac-errors/*',
+      'tests/calledmethods-delomboked/*',
+      'tests/build/**',
+      'dist/**'
+    ],
+    'dataflow': ['manual/examples/'],
+    'framework': [
+      'tests/returnsrcvrdelomboked/*',
+      'tests/build/**'
+    ],
+  ]
   spotless {
     // If you add any formatters to this block that require dependencies, then you must also
     // add them to the spotlessPredeclare block.
+    def doNotFormat = ['build/**']
+    if (currentProj != project.rootProject) {
+      if (doNotFormatMap.containsKey(currentProj.name)) {
+        doNotFormat += doNotFormatMap[currentProj.name]
+      }
 
-    def doNotFormat = [
-      'checker/bin-devel/.plume-scripts/**',
-      'checker/tests/ainfer-*/annotated/*',
-      'dataflow/manual/examples/',
-      '**/nullness-javac-errors/*',
-      '**/calledmethods-delomboked/*',
-      '**/returnsreceiverdelomboked/*',
-      '**/build/**',
-      '*/dist/**',
-    ]
-    if (!isJava17orHigher) {
-      doNotFormat += ['**/java17/', '**/*record*/']
+      if (!isJava17orHigher) {
+        doNotFormat += [
+          'tests/**/java17/',
+          'tests/*record*/'
+        ]
+      }
+
+      // As of 2023-09-24, google-java-format cannot parse Java 21 language features.
+      // See https://github.com/google/google-java-format/releases.
+      if (true) {
+        doNotFormat += ['tests/**/java21/']
+      }
+
+      if (!isJava21orHigher) {
+        doNotFormat += ['tests/**/java21/']
+      }
     }
-
-    // As of 2023-09-24, google-java-format cannot parse Java 21 language features.
-    // See https://github.com/google/google-java-format/releases.
-    if (true) {
-      doNotFormat += ['**/java21/']
-    }
-
-    if (!isJava21orHigher) {
-      doNotFormat += ['**/java21/']
-    }
-
     format 'misc', {
       // define the files to apply `misc` to
       target '*.md', '*.tex', '.gitignore', 'Makefile'
@@ -222,18 +235,10 @@ allprojects {
     }
 
     java {
-      def targets = [
-        // add target folders here
-        'checker',
-        'checker-qual',
-        'checker-util',
-        'dataflow',
+      def targets = (currentProj == currentProj.rootProject) ? [
         'docs/examples',
         'docs/tutorial',
-        'framework',
-        'framework-test',
-        'javacutil',
-      ]
+      ] : ['.']
       targets = targets.collectMany {
         [
           // must call toString() to convert GString to String
@@ -249,7 +254,11 @@ allprojects {
     }
 
     groovyGradle {
-      target '**/*.gradle'
+      if (currentProj == currentProj.rootProject) {
+        target '**/*.gradle'
+      } else {
+        target '*.gradle'
+      }
       targetExclude doNotFormat
       greclipse()  // which formatter Spotless should use to format .gradle files.
       indentWithSpaces(2)

--- a/build.gradle
+++ b/build.gradle
@@ -235,18 +235,22 @@ allprojects { currentProj ->
     }
 
     java {
-      def targets = (currentProj == currentProj.rootProject) ? [
-        'docs/examples',
-        'docs/tutorial',
-      ] : ['.']
-      targets = targets.collectMany {
-        [
-          // must call toString() to convert GString to String
-          "${it}/**/*.java".toString(),
-          // Not .ajava files because formatting would remove import statements.
+      if (currentProj == currentProj.rootProject) {
+        def targets = [
+          'docs/examples',
+          'docs/tutorial',
         ]
+        targets = targets.collectMany {
+          [
+            // must call toString() to convert GString to String
+            "${it}/**/*.java".toString(),
+            // Not .ajava files because formatting would remove import statements.
+          ]
+        }
+        target targets
+      } else {
+        target '**/*.java'
       }
-      target targets
       targetExclude doNotFormat
 
       googleJavaFormat() // the formatter to apply to Java files
@@ -255,7 +259,7 @@ allprojects { currentProj ->
 
     groovyGradle {
       if (currentProj == currentProj.rootProject) {
-        target '**/*.gradle'
+        target '*.gradle', 'docs/examples/**/*.gradle'
       } else {
         target '*.gradle'
       }
@@ -264,6 +268,20 @@ allprojects { currentProj ->
       indentWithSpaces(2)
       trimTrailingWhitespace()
       // endWithNewline() // Don't want to end empty files with a newline
+    }
+  }
+
+  tasks.register('printSpotlessTaskInputs') {
+    doLast {
+      project.tasks.forEach { task ->
+        if (task.name.contains('spotless')) {
+          println "Inputs for task '${task.name}':"
+
+          task.inputs.files.each { inputFile ->
+            println "  Input: $inputFile"
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #6297 

We make two key changes:

1. Split formatting of `.java` source files among individual sub-projects, so formatting / checking for each sub-project can run in parallel.
2. Remove exclusion patterns that start in `**`, which are expensive to evaluate.

With these changes, `./gradlew spotlessCheck` (which runs in the pre-commit script) runs much faster for me (on my M1 Mac the running time is reduced from ~9.2 seconds before this PR to ~2 seconds after).

To test, we add tasks named `printSpotlessTaskInputs` that print which files are being formatted.  Using these tasks I confirmed that exactly the same files are being checked and formatted before and after this PR.