### PR TITLE
Add property for specifying which Java version to use with tests.

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: ./checker/bin-devel/test-cftests-junit.sh
+  - bash:  export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 
 - job: nonjunit_jdk24

--- a/build.gradle
+++ b/build.gradle
@@ -423,8 +423,8 @@ allprojects { currentProj ->
           languageVersion = JavaLanguageVersion.of(21)
         }
       }
-      int jdkTestVersion = Integer.valueOf(project.getProperties().getOrDefault('jdkTestVersion', -1))
-      if(jdkTestVersion != -1) {
+      if(project.getProperties().containsKey('jdkTestVersion')) {
+        int jdkTestVersion = Integer.valueOf(project.getProperties().get('jdkTestVersion'))
         java {
           toolchain {
             languageVersion = JavaLanguageVersion.of(jdkTestVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -423,6 +423,19 @@ allprojects { currentProj ->
           languageVersion = JavaLanguageVersion.of(21)
         }
       }
+      int jdkTestVersion = Integer.valueOf(project.getProperties().getOrDefault('jdkTestVersion', -1))
+      if(jdkTestVersion != -1) {
+        java {
+          toolchain {
+            languageVersion = JavaLanguageVersion.of(jdkTestVersion)
+          }
+        }
+        tasks.withType(JavaExec).configureEach {
+          javaLauncher = javaToolchains.launcherFor {
+            languageVersion = JavaLanguageVersion.of(jdkTestVersion)
+          }
+        }
+      }
 
       // Sorting is commented out because it disables incremental compilation.
       // Uncomment when needed.
@@ -1158,5 +1171,12 @@ final sharedPublicationConfiguration(publication) {
       connection = 'scm:git:https://github.com/typetools/checker-framework.git'
       developerConnection = 'scm:git:ssh://git@github.com/typetools/checker-framework.git'
     }
+  }
+}
+tasks.register('printJavaVersion') {
+  doLast {
+    println "Java version: ${System.getProperty('java.version')}"
+    def currentJvm = org.gradle.internal.jvm.Jvm.current()
+    println currentJvm
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1174,8 +1174,9 @@ final sharedPublicationConfiguration(publication) {
   }
 }
 tasks.register('printJavaVersion') {
+  description = "Prints the Java version used to run Gradle."
   doLast {
-    println "Java version: ${System.getProperty('java.version')}"
+    println "Java version used to run Gradle: ${System.getProperty('java.version')}"
     def currentJvm = org.gradle.internal.jvm.Jvm.current()
     println currentJvm
   }

--- a/build.gradle
+++ b/build.gradle
@@ -423,6 +423,8 @@ allprojects { currentProj ->
           languageVersion = JavaLanguageVersion.of(21)
         }
       }
+
+      // Use ./gradlew test -PjdkTestVersion=25 to test a specific version of Java.
       if(project.getProperties().containsKey('jdkTestVersion')) {
         int jdkTestVersion = Integer.valueOf(project.getProperties().get('jdkTestVersion'))
         java {

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -9,6 +9,12 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
 export ORG_GRADLE_PROJECT_useJdk21Compiler=true
+mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_21_HOME" >> ~/.gradle/gradle.properties
+
 source "$SCRIPT_DIR"/clone-related.sh
 
+./gradlew printJavaVersion
+
 ./gradlew test --console=plain --warning-mode=all
+
+javap -v checker/tests/build/testclasses/AnoymousAndInnerClass.class | grep major

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
 export ORG_GRADLE_PROJECT_useJdk21Compiler=true
-mkdir ~/.gradle && echo "org.gradle.java.home=$JAVA_21_HOME" >> ~/.gradle/gradle.properties
+mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 
 source "$SCRIPT_DIR"/clone-related.sh
 

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
 export ORG_GRADLE_PROJECT_useJdk21Compiler=true
-mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
+# mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 
 source "$SCRIPT_DIR"/clone-related.sh
 

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -8,7 +8,6 @@ echo "SHELLOPTS=${SHELLOPTS}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
-export ORG_GRADLE_PROJECT_useJdk21Compiler=true
 mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 
 source "$SCRIPT_DIR"/clone-related.sh

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -8,6 +8,8 @@ echo "SHELLOPTS=${SHELLOPTS}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
+export ORG_GRADLE_PROJECT_useJdk21Compiler=true
+
 # This lines makes it so that Gradle is run using Java 21.
 mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -9,7 +9,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
 export ORG_GRADLE_PROJECT_useJdk21Compiler=true
-# mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
+mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 
 source "$SCRIPT_DIR"/clone-related.sh
 

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -8,6 +8,7 @@ echo "SHELLOPTS=${SHELLOPTS}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 # Test that the CF, when built with JDK 21, works on other JDKs.
+# This lines makes it so that Gradle is run using Java 21.
 mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
 
 source "$SCRIPT_DIR"/clone-related.sh

--- a/checker/bin-devel/test-cftests-junit.sh
+++ b/checker/bin-devel/test-cftests-junit.sh
@@ -12,8 +12,10 @@ mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64
 
 source "$SCRIPT_DIR"/clone-related.sh
 
+# Print the version of Java used to run Gradle. (This is for debugging.)
 ./gradlew printJavaVersion
 
 ./gradlew test --console=plain --warning-mode=all
 
+# Print the version of Java used to test the Checker Framework. (This is for debugging.)
 javap -v checker/tests/build/testclasses/AnoymousAndInnerClass.class | grep major


### PR DESCRIPTION
1. Run Gradle using JDK 21:
```
mkdir ~/.gradle && echo "org.gradle.java.home=/usr/lib/jvm/java-21-openjdk-amd64" >> ~/.gradle/gradle.properties
```

2. Use JDK 24 for all Java tasks: (24 could be replaced with any version.)

```
export ORG_GRADLE_PROJECT_jdkTestVersion=24
```
or
```
./gradlew sometask -PjdkTestVersion=24
```


3. Compile the Checker Framework using JDK 21: (Overrides the version specified in `jdkTestVersion` for  compiling only.)
```
export ORG_GRADLE_PROJECT_useJdk21Compiler=true
```
or
```
./gradlew sometask -PuseJdk21Compiler=true
```

 I've changed just the junit_jdk24 to use all three to make sure they are working as intended, but we should not merge those changes.   Instead we need a new job that tests the Checker Framework with Java 25.

