### PR TITLE
Disable Returns Receiver Checker by default for RLC

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsChecker.java
@@ -72,7 +72,7 @@ public class CalledMethodsChecker extends AccumulationChecker {
    *
    * @return whether the -AdisableReturnsReceiver option was specified on the command line
    */
-  private boolean isReturnsReceiverDisabled() {
+  protected boolean isReturnsReceiverDisabled() {
     if (returnsReceiverDisabled == null) {
       returnsReceiverDisabled = hasOptionNoSubcheckers(DISABLE_RETURNS_RECEIVER);
     }

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakChecker.java
@@ -35,6 +35,7 @@ import org.checkerframework.framework.source.SupportedOptions;
   MustCallChecker.NO_LIGHTWEIGHT_OWNERSHIP,
   MustCallChecker.NO_RESOURCE_ALIASES,
   ResourceLeakChecker.ENABLE_WPI_FOR_RLC,
+  ResourceLeakChecker.ENABLE_RETURNS_RECEIVER
 })
 @StubFiles("IOUtils.astub")
 public class ResourceLeakChecker extends CalledMethodsChecker {
@@ -115,6 +116,8 @@ public class ResourceLeakChecker extends CalledMethodsChecker {
    */
   public static final String ENABLE_WPI_FOR_RLC = "enableWpiForRlc";
 
+  public static final String ENABLE_RETURNS_RECEIVER = "enableReturnsReceiverForRlc";
+
   /**
    * The number of expressions with must-call obligations that were checked. Incremented only if the
    * {@link #COUNT_MUST_CALL} command-line option was supplied.
@@ -177,6 +180,12 @@ public class ResourceLeakChecker extends CalledMethodsChecker {
           numMustCall - numMustCallFailed);
     }
     super.typeProcessingOver();
+  }
+
+  @Override
+  protected boolean isReturnsReceiverDisabled() {
+    // disable by default, unless the flag is set
+    return !hasOption(ENABLE_RETURNS_RECEIVER) || super.isReturnsReceiverDisabled();
   }
 
   /**

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakChecker.java
@@ -116,6 +116,11 @@ public class ResourceLeakChecker extends CalledMethodsChecker {
    */
   public static final String ENABLE_WPI_FOR_RLC = "enableWpiForRlc";
 
+  /**
+   * The Returns Receiver Checker is disabled by default for the Resource Leak Checker, as it adds
+   * significant overhead and typically provides little benefit. To enable it, use the
+   * -AenableReturnsReceiverForRlc flag.
+   */
   public static final String ENABLE_RETURNS_RECEIVER = "enableReturnsReceiverForRlc";
 
   /**
@@ -182,9 +187,12 @@ public class ResourceLeakChecker extends CalledMethodsChecker {
     super.typeProcessingOver();
   }
 
+  /**
+   * Disable the Returns Receiver Checker unless it has been explicitly enabled with the {@link
+   * #ENABLE_RETURNS_RECEIVER} option.
+   */
   @Override
   protected boolean isReturnsReceiverDisabled() {
-    // disable by default, unless the flag is set
     return !hasOption(ENABLE_RETURNS_RECEIVER) || super.isReturnsReceiverDisabled();
   }
 

--- a/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakReturnsReceiverTest.java
+++ b/checker/src/test/java/org/checkerframework/checker/test/junit/ResourceLeakReturnsReceiverTest.java
@@ -1,0 +1,26 @@
+package org.checkerframework.checker.test.junit;
+
+import java.io.File;
+import java.util.List;
+import org.checkerframework.checker.resourceleak.ResourceLeakChecker;
+import org.checkerframework.framework.test.CheckerFrameworkPerDirectoryTest;
+import org.junit.runners.Parameterized.Parameters;
+
+/** Tests for the Resource Leak Checker that require the Returns Receiver Checker to be enabled. */
+public class ResourceLeakReturnsReceiverTest extends CheckerFrameworkPerDirectoryTest {
+  public ResourceLeakReturnsReceiverTest(List<File> testFiles) {
+    super(
+        testFiles,
+        ResourceLeakChecker.class,
+        "resourceleak",
+        "-AwarnUnneededSuppressions",
+        "-AenableReturnsReceiverForRlc",
+        "-encoding",
+        "UTF-8");
+  }
+
+  @Parameters
+  public static String[] getTestDirs() {
+    return new String[] {"resourceleak-returns-receiver"};
+  }
+}

--- a/checker/tests/resourceleak-returns-receiver/ReturnsReceiverExamples.java
+++ b/checker/tests/resourceleak-returns-receiver/ReturnsReceiverExamples.java
@@ -1,0 +1,106 @@
+// tests that require the Returns Receiver Checker to be enabled.
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.common.returnsreceiver.qual.*;
+
+class ReturnsReceiverExamples {
+
+  @InheritableMustCall("a")
+  class Foo {
+    void a() {}
+
+    @This Foo b() {
+      return this;
+    }
+
+    void c() {}
+  }
+
+  @Owning
+  Foo makeFoo() {
+    return new Foo();
+  }
+
+  @Owning
+  @CalledMethods({"b"}) Foo makeFooFinalize2() {
+    Foo f = new Foo();
+    f.b();
+    return f;
+  }
+
+  void CallMethodsInSequence2() {
+    makeFoo().b().a();
+  }
+
+  void testFluentAPIWrong() {
+    // :: error: (required.method.not.called)
+    makeFoo().b();
+  }
+
+  void testFluentAPIWrong2() {
+    // :: error: (required.method.not.called)
+    makeFoo();
+  }
+
+  @CalledMethods({"a"}) Foo makeFooFinalize() {
+    Foo f = new Foo();
+    f.a();
+    return f;
+  }
+
+  void invokeMethodWithCallA() {
+    makeFooFinalize();
+  }
+
+  void invokeMethodWithCallBWrong() {
+    // :: error: (required.method.not.called)
+    makeFooFinalize2();
+  }
+
+  void invokeMethodAndCallCWrong() {
+    // :: error: (required.method.not.called)
+    makeFoo().c();
+  }
+
+  void makeFooFinalizeWrong() {
+    Foo m;
+    // :: error: (required.method.not.called)
+    m = new Foo();
+    // :: error: (required.method.not.called)
+    Foo f = new Foo();
+    f.b();
+  }
+
+  Foo ifElseWithReturnExit(boolean b, boolean c) {
+    // :: error: (required.method.not.called)
+    Foo f1 = makeFoo();
+    // :: error: (required.method.not.called)
+    Foo f3 = new Foo();
+    // :: error: (required.method.not.called)
+    Foo f4 = new Foo();
+
+    if (b) {
+      // :: error: (required.method.not.called)
+      Foo f2 = new Foo();
+      if (c) {
+        f4.a();
+      } else {
+        f4.b();
+      }
+      return f1;
+    } else {
+      // :: error: (required.method.not.called)
+      Foo f2 = new Foo();
+      f2 = new Foo();
+      f2.a();
+    }
+    return f3;
+  }
+
+  void ownershipTransfer() {
+    Foo f1 = new Foo();
+    Foo f2 = f1;
+    Foo f3 = f2.b();
+    f3.a();
+  }
+}

--- a/checker/tests/resourceleak/ACMethodInvocationTest.java
+++ b/checker/tests/resourceleak/ACMethodInvocationTest.java
@@ -1,6 +1,5 @@
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
-import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACMethodInvocationTest {
 
@@ -8,7 +7,7 @@ class ACMethodInvocationTest {
   class Foo {
     void a() {}
 
-    @This Foo b() {
+    Foo b() {
       return this;
     }
 
@@ -26,19 +25,8 @@ class ACMethodInvocationTest {
     return f;
   }
 
-  @Owning
-  @CalledMethods({"b"}) Foo makeFooFinalize2() {
-    Foo f = new Foo();
-    f.b();
-    return f;
-  }
-
   void CallMethodsInSequence() {
     makeFoo().a();
-  }
-
-  void CallMethodsInSequence2() {
-    makeFoo().b().a();
   }
 
   void testFluentAPIWrong() {
@@ -53,11 +41,6 @@ class ACMethodInvocationTest {
 
   void invokeMethodWithCallA() {
     makeFooFinalize();
-  }
-
-  void invokeMethodWithCallBWrong() {
-    // :: error: (required.method.not.called)
-    makeFooFinalize2();
   }
 
   void invokeMethodAndCallCWrong() {

--- a/checker/tests/resourceleak/ACRegularExitPointTest.java
+++ b/checker/tests/resourceleak/ACRegularExitPointTest.java
@@ -2,7 +2,6 @@ import java.io.IOException;
 import java.util.function.Function;
 import org.checkerframework.checker.calledmethods.qual.*;
 import org.checkerframework.checker.mustcall.qual.*;
-import org.checkerframework.common.returnsreceiver.qual.*;
 
 class ACRegularExitPointTest {
 
@@ -10,7 +9,7 @@ class ACRegularExitPointTest {
   class Foo {
     void a() {}
 
-    @This Foo b() {
+    Foo b() {
       return this;
     }
 
@@ -37,15 +36,6 @@ class ACRegularExitPointTest {
   void makeFooFinalize() {
     Foo f = new Foo();
     f.a();
-  }
-
-  void makeFooFinalizeWrong() {
-    Foo m;
-    // :: error: (required.method.not.called)
-    m = new Foo();
-    // :: error: (required.method.not.called)
-    Foo f = new Foo();
-    f.b();
   }
 
   void testStoringInLocalWrong() {
@@ -134,32 +124,6 @@ class ACRegularExitPointTest {
       // :: error: (required.method.not.called)
       Foo f2 = new Foo();
     }
-  }
-
-  Foo ifElseWithReturnExit(boolean b, boolean c) {
-    // :: error: (required.method.not.called)
-    Foo f1 = makeFoo();
-    // :: error: (required.method.not.called)
-    Foo f3 = new Foo();
-    // :: error: (required.method.not.called)
-    Foo f4 = new Foo();
-
-    if (b) {
-      // :: error: (required.method.not.called)
-      Foo f2 = new Foo();
-      if (c) {
-        f4.a();
-      } else {
-        f4.b();
-      }
-      return f1;
-    } else {
-      // :: error: (required.method.not.called)
-      Foo f2 = new Foo();
-      f2 = new Foo();
-      f2.a();
-    }
-    return f3;
   }
 
   void ifElseWithDeclaration(boolean b) {
@@ -263,13 +227,6 @@ class ACRegularExitPointTest {
     } else {
 
     }
-  }
-
-  void ownershipTransfer() {
-    Foo f1 = new Foo();
-    Foo f2 = f1;
-    Foo f3 = f2.b();
-    f3.a();
   }
 
   void ownershipTransfer2() {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@ Version 3.48.1 (November 1, 2024)
 
 **User-visible changes:**
 
+The Returns Receiver sub-checker is now disabled by default when running the Resource Leak Checker,
+as usually it is not needed and it adds overhead. To enable it, use the new
+`-AenableReturnsReceiverForRlc` command-line argument.
+
 **Implementation details:**
 
 **Closed issues:**


### PR DESCRIPTION
Fixes #6434

We separate test cases that require the Returns Receiver Checker to be enabled and only run those tests with the new flag.