### PR TITLE
Preprocess unicode escapes when parsing using JavaParser

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
@@ -61,6 +61,7 @@ public class JavaParserUtil {
   public static CompilationUnit parseCompilationUnit(InputStream inputStream) {
     ParserConfiguration parserConfiguration = new ParserConfiguration();
     parserConfiguration.setLanguageLevel(DEFAULT_LANGUAGE_LEVEL);
+    parserConfiguration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(parserConfiguration);
     ParseResult<CompilationUnit> parseResult = javaParser.parse(inputStream);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {
@@ -86,6 +87,7 @@ public class JavaParserUtil {
   public static CompilationUnit parseCompilationUnit(File file) throws FileNotFoundException {
     ParserConfiguration configuration = new ParserConfiguration();
     configuration.setLanguageLevel(DEFAULT_LANGUAGE_LEVEL);
+    configuration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(configuration);
     ParseResult<CompilationUnit> parseResult = javaParser.parse(file);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {
@@ -110,6 +112,7 @@ public class JavaParserUtil {
   public static CompilationUnit parseCompilationUnit(String javaSource) {
     ParserConfiguration parserConfiguration = new ParserConfiguration();
     parserConfiguration.setLanguageLevel(DEFAULT_LANGUAGE_LEVEL);
+    parserConfiguration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(parserConfiguration);
     ParseResult<CompilationUnit> parseResult = javaParser.parse(javaSource);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {
@@ -142,6 +145,7 @@ public class JavaParserUtil {
     configuration.setLexicalPreservationEnabled(false);
     configuration.setAttributeComments(false);
     configuration.setDetectOriginalLineSeparator(false);
+    configuration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(configuration);
     ParseResult<StubUnit> parseResult = javaParser.parseStubUnit(inputStream);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {
@@ -188,6 +192,7 @@ public class JavaParserUtil {
     configuration.setLexicalPreservationEnabled(false);
     configuration.setAttributeComments(false);
     configuration.setDetectOriginalLineSeparator(false);
+    configuration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(configuration);
     ParseResult<Expression> parseResult = javaParser.parseExpression(expression);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
@@ -112,7 +112,6 @@ public class JavaParserUtil {
   public static CompilationUnit parseCompilationUnit(String javaSource) {
     ParserConfiguration parserConfiguration = new ParserConfiguration();
     parserConfiguration.setLanguageLevel(DEFAULT_LANGUAGE_LEVEL);
-    parserConfiguration.setPreprocessUnicodeEscapes(true);
     JavaParser javaParser = new JavaParser(parserConfiguration);
     ParseResult<CompilationUnit> parseResult = javaParser.parse(javaSource);
     if (parseResult.isSuccessful() && parseResult.getResult().isPresent()) {

--- a/framework/tests/all-systems/UnicodeEscape.java
+++ b/framework/tests/all-systems/UnicodeEscape.java
@@ -1,0 +1,9 @@
+// Test case for https://github.com/typetools/checker-framework/issues/6631.
+
+public class UnicodeEscape {
+  void foo() {
+    while (true) {
+      System.out.print("Enter an expression like \u005c"1+(2+3)*4;\u005c" :");
+    }
+  }
+}


### PR DESCRIPTION
Fixes #6631.

Only the change at line 90 is actually required for the test to pass. However, it seemed like we'd want to use this option all the time, to match javac's behavior (JLS 3.3: javac removes all unicode escapes before it invokes the lexer). The downside of this change is that it could make error-reporting slightly less useful: problems in annotation files with unicode escapes will be reported at the "post-unicode preprocessing" location rather than the location before unicode preprocessing (which is a JavaParser limitation, and the reason that JavaParser has this option off by default even though it is the correct behavior from the JLS' perspective).