### PR TITLE
All primitive types are `@Interned`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/interning/InterningAnnotatedTypeFactory.java
@@ -242,6 +242,13 @@ public class InterningAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
       }
       return super.visitDeclared(t, p);
     }
+
+    @Override
+    public Void visitPrimitive(AnnotatedPrimitiveType t, Void p) {
+      // case 4: primitive types are interned
+      t.replaceAnnotation(INTERNED);
+      return super.visitPrimitive(t, p);
+    }
   }
 
   /**

--- a/checker/tests/interning/UnboxUninterned.java
+++ b/checker/tests/interning/UnboxUninterned.java
@@ -10,4 +10,10 @@ public class UnboxUninterned {
     int i1 = -x.intValue();
     int i2 = -x;
   }
+
+  void loopVariables(java.util.List<Long> list) {
+    for (long i : list) {
+      long unused = Math.addExact(i, 0L);
+    }
+  }
 }


### PR DESCRIPTION
Fixes #6371.

The interning checker does not apply `@Interned` to every occurrence of every primitive type.  This allows some language constructs to fabricate non-interned primitive values, leading to false positives.

For instance, in the new `loopVariables` test, the loop variable `i` was assigned the type `@UnknownInterned long`.  Thus `i` could not be used as an argument to `addExact` which requires interned arguments.