### PR TITLE
Don't call Optional.isEmpty(), for Java 8 compatibility

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceJavaParserStorage.java
@@ -745,7 +745,7 @@ public class WholeProgramInferenceJavaParserStorage
               // be sufficient for WPI's purposes here: if the wrong name is computed, the worst
               // outcome is a false positive because WPI inferred an untrue annotation.
               Optional<String> ofqn = javaParserClass.getFullyQualifiedName();
-              if (ofqn.isEmpty()) {
+              if (!ofqn.isPresent()) {
                 throw new BugInCF("Missing getFullyQualifiedName() for " + javaParserClass);
               }
               if ("".contentEquals(tree.getSimpleName())) {

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileUtil.java
@@ -130,7 +130,7 @@ public class AnnotationFileUtil {
     if (indexOfDot == -1) {
       // classes not within a package needs to be the first in the index file
       CompilationUnit cu = indexFile.getCompilationUnits().get(0);
-      assert cu.getPackageDeclaration().isEmpty();
+      assert !cu.getPackageDeclaration().isPresent();
       return findDeclaration(className, cu);
     }
 


### PR DESCRIPTION
`isEmpty()` was only introduced in Java 11.  Since we are still trying to preserve Java 8 compatibility (I think), we should use `isPresent()` instead.