### PR TITLE
Add toString() for DeconstructorPatternNode and AnyPatternNode

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AnyPatternNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/AnyPatternNode.java
@@ -46,4 +46,9 @@ public class AnyPatternNode extends Node {
   public Collection<Node> getOperands() {
     return Collections.emptySet();
   }
+
+  @Override
+  public String toString() {
+    return "_";
+  }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/DeconstructorPatternNode.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/node/DeconstructorPatternNode.java
@@ -93,4 +93,9 @@ public class DeconstructorPatternNode extends Node {
     }
     return bindingVariables;
   }
+
+  @Override
+  public String toString() {
+    return deconstructorPattern.toString();
+  }
 }

--- a/dataflow/tests/java22/unnamed-pattern/Expected.txt
+++ b/dataflow/tests/java22/unnamed-pattern/Expected.txt
@@ -26,9 +26,9 @@ switch#num0   [ LocalVariable ]
 i   [ LocalVariable ]
 switch#num0 = i   [ Assignment ]
 marker (start of switch statement #0)   [ Marker ]
-org.checkerframework.dataflow.cfg.node.AnyPatternNode@6743e411   [ AnyPattern ]
-org.checkerframework.dataflow.cfg.node.DeconstructorPatternNode@3eb25e1a   [ DeconstructorPattern ]
-case org.checkerframework.dataflow.cfg.node.DeconstructorPatternNode@3eb25e1a:   [ Case ]
+_   [ AnyPattern ]
+WrappedInt(_)   [ DeconstructorPattern ]
+case WrappedInt(_):   [ Case ]
 ~~~~~~~~~
 AnalysisResult#0
 After:   reaching definitions = { x = 0, switch#num0 = i }


### PR DESCRIPTION
Without this, the default `toString()` includes some non-deterministic object id, which can cause the new dataflow test case to fail:

https://dev.azure.com/checkerframework/checkerframework/_build/results?buildId=17676&view=logs&j=1082351f-0229-59e0-d5d1-f10d4a9093e1&t=a5668178-fe8d-5b50-d740-18fc5de8f723&l=1464

