### PR TITLE
Updating macOS installation instructions

### DIFF
--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -793,7 +793,7 @@ export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-XX.jdk/Contents/
 \end{Verbatim}
 
 where \emph{XX} is a JDK version such as 17, 21, 23, etc. that is one of
-the ones listed in  \<checker/bin-devel/Dockerfile-ubuntu-jdk\emph{XX}-plus>.
+the ones listed in \<checker/bin-devel/Dockerfile-ubuntu-jdk\emph{XX}-plus>.
 
 \item[Windows]
   To build on Windows 10 or later,

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -761,7 +761,7 @@ In a startup file, write:
 \end{smaller}
 %END LATEX
 
-\item[Mac OS]
+\item[macOS]
   If you employ \href{https://brew.sh}{homebrew} to install packages, run
   the following commands:
 
@@ -785,13 +785,15 @@ Note: If copy permission is denied, try \<sudo>.
 In a startup file, write:
 
 \begin{Verbatim}
-export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+export JAVA_HOME=$(/usr/libexec/java_home -v XX)
 \end{Verbatim}
 or
 \begin{Verbatim}
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-17.jdk/Contents/Home/
+export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-XX.jdk/Contents/Home/
 \end{Verbatim}
 
+where \emph{XX} is a JDK version such as 17, 21, 23, etc. that is one of
+the ones listed in  \<checker/bin-devel/Dockerfile-ubuntu-jdk\emph{XX}-plus>.
 
 \item[Windows]
   To build on Windows 10 or later,

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -768,7 +768,6 @@ In a startup file, write:
 \begin{Verbatim}
 brew update
 brew install git graphviz ant hevea maven librsvg unzip make
-brew tap homebrew/cask-versions
 brew install --cask temurin17
 brew install --cask mactex
 \end{Verbatim}

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -772,6 +772,9 @@ brew install --cask temurin17
 brew install --cask mactex
 \end{Verbatim}
 
+Note: Running \<brew install --cask temurin17> is only necessary if you do not
+already have a JDK that is compatible with the Checker Framework installed.
+
 Make a \<latex> directory and copy \<hevea.sty> file into it.
 (\url{https://hevea.inria.fr/} gives the current version number.)
 

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -777,7 +777,7 @@ Make a \<latex> directory and copy \<hevea.sty> file into it.
 
 \begin{Verbatim}
 mkdir -p $HOME/Library/texmf/tex/latex
-cp -p /usr/local/Cellar/hevea/2.36/lib/hevea/hevea.sty $HOME/Library/texmf/tex/latex/
+cp -p /opt/homebrew/Cellar/hevea/2.36/lib/hevea/hevea.sty $HOME/Library/texmf/tex/latex/
 \end{Verbatim}
 
 Note: If copy permission is denied, try \<sudo>.

--- a/docs/manual/troubleshooting.tex
+++ b/docs/manual/troubleshooting.tex
@@ -795,8 +795,9 @@ or
 export JAVA_HOME=/Library/Java/JavaVirtualMachines/adoptopenjdk-XX.jdk/Contents/Home/
 \end{Verbatim}
 
-where \emph{XX} is a JDK version such as 17, 21, 23, etc. that is one of
-the ones listed in \<checker/bin-devel/Dockerfile-ubuntu-jdk\emph{XX}-plus>.
+where \emph{XX} is a JDK version such as 17, 21, 23, etc. that appears in one
+of the names for the files in \<checker/bin-devel>, e.g.,
+\<Dockerfile-ubuntu-jdk\emph{XX}-plus>.
 
 \item[Windows]
   To build on Windows 10 or later,


### PR DESCRIPTION
Users who wish to locally-build and develop the Checker Framework on macOS are asked to run the following command:

```sh
brew tap homebrew/cask-versions
```

Which appears to be deprecated as per the output:

```sh
Error: homebrew/cask-versions was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```

An alternative is to run:

```sh
brew tap homebrew/homebrew-core
```
But homebrew suggests that it isn't necessary:
```sh
brew tap homebrew/homebrew-core
Error: Tapping homebrew/core is no longer typically necessary.
```