### PR TITLE
Try another way to disable parallel jobs.

### DIFF
--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -12,4 +12,4 @@ source "$SCRIPTDIR"/clone-related.sh
 
 
 
-./gradlew test --console=plain --warning-mode=all
+./gradlew test --console=plain --warning-mode=all "-Dorg.gradle.parallel=false"


### PR DESCRIPTION
This job is still showing multiple tests run in parallel: https://dev.azure.com/checkerframework/checkerframework/_build/results?buildId=15353&view=logs&j=8fc623b7-a91d-5b06-fdce-5d098834cb65&s=d654deb9-056d-50a2-1717-90c08683d50a&t=539ea6b1-9aa9-510c-4898-b7f7f2628752&l=378