### PR TITLE
Only capture fields that. are not on the LHS of assignments

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -284,7 +284,9 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
       // Only capture the type if this is not the left hand side of an assignment.
       if (path != null && path.getParentPath().getLeaf().getKind() == Kind.ASSIGNMENT) {
         AssignmentTree assignmentTree = (AssignmentTree) path.getParentPath().getLeaf();
-        if (assignmentTree.getExpression() != tree) {
+        @SuppressWarnings("interning:not.interned") // Looking for exact object.
+        boolean leftHandSide = assignmentTree.getExpression() != tree;
+        if (leftHandSide) {
           return typeOfFieldAccess;
         }
       }

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -280,6 +280,8 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
       AnnotatedTypeMirror typeOfFieldAccess =
           AnnotatedTypes.asMemberOf(f.types, f, typeOfReceiver, elt);
       TreePath path = f.getPath(tree);
+
+      // Only capture the type if this is not the left hand side of an assignment.
       if (path != null && path.getParentPath().getLeaf().getKind() == Kind.ASSIGNMENT) {
         AssignmentTree assignmentTree = (AssignmentTree) path.getParentPath().getLeaf();
         if (assignmentTree.getExpression() != tree) {

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromExpressionVisitor.java
@@ -22,9 +22,11 @@ import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.ParenthesizedTree;
 import com.sun.source.tree.PrimitiveTypeTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.Tree.Kind;
 import com.sun.source.tree.TypeCastTree;
 import com.sun.source.tree.UnaryTree;
 import com.sun.source.tree.WildcardTree;
+import com.sun.source.util.TreePath;
 import java.util.List;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -271,11 +273,20 @@ class TypeFromExpressionVisitor extends TypeFromTreeVisitor {
       return AnnotatedTypes.asSuper(
           f, thisType, AnnotatedTypeMirror.createType(superTypeMirror, f, false));
     } else {
-      // tree must be a field access, so get the type of the (receiver) expression, and then call
-      // asMemberOf.
+      // tree must be a field access or an enum constant, so get the type of the (receiver)
+      // expression, and then call asMemberOf.
       AnnotatedTypeMirror typeOfReceiver = f.getAnnotatedType(tree.getExpression());
       typeOfReceiver = f.applyCaptureConversion(typeOfReceiver);
-      return f.applyCaptureConversion(AnnotatedTypes.asMemberOf(f.types, f, typeOfReceiver, elt));
+      AnnotatedTypeMirror typeOfFieldAccess =
+          AnnotatedTypes.asMemberOf(f.types, f, typeOfReceiver, elt);
+      TreePath path = f.getPath(tree);
+      if (path != null && path.getParentPath().getLeaf().getKind() == Kind.ASSIGNMENT) {
+        AssignmentTree assignmentTree = (AssignmentTree) path.getParentPath().getLeaf();
+        if (assignmentTree.getExpression() != tree) {
+          return typeOfFieldAccess;
+        }
+      }
+      return f.applyCaptureConversion(typeOfFieldAccess);
     }
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -234,7 +234,7 @@ public class InferenceType extends AbstractType {
 
   @Override
   public TypeMirror getJavaType() {
-    return typeMirror;
+    return type.getUnderlyingType();
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
@@ -240,7 +240,7 @@ public class ProperType extends AbstractType {
 
   @Override
   public TypeMirror getJavaType() {
-    return properType;
+    return type.getUnderlyingType();
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
@@ -95,7 +95,7 @@ public class UseOfVariable extends AbstractType {
 
   @Override
   public TypeVariable getJavaType() {
-    return variable.typeVariableJava;
+    return variable.typeVariable.getUnderlyingType();
   }
 
   @Override

--- a/framework/tests/all-systems/Issue6825.java
+++ b/framework/tests/all-systems/Issue6825.java
@@ -1,3 +1,6 @@
+import java.util.ArrayList;
+import java.util.List;
+
 @SuppressWarnings("all") // Just check for crashes.
 public class Issue6825 {
   static class ClassA<T extends Number> {}
@@ -8,5 +11,14 @@ public class Issue6825 {
   void method(Number n) {
     var y = flag ? f : new ClassA<Number>();
     var x = flag ? this.f : new ClassA<Number>();
+  }
+
+  static class SomeClass {}
+
+  private List<? extends SomeClass> typeParameters = null;
+
+  public Issue6825(InferenceCrash other) {
+    this.typeParameters =
+        other.typeParameters == null ? null : new ArrayList<>(other.typeParameters);
   }
 }

--- a/framework/tests/all-systems/Issue6825.java
+++ b/framework/tests/all-systems/Issue6825.java
@@ -17,7 +17,7 @@ public class Issue6825 {
 
   private List<? extends SomeClass> typeParameters = null;
 
-  public Issue6825(InferenceCrash other) {
+  public Issue6825(Issue6825 other) {
     this.typeParameters =
         other.typeParameters == null ? null : new ArrayList<>(other.typeParameters);
   }


### PR DESCRIPTION
This seems to be what javac is doing.  (This crash the crash in annotation-tools.)