### PR TITLE
Correct type argument inference for method references with var args.

### DIFF
--- a/framework/tests/all-systems/Issue6664.java
+++ b/framework/tests/all-systems/Issue6664.java
@@ -1,0 +1,30 @@
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+public abstract class Issue6664<A, B> {
+
+  public static <A, B> Collector<Issue6664<A, B>, ?, Issue6664<A, List<B>>> breakIt() {
+    return Collectors.reducing(
+        Eithers.right(new ArrayList<>()),
+        either -> either.map(Arrays::asList),
+        (either, eithers) -> either);
+  }
+
+  public <C> Issue6664<A, C> map(Function<B, C> function) {
+    throw new RuntimeException();
+  }
+
+  public static final class Eithers {
+    public static <A, B> Issue6664<A, B> left(A left) {
+      throw new RuntimeException();
+    }
+
+    public static <A, B> Issue6664<A, B> right(B right) {
+      throw new RuntimeException();
+    }
+  }
+}

--- a/framework/tests/all-systems/Issue6664B.java
+++ b/framework/tests/all-systems/Issue6664B.java
@@ -1,0 +1,28 @@
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+public abstract class Issue6664B {
+
+  void method2() {
+    // Doesn't use variable arity for method applicability.
+    Function<Object[], List<Object>> f1 = Arrays::asList;
+
+    // Equivalent to Arrays.asList(obj).
+    Function<Object, List<Object>> f2 = Arrays::asList;
+    // Equivalent to Arrays.asList(o1,o2,o3).
+    Foo f3 = Arrays::asList;
+    // Equivalent to Arrays.asList().
+    Foo2 f4 = Arrays::asList;
+  }
+
+  interface Foo {
+
+    List<Object> apply(Object o1, Object o2, Object o3);
+  }
+
+  interface Foo2 {
+
+    List<Object> apply();
+  }
+}

--- a/framework/tests/all-systems/Issue6664B.java
+++ b/framework/tests/all-systems/Issue6664B.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 public abstract class Issue6664B {
 
+  @SuppressWarnings("purity.methodref")
   void method2() {
     // Doesn't use variable arity for method applicability.
     Function<Object[], List<Object>> f1 = Arrays::asList;

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -2571,12 +2571,12 @@ public final class TreeUtils {
   }
 
   /**
-   * Returns true if the given method references has a vararg element.
+   * Returns true if the given method reference has a varargs formal parameter.
    *
-   * @param methref the method reference
-   * @return if the given method references has a vararg element
+   * @param methref a method reference
+   * @return if the given method reference has a varargs formal parameter
    */
-  public static boolean hasVarArgElement(MemberReferenceTree methref) {
+  public static boolean hasVarargsParameter(MemberReferenceTree methref) {
     JCMemberReference jcMethoRef = (JCMemberReference) methref;
     return jcMethoRef.varargsElement != null;
   }
@@ -2594,7 +2594,7 @@ public final class TreeUtils {
       case NEW_CLASS:
         return isVarargsCall((NewClassTree) tree);
       case MEMBER_REFERENCE:
-        return hasVarArgElement((MemberReferenceTree) tree);
+        return hasVarargsParameter((MemberReferenceTree) tree);
       default:
         return false;
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -2571,6 +2571,17 @@ public final class TreeUtils {
   }
 
   /**
+   * Returns true if the given method references has a vararg element.
+   *
+   * @param methref the method reference
+   * @return if the given method references has a vararg element
+   */
+  public static boolean hasVarArgElement(MemberReferenceTree methref) {
+    JCMemberReference jcMethoRef = (JCMemberReference) methref;
+    return jcMethoRef.varargsElement != null;
+  }
+
+  /**
    * Returns true if the given method/constructor invocation is a varargs invocation.
    *
    * @param tree a method/constructor invocation
@@ -2582,6 +2593,8 @@ public final class TreeUtils {
         return isVarargsCall((MethodInvocationTree) tree);
       case NEW_CLASS:
         return isVarargsCall((NewClassTree) tree);
+      case MEMBER_REFERENCE:
+        return hasVarArgElement((MemberReferenceTree) tree);
       default:
         return false;
     }


### PR DESCRIPTION
Fixes #6664.