### PR TITLE
Output standard error as well as standard output

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,9 +15,10 @@ include 'checker-util'
 include 'framework-test'
 includeBuild ('../annotation-tools/annotation-file-utilities') {
   if (!file('../annotation-tools/annotation-file-utilities').exists()) {
-    def output = providers.exec {
+    def executed = providers.exec {
       commandLine("checker/bin-devel/clone-related.sh")
-    }.standardOutput.asText.get()
-    println output
+    }
+    println executed.standardOutput.asText.get()
+    println executed.standardError.asText.get()
   }
 }


### PR DESCRIPTION
There is another problem:  The standard output and standard error are only printed if the command succeeds.  We want to see them regardless.  Here is an example execution: https://dev.azure.com/mernstdaikon/b8079554-0ed5-466e-9205-8aceed9390e7/_apis/build/builds/1840/logs/270