### PR TITLE
Update to Google Java Format 1.25.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ ext {
 
   versions = [
     autoValue       : '1.11.0',
-    googleJavaFormat : '1.19.2',
+    googleJavaFormat : '1.25.2',
     lombok          : '1.18.36',
     hashmapUtil : '0.0.1',
     reflectionUtil : '1.1.4',

--- a/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/formatter/FormatterVisitor.java
@@ -127,10 +127,10 @@ public class FormatterVisitor extends BaseTypeVisitor<FormatterAnnotatedTypeFact
             if (!isWrappedFormatCall(fc, enclosingMethod)) {
               ftu.warning(invc, "format.indirect.arguments");
             }
-            // TODO:  If it is explict array construction, such as "new Object[] {
-            // ... }", then we could treat it like the VARARGS case, analyzing each
-            // argument.  "new array" is probably rare, in the varargs position.
-            // fall through
+          // TODO:  If it is explict array construction, such as "new Object[] {
+          // ... }", then we could treat it like the VARARGS case, analyzing each
+          // argument.  "new array" is probably rare, in the varargs position.
+          // fall through
           case NULLARRAY:
             for (ConversionCategory cat : formatCats) {
               if (cat == ConversionCategory.NULL) {

--- a/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/i18nformatter/I18nFormatterVisitor.java
@@ -101,7 +101,7 @@ public class I18nFormatterVisitor extends BaseTypeVisitor<I18nFormatterAnnotated
             }
             break;
           case NULLARRAY:
-            // fall-through
+          // fall-through
           case ARRAY:
             for (I18nConversionCategory cat : formatCats) {
               if (cat == I18nConversionCategory.UNUSED) {

--- a/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/NullnessVisitor.java
@@ -191,7 +191,7 @@ public class NullnessVisitor
             || !((IdentifierTree) receiver).getName().contentEquals("this")) {
           return null;
         }
-        // fallthrough
+      // fallthrough
       case IDENTIFIER:
         TreePath path = getCurrentPath();
         if (TreePathUtil.inConstructor(path)) {

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/ResourceLeakAnnotatedTypeFactory.java
@@ -379,7 +379,8 @@ public class ResourceLeakAnnotatedTypeFactory extends CalledMethodsAnnotatedType
 
   @Override
   @SuppressWarnings("TypeParameterUnusedInFormals") // Intentional abuse
-  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>> @Nullable T getTypeFactoryOfSubcheckerOrNull(Class<? extends SourceChecker> subCheckerClass) {
+  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>>
+      @Nullable T getTypeFactoryOfSubcheckerOrNull(Class<? extends SourceChecker> subCheckerClass) {
     if (subCheckerClass == MustCallChecker.class) {
       if (!canCreateObligations()) {
         return super.getTypeFactoryOfSubcheckerOrNull(MustCallNoCreatesMustCallForChecker.class);

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessVisitor.java
@@ -142,8 +142,8 @@ public class SignednessVisitor extends BaseTypeVisitor<SignednessAnnotatedTypeFa
           }
           break;
         }
-        // Other plus binary trees should be handled in the default case.
-        // fall through
+      // Other plus binary trees should be handled in the default case.
+      // fall through
       default:
         if (leftOpType.hasPrimaryAnnotation(Unsigned.class)
             && rightOpType.hasPrimaryAnnotation(Signed.class)) {
@@ -305,8 +305,8 @@ public class SignednessVisitor extends BaseTypeVisitor<SignednessAnnotatedTypeFa
           }
           break;
         }
-        // Other plus binary trees should be handled in the default case.
-        // fall through
+      // Other plus binary trees should be handled in the default case.
+      // fall through
       default:
         if (varType.hasPrimaryAnnotation(Unsigned.class)
             && exprType.hasPrimaryAnnotation(Signed.class)) {

--- a/checker/tests/calledmethods-lombok/CheckerFrameworkBuilder.java
+++ b/checker/tests/calledmethods-lombok/CheckerFrameworkBuilder.java
@@ -187,7 +187,8 @@ public class CheckerFrameworkBuilder {
 
   @org.checkerframework.dataflow.qual.SideEffectFree
   @java.lang.SuppressWarnings("all")
-  public static CheckerFrameworkBuilder.@org.checkerframework.common.aliasing.qual.Unique CheckerFrameworkBuilderBuilder builder() {
+  public static CheckerFrameworkBuilder.@org.checkerframework.common.aliasing.qual.Unique CheckerFrameworkBuilderBuilder
+      builder() {
     return new CheckerFrameworkBuilder.CheckerFrameworkBuilderBuilder();
   }
 }

--- a/checker/tests/fenum/TestSwitch.java
+++ b/checker/tests/fenum/TestSwitch.java
@@ -11,7 +11,7 @@ public class TestSwitch {
     int plain = 9; // FenumUnqualified
 
     switch (plain) {
-        // :: error: (type.incompatible)
+      // :: error: (type.incompatible)
       case annotated:
       default:
     }
@@ -24,7 +24,7 @@ public class TestSwitch {
     }
 
     switch (annotated) {
-        // :: error: (type.incompatible)
+      // :: error: (type.incompatible)
       case 45:
       default:
     }

--- a/checker/tests/nullness/java17/SwitchExpressionInvariant.java
+++ b/checker/tests/nullness/java17/SwitchExpressionInvariant.java
@@ -12,14 +12,14 @@ public class SwitchExpressionInvariant {
     List<@NonNull String> list =
         // :: error: (assignment)
         switch (fenum) {
-            // :: error: (switch.expression)
+          // :: error: (switch.expression)
           case 1 -> nonnullStrings;
           default -> nullableStrings;
         };
 
     List<@Nullable String> list2 =
         switch (fenum) {
-            // :: error: (switch.expression)
+          // :: error: (switch.expression)
           case 1 -> nonnullStrings;
           default -> nullableStrings;
         };

--- a/checker/tests/nullness/java17/SwitchTestIssue5412.java
+++ b/checker/tests/nullness/java17/SwitchTestIssue5412.java
@@ -27,9 +27,9 @@ class SwitchTestExhaustive {
           case VAL1 -> "1";
           case VAL2 -> "2";
           case VAL3 -> "3";
-            // The default case is dead code, so it would be possible for type-checking
-            // to skip it and not issue this warning.  But giving the warning is also
-            // good.
+          // The default case is dead code, so it would be possible for type-checking
+          // to skip it and not issue this warning.  But giving the warning is also
+          // good.
           default -> null;
         };
     // :: error: (return)
@@ -82,8 +82,8 @@ class SwitchTestExhaustive {
       case VAL3:
         aString = "c";
         break;
-        // The `default:` case is dead code, so it is acceptable for this method to compile
-        // without nullness errors.
+      // The `default:` case is dead code, so it is acceptable for this method to compile
+      // without nullness errors.
       default:
         break;
     }
@@ -103,8 +103,8 @@ class SwitchTestExhaustive {
       case VAL3:
         aString = "c";
         break;
-        // The `default:` case is dead code, so it is acceptable for this method to compile
-        // without nullness errors.
+      // The `default:` case is dead code, so it is acceptable for this method to compile
+      // without nullness errors.
       default:
         aString = null;
         break;

--- a/checker/tests/nullness/java21/FlowSwitch.java
+++ b/checker/tests/nullness/java21/FlowSwitch.java
@@ -27,7 +27,8 @@ public class FlowSwitch {
       case -1, 1:
         msg = "-1 or 1";
         break;
-      case Integer j when j > 0:
+      case Integer j
+      when j > 0:
         msg = "pos";
         break;
       case Integer j:

--- a/checker/tests/nullness/java21/NullableSwitchSelector.java
+++ b/checker/tests/nullness/java21/NullableSwitchSelector.java
@@ -13,7 +13,7 @@ public class NullableSwitchSelector {
     return switch (obj) {
       case Integer i -> obj.toString();
       case String s -> String.format("String %s", s);
-        // :: error: (dereference.of.nullable)
+      // :: error: (dereference.of.nullable)
       case null -> obj.toString();
       default -> obj.toString();
     };
@@ -24,9 +24,9 @@ public class NullableSwitchSelector {
     return switch (obj) {
       case Integer i -> obj.toString();
       case String s -> String.format("String %s", s);
-        // TODO: If obj is null, this case isn't reachable, because a null pointer exception happens
-        // at the selector expression.
-        // :: error: (dereference.of.nullable)
+      // TODO: If obj is null, this case isn't reachable, because a null pointer exception happens
+      // at the selector expression.
+      // :: error: (dereference.of.nullable)
       default -> obj.toString();
     };
   }
@@ -35,7 +35,7 @@ public class NullableSwitchSelector {
     return switch (obj) {
       case Integer i -> obj.toString();
       case String s -> String.format("String %s", s);
-        // :: error: (dereference.of.nullable)
+      // :: error: (dereference.of.nullable)
       case null, default -> obj.toString();
     };
   }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -325,11 +325,11 @@ public final class CFGVisualizeLauncher {
    */
   private static <V extends AbstractValue<V>, S extends Store<S>, T extends TransferFunction<V, S>>
       @Nullable Map<String, Object> generateStringOfCFG(
-      String inputFile,
-      String method,
-      String clas,
-      boolean verbose,
-      @Nullable Analysis<V, S, T> analysis) {
+          String inputFile,
+          String method,
+          String clas,
+          boolean verbose,
+          @Nullable Analysis<V, S, T> analysis) {
     ControlFlowGraph cfg = generateMethodCFG(inputFile, clas, method);
     if (analysis != null) {
       analysis.performAnalysis(cfg);

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeChecker.java
@@ -152,7 +152,9 @@ public abstract class BaseTypeChecker extends SourceChecker {
    * @return the type factory of the requested subchecker or null if not found
    */
   @SuppressWarnings("TypeParameterUnusedInFormals") // Intentional abuse
-  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>> @Nullable T getTypeFactoryOfSubcheckerOrNull(Class<? extends BaseTypeChecker> subCheckerClass) {
+  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>>
+      @Nullable T getTypeFactoryOfSubcheckerOrNull(
+          Class<? extends BaseTypeChecker> subCheckerClass) {
     return getTypeFactory().getTypeFactoryOfSubcheckerOrNull(subCheckerClass);
   }
 

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -2773,7 +2773,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     while (true) {
       switch (t.getKind()) {
 
-          // Recurse for compound types whose top level is not at the far left.
+        // Recurse for compound types whose top level is not at the far left.
         case ARRAY_TYPE:
           t = ((ArrayTypeTree) t).getType();
           continue;
@@ -2784,7 +2784,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
           t = ((ParameterizedTypeTree) t).getType();
           continue;
 
-          // Base cases
+        // Base cases
         case PRIMITIVE_TYPE:
         case IDENTIFIER:
           maybeReportAnnoOnIrrelevant(t, TreeUtils.typeOf(t), annoTrees);

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/AnnotationConverter.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/AnnotationConverter.java
@@ -122,7 +122,7 @@ public class AnnotationConverter {
     switch (tm.getKind()) {
       case BOOLEAN:
         return BasicAFT.forType(boolean.class);
-        // Primitives
+      // Primitives
       case BYTE:
         return BasicAFT.forType(byte.class);
       case CHAR:

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -1088,19 +1088,19 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
         break;
       case WILDCARD:
         break;
-        // throw new BugInCF("This can't happen");
-        // TODO: This comment is wrong: the wildcard case does get entered.
-        // Because inferring type arguments is not supported, wildcards won't be
-        // encountered.
-        // updateATMWithLUB(
-        //         atf,
-        //         ((AnnotatedWildcardType) sourceCodeATM).getExtendsBound(),
-        //         ((AnnotatedWildcardType) ajavaATM).getExtendsBound());
-        // updateATMWithLUB(
-        //         atf,
-        //         ((AnnotatedWildcardType) sourceCodeATM).getSuperBound(),
-        //         ((AnnotatedWildcardType) ajavaATM).getSuperBound());
-        // break;
+      // throw new BugInCF("This can't happen");
+      // TODO: This comment is wrong: the wildcard case does get entered.
+      // Because inferring type arguments is not supported, wildcards won't be
+      // encountered.
+      // updateATMWithLUB(
+      //         atf,
+      //         ((AnnotatedWildcardType) sourceCodeATM).getExtendsBound(),
+      //         ((AnnotatedWildcardType) ajavaATM).getExtendsBound());
+      // updateATMWithLUB(
+      //         atf,
+      //         ((AnnotatedWildcardType) sourceCodeATM).getSuperBound(),
+      //         ((AnnotatedWildcardType) ajavaATM).getSuperBound());
+      // break;
       case ARRAY:
         AnnotatedTypeMirror sourceCodeComponent =
             ((AnnotatedArrayType) sourceCodeATM).getComponentType();
@@ -1120,11 +1120,11 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
           }
         }
         break;
-        // case DECLARED:
-        // Inferring annotations on type arguments is not supported, so no need to recur on
-        // generic types. If this was ever implemented, this method would need a
-        // VisitHistory object to prevent infinite recursion on types such as T extends
-        // List<T>.
+      // case DECLARED:
+      // Inferring annotations on type arguments is not supported, so no need to recur on
+      // generic types. If this was ever implemented, this method would need a
+      // VisitHistory object to prevent infinite recursion on types such as T extends
+      // List<T>.
       default:
         // ATM only has primary annotations
         break;

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceScenesStorage.java
@@ -628,25 +628,25 @@ public class WholeProgramInferenceScenesStorage
             ((AnnotatedTypeVariable) sourceCodeATM).getUpperBound(),
             ((AnnotatedTypeVariable) jaifATM).getUpperBound());
         break;
-        //        case WILDCARD:
-        // Because inferring type arguments is not supported, wildcards won't be encoutered
-        //            updateAtmWithLub(((AnnotatedWildcardType)
-        // sourceCodeATM).getExtendsBound(),
-        //                              ((AnnotatedWildcardType)
-        // jaifATM).getExtendsBound());
-        //            updateAtmWithLub(((AnnotatedWildcardType)
-        // sourceCodeATM).getSuperBound(),
-        //                              ((AnnotatedWildcardType) jaifATM).getSuperBound());
-        //            break;
+      //        case WILDCARD:
+      // Because inferring type arguments is not supported, wildcards won't be encoutered
+      //            updateAtmWithLub(((AnnotatedWildcardType)
+      // sourceCodeATM).getExtendsBound(),
+      //                              ((AnnotatedWildcardType)
+      // jaifATM).getExtendsBound());
+      //            updateAtmWithLub(((AnnotatedWildcardType)
+      // sourceCodeATM).getSuperBound(),
+      //                              ((AnnotatedWildcardType) jaifATM).getSuperBound());
+      //            break;
       case ARRAY:
         updateAtmWithLub(
             ((AnnotatedArrayType) sourceCodeATM).getComponentType(),
             ((AnnotatedArrayType) jaifATM).getComponentType());
         break;
-        // case DECLARED:
-        // inferring annotations on type arguments is not supported, so no need to recur on
-        // generic types. If this was every implemented, this method would need VisitHistory
-        // object to prevent infinite recursion on types such as T extends List<T>.
+      // case DECLARED:
+      // inferring annotations on type arguments is not supported, so no need to recur on
+      // generic types. If this was every implemented, this method would need VisitHistory
+      // object to prevent infinite recursion on types such as T extends List<T>.
       default:
         // ATM only has primary annotations
         break;

--- a/framework/src/main/java/org/checkerframework/framework/flow/CFTreeBuilder.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFTreeBuilder.java
@@ -161,8 +161,8 @@ public class CFTreeBuilder extends TreeBuilder {
         }
         typeTree = maker.TypeIntersection(components);
         break;
-        // case UNION:
-        // TODO: case UNION similar to INTERSECTION, but write test first.
+      // case UNION:
+      // TODO: case UNION similar to INTERSECTION, but write test first.
       case DECLARED:
         typeTree = maker.Type((Type) type);
 

--- a/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
+++ b/framework/src/main/java/org/checkerframework/framework/stub/AnnotationFileParser.java
@@ -2578,9 +2578,9 @@ public class AnnotationFileParser {
       return convert(((LongLiteralExpr) expr).asNumber(), valueKind);
     } else if (expr instanceof UnaryExpr) {
       switch (expr.toString()) {
-          // Special-case the minimum values.  Separately parsing a "-" and a value
-          // doesn't correctly handle the minimum values, because the absolute value of
-          // the smallest member of an integral type is larger than the largest value.
+        // Special-case the minimum values.  Separately parsing a "-" and a value
+        // doesn't correctly handle the minimum values, because the absolute value of
+        // the smallest member of an integral type is larger than the largest value.
         case "-9223372036854775808L":
         case "-9223372036854775808l":
           return convert(Long.MIN_VALUE, valueKind, false);

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -2672,23 +2672,23 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
           return dt.getTypeArguments().get(0);
         }
 
-        // TODO: Properly desugar Iterator.next(), which is needed if an annotated JDK has
-        // annotations on Iterator#next.
-        // The below doesn't work because methodFromUse() assumes that the expression tree
-        // matches the method element.
-        // TypeElement iteratorElement =
-        //         ElementUtils.getTypeElement(processingEnv, Iterator.class);
-        // AnnotatedTypeMirror iteratorType =
-        //         AnnotatedTypeMirror.createType(iteratorElement.asType(), this, false);
-        // Map<TypeVariable, AnnotatedTypeMirror> mapping = new HashMap<>();
-        // mapping.put(
-        //         (TypeVariable) iteratorElement.getTypeParameters().get(0).asType(),
-        //          typeArg);
-        // iteratorType = typeVarSubstitutor.substitute(mapping, iteratorType);
-        // ExecutableElement next =
-        //         TreeUtils.getMethod("java.util.Iterator", "next", 0, processingEnv);
-        // ParameterizedExecutableType m = methodFromUse(expression, next, iteratorType);
-        // return m.executableType.getReturnType();
+      // TODO: Properly desugar Iterator.next(), which is needed if an annotated JDK has
+      // annotations on Iterator#next.
+      // The below doesn't work because methodFromUse() assumes that the expression tree
+      // matches the method element.
+      // TypeElement iteratorElement =
+      //         ElementUtils.getTypeElement(processingEnv, Iterator.class);
+      // AnnotatedTypeMirror iteratorType =
+      //         AnnotatedTypeMirror.createType(iteratorElement.asType(), this, false);
+      // Map<TypeVariable, AnnotatedTypeMirror> mapping = new HashMap<>();
+      // mapping.put(
+      //         (TypeVariable) iteratorElement.getTypeParameters().get(0).asType(),
+      //          typeArg);
+      // iteratorType = typeVarSubstitutor.substitute(mapping, iteratorType);
+      // ExecutableElement next =
+      //         TreeUtils.getMethod("java.util.Iterator", "next", 0, processingEnv);
+      // ParameterizedExecutableType m = methodFromUse(expression, next, iteratorType);
+      // return m.executableType.getReturnType();
       default:
         throw new BugInCF(
             "AnnotatedTypeFactory.getIterableElementType: not iterable type: " + iterableType);

--- a/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/GenericAnnotatedTypeFactory.java
@@ -2256,7 +2256,8 @@ public abstract class GenericAnnotatedTypeFactory<
    * @see #getTypeFactoryOfSubchecker
    */
   @SuppressWarnings("TypeParameterUnusedInFormals") // Intentional abuse
-  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>> @Nullable T getTypeFactoryOfSubcheckerOrNull(Class<? extends SourceChecker> subCheckerClass) {
+  public <T extends GenericAnnotatedTypeFactory<?, ?, ?, ?>>
+      @Nullable T getTypeFactoryOfSubcheckerOrNull(Class<? extends SourceChecker> subCheckerClass) {
     SourceChecker subSouceChecker = checker.getSubchecker(subCheckerClass);
     if (subSouceChecker == null || !(subSouceChecker instanceof BaseTypeChecker)) {
       return null;
@@ -2522,8 +2523,8 @@ public abstract class GenericAnnotatedTypeFactory<
 
     switch (tm.getKind()) {
 
-        // Primitives have no subtyping relationships, but the lookup might have failed
-        // because tm has metadata such as annotations.
+      // Primitives have no subtyping relationships, but the lookup might have failed
+      // because tm has metadata such as annotations.
       case BOOLEAN:
       case BYTE:
       case CHAR:
@@ -2539,7 +2540,7 @@ public abstract class GenericAnnotatedTypeFactory<
         }
         return false;
 
-        // Void is never relevant
+      // Void is never relevant
       case VOID:
         return false;
 

--- a/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/JavaParserUtil.java
@@ -407,12 +407,12 @@ public class JavaParserUtil {
         case "RELEASE_17":
           currentSourceVersion = ParserConfiguration.LanguageLevel.JAVA_17;
           break;
-          // JavaParser's ParserConfiguration.LanguageLevel has no constant for JDK 18, as
-          // of version 3.25.1 (2023-02-28).  See
-          // https://www.javadoc.io/doc/com.github.javaparser/javaparser-core/latest/com/github/javaparser/ParserConfiguration.LanguageLevel.html .
-          // case "RELEASE_18":
-          //   currentSourceVersion = ParserConfiguration.LanguageLevel.JAVA_18;
-          //   break;
+        // JavaParser's ParserConfiguration.LanguageLevel has no constant for JDK 18, as
+        // of version 3.25.1 (2023-02-28).  See
+        // https://www.javadoc.io/doc/com.github.javaparser/javaparser-core/latest/com/github/javaparser/ParserConfiguration.LanguageLevel.html .
+        // case "RELEASE_18":
+        //   currentSourceVersion = ParserConfiguration.LanguageLevel.JAVA_18;
+        //   break;
         default:
           currentSourceVersion = DEFAULT_LANGUAGE_LEVEL;
       }

--- a/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/defaults/QualifierDefaults.java
@@ -533,9 +533,9 @@ public class QualifierDefaults {
         elt = TreeUtils.elementFromUse((MethodInvocationTree) tree);
         break;
 
-        // TODO cases for array access, etc. -- every expression tree
-        // (The above probably means that we should use defaults in the
-        // scope of the declaration of the array.  Is that right?  -MDE)
+      // TODO cases for array access, etc. -- every expression tree
+      // (The above probably means that we should use defaults in the
+      // scope of the declaration of the array.  Is that right?  -MDE)
 
       default:
         // If no associated symbol was found, use the tree's (lexical) scope.

--- a/framework/tests/all-systems/java17/SwitchTests.java
+++ b/framework/tests/all-systems/java17/SwitchTests.java
@@ -127,7 +127,7 @@ class SwitchTests {
     switch (myInt) {
       case 1:
         System.out.print("Hello ");
-        // Fall through to next case
+      // Fall through to next case
       case 2:
         System.out.println("World");
         break;

--- a/javacutil/src/main/java/org/checkerframework/javacutil/CollectionUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/CollectionUtils.java
@@ -57,7 +57,8 @@ public class CollectionUtils {
     "nullness" // generics problem
   })
   @Deprecated // 2023-06-02
-  public static <T extends @Nullable Object, C extends @Nullable Collection<T>> @PolyNull C cloneElements(@PolyNull C orig) {
+  public static <T extends @Nullable Object, C extends @Nullable Collection<T>>
+      @PolyNull C cloneElements(@PolyNull C orig) {
     if (orig == null) {
       return null;
     }
@@ -144,7 +145,8 @@ public class CollectionUtils {
    */
   @Deprecated // 2023-06-02
   @SuppressWarnings({"signedness", "nullness:argument"}) // problem with clone()
-  public static <T extends @Nullable DeepCopyable<T>, C extends @Nullable Collection<T>> @PolyNull C deepCopy(@PolyNull C orig) {
+  public static <T extends @Nullable DeepCopyable<T>, C extends @Nullable Collection<T>>
+      @PolyNull C deepCopy(@PolyNull C orig) {
     if (orig == null) {
       return null;
     }
@@ -203,7 +205,8 @@ public class CollectionUtils {
    */
   @Deprecated // 2023-06-02
   @SuppressWarnings({"nullness", "signedness"}) // generics problem with clone
-  public static <K, V extends @Nullable DeepCopyable<V>, M extends @Nullable Map<K, V>> @PolyNull M deepCopyValues(@PolyNull M orig) {
+  public static <K, V extends @Nullable DeepCopyable<V>, M extends @Nullable Map<K, V>>
+      @PolyNull M deepCopyValues(@PolyNull M orig) {
     if (orig == null) {
       return null;
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -687,8 +687,8 @@ public final class TreeUtils {
     }
 
     switch (tree.getKind()) {
-        // symbol() only works on MethodSelects, so we need to get it manually
-        // for method invocations.
+      // symbol() only works on MethodSelects, so we need to get it manually
+      // for method invocations.
       case METHOD_INVOCATION:
         return TreeInfo.symbol(((JCMethodInvocation) tree).getMethodSelect());
 
@@ -2186,7 +2186,7 @@ public final class TreeUtils {
         // These operators do binary promotion on the two arguments together.
         return true;
 
-        // TODO: CONDITIONAL_EXPRESSION (?:) sometimes does numeric promotion.
+      // TODO: CONDITIONAL_EXPRESSION (?:) sometimes does numeric promotion.
 
       default:
         return false;


### PR DESCRIPTION
Some formatting has changed, particularly around comments on `case`s in `switch` statements.