### PR TITLE
Fix a resource leak false positive due to a cast

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -54,7 +54,6 @@ import org.checkerframework.dataflow.cfg.block.Block;
 import org.checkerframework.dataflow.cfg.block.Block.BlockType;
 import org.checkerframework.dataflow.cfg.block.ConditionalBlock;
 import org.checkerframework.dataflow.cfg.block.ExceptionBlock;
-import org.checkerframework.dataflow.cfg.block.SingleSuccessorBlock;
 import org.checkerframework.dataflow.cfg.node.AssignmentNode;
 import org.checkerframework.dataflow.cfg.node.ClassNameNode;
 import org.checkerframework.dataflow.cfg.node.FieldAccessNode;
@@ -66,7 +65,6 @@ import org.checkerframework.dataflow.cfg.node.ObjectCreationNode;
 import org.checkerframework.dataflow.cfg.node.ReturnNode;
 import org.checkerframework.dataflow.cfg.node.SuperNode;
 import org.checkerframework.dataflow.cfg.node.ThisNode;
-import org.checkerframework.dataflow.cfg.node.TypeCastNode;
 import org.checkerframework.dataflow.expression.FieldAccess;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.LocalVariable;
@@ -984,36 +982,6 @@ class MustCallConsistencyAnalyzer {
       }
     }
     return !mustCallAliasArguments.isEmpty();
-  }
-
-  /**
-   * Checks if {@code node} is either directly enclosed by a {@link TypeCastNode}, by looking at the
-   * successor block in the CFG. In this case the enclosing operator is a "no-op" that evaluates to
-   * the same value as {@code node}. This method is only used within {@link
-   * #propagateObligationsToSuccessorBlocks(ControlFlowGraph, Set, Block, Set, Deque)} to ensure
-   * Obligations are propagated to cast nodes properly. It relies on the assumption that a {@link
-   * TypeCastNode} will only appear in a CFG as the first node in a block.
-   *
-   * @param node the CFG node
-   * @return {@code true} if {@code node} is in a {@link SingleSuccessorBlock} {@code b}, the first
-   *     {@link Node} in {@code b}'s successor block is a {@link TypeCastNode}, and {@code node} is
-   *     an operand of the successor node; {@code false} otherwise
-   */
-  private boolean inCast(Node node) {
-    if (!(node.getBlock() instanceof SingleSuccessorBlock)) {
-      return false;
-    }
-    Block successorBlock = ((SingleSuccessorBlock) node.getBlock()).getSuccessor();
-    if (successorBlock != null) {
-      List<Node> succNodes = successorBlock.getNodes();
-      if (succNodes.size() > 0) {
-        Node succNode = succNodes.get(0);
-        if (succNode instanceof TypeCastNode) {
-          return ((TypeCastNode) succNode).getOperand().equals(node);
-        }
-      }
-    }
-    return false;
   }
 
   /**
@@ -2071,17 +2039,6 @@ class MustCallConsistencyAnalyzer {
               && obligation.canBeSatisfiedThrough(tmpVarForExcNode)) {
             continue;
           }
-        }
-
-        // Always propagate the Obligation to the successor if current block represents
-        // code nested in a cast.  Without this logic, the analysis may report a false
-        // positive when the Obligation represents a temporary variable for a nested
-        // expression, as the temporary may not appear in the successor store and hence
-        // seems to be going out of scope.  The temporary will be handled with special
-        // logic; casts are unwrapped at various points in the analysis.
-        if (currentBlockNodes.size() == 1 && inCast(currentBlockNodes.get(0))) {
-          successorObligations.add(obligation);
-          continue;
         }
 
         // At this point, a consistency check will definitely occur, unless the

--- a/checker/tests/resourceleak/CastBeforeFinallyBlock.java
+++ b/checker/tests/resourceleak/CastBeforeFinallyBlock.java
@@ -1,0 +1,24 @@
+import java.io.Closeable;
+
+public abstract class CastBeforeFinallyBlock {
+
+  protected abstract Closeable alloc() throws Exception;
+
+  protected abstract Object getInt() throws Exception;
+
+  public void f() throws Exception {
+    // Previous versions of the resource leak checker reported a false positive
+    // for this code ("close may not have been invoked on y").  However, this
+    // code is correct.
+
+    Integer x = null;
+    try {
+      try (Closeable y = alloc()) {
+        System.out.println(y);
+      }
+      x = (Integer) getInt();
+    } finally {
+      System.out.println(x);
+    }
+  }
+}

--- a/checker/tests/resourceleak/SafeCast.java
+++ b/checker/tests/resourceleak/SafeCast.java
@@ -1,0 +1,13 @@
+// simple test that the Resource Leak Checker can track data flow through a downcast
+import java.io.Closeable;
+import java.io.InputStream;
+
+public abstract class SafeCast {
+
+  protected abstract Closeable alloc() throws Exception;
+
+  public void f() throws Exception {
+    InputStream s = (InputStream) alloc();
+    s.close();
+  }
+}


### PR DESCRIPTION
The reason for the false positive is essentially:

 - At `x = (Integer) getInt()`, the variable `y` is still in-scope. (The dataflow framework seems a bit sloppy about scopes in ways that don't matter to most checkers.)  There is an obligation to close `y`, but `y` has type `@CalledMethods("close")`, so there is no violation yet.
 - There is a special rule that cast nodes ALWAYS propagate obligations.  So, the obligation for `y` gets propagated to the successor, which is a marker node at the start of the `finally` block.  (Normally this wouldn't happen, because `y` is not in-scope in the successor block.)
 - When propagating that obligation from the marker node to the first "real" node in the `finally` block (the condition node `x != null`), the checker reports a spurious violation because
    1. There is an obligation to close `y`.
    2. `y` is not in-scope in the successor, so it must be going out of scope.
    3. The type of `y` is unknown (to the dataflow framework it is NOT in-scope here), so it is treated as `@CalledMethods({})` (top).

There are a few possible fixes.  By far the most elegant is to simply remove the special handling for casts.  No tests break without it, and the new test case in `CastBeforeFinallyBlock.java` now passes.