### PR TITLE
Use `CFAbstractStore.replaceValue` in `MustCallTransfer`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/mustcall/MustCallTransfer.java
@@ -155,8 +155,7 @@ public class MustCallTransfer extends CFTransfer {
     CFValue defaultTypeAsCFValue =
         analysis.createSingleAnnotationValue(defaultType, expr.getType());
     CFValue newValue = defaultTypeAsCFValue.leastUpperBound(value);
-    store.clearValue(expr);
-    store.insertValue(expr, newValue);
+    store.replaceValue(expr, newValue);
   }
 
   /**


### PR DESCRIPTION
Found this pattern while implementing a similar refinement in the Non-Empty Checker, did not want to make this change as part of that work.