### PR TITLE
[RLC Inference] Handle non-localvar entries in the tempvar map

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallInference.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallInference.java
@@ -842,10 +842,13 @@ public class MustCallInference {
       }
 
       Node arg = mcca.removeCastsAndGetTmpVarIfPresent(arguments.get(i));
+      if (!(arg instanceof LocalVariableNode)) {
+        continue;
+      }
       Obligation argObligation =
           MustCallConsistencyAnalyzer.getObligationForVar(obligations, (LocalVariableNode) arg);
       if (argObligation == null) {
-        return;
+        continue;
       }
       int index = getIndexOfParam(argObligation);
       if (index != -1) {


### PR DESCRIPTION
Based on some suggestions from @mernst.