### PR TITLE
Fix exponential-time handling of `@This` in CalledMethodsChecker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsAnnotatedTypeFactory.java
@@ -293,7 +293,7 @@ public class CalledMethodsAnnotatedTypeFactory extends AccumulationAnnotatedType
    * At a fluent method call (which returns {@code this}), add the method to the type of the return
    * value.
    */
-  private class CalledMethodsTreeAnnotator extends AccumulationTreeAnnotator {
+  private class CalledMethodsTreeAnnotator extends TreeAnnotator {
     /**
      * Creates an instance of this tree annotator for the given type factory.
      *

--- a/checker/tests/resourceleak-returns-receiver/ReturnsReceiverPerformance.java
+++ b/checker/tests/resourceleak-returns-receiver/ReturnsReceiverPerformance.java
@@ -1,0 +1,163 @@
+// Earlier versions of the Checker Framework exhibited exponentially-long run time on this code due
+// to the long chain of `@This` methods.
+
+import org.checkerframework.common.returnsreceiver.qual.*;
+
+class ReturnsReceiverPerformance {
+
+  static class Builder {
+    @This Builder m01() {
+      return this;
+    }
+
+    @This Builder m02() {
+      return this;
+    }
+
+    @This Builder m03() {
+      return this;
+    }
+
+    @This Builder m04() {
+      return this;
+    }
+
+    @This Builder m05() {
+      return this;
+    }
+
+    @This Builder m06() {
+      return this;
+    }
+
+    @This Builder m07() {
+      return this;
+    }
+
+    @This Builder m08() {
+      return this;
+    }
+
+    @This Builder m09() {
+      return this;
+    }
+
+    @This Builder m10() {
+      return this;
+    }
+
+    @This Builder m11() {
+      return this;
+    }
+
+    @This Builder m12() {
+      return this;
+    }
+
+    @This Builder m13() {
+      return this;
+    }
+
+    @This Builder m14() {
+      return this;
+    }
+
+    @This Builder m15() {
+      return this;
+    }
+
+    @This Builder m16() {
+      return this;
+    }
+
+    @This Builder m17() {
+      return this;
+    }
+
+    @This Builder m18() {
+      return this;
+    }
+
+    @This Builder m19() {
+      return this;
+    }
+
+    @This Builder m20() {
+      return this;
+    }
+
+    @This Builder m21() {
+      return this;
+    }
+
+    @This Builder m22() {
+      return this;
+    }
+
+    @This Builder m23() {
+      return this;
+    }
+
+    @This Builder m24() {
+      return this;
+    }
+
+    @This Builder m25() {
+      return this;
+    }
+
+    @This Builder m26() {
+      return this;
+    }
+
+    @This Builder m27() {
+      return this;
+    }
+
+    @This Builder m28() {
+      return this;
+    }
+
+    @This Builder m29() {
+      return this;
+    }
+
+    Object build() {
+      return new Object();
+    }
+  }
+
+  Object go() {
+    return new Builder()
+        .m01()
+        .m02()
+        .m03()
+        .m04()
+        .m05()
+        .m06()
+        .m07()
+        .m08()
+        .m09()
+        .m10()
+        .m11()
+        .m12()
+        .m13()
+        .m14()
+        .m15()
+        .m16()
+        .m17()
+        .m18()
+        .m19()
+        .m20()
+        .m21()
+        .m22()
+        .m23()
+        .m24()
+        .m25()
+        .m26()
+        .m27()
+        .m28()
+        .m29()
+        .build();
+  }
+}


### PR DESCRIPTION
Fixes #7024.

When run with `-AenableReturnsReceiverForRlc`, the resource leak checker takes exponential time to check code with long chains of `@This` methods.

The root cause lies in `CalledMethodsChecker`, which inadvertently violates this rule from the manual:

> A subclass of `TreeAnnotator` should not, in general, call
> `getAnnotatedType()` more than once. [...] expressions at the base of
> a large binary tree will be visited exponentially many times, leading
> to slowdowns or the appearance of an infinite loop.

The violation is not obvious:

`CalledMethodsAnnotatedTypeFactory.createTreeAnnotator()` returns a `ListTreeAnnotator` that includes both an `AccumulationTreeAnnotator` and a `CalledMethodsTreeAnnotator`.  But of those tree annotators call `getAnnotatedType()` from `visitMethodInvocation()`;  therefore we have inadvertently built a composite tree annotator that makes two calls to `getAnnotatedType()` when visiting a method invocation.

The quickest fix is to simply remove one of those invocations.  The one in `CalledMethodsTreeAnnotator` can easily be avoided by breaking its inheritance relationship with `AccumulationTreeAnnotator`.  Since `AccumulationTreeAnnotator` already appears in the list of tree annotators, there isn't any reason for `CalledMethodsTreeAnnotator` to extend it.