### PR TITLE
Fix resource leak unsoundness due to `finally { throw }`

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -193,6 +193,10 @@ class MustCallConsistencyAnalyzer {
     /** The method exits by throwing an exception. */
     EXCEPTIONAL_EXIT;
 
+    /** An immutable set containing only {@link #NORMAL_RETURN}. */
+    public static final Set<MethodExitKind> ONLY_NORMAL_RETURN =
+        Collections.singleton(NORMAL_RETURN);
+
     /** An immutable set containing all possible ways for a method to exit. */
     public static final Set<MethodExitKind> ALL =
         ImmutableSet.copyOf(EnumSet.allOf(MethodExitKind.class));
@@ -1061,7 +1065,11 @@ class MustCallConsistencyAnalyzer {
       Node returnExpr = node.getResult();
       returnExpr = getTempVarOrNode(returnExpr);
       if (returnExpr instanceof LocalVariableNode) {
-        removeObligationsContainingVar(obligations, (LocalVariableNode) returnExpr);
+        removeObligationsContainingVar(
+            obligations,
+            (LocalVariableNode) returnExpr,
+            MustCallAliasHandling.NO_SPECIAL_HANDLING,
+            MethodExitKind.ONLY_NORMAL_RETURN);
       }
     }
   }

--- a/checker/tests/resourceleak/FinallyThrowsException.java
+++ b/checker/tests/resourceleak/FinallyThrowsException.java
@@ -1,0 +1,166 @@
+// Tests for cases where a finally-block throws an exception.
+// try { return } finally { ... } creates complex control flow since the finally block executes
+// AFTER the return.  Normally a method doesn't do anything after it returns.
+
+import java.io.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+abstract class FinallyThrowsException {
+
+  public abstract boolean choice();
+
+  public abstract @Owning @Nullable Closeable alloc() throws IOException;
+
+  public @Owning Closeable test1() throws IOException {
+    // Resource leak: the allocated resource is lost when the exception is thrown
+    try {
+      // :: error: (required.method.not.called)
+      return alloc();
+    } finally {
+      throw new IOException();
+    }
+  }
+
+  public @Owning Closeable test2(@Owning Closeable r1) throws IOException {
+    // OK: we are not obligated to close @Owning parameters if we throw an exception
+    try {
+      return r1;
+    } finally {
+      throw new IOException();
+    }
+  }
+
+  public @Owning Closeable test3() throws IOException {
+    // Resource leak: the allocated resource is lost if x.close() throws
+    try (Closeable x = alloc()) {
+      // :: error: (required.method.not.called)
+      return alloc();
+    }
+  }
+
+  public @Owning Closeable test4(@Owning Closeable r1) throws IOException {
+    // OK: we are not obligated to close @Owning parameters if we throw an exception
+    try (Closeable x = alloc()) {
+      return r1;
+    }
+  }
+
+  // Demonstration of a particular pattern that should work; there are some variants
+  // involving finally-blocks below.
+  public @Owning @Nullable Closeable test5(@Owning Closeable r1) throws IOException {
+    if (choice()) {
+      return r1;
+    } else {
+      r1.close();
+      return null;
+    }
+  }
+
+  // Identical to test5, but wrapped in try-finally-throw.
+  // OK: we are not obligated to close @Owning parameters if we throw an exception.
+  public @Owning @Nullable Closeable test6(@Owning Closeable r1) throws IOException {
+    try {
+      if (choice()) {
+        return r1;
+      } else {
+        r1.close();
+        return null;
+      }
+    } finally {
+      throw new IOException();
+    }
+  }
+
+  // Identical to test5, but wrapped in try-with-resources.
+  // This is a false positive: we are not obligated to close @Owning parameters if we throw an
+  // exception.  The cause of the false positive is the same control-flow merge described in
+  // IfBranch.test1(), although the merge is more subtle: both returns have an edge to the
+  // implicit `finally { x.close(); }` of the try-with-resources block.
+  // :: error: (required.method.not.called)
+  public @Owning @Nullable Closeable test7(@Owning Closeable r1) throws IOException {
+    try (Closeable x = alloc()) {
+      if (choice()) {
+        return r1;
+      } else {
+        r1.close();
+        return null;
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Larger examples demonstrating the principles above.
+
+  // A complicated method that either (1) returns its r1 argument unchanged or (2) allocates
+  // a new resource r2, closes its r1 argument, and returns r2.
+  public @Owning Closeable test8(@Owning Closeable r1) throws IOException {
+    Closeable r2 = alloc();
+
+    // If allocation failed, return r1 unchanged.
+    if (r2 == null) {
+      return r1;
+    }
+
+    // If allocation succeeded, close r1 and return r2.
+    try {
+      r1.close();
+      return r2;
+    } catch (Exception e) {
+      // If we fail to close r1, we want to raise that exception.
+      // But, we have to close r2 before throwing.
+      try {
+        r2.close();
+      } catch (Exception onClose) {
+        e.addSuppressed(onClose);
+      }
+      throw e;
+    }
+  }
+
+  // Variant of test8 wrapped in try-with-resources.
+  // This exhibits one false positive on r1 (see test7) and one true positive on r2 (see test3).
+  // The true positive might be very surprising because the same code is resource-leak-free when
+  // it does not appear under try-with-resources (see test8).
+  // :: error: (required.method.not.called)
+  public @Owning Closeable test9(@Owning Closeable r1) throws IOException {
+    try (Closeable x = alloc()) {
+      // :: error: (required.method.not.called)
+      Closeable r2 = alloc();
+      if (r2 == null) {
+        return r1;
+      }
+      try {
+        r1.close();
+        return r2; // possible leak if x.close() throws
+      } catch (Exception e) {
+        try {
+          r2.close();
+        } catch (Exception onClose) {
+          e.addSuppressed(onClose);
+        }
+        throw e;
+      }
+    }
+  }
+
+  // Rewrite of test9 with no resource leaks or false positives.  The key idea is to move the
+  // `return` outside the try-with-resources.  We need the complicated catch-block in case the
+  // implicit call to `x.close()` throws.
+  public @Owning Closeable test10(@Owning Closeable r1) throws IOException {
+    Closeable result = null;
+    try (Closeable x = alloc()) {
+      result = test8(r1);
+    } catch (Exception e) {
+      try {
+        if (result != null) {
+          result.close();
+        }
+      } catch (Exception onClose) {
+        e.addSuppressed(onClose);
+      }
+      throw e;
+    }
+    return result;
+  }
+}

--- a/checker/tests/resourceleak/IfBranch.java
+++ b/checker/tests/resourceleak/IfBranch.java
@@ -8,8 +8,6 @@ abstract class IfBranch {
 
   public abstract boolean choice();
 
-  public abstract @Owning Closeable alloc() throws IOException;
-
   // False positive.  The then-branch moves r1 to result, and the else-branch closes r1.
   // After the if-else block we should be left only with an obligation to close result,
   // which should be satisfied by `retun result`.

--- a/checker/tests/resourceleak/IfBranch.java
+++ b/checker/tests/resourceleak/IfBranch.java
@@ -10,7 +10,7 @@ abstract class IfBranch {
 
   // False positive.  The then-branch moves r1 to result, and the else-branch closes r1.
   // After the if-else block we should be left only with an obligation to close result,
-  // which should be satisfied by `retun result`.
+  // which should be satisfied by `return result`.
   //
   // Obligation tracking by the MustCallConsistencyAnalyzer is indeed path sensitive, in that it
   // does not lose information at control-flow merges; it just tracks the obligation(s) from each

--- a/checker/tests/resourceleak/IfBranch.java
+++ b/checker/tests/resourceleak/IfBranch.java
@@ -1,0 +1,42 @@
+// Tests for cases where an interesting state merge has to happen after an if-branch.
+
+import java.io.*;
+import org.checkerframework.checker.mustcall.qual.*;
+import org.checkerframework.checker.nullness.qual.*;
+
+abstract class IfBranch {
+
+  public abstract boolean choice();
+
+  public abstract @Owning Closeable alloc() throws IOException;
+
+  // False positive that confuses the consistency analyzer:
+  //  - The then-branch makes r1 and result resource aliases.
+  //  - The else-branch closes r1.
+  //  - When control flow merges, we end up with
+  //    + An obligation to close r1 (from the then-branch)
+  //    + r1 has no called methods (from the else-branch)
+  //    + r1 and result are not necessarily aliases
+  //    resulting in a spurious violation on return.
+  // :: error: (required.method.not.called)
+  public @Owning @Nullable Closeable test1(@Owning Closeable r1) throws IOException {
+    Closeable result;
+    if (choice()) {
+      result = r1;
+    } else {
+      r1.close();
+      result = null;
+    }
+    return result;
+  }
+
+  // Variant of test1 using multiple returns instead of a result variable.  This one works.
+  public @Owning @Nullable Closeable test2(@Owning Closeable r1) throws IOException {
+    if (choice()) {
+      return r1;
+    } else {
+      r1.close();
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This commit fixes a subtle unsoundness in the resource leak checker concerning try-finally blocks where the `finally` block might throw an exception.

The simplest variant of this confusing control flow is shown in the first test case in FinallyThrowsException.java:

    try {
      return alloc();
    } finally {
      throw new IOException();
    }

The allocated resource will be leaked because the method does not return; it throws an exception.  Previously the resource leak checker would accept that code because _all_ obligations were cleared at return statements.  Instead, only normal-return-obligations should be cleared at return statements, and exceptional-exit-obligations should remain unsatisfied in case a post-return-finally-block ends up throwing.

This change also affects try-with-resources blocks, where there is an implicit finally-block that might throw.

In developing this fix I also discovered an interesting false positive, explained and tested in IfBranch.java.  That false positive is vaguely related to this fix because it affects the case where there are multiple return statements appearing in a try-finally block: control flow merges after the returns, jumping to the common finally-block. `MustCallConsistencyAnalyzer` does not handle the control flow merge correctly.