### PR TITLE
Add `graphviz` to list of dev dependencies for macOS

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -767,7 +767,7 @@ In a startup file, write:
 
 \begin{Verbatim}
 brew update
-brew install git ant hevea maven librsvg unzip make
+brew install git graphviz ant hevea maven librsvg unzip make
 brew tap homebrew/cask-versions
 brew install --cask temurin17
 brew install --cask mactex


### PR DESCRIPTION
I am experimenting with the Checker Framework at work, and needed to make a clean installation on macOS.

`graphviz` is needed to create CFG visualizations after running with `-Aflowdotdir`, but isn't included in the list of developer documentation for macOS.

Not sure if the same issue persists for Linux systems, but I'm happy to update the list of dependencies there, too.