### PR TITLE
Add desugaring information to MethodInvocationNode

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3014,6 +3014,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
       // annotations, so save the expression in the node so that the full type can be
       // found later.
       nextCallNode.setIterableExpression(expression);
+      nextCallNode.setEnhancedForLoop(tree);
       nextCallNode.setInSource(false);
       extendWithNode(nextCallNode);
 
@@ -3022,6 +3023,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
       // translateAssignment() scans variable and creates new nodes, so set the expression
       // there, too.
       ((MethodInvocationNode) assignNode.getExpression()).setIterableExpression(expression);
+      ((MethodInvocationNode) assignNode.getExpression()).setEnhancedForLoop(tree);
 
       assert statement != null;
       scan(statement, p);
@@ -3124,6 +3126,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
         // conversion. Treat that as an iterator.
         MethodInvocationNode boxingNode = (MethodInvocationNode) arrayAccessAssignNodeExpr;
         boxingNode.setIterableExpression(expression);
+        boxingNode.setEnhancedForLoop(tree);
       }
 
       assert statement != null;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/MethodInvocationNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/MethodInvocationNode.java
@@ -1,5 +1,6 @@
 package org.checkerframework.dataflow.cfg.node;
 
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
@@ -49,6 +50,15 @@ public class MethodInvocationNode extends Node {
    * <p>Is set by {@link #setIterableExpression}.
    */
   protected @Nullable ExpressionTree iterableExpression;
+
+  /**
+   * If this MethodInvocationNode is a node for an {@link Iterator#next()} desugared from an
+   * enhanced for loop, then the {@code enhancedForLoop} field is the {@code EnhancedForLoopTree}
+   * AST node.
+   *
+   * <p>Is set by {@link #setEnhancedForLoop}.
+   */
+  protected @Nullable EnhancedForLoopTree enhancedForLoop;
 
   /**
    * Create a MethodInvocationNode.
@@ -103,6 +113,18 @@ public class MethodInvocationNode extends Node {
   }
 
   /**
+   * If this MethodInvocationNode is a node for an {@link Iterator#next()} desugared from an
+   * enhanced for loop, then return the corresponding {@code EnhancedForLoopTree} AST node.
+   * Otherwise, return null.
+   *
+   * @return the {@code EnhancedForLoopTree}, or null if this is not a {@link Iterator#next()} from
+   *     an enhanced for loop
+   */
+  public @Nullable EnhancedForLoopTree getEnhancedForLoop() {
+    return enhancedForLoop;
+  }
+
+  /**
    * Set the iterable expression from a for loop.
    *
    * @param iterableExpression iterable expression
@@ -110,6 +132,16 @@ public class MethodInvocationNode extends Node {
    */
   public void setIterableExpression(@Nullable ExpressionTree iterableExpression) {
     this.iterableExpression = iterableExpression;
+  }
+
+  /**
+   * Set the enhanced for loop for which {@code this} is the desugared loop update.
+   *
+   * @param enhancedForLoop the {@code EnhancedForLoopTree}
+   * @see #getEnhancedForLoop()
+   */
+  public void setEnhancedForLoop(@Nullable EnhancedForLoopTree enhancedForLoop) {
+    this.enhancedForLoop = enhancedForLoop;
   }
 
   @Override


### PR DESCRIPTION
When an enhanced-for-loop over an Iterable (as opposed to over an array) is desugared by the CFG translation phase one, the translator logic sets a field for the MethodInvocationNode corresponding to the loop update statement (Iterator.next()), which is the ExpressionTree AST-node corresponding to the Iterable.

This PR now adds a reference to the EnhancedForLoopTree AST-node as well.

This additional desugaring information is required by the loop-body-analysis of the RLC4Collections.