### PR TITLE
Add an option to turn exception messages into a single line.

### DIFF
--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -2025,6 +2025,9 @@ This prevents the message from being elevated to an error by \code{-Werror}.
 
 \item \code{-AdumpOnErrors}: Outputs a stack trace when reporting errors or warnings.
 
+\item \code{-AexceptionLineSeparator}:Controls what line separator is used when printing exceptions.
+This is useful when tools, such as Maven, do not display a full exception messsage.
+
 \end{itemize}
 
 

--- a/docs/manual/creating-a-checker.tex
+++ b/docs/manual/creating-a-checker.tex
@@ -2025,8 +2025,9 @@ This prevents the message from being elevated to an error by \code{-Werror}.
 
 \item \code{-AdumpOnErrors}: Outputs a stack trace when reporting errors or warnings.
 
-\item \code{-AexceptionLineSeparator}:Controls what line separator is used when printing exceptions.
-This is useful when tools, such as Maven, do not display a full exception messsage.
+\item \code{-AexceptionLineSeparator}: Controls what line separator is used when printing exceptions.
+This is useful when tools, such as Maven, only display the first line of exception messsages. For
+example, \code{-AexceptionLineSeparator="    "}.
 
 \end{itemize}
 

--- a/docs/manual/introduction.tex
+++ b/docs/manual/introduction.tex
@@ -772,6 +772,7 @@ Debugging
  \<-AprintVerboseGenerics>,
  \<-Anomsgtext>,
  \<-AdumpOnErrors>
+ \<-AexceptionLineSeparator>
 Amount of detail in messages; see Section~\ref{creating-debugging-options-detail}.
 
 \item

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -314,6 +314,10 @@ import org.plumelib.util.UtilPlume;
   // org.checkerframework.framework.source.SourceChecker.message(Kind, Object, String, Object...)
   "nomsgtext",
 
+  // Controls the line separator output in Checker Framework exceptions.
+  // org.checkerframework.framework.source.SourceChecker.logBug
+  "exceptionLineSeparator",
+
   /// Format of messages
 
   // Output detailed message in simple-to-parse format, useful
@@ -2741,7 +2745,8 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
    * @param culprit a message to print about the cause
    */
   private void logBug(Throwable ce, String culprit) {
-    StringJoiner msg = new StringJoiner(System.lineSeparator());
+    String lineSeparator = getOption("exceptionLineSeparator", System.lineSeparator());
+    StringJoiner msg = new StringJoiner(lineSeparator);
     if (ce.getCause() != null && ce.getCause() instanceof OutOfMemoryError) {
       msg.add(
           String.format(
@@ -2750,7 +2755,13 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
               Runtime.getRuntime().totalMemory(),
               Runtime.getRuntime().freeMemory()));
     } else {
-      msg.add(ce.getMessage());
+      String message;
+      if (hasOption("exceptionLineSeparator")) {
+        message = ce.getMessage().replaceAll(System.lineSeparator(), lineSeparator);
+      } else {
+        message = ce.getMessage();
+      }
+      msg.add(message);
       boolean noPrintErrorStack =
           (processingEnv != null
               && processingEnv.getOptions() != null

--- a/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
+++ b/framework/src/main/java/org/checkerframework/framework/source/SourceChecker.java
@@ -2745,7 +2745,8 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
    * @param culprit a message to print about the cause
    */
   private void logBug(Throwable ce, String culprit) {
-    String lineSeparator = getOption("exceptionLineSeparator", System.lineSeparator());
+    String lineSeparator =
+        getOptions().getOrDefault("exceptionLineSeparator", System.lineSeparator());
     StringJoiner msg = new StringJoiner(lineSeparator);
     if (ce.getCause() != null && ce.getCause() instanceof OutOfMemoryError) {
       msg.add(
@@ -2756,7 +2757,7 @@ public abstract class SourceChecker extends AbstractTypeProcessor implements Opt
               Runtime.getRuntime().freeMemory()));
     } else {
       String message;
-      if (hasOption("exceptionLineSeparator")) {
+      if (getOptions().containsKey("exceptionLineSeparator")) {
         message = ce.getMessage().replaceAll(System.lineSeparator(), lineSeparator);
       } else {
         message = ce.getMessage();

--- a/framework/tests/all-systems/Issue6725.java
+++ b/framework/tests/all-systems/Issue6725.java
@@ -1,0 +1,14 @@
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// @skip-test
+public class Issue6725 {
+  static <T> Iterable<T> prefix(Collection<? extends Iterable<? extends T>> iterables) {
+    Collection<? extends Iterator<? extends T>> iterators =
+        iterables.stream().map(Iterable::iterator).collect(Collectors.toList());
+    // ...
+    return List.of();
+  }
+}


### PR DESCRIPTION
You can run the following to test it:
```
  javacheck -processor tainting -AexceptionLineSeparator=** framework/tests/all-systems/Issue6725.java
```