### PR TITLE
Make it so that you can tell which test failed.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -969,14 +969,6 @@ subprojects {
         // Per Manu's comment above, on CI, parallelism seems to lead to flaky failures.
         maxParallelForks = 1
 
-        // Azure seems to time out when a task doesn't produce periodic output.
-        if (project.name.is('checker')) {
-          testLogging {
-            events "started", "skipped", "failed", "passed"
-            displayGranularity 3
-          }
-        }
-
         // Fork the test to try to improve performance.
         // https://docs.gradle.org/current/userguide/performance.html#fork_tests_into_multiple_processes
         tasks.withType(Test).configureEach {


### PR DESCRIPTION
Without this, when a test fails it doesn't show which test class failed:

https://dev.azure.com/checkerframework/checkerframework/_build/results?buildId=15642&view=logs&j=e43dad68-5e3b-5c73-4a4a-12eda19916b0&t=fbbfbd16-76f1-5ebc-8cbf-485046fc23ef&l=2411