### PR TITLE
Fix spotless rule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ allprojects { currentProj ->
     'dataflow': ['manual/examples/'],
     'framework': [
       'tests/build/**',
-      'tests/returnsreceiverdelomboked/',
+      'tests/returnsreceiverdelomboked/*',
     ],
   ]
   spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -191,12 +191,11 @@ allprojects { currentProj ->
       'tests/build/**',
       'tests/calledmethods-delomboked/*',
       'tests/nullness-javac-errors/*',
-      'tests/returnsreceiverdelomboked/*',
     ],
     'dataflow': ['manual/examples/'],
     'framework': [
       'tests/build/**',
-      'tests/returnsrcvrdelomboked/*',
+      'tests/returnsreceiverdelomboked/',
     ],
   ]
   spotless {


### PR DESCRIPTION
The folder exclusion for `returnsreceiverdelomboked` was in the wrong place and had a typo
