### PR TITLE
Fix two possible type inference crashes

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
@@ -8,10 +8,12 @@ import com.sun.source.tree.ThrowTree;
 import com.sun.source.tree.TryTree;
 import com.sun.source.util.TreeScanner;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.UnionType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.javacutil.TreeUtils;
@@ -31,14 +33,16 @@ public class CheckedExceptionsUtil {
    */
   public static List<TypeMirror> thrownCheckedExceptions(
       LambdaExpressionTree lambda, Java8InferenceContext context) {
-    return new CheckedExceptionVisitor(context).scan(lambda, null);
+    @Nullable List<TypeMirror> result = new CheckedExceptionVisitor(context).scan(lambda, null);
+    return result != null ? result : Collections.emptyList();
   }
 
   /**
    * Helper class for gathering the types of checked exceptions in a lambda. See
    * https://docs.oracle.com/javase/specs/jls/se9/html/jls-11.html#jls-11.2.2
    */
-  private static class CheckedExceptionVisitor extends TreeScanner<List<TypeMirror>, Void> {
+  private static class CheckedExceptionVisitor
+      extends TreeScanner<@Nullable List<TypeMirror>, Void> {
 
     /** the context. */
     private final Java8InferenceContext context;
@@ -70,7 +74,7 @@ public class CheckedExceptionsUtil {
       if (result == null) {
         result = new ArrayList<>();
       }
-      TypeMirror type = TreeUtils.typeOf(node);
+      TypeMirror type = TreeUtils.typeOf(node.getExpression());
       if (isCheckedException(type, context)) {
         result.add(type);
       }
@@ -171,7 +175,9 @@ public class CheckedExceptionsUtil {
    */
   public static List<AnnotatedTypeMirror> thrownCheckedExceptionsATM(
       LambdaExpressionTree lambda, Java8InferenceContext context) {
-    return new CheckedExceptionATMVisitor(context).scan(lambda, null);
+    @Nullable List<AnnotatedTypeMirror> result =
+        new CheckedExceptionATMVisitor(context).scan(lambda, null);
+    return result != null ? result : Collections.emptyList();
   }
 
   /**
@@ -179,7 +185,7 @@ public class CheckedExceptionsUtil {
    * https://docs.oracle.com/javase/specs/jls/se9/html/jls-11.html#jls-11.2.2
    */
   private static class CheckedExceptionATMVisitor
-      extends TreeScanner<List<AnnotatedTypeMirror>, Void> {
+      extends TreeScanner<@Nullable List<AnnotatedTypeMirror>, Void> {
 
     /** The context. */
     private final Java8InferenceContext context;
@@ -212,7 +218,7 @@ public class CheckedExceptionsUtil {
       if (result == null) {
         result = new ArrayList<>();
       }
-      AnnotatedTypeMirror type = context.typeFactory.getAnnotatedType(node);
+      AnnotatedTypeMirror type = context.typeFactory.getAnnotatedType(node.getExpression());
       if (isCheckedException(type, context)) {
         result.add(type);
       }

--- a/framework/tests/all-systems/java8inference/Issue6887.java
+++ b/framework/tests/all-systems/java8inference/Issue6887.java
@@ -1,0 +1,26 @@
+// https://github.com/typetools/checker-framework/issues/6887
+
+import java.io.IOException;
+
+public final class Issue6887<E extends Exception> {
+
+  public Issue6887(ThrowingFunctionalInterface<E> throwingFunctionalInterface) {}
+
+  public static void main(String[] args) throws IOException {
+    new Issue6887<IOException>(
+        () -> {
+          throw new IOException("");
+        });
+    new Issue6887<>(
+        () -> {
+          throw new IOException("");
+        });
+    new Issue6887<RuntimeException>(() -> {});
+    new Issue6887<>(() -> {});
+  }
+
+  @FunctionalInterface
+  public interface ThrowingFunctionalInterface<E extends Exception> {
+    void throwingFunction() throws E;
+  }
+}


### PR DESCRIPTION
Fixes #6887.  In a few positions, the type inference code was trying to obtain the type of `throw E` rather than the type of `E`.

Also fixes another latent bug: the Checker Framework would throw NPE on the line

    new Issue6887<>(() -> {});

because with no body statements, the various tree visitors in `CheckedExceptionsUtil` return null.

This commit includes test code written by @veikokaap.