### PR TITLE
Add test case for closing over an `Optional` value

### DIFF
--- a/checker/tests/optional/OptionalClosureTest.java
+++ b/checker/tests/optional/OptionalClosureTest.java
@@ -1,0 +1,21 @@
+import java.util.Optional;
+import java.util.function.Function;
+
+class OptionalClosureTest {
+
+  @SuppressWarnings("optional:field") // We don't care, not the point of this test
+  public Optional<String> opt;
+
+  public Function<String, String> test() {
+    if (opt.isPresent()) {
+      // We *should* issue an error here. It's no good that opt is @Present here; it might be
+      // @MaybePresent at the time of invocation.
+      // :: error: (method.invocation)
+      return str -> opt.get();
+    }
+    return str -> "Hello";
+  }
+
+  @SuppressWarnings("optional:parameter") // We don't care, not the point of this test
+  public void setOpt(Optional<String> opt) {}
+}

--- a/checker/tests/optional/OptionalClosureTest.java
+++ b/checker/tests/optional/OptionalClosureTest.java
@@ -9,7 +9,7 @@ class OptionalClosureTest {
   public Function<String, String> test() {
     if (opt.isPresent()) {
       // We *should* issue an error here. It's no good that opt is @Present here; it might be
-      // @MaybePresent at the time of invocation.
+      // @MaybePresent at the time of invocation, for which get() is illegal.
       // :: error: (method.invocation)
       return str -> opt.get();
     }


### PR DESCRIPTION
With all the changes I'm making over in the Side Effects Only Checker (particularly wrt. unrefinement and lambda expressions), I want to add some test cases that can catch regressions that we should really care about.