### PR TITLE
Avoid a crashing when inference crashed.

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1893,6 +1893,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     if (args != null && !args.inferenceFailed()) {
       return true;
     }
+    if (args.inferenceCrashed()) {
+      checker.reportError(
+          tree,
+          "type.argument.inference.crashed",
+          ElementUtils.getSimpleDescription(methodType.getElement()),
+          args == null ? "" : args.getErrorMsg());
+      return false;
+    }
     checker.reportError(
         tree,
         "type.arguments.not.inferred",

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -54,6 +54,7 @@ this.invocation=Constructor of type %s cannot call %s of type %s.
 method.invocation=call to %s not allowed on the given receiver.%nfound   : %s%nrequired: %s
 constructor.invocation=creation of %s not allowed with given receiver.%nfound   : %s%nrequired: %s
 type.arguments.not.inferred=Could not infer type arguments for %s%nunsatisfiable constraint: %s
+type.argument.inference.crashed=Type argument inference crashed for %s%nerror: %s
 type.argument.hasqualparam=Types with qualifier parameters are not allowed as type arguments.%nfound qualifier parameter of %s hierarchy.
 declaration.inconsistent.with.extends.clause=Class with annotation %s cannot extend %s
 declaration.inconsistent.with.implements.clause=Class with annotation %s cannot implement %s

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2858,7 +2858,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     if (typeArguments.inferenceCrash) {
       // If inference crashed, then the return type will not be the correct Java type.  This can
-      // cause crashes else where in the framework.  To avoid those crashes, create an ATM with the
+      // cause crashes elsewhere in the framework.  To avoid those crashes, create an ATM with the
       // correct Java type and default annotations.  (If inference crashes an error will be issued
       // in the BaseTypeVisitor.)
       TypeMirror typeTM = TreeUtils.typeOf(tree);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2473,7 +2473,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
 
     if (typeArguments.inferenceCrash && tree instanceof MethodInvocationTree) {
       // If inference crashed, then the return type will not be the correct Java type.  This can
-      // cause crashes else where in the framework.  To avoid those crashes, create an ATM with the
+      // cause crashes elsewhere in the framework.  To avoid those crashes, create an ATM with the
       // correct Java type and default annotations.  (If inference crashes an error will be issued
       // in the BaseTypeVisitor.)
       TypeMirror type = TreeUtils.typeOf(tree);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -115,6 +115,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcard
 import org.checkerframework.framework.type.visitor.AnnotatedTypeCombiner;
 import org.checkerframework.framework.type.visitor.SimpleAnnotatedTypeScanner;
 import org.checkerframework.framework.util.AnnotatedTypes;
+import org.checkerframework.framework.util.AnnotatedTypes.TypeArguments;
 import org.checkerframework.framework.util.CheckerMain;
 import org.checkerframework.framework.util.FieldInvariants;
 import org.checkerframework.framework.util.TreePathCacher;
@@ -2459,29 +2460,27 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
         AnnotatedTypes.asMemberOf(types, this, receiverType, methodElt, memberTypeWithOverrides);
     List<AnnotatedTypeMirror> typeargs = new ArrayList<>(methodElt.getTypeParameters().size());
 
-    IPair<Map<TypeVariable, AnnotatedTypeMirror>, Boolean> pair =
+    TypeArguments typeArguments =
         AnnotatedTypes.findTypeArguments(this, tree, methodElt, methodType, inferTypeArgs);
-    Map<TypeVariable, AnnotatedTypeMirror> typeParamToTypeArg = pair.first;
+    Map<TypeVariable, AnnotatedTypeMirror> typeParamToTypeArg = typeArguments.typeArguments;
     if (!typeParamToTypeArg.isEmpty()) {
       for (AnnotatedTypeVariable tv : methodType.getTypeVariables()) {
-        if (typeParamToTypeArg.get(tv.getUnderlyingType()) == null) {
-          //          throw new BugInCF(
-          //              "AnnotatedTypeFactory.methodFromUse:mismatch between"
-          //                  + " declared method type variables and the inferred method
-          // type arguments."
-          //                  + " Method type variables: "
-          //                  + methodType.getTypeVariables()
-          //                  + "; "
-          //                  + "Inferred method type arguments: "
-          //                  + typeParamToTypeArg);
-        }
         typeargs.add(typeParamToTypeArg.get(tv.getUnderlyingType()));
       }
       methodType =
           (AnnotatedExecutableType) typeVarSubstitutor.substitute(typeParamToTypeArg, methodType);
     }
 
-    if (pair.second) {
+    if (typeArguments.inferenceCrash && tree instanceof MethodInvocationTree) {
+      // If inference crashed, then the return type will not be the correct Java type.  This can
+      // cause crashes else where in the framework.  To avoid those crashes, create an ATM with the
+      // correct Java type and default annotations.  (If inference crashes an error will be issued
+      // in the BaseTypeVisitor.)
+      TypeMirror type = TreeUtils.typeOf(tree);
+      AnnotatedTypeMirror returnType = AnnotatedTypeMirror.createType(type, this, false);
+      addDefaultAnnotations(returnType);
+      methodType.setReturnType(returnType);
+    } else if (typeArguments.uncheckedConversion) {
       methodType.setReturnType(methodType.getReturnType().getErased());
     }
 
@@ -2839,9 +2838,10 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     } else {
       con = AnnotatedTypes.asMemberOf(types, this, type, ctor, con);
     }
-    IPair<Map<TypeVariable, AnnotatedTypeMirror>, Boolean> pair =
+    TypeArguments typeArguments =
         AnnotatedTypes.findTypeArguments(this, tree, ctor, con, inferTypeArgs);
-    Map<TypeVariable, AnnotatedTypeMirror> typeParamToTypeArg = new HashMap<>(pair.first);
+    Map<TypeVariable, AnnotatedTypeMirror> typeParamToTypeArg =
+        new HashMap<>(typeArguments.typeArguments);
     List<AnnotatedTypeMirror> typeargs;
     if (typeParamToTypeArg.isEmpty()) {
       typeargs = Collections.emptyList();
@@ -2855,6 +2855,17 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
     con = (AnnotatedExecutableType) typeVarSubstitutor.substitute(typeParamToTypeArg, con);
 
     stubTypes.injectRecordComponentType(types, ctor, con);
+
+    if (typeArguments.inferenceCrash) {
+      // If inference crashed, then the return type will not be the correct Java type.  This can
+      // cause crashes else where in the framework.  To avoid those crashes, create an ATM with the
+      // correct Java type and default annotations.  (If inference crashes an error will be issued
+      // in the BaseTypeVisitor.)
+      TypeMirror typeTM = TreeUtils.typeOf(tree);
+      AnnotatedTypeMirror returnType = AnnotatedTypeMirror.createType(typeTM, this, false);
+      addDefaultAnnotations(returnType);
+      con.setReturnType(returnType);
+    }
     if (enclosingType != null) {
       // Reset the enclosing type because it can be substituted incorrectly.
       ((AnnotatedDeclaredType) con.getReturnType()).setEnclosingType(enclosingType);

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -802,9 +802,16 @@ public class AnnotatedTypes {
     /** Whether unchecked conversion was needed for inference. */
     public final boolean uncheckedConversion;
 
-    /** Whether type arguement inference crashed. */
+    /** Whether type argument inference crashed. */
     public final boolean inferenceCrash;
 
+    /**
+     * Creates a {@link TypeArguments} object.
+     *
+     * @param typeArguments a mapping from {@link TypeVariable} to its annotated type argument
+     * @param uncheckedConversion whether unchecked conversion was needed for inference
+     * @param inferenceCrash whether type argument inference crashed
+     */
     public TypeArguments(
         Map<TypeVariable, AnnotatedTypeMirror> typeArguments,
         boolean uncheckedConversion,

--- a/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/AnnotatedTypes.java
@@ -694,7 +694,6 @@ public class AnnotatedTypes {
    */
   private static final TypeArguments emptyFalsePair =
       new TypeArguments(Collections.emptyMap(), false, false);
-  ;
 
   /**
    * Given a method or constructor invocation, return a mapping of the type variables to their type

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/DefaultTypeArgumentInference.java
@@ -124,6 +124,7 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
             Collections.emptyList(),
             false,
             true,
+            true,
             "An exception occurred: " + ex.getLocalizedMessage());
       }
       throw BugInCF.addLocation(outerTree, ex);

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
@@ -119,6 +119,11 @@ public class InferenceResult {
     return annoInferenceFailed;
   }
 
+  /**
+   * Whether inference crashed.
+   *
+   * @return whether inference crashed
+   */
   public boolean inferenceCrashed() {
     return inferenceCrashed;
   }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InferenceResult.java
@@ -46,6 +46,9 @@ public class InferenceResult {
   /** Whether unchecked conversion was necessary to infer the type arguments. */
   private final boolean uncheckedConversion;
 
+  /** Whether inference crashed. */
+  private final boolean inferenceCrashed;
+
   /** If {@code annoInferenceFailed}, then this is the error message to report to the user. */
   private final String errorMsg;
 
@@ -62,10 +65,29 @@ public class InferenceResult {
       boolean uncheckedConversion,
       boolean annoInferenceFailed,
       String errorMsg) {
+    this(variables, uncheckedConversion, annoInferenceFailed, false, errorMsg);
+  }
+
+  /**
+   * Creates an inference result.
+   *
+   * @param variables instantiated variables
+   * @param uncheckedConversion where unchecked conversion was required to infer the type arguments
+   * @param annoInferenceFailed whether inference failed because of annotations
+   * @param inferenceCrashed the type argument inference code crashed
+   * @param errorMsg message to report to users if inference failed
+   */
+  public InferenceResult(
+      Collection<Variable> variables,
+      boolean uncheckedConversion,
+      boolean annoInferenceFailed,
+      boolean inferenceCrashed,
+      String errorMsg) {
     this.results = convert(variables);
     this.uncheckedConversion = uncheckedConversion;
     this.annoInferenceFailed = annoInferenceFailed;
     this.errorMsg = errorMsg;
+    this.inferenceCrashed = inferenceCrashed;
   }
 
   /**
@@ -95,6 +117,10 @@ public class InferenceResult {
    */
   public boolean inferenceFailed() {
     return annoInferenceFailed;
+  }
+
+  public boolean inferenceCrashed() {
+    return inferenceCrashed;
   }
 
   /**


### PR DESCRIPTION
If type argument inference crashes, the crash is caught and an error is reported, but the underlying java type of the method expression may be incorrect and cause further crashes.  In this case, use the Java computed method call expression type to created an annotated type of the method call.  This way the rest of the framework won't crash.