### PR TITLE
Fix bug in CFG construction for preincrement

### DIFF
--- a/checker/tests/resourceleak/DequePushIncrement.java
+++ b/checker/tests/resourceleak/DequePushIncrement.java
@@ -1,0 +1,12 @@
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class DequePushIncrement {
+
+  Deque<Integer> counters = new ArrayDeque<Integer>();
+
+  public void visitNewClass() {
+    int i = 0;
+    counters.push(++i);
+  }
+}

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -4159,7 +4159,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
 
   @Override
   public Node visitUnary(UnaryTree tree, Void p) {
-    Node result;
+    Node result = null;
     Tree.Kind kind = tree.getKind();
     switch (kind) {
       case BITWISE_COMPLEMENT:
@@ -4186,7 +4186,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
               throw new BugInCF("Unexpected unary tree kind: " + kind);
           }
           extendWithNode(result);
-          return result;
+          break;
         }
 
       case LOGICAL_COMPLEMENT:
@@ -4195,7 +4195,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           Node expr = scan(tree.getExpression(), p);
           result = new ConditionalNotNode(tree, unbox(expr));
           extendWithNode(result);
-          return result;
+          break;
         }
 
       case POSTFIX_DECREMENT:
@@ -4239,12 +4239,13 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
             result = new LocalVariableNode(resultExpr);
             result.setInSource(false);
             extendWithNode(result);
-            createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
-          } else {
-            result = createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
-            extendWithNode(result);
           }
-          return result;
+          AssignmentNode unaryAssign =
+              createIncrementOrDecrementAssign(tree, expr, isIncrement, isPostfix);
+          if (!isPostfix) {
+            result = unaryAssign;
+          }
+          break;
         }
 
       case OTHER:
@@ -4254,11 +4255,13 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           Node expr = scan(tree.getExpression(), p);
           result = new NullChkNode(tree, expr);
           extendWithNode(result);
-          return result;
+          break;
         }
 
         throw new BugInCF("Unknown kind (" + kind + ") of unary expression: " + tree);
     }
+
+    return result;
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -4245,7 +4245,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           if (!isPostfix) {
             result = unaryAssign;
           }
-          break;
+          return result;
         }
 
       case OTHER:

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -4159,7 +4159,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
 
   @Override
   public Node visitUnary(UnaryTree tree, Void p) {
-    Node result = null;
+    Node result;
     Tree.Kind kind = tree.getKind();
     switch (kind) {
       case BITWISE_COMPLEMENT:
@@ -4186,7 +4186,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
               throw new BugInCF("Unexpected unary tree kind: " + kind);
           }
           extendWithNode(result);
-          break;
+          return result;
         }
 
       case LOGICAL_COMPLEMENT:
@@ -4195,7 +4195,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           Node expr = scan(tree.getExpression(), p);
           result = new ConditionalNotNode(tree, unbox(expr));
           extendWithNode(result);
-          break;
+          return result;
         }
 
       case POSTFIX_DECREMENT:
@@ -4211,6 +4211,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           boolean isPostfix =
               kind == Tree.Kind.POSTFIX_INCREMENT || kind == Tree.Kind.POSTFIX_DECREMENT;
 
+          result = null; // for definite assignment; it is assigned in isPostfix and in !isPostfix
           if (isPostfix) {
             TypeMirror exprType = TreeUtils.typeOf(exprTree);
             VariableTree tempVarDecl =
@@ -4255,13 +4256,11 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
           Node expr = scan(tree.getExpression(), p);
           result = new NullChkNode(tree, expr);
           extendWithNode(result);
-          break;
+          return result;
         }
 
         throw new BugInCF("Unknown kind (" + kind + ") of unary expression: " + tree);
     }
-
-    return result;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrects handling of prefix/postfix increment operations, ensuring accurate value evaluation and eliminating definite-assignment issues. This improves analysis precision and reduces false positives/negatives around ++/-- expressions.

- Tests
  - Added a new test case exercising pre-increment usage in a deque operation to verify the corrected behavior and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->