### PR TITLE
Improve inference of `@MustCall` for exceptional type arguments

### DIFF
--- a/checker/tests/mustcall/ExceptionTypeArgumentInference.java
+++ b/checker/tests/mustcall/ExceptionTypeArgumentInference.java
@@ -1,0 +1,35 @@
+// Earlier versions of the Checker Framework would report cryptic type inference errors on this
+// code.
+
+import java.io.IOException;
+import org.checkerframework.checker.mustcall.qual.*;
+
+public class ExceptionTypeArgumentInference {
+
+  interface ThrowingRunnable<E extends Throwable> {
+    void run() throws E;
+  }
+
+  <E extends Throwable> void run(ThrowingRunnable<E> job) throws E {
+    job.run();
+  }
+
+  void testRunNoThrow() {
+    this.run(() -> {});
+  }
+
+  void testRunThrowIOException() throws IOException {
+    this.run(
+        () -> {
+          throw new IOException();
+        });
+  }
+
+  void testRunNoThrowMethodReference() {
+    this.run(this::testRunNoThrow);
+  }
+
+  void testRunThrowIOExceptionMethodReference() throws IOException {
+    this.run(this::testRunThrowIOException);
+  }
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -945,8 +945,7 @@ public class InferenceFactory {
    * @return the proper type for RuntimeException
    */
   public ProperType getRuntimeException() {
-    AnnotatedTypeMirror runtimeEx =
-        AnnotatedTypeMirror.createType(context.runtimeEx, typeFactory, false);
+    AnnotatedTypeMirror runtimeEx = typeFactory.getAnnotatedType(RuntimeException.class);
     runtimeEx.addMissingAnnotations(typeFactory.getQualifierHierarchy().getTopAnnotations());
     return new ProperType(runtimeEx, context.runtimeEx, context);
   }


### PR DESCRIPTION
Some libraries encourage (or require) use of functional interfaces with generic exception type arguments, similar to the new test case in this commit.  Prior to this change, the Checker Framework would report some nonsense errors:

    ExceptionTypeArgumentInference.java:30: error: [type.arguments.not.inferred] Could not infer type arguments for ExceptionTypeArgumentInference.run
        this.run(() -> {});
                ^
      unsatisfiable constraint: @MustCallUnknown RuntimeException</*Type args not initialized*/> <: @MustCall Throwable
    ExceptionTypeArgumentInference.java:34: error: [type.arguments.not.inferred] Could not infer type arguments for ExceptionTypeArgumentInference.run
        this.run(
                ^
      unsatisfiable constraint: @MustCallUnknown RuntimeException</*Type args not initialized*/> <: @MustCall Throwable
    2 errors

These errors are difficult to understand, and mostly serve to slow adoption of the Resource Leak Checker.  They can be silenced by adding explicit type annotations, but doing so adds a lot of verbosity and makes otherwise elegant code difficult to read.

As I understand it, the issue is that the type inference algorithm unconditionally uses `@TopAnnotation RuntimeException` as a starting point for inferring exceptional type parameters.  However, the Must Call Checker assigns a more specific annotation to most types, including the implicit appearance of `Throwable`, leading to an unsatisfiable constraint.

This commit changes the inference algorithm to use the checker's preferred annotation for `RuntimeException`, fixing the constraint.

While I am not _certain_ that this is a universally good fix, it seems to improve the Must Call situation without breaking any existing tests.