### PR TITLE
Updating docs: "non-empty" to "present" `Optional`

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/optional/qual/EnsuresPresent.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/optional/qual/EnsuresPresent.java
@@ -9,10 +9,10 @@ import org.checkerframework.framework.qual.InheritedAnnotation;
 import org.checkerframework.framework.qual.PostconditionAnnotation;
 
 /**
- * Indicates that the expression evaluates to a non-empty Optional, if the method terminates
+ * Indicates that the expression evaluates to a present Optional, if the method terminates
  * successfully.
  *
- * <p>This postcondition annotation is useful for methods that construct a non-empty Optional:
+ * <p>This postcondition annotation is useful for methods that construct a present Optional:
  *
  * <pre><code>
  *   {@literal @}EnsuresPresent("optStr")

--- a/docs/manual/optional-checker.tex
+++ b/docs/manual/optional-checker.tex
@@ -179,7 +179,7 @@ An example use is
     Optional<T> wrapWithOptional(...) { ... }
 
     void myMethod() {
-      @SuppressWarnings("optional") // with argument x, wrapWithOptional always returns a non-empty Optional
+      @SuppressWarnings("optional") // with argument x, wrapWithOptional always returns a present Optional
       @Present Optional<T> optX = wrapWithOptional(x);
     }
 \end{Verbatim}
@@ -214,7 +214,7 @@ The rest of this section discusses the \<castPresent> method.
 It is useful if you wish to suppress a warning within an expression.
 
 The Optional Checker considers both the return value, and also the
-argument, to be an instance of a non-empty Optional after the \<castPresent>
+argument, to be an instance of a present Optional after the \<castPresent>
 method call.
 The Optional Checker issues no warnings in any of the following
 code:


### PR DESCRIPTION
Helps to avoid overloaded use of "non-empty" with future checkers (e.g., the Non-Empty Checker)