### PR TITLE
Fix manual Gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -676,13 +676,9 @@ def createJavadocTask(taskName, taskDescription, memberLevel) {
 
 createJavadocTask('javadocDoclintAll', 'Runs javadoc with -Xdoclint:all option.', JavadocMemberLevel.PRIVATE)
 
-task manual(group: 'Documentation') {
+task manual(type: Exec, group: 'Documentation') {
   description 'Build the manual'
-  doLast {
-    exec {
-      commandLine 'make', '-C', 'docs/manual', 'all'
-    }
-  }
+  commandLine 'make', '-C', 'docs/manual', 'all'
 }
 
 /**


### PR DESCRIPTION
exec with a closure :
```
exec { ... }
```
Has been deprecated 
https://docs.gradle.org/8.12/userguide/upgrading_version_8.html#deprecated_project_exec

And appears to not be working in Gradle version 8.12.  (See https://github.com/typetools/checker-framework/pull/6937
) I'm working to remove all the uses, but I need to rewrite each use.