### PR TITLE
Update example of message key substrings

### DIFF
--- a/docs/manual/warnings.tex
+++ b/docs/manual/warnings.tex
@@ -140,10 +140,10 @@ MyFile.java:107: error: [dereference.of.nullable] dereference of possibly-null r
 You are allowed to use any substring of a message key, so long as the
 substring extends at each end to a period or an end of the key.  For
 example, to suppress a warning with message key
-\code{"assignment"}, you could use
-\<@SuppressWarnings("assignment")>,
-\<@SuppressWarnings("assignment.type")>,
-\<@SuppressWarnings("type.incompatible")>, or other variants.
+\code{"lock.expression.possibly.not.final"}, you could use
+\<@SuppressWarnings("lock.expression.possibly.not.final")>,
+\<@SuppressWarnings("lock.expression")>,
+\<@SuppressWarnings("not.final")>, or other variants.
 We recommend using
 the longest possible message key; a short message might suppress more
 warnings than you expect.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved the @SuppressWarnings guidance by updating the examples to use longer, dot-delimited message keys, clarifying how suppression works with full and partial keys.
  * Enhanced clarity of the explanation without altering any functionality or behavior.
  * No changes to public APIs or exported entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->