### PR TITLE
Disable parallel tests on CI to address flakiness

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -937,12 +937,9 @@ subprojects {
     tasks.withType(Test) {
       jvmArgs += compilerArgsForRunningCF
 
-      // Run tests in parallel, but not on CI.  Azure Pipelines CI jobs have the TF_BUILD env var set.
-      String tfBuild = System.getenv('TF_BUILD')
-      if (!tfBuild?.equals('True')) {
+      // Run tests in parallel, except on CI where it seems to lead to flaky failures.
+      if (!System.getenv('TF_BUILD')?.equals('True')) {
         maxParallelForks = Integer.MAX_VALUE
-      } else {
-        println("Disabling parallel tests on CI")
       }
 
       if (project.name.is('checker')) {

--- a/build.gradle
+++ b/build.gradle
@@ -937,7 +937,13 @@ subprojects {
     tasks.withType(Test) {
       jvmArgs += compilerArgsForRunningCF
 
-      maxParallelForks = Integer.MAX_VALUE
+      // Run tests in parallel, but not on CI.  Azure Pipelines CI jobs have the TF_BUILD env var set.
+      String tfBuild = System.getenv('TF_BUILD')
+      if (!tfBuild?.equals('True')) {
+        maxParallelForks = Integer.MAX_VALUE
+      } else {
+        println("Disabling parallel tests on CI")
+      }
 
       if (project.name.is('checker')) {
         dependsOn('assembleForJavac')

--- a/build.gradle
+++ b/build.gradle
@@ -938,6 +938,7 @@ subprojects {
       jvmArgs += compilerArgsForRunningCF
 
       // Run tests in parallel, except on CI where it seems to lead to flaky failures.
+      // The TF_BUILD environment variable is set to 'True' for jobs running on Azure Pipelines.
       if (!System.getenv('TF_BUILD')?.equals('True')) {
         maxParallelForks = Integer.MAX_VALUE
       }


### PR DESCRIPTION
I ran several CI builds with parallel tests disabled on #6419 and none of them had the weird timeout failure we have been observing recently.  So I'm hoping this will address the problem.  As to _why_ this fixes the problem, I'm not really sure.  My best guess is that when tests run in parallel, if the wrong tests run simultaneously, the allocation rate is too high for the garbage collector to handle and things freeze up.  If we land some optimizations we should try reverting this change to see if the timeouts return.