### PR TITLE
Fix a false positive in the Resource Leak Checker

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -141,7 +141,7 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
       Node node, TransferResult<AccumulationValue, AccumulationStore> result, String... values) {
     super.accumulate(node, result, values);
 
-    @Nullable Map<TypeMirror, AccumulationStore> exceptionalStores = result.getExceptionalStores();
+    Map<TypeMirror, AccumulationStore> exceptionalStores = result.getExceptionalStores();
     if (exceptionalStores == null) {
       return;
     }

--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -40,18 +40,6 @@ import org.plumelib.util.CollectionsPlume;
 public class CalledMethodsTransfer extends AccumulationTransfer {
 
   /**
-   * {@link #makeExceptionalStores(MethodInvocationNode, TransferInput)} requires a TransferInput,
-   * but the actual exceptional stores need to be modified in {@link #accumulate(Node,
-   * TransferResult, String...)}, which only has access to a TransferResult. So this field is set to
-   * non-null in {@link #visitMethodInvocation(MethodInvocationNode, TransferInput)} via a call to
-   * {@link #makeExceptionalStores(MethodInvocationNode, TransferInput)} (which reads the CFStores
-   * from the TransferInput) before the call to accumulate(); accumulate() can then use this field
-   * to read the CFStores; and then finally this field is then reset to null afterwards to prevent
-   * it from being used somewhere it shouldn't be.
-   */
-  private @Nullable Map<TypeMirror, AccumulationStore> exceptionalStores;
-
-  /**
    * The element for the CalledMethods annotation's value element. Stored in a field in this class
    * to prevent the need to cast to CalledMethods ATF every time it's used.
    */
@@ -118,9 +106,16 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
   @Override
   public TransferResult<AccumulationValue, AccumulationStore> visitMethodInvocation(
       MethodInvocationNode node, TransferInput<AccumulationValue, AccumulationStore> input) {
-    exceptionalStores = makeExceptionalStores(node, input);
     TransferResult<AccumulationValue, AccumulationStore> superResult =
         super.visitMethodInvocation(node, input);
+
+    // Ensure that the result has a store for each possible exception.  This affects the behavior of
+    // accumulate(), which will accumulate values into the result's exceptional stores as well.
+    Map<TypeMirror, AccumulationStore> exceptionalStores = superResult.getExceptionalStores();
+    if (exceptionalStores == null) {
+      exceptionalStores = makeExceptionalStores(node, input);
+      superResult = superResult.withExceptionalStores(exceptionalStores);
+    }
 
     ExecutableElement method = TreeUtils.elementFromUse(node.getTree());
     handleEnsuresCalledMethodsVarargs(node, method, superResult);
@@ -134,20 +129,19 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
               .adjustMethodNameUsingValueChecker(methodName, node.getTree());
       accumulate(receiver, superResult, methodName);
     }
-    TransferResult<AccumulationValue, AccumulationStore> finalResult =
-        new ConditionalTransferResult<>(
-            superResult.getResultValue(),
-            superResult.getThenStore(),
-            superResult.getElseStore(),
-            exceptionalStores);
-    exceptionalStores = null;
-    return finalResult;
+    return new ConditionalTransferResult<>(
+        superResult.getResultValue(),
+        superResult.getThenStore(),
+        superResult.getElseStore(),
+        exceptionalStores);
   }
 
   @Override
   public void accumulate(
       Node node, TransferResult<AccumulationValue, AccumulationStore> result, String... values) {
     super.accumulate(node, result, values);
+
+    @Nullable Map<TypeMirror, AccumulationStore> exceptionalStores = result.getExceptionalStores();
     if (exceptionalStores == null) {
       return;
     }

--- a/checker/tests/resourceleak/TemporaryVariables.java
+++ b/checker/tests/resourceleak/TemporaryVariables.java
@@ -1,0 +1,30 @@
+// For some expressions like `alloc()`, the Resource Leak Checker creates anonymous "temporary
+// variables" to track must-call obligations.  These tests exercise some interesting interactions
+// involving temporary variables.
+
+import java.io.*;
+import org.checkerframework.checker.calledmethods.qual.*;
+import org.checkerframework.checker.mustcall.qual.*;
+
+abstract class TemporaryVariables {
+  public abstract Closeable alloc();
+
+  public void test1() throws IOException {
+    alloc().close();
+  }
+
+  // Identical to test1() but with explicit exception handling.
+  public void test2() throws IOException {
+    try {
+      alloc().close();
+    } catch (IOException e) {
+      throw e;
+    }
+  }
+
+  @EnsuresCalledMethods(value = "#1", methods = "close")
+  @EnsuresCalledMethodsOnException(value = "#1", methods = "close")
+  public void close(Closeable x) throws IOException {
+    x.close();
+  }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ConditionalTransferResult.java
@@ -150,4 +150,11 @@ public class ConditionalTransferResult<V extends AbstractValue<V>, S extends Sto
   public boolean storeChanged() {
     return storeChanged;
   }
+
+  @Override
+  public ConditionalTransferResult<V, S> withExceptionalStores(
+      Map<TypeMirror, S> exceptionalStores) {
+    return new ConditionalTransferResult<>(
+        resultValue, thenStore, elseStore, exceptionalStores, storeChanged);
+  }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/RegularTransferResult.java
@@ -150,4 +150,9 @@ public class RegularTransferResult<V extends AbstractValue<V>, S extends Store<S
   public boolean storeChanged() {
     return storeChanged;
   }
+
+  @Override
+  public RegularTransferResult<V, S> withExceptionalStores(Map<TypeMirror, S> exceptionalStores) {
+    return new RegularTransferResult<>(resultValue, store, exceptionalStores, storeChanged);
+  }
 }

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -143,7 +143,8 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
   public abstract boolean storeChanged();
 
   /**
-   * Construct a copy of this {@code TransferResult} that uses the given {@code exceptionalStores}.
+   * Construct a shallow copy of this {@code TransferResult}, but with the given {@code
+   * exceptionalStores}.
    *
    * @param exceptionalStores the new exceptional stores to use
    * @return a copy of this object modified to use the given exceptional stores

--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/TransferResult.java
@@ -141,4 +141,13 @@ public abstract class TransferResult<V extends AbstractValue<V>, S extends Store
    *     changed the regularStore, elseStore, or thenStore
    */
   public abstract boolean storeChanged();
+
+  /**
+   * Construct a copy of this {@code TransferResult} that uses the given {@code exceptionalStores}.
+   *
+   * @param exceptionalStores the new exceptional stores to use
+   * @return a copy of this object modified to use the given exceptional stores
+   * @see #getExceptionalStores()
+   */
+  public abstract TransferResult<V, S> withExceptionalStores(Map<TypeMirror, S> exceptionalStores);
 }


### PR DESCRIPTION
Previously, the RLC would report an error on this code:

    try {
      alloc().close();
    } catch (IOException e) {
      throw e;
    }

It would report that the result of `alloc()` was not closed if `close()` throws IOException, which is clearly incorrect.

That test case is meant to be handled by `visitMethodInvocation()` in `RLCCalledMethodsTransfer`, which looks at whether the receiver of a method call has a corresponding temporary variable (which will be true for expressions like `alloc()` that are not normally tracked by flow analysis).

However, the `visitMethodInvocation()` override did not consider exceptional paths.  These were ignored due to an awkward construct in CalledMethodsTransfer.java: a private `exceptionalStores` field enabled `accumulate()` to record information along exceptional control flow edges, but only temporarily while `CalledMethodsTransfer.visitMethodInvocation()` was running.  The overridden `visitMethodInvocation()` in RLCCalledMethodsTransfer.java makes additional calls to `accumulate()` after the call to `super` returns, but that work did not properly update the exceptional stores because after the super method returns the private field has been unset.

This commit fixes the problem (and makes the code a little less confusing) by removing the awkward private field.  The behavior of `accumulate()` now depends on whether accumulate's `result` argument has exceptional stores, not on the value of a private field.

I don't think the new code is 100% wart-free, but it is an improvement.