### PR TITLE
Add missing dependencies for copyAndMinimizeAnnotatedJdkFiles task

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -89,6 +89,10 @@ task cloneTypetoolsJdk() {
 
 task copyAndMinimizeAnnotatedJdkFiles(dependsOn: cloneTypetoolsJdk, group: 'Build') {
   dependsOn ':framework:compileJava'
+  // we need the next two dependencies because we run JavaStubifier using this project's runtimeClasspath,
+  // which refers to the jars for these other projects
+  dependsOn ':javacutil:jar'
+  dependsOn ':dataflow:jar'
   def inputDir = "${annotatedJdkHome}/src"
   def outputDir = "${buildDir}/generated/resources/annotated-jdk/"
 


### PR DESCRIPTION
To see the problem on the current master branch, run:
```
./gradlew clean :framework:copyAndMinimizeAnnotatedJdkFiles --console=plain --no-parallel --no-daemon --no-build-cache
```
This causes a failure:
```
> Task :framework:copyAndMinimizeAnnotatedJdkFiles
Exception in thread "main" java.lang.NoClassDefFoundError: org/checkerframework/javacutil/BugInCF
	at org.checkerframework.framework.stub.JavaStubifier.process(JavaStubifier.java:71)
	at org.checkerframework.framework.stub.JavaStubifier.main(JavaStubifier.java:56)
Caused by: java.lang.ClassNotFoundException: org.checkerframework.javacutil.BugInCF
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
	... 2 more

> Task :framework:copyAndMinimizeAnnotatedJdkFiles FAILED
```
This PR fixes the failure by adding the right dependencies to the `:framework:copyAndMinimizeAnnotatedJdkFiles` task.