### PR TITLE
Fix a latent bug in `AbstractAnalysis.setNodeValues()`

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -226,8 +226,14 @@ public abstract class AbstractAnalysis<
    */
   /*package-private*/ void setNodeValues(IdentityHashMap<Node, V> in) {
     assert !isRunning;
-    nodeValues.clear();
-    nodeValues.putAll(in);
+    // The if-check below is not just an optimization.  Without it, this method misbehaves
+    // when `in` and `nodeValues` alias: the call to `clear()` clears BOTH objects.  There
+    // are some places where `this.nodeValues` flows to the `in` argument (through several
+    // other layers of abstraction).
+    if (nodeValues != in) {
+      nodeValues.clear();
+      nodeValues.putAll(in);
+    }
   }
 
   @Override

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -224,6 +224,7 @@ public abstract class AbstractAnalysis<
    *
    * @param in the current node values
    */
+  @SuppressWarnings("interning:not.interned") // see comment about if-check below
   /*package-private*/ void setNodeValues(IdentityHashMap<Node, V> in) {
     assert !isRunning;
     // The if-check below is not just an optimization.  Without it, this method misbehaves


### PR DESCRIPTION
Along some code paths to `setNodeValues()`, `in == this.nodeValues`.  When that happens, the call to `nodeValues.clear()` actually clears _both_ maps, meaning the method deletes all knowledge about CFG nodes.

The main path to this misbehavior is through `GenericAnnotatedTypeFactory.getStoreAfter(node)`, which reads `analysis.getNodeValues()`.  That value is passed through several other layers of abstraction and eventually reaches `setNodeValues()`.

I found this while working on some unrelated improvements that weren't working how I expected.  Although I believe this fix doesn't change any user-visible behavior, I still think it is important.  Right now the Resource Leak Checker seems to work entirely by accident, and small changes to when it calls `getStoreAfter(node)` cause havoc.