### PR TITLE
Augment arrayaccess node

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -3123,6 +3123,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
       handleArtificialTree(arrayAccess);
       ArrayAccessNode arrayAccessNode = new ArrayAccessNode(arrayAccess, arrayNode2, indexNode2);
       arrayAccessNode.setArrayExpression(expression);
+      arrayAccessNode.setEnhancedForLoop(tree);
       arrayAccessNode.setInSource(false);
       extendWithNode(arrayAccessNode);
       AssignmentNode arrayAccessAssignNode =
@@ -3133,6 +3134,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
       Node arrayAccessAssignNodeExpr = arrayAccessAssignNode.getExpression();
       if (arrayAccessAssignNodeExpr instanceof ArrayAccessNode) {
         ((ArrayAccessNode) arrayAccessAssignNodeExpr).setArrayExpression(expression);
+        ((ArrayAccessNode) arrayAccessAssignNodeExpr).setEnhancedForLoop(tree);
       } else if (arrayAccessAssignNodeExpr instanceof MethodInvocationNode) {
         // If the array component type is a primitive, there may be a boxing or unboxing
         // conversion. Treat that as an iterator.

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
@@ -41,8 +41,8 @@ public class ArrayAccessNode extends Node {
   protected @Nullable ExpressionTree arrayExpression;
 
   /**
-   * If this ArrayAccessNode is a node for an array desugared from an enhanced for loop, then the
-   * {@code enhancedForLoop} field is the {@code EnhancedForLoopTree} AST node.
+   * If this ArrayAccessNode is a node for an array access desugared from an enhanced for loop, then
+   * the {@code enhancedForLoop} field is the {@code EnhancedForLoopTree} AST node.
    *
    * <p>Is set by {@link #setEnhancedForLoop}.
    */
@@ -85,11 +85,11 @@ public class ArrayAccessNode extends Node {
   }
 
   /**
-   * If this ArrayAccessNode is a node for an array desugared from an enhanced for loop, then return
-   * the {@code enhancedForLoop} AST node. Otherwise, return null.
+   * If this ArrayAccessNode is a node for an array access desugared from an enhanced for loop, then
+   * return the {@code EnhancedForLoopTree} AST node. Otherwise, return null.
    *
-   * @return the {@code EnhancedForLoopTree}, or null if this is not an array desugared from an
-   *     enhanced for loop
+   * @return the {@code EnhancedForLoopTree}, or null if this is not an array access desugared from
+   *     an enhanced for loop
    */
   public @Nullable EnhancedForLoopTree getEnhancedForLoop() {
     return enhancedForLoop;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/ArrayAccessNode.java
@@ -1,6 +1,7 @@
 package org.checkerframework.dataflow.cfg.node;
 
 import com.sun.source.tree.ArrayAccessTree;
+import com.sun.source.tree.EnhancedForLoopTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.Tree;
 import java.util.Arrays;
@@ -40,6 +41,14 @@ public class ArrayAccessNode extends Node {
   protected @Nullable ExpressionTree arrayExpression;
 
   /**
+   * If this ArrayAccessNode is a node for an array desugared from an enhanced for loop, then the
+   * {@code enhancedForLoop} field is the {@code EnhancedForLoopTree} AST node.
+   *
+   * <p>Is set by {@link #setEnhancedForLoop}.
+   */
+  protected @Nullable EnhancedForLoopTree enhancedForLoop;
+
+  /**
    * Create an ArrayAccessNode.
    *
    * @param t tree for the array access
@@ -73,6 +82,27 @@ public class ArrayAccessNode extends Node {
    */
   public void setArrayExpression(@Nullable ExpressionTree arrayExpression) {
     this.arrayExpression = arrayExpression;
+  }
+
+  /**
+   * If this ArrayAccessNode is a node for an array desugared from an enhanced for loop, then return
+   * the {@code enhancedForLoop} AST node. Otherwise, return null.
+   *
+   * @return the {@code EnhancedForLoopTree}, or null if this is not an array desugared from an
+   *     enhanced for loop
+   */
+  public @Nullable EnhancedForLoopTree getEnhancedForLoop() {
+    return enhancedForLoop;
+  }
+
+  /**
+   * Set the enhanced for loop from which {@code this} is desugared from.
+   *
+   * @param enhancedForLoop the {@code EnhancedForLoopTree}
+   * @see #getEnhancedForLoop()
+   */
+  public void setEnhancedForLoop(@Nullable EnhancedForLoopTree enhancedForLoop) {
+    this.enhancedForLoop = enhancedForLoop;
   }
 
   /**


### PR DESCRIPTION
For ArrayAccessNode's desugared from enhanced for loops, add the EnhancedForLoopTree AST node as a field. This allows us to traverse the CFG and detect enhanced for loops. Will be used in the MustCallOnElements checker.