### PR TITLE
Must include `<fork>true</fork>` in Maven `pom.xml`

### DIFF
--- a/docs/examples/MavenExample/pom.xml
+++ b/docs/examples/MavenExample/pom.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.checkerframework</groupId>

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -1214,8 +1214,8 @@ version number that is output when you run \<./gradlew version>.
 
 If you get an error like ``module jdk.compiler does not export
 com.sun.tools.javac.processing to unnamed module'' (discussed in
-Section~\ref{javac-jdk11-non-modularized} but your \<pom.xml> contains
-lines such as
+Section~\ref{javac-jdk11-non-modularized}) even though your \<pom.xml>
+contains lines such as
 
 \begin{mysmall}
 \begin{alltt}

--- a/docs/manual/external-tools.tex
+++ b/docs/manual/external-tools.tex
@@ -1195,6 +1195,7 @@ disable animal sniffer by modifying your POM file's properties:
 \end{alltt}
 \end{mysmall}
 
+
 \subsectionAndLabel{Maven, with a locally-built version of the Checker Framework}{maven-locally-built}
 
 To use a locally-built version of the Checker Framework, first run:
@@ -1207,6 +1208,29 @@ To use a locally-built version of the Checker Framework, first run:
 Then use the Maven instructions, but modify the version number for the
 Checker Framework artifacts.  Instead of \<\ReleaseVersion{}>, use the
 version number that is output when you run \<./gradlew version>.
+
+
+\subsectionAndLabel{Maven troubleshooting}{maven-troubleshooting}
+
+If you get an error like ``module jdk.compiler does not export
+com.sun.tools.javac.processing to unnamed module'' (discussed in
+Section~\ref{javac-jdk11-non-modularized} but your \<pom.xml> contains
+lines such as
+
+\begin{mysmall}
+\begin{alltt}
+  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+\end{alltt}
+\end{mysmall}
+
+\noindent
+then perhaps you have omitted this line from your \<pom.xml>:
+
+\begin{mysmall}
+\begin{alltt}
+          <fork>true</fork> <!-- Must fork or else JVM arguments are ignored. -->
+\end{alltt}
+\end{mysmall}
 
 
 \sectionAndLabel{NetBeans}{netbeans}


### PR DESCRIPTION
Related to #7258.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using a locally built Checker Framework with Maven (publish to local repo and select the correct version).
  * Added Maven troubleshooting for jdk.compiler export issues (JVM args and process forking).
  * Note: the new documentation sections were added twice (duplicate blocks).

* **Bug Fixes**
  * Improved the Maven example by adding an XML declaration and switching the schema URL to HTTPS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->