### PR TITLE
Rename `AbstractCFGVisualizer.visualizeBlockHelper()` to `visualizeBlockWithSeparator()`

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -56,8 +56,8 @@ public abstract class AbstractAnalysis<
   protected @MonotonicNonNull ControlFlowGraph cfg;
 
   /**
-   * The transfer inputs of every basic block (assumed to be 'no information' if not present, inputs
-   * before blocks in forward analysis, after blocks in backward analysis).
+   * The transfer inputs of every basic block; assumed to be 'no information' if not present. The
+   * inputs are before blocks in forward analysis, and are after blocks in backward analysis.
    */
   protected final IdentityHashMap<Block, TransferInput<V, S>> inputs = new IdentityHashMap<>();
 

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/AbstractCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/AbstractCFGVisualizer.java
@@ -196,7 +196,7 @@ public abstract class AbstractCFGVisualizer<
    *     {@link StringCFGVisualizer}
    * @return the String representation of the block
    */
-  protected String visualizeBlockHelper(
+  protected String visualizeBlockWithSeparator(
       Block bb, @Nullable Analysis<V, S, T> analysis, String separator) {
     StringBuilder sbBlock = new StringBuilder();
     String contents = loopOverBlockContents(bb, analysis, separator);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/DOTCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/DOTCFGVisualizer.java
@@ -153,7 +153,7 @@ public class DOTCFGVisualizer<
 
   @Override
   public String visualizeBlock(Block bb, @Nullable Analysis<V, S, T> analysis) {
-    return super.visualizeBlockHelper(bb, analysis, getSeparator());
+    return super.visualizeBlockWithSeparator(bb, analysis, getSeparator());
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/StringCFGVisualizer.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/StringCFGVisualizer.java
@@ -97,7 +97,7 @@ public class StringCFGVisualizer<
 
   @Override
   public String visualizeBlock(Block bb, @Nullable Analysis<V, S, T> analysis) {
-    return super.visualizeBlockHelper(bb, analysis, lineSeparator).trim();
+    return super.visualizeBlockWithSeparator(bb, analysis, lineSeparator).trim();
   }
 
   @Override

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+Version 3.44.0 (February ??, 2024)
+----------------------------------
+
+**User-visible changes:**
+
+**Implementation details:**
+
+Renamed `AbstractCFGVisualizer.visualizeBlockHelper()` to
+`visualizeBlockWithSeparator()`.
+
+**Closed issues:**
+
+
 Version 3.43.0 (January 2, 2024)
 --------------------------------
 

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -2144,10 +2144,15 @@ command-line options. \\
   The graph also contains information about flow-sensitively refined
   types of various expressions at many program points.
 
-  The argument is a comma-separated sequence of keys or key--value pairs.
-  The first argument is the fully-qualified name of the
+  The argument is a comma-separated sequence.
+  The first element is the fully-qualified name of the
   \<org.checkerframework.dataflow.cfg.CFGVisualizer> implementation
-  that should be used. The remaining keys or key--value pairs are
+  that should be used. Currently, the possibilities are:
+  \begin{itemize}
+  \item \<org.checkerframework.dataflow.cfg.visualize.>\refclass{org/checkerframework/dataflow/cfg/visualize}{DOTCFGVisualizer}
+  \item \<org.checkerframework.dataflow.cfg.visualize.>\refclass{org/checkerframework/dataflow/cfg/visualize}{StringCFGVisualizer}
+  \end{itemize}
+  The remaining keys or key--value pairs are
   passed to \<CFGVisualizer.init>.  Supported keys include
   \begin{itemize}
   \item \<verbose>

--- a/docs/manual/manual-style.tex
+++ b/docs/manual/manual-style.tex
@@ -150,7 +150,7 @@
 % qualifier name and includes parentheses around the parameters.
 \newcommand{\refqualclasswithparams}[3]{\href{../api/org/checkerframework/#1/#2.html}{\<@#2>}\<(\allowbreak #3)>}
 
-% Reference to Checker Framework Javadoc for a method or field.).
+% Reference to Checker Framework Javadoc for a method or field.
 % Arg 1: package name under org/checkerframework, using "/" as a separator,
 % with no leading or trailing "/". example: "checker/nullness/qual"
 % Arg 2: class name.
@@ -170,7 +170,7 @@
 % ``Class.field''.  The last argument is usually empty {}.
 \newcommand{\refenum}[4]{\href{../api/org/checkerframework/#1/#2.html\##3#4}{\<#3>}}
 
-% Reference to Sun Javadoc.
+% Reference to Oracle (previously Sun) Javadoc.
 % Arg 1: .html reference, without the .../api/ prefix
 % Arg 2: What will appear in the formatted manual.
 % Do not use \url in the body of any macro

--- a/docs/manual/manual.bbl
+++ b/docs/manual/manual.bbl
@@ -585,6 +585,13 @@ Fausto Spoto and Michael~D. Ernst.
 \newblock In {\em ICSE 2011, Proceedings of the 33rd International Conference
   on Software Engineering}, pages 231--240, Waikiki, Hawaii, USA, May 2011.
 
+\bibitem[SGT{\etalchar{+}}23]{ShadabGTEKLLS2023}
+Narges Shadab, Pritam Gharat, Shrey Tiwari, Michael~D. Ernst, Martin Kellogg,
+  Shuvendu Lahiri, Akash Lal, and Manu Sridharan.
+\newblock Inference of resource management specifications.
+\newblock {\em Proceedings of the ACM on Programming Languages}, 7(OOPSLA2,
+  article \#282):1705--1728, October 2023.
+
 \bibitem[She11]{Sherwany2011}
 Amanj Sherwany.
 \newblock The design, implementation and evaluation of a pluggable type checker

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractStore.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractStore.java
@@ -1324,8 +1324,9 @@ public abstract class CFAbstractStore<V extends CFAbstractValue<V>, S extends CF
 
   @Override
   public String visualize(CFGVisualizer<?, S, ?> viz) {
-    /* This cast is guaranteed to be safe, as long as the CFGVisualizer is created by
-     * CFGVisualizer<Value, Store, TransferFunction> createCFGVisualizer() of GenericAnnotatedTypeFactory */
+    // This cast is guaranteed to be safe, as long as the CFGVisualizer is created by
+    // CFGVisualizer<Value, Store, TransferFunction> createCFGVisualizer() of
+    // GenericAnnotatedTypeFactory.
     @SuppressWarnings("unchecked")
     CFGVisualizer<V, S, ?> castedViz = (CFGVisualizer<V, S, ?>) viz;
     String internal = internalVisualize(castedViz);


### PR DESCRIPTION
Merge after https://github.com/typetools/checker-framework/pull/6461.