### PR TITLE
explicitly set fetchDepth to 0 for misc jobs, disabling shallow fetch

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -83,6 +83,7 @@ jobs:
 
 
 # Unlimited fetchDepth for misc_jobs, because of need to make contributors.tex
+# explicit fetchDepth of 0 disables shallow fetch and fetches full commit history
 - job: misc_jdk11
   dependsOn:
    - canary_jobs
@@ -92,6 +93,7 @@ jobs:
   container: mdernst/cf-ubuntu-jdk11-plus:latest
   steps:
   - checkout: self
+    fetchDepth: 0
   - bash: ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 - job: misc_jdk17
@@ -103,6 +105,7 @@ jobs:
   container: mdernst/cf-ubuntu-jdk17-plus:latest
   steps:
   - checkout: self
+    fetchDepth: 0
   - bash: ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 - job: misc_jdk21
@@ -111,6 +114,7 @@ jobs:
   container: mdernst/cf-ubuntu-jdk21-plus:latest
   steps:
   - checkout: self
+    fetchDepth: 0
   - bash: ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 - job: misc_jdk23
@@ -119,6 +123,7 @@ jobs:
   container: mdernst/cf-ubuntu-jdk23-plus:latest
   steps:
   - checkout: self
+    fetchDepth: 0
   - bash: ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 


### PR DESCRIPTION
Since the September 2022 Azure DevOps update, the default fetch depth is 1, instead of unlimited. This affects pipelines created after this date. As a result, the misc jobs fail if the branch contains more than one commit, since no common ancestor can be found.

One can disable this shallow fetch by explicitly setting the fetchDepth to 0, which again fetches the full commit history.

As per: 
https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps-checkout?view=azure-pipelines (under shallow fetch).