### PR TITLE
Run CI tests under Java 25

### DIFF
--- a/.azure/azure-pipelines-daily.yml
+++ b/.azure/azure-pipelines-daily.yml
@@ -24,12 +24,12 @@ jobs:
 
 - job: canary_jobs
   dependsOn:
-   - junit_jdk24
-   - nonjunit_jdk24
-   - inference_part1_jdk24
-   - inference_part2_jdk24
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
+   - junit_jdk25
+   - nonjunit_jdk25
+   - inference_part1_jdk25
+   - inference_part2_jdk25
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   steps:
@@ -39,7 +39,7 @@ jobs:
 - job: junit_jdk11
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11:latest
@@ -52,7 +52,7 @@ jobs:
 - job: junit_jdk17
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -65,7 +65,7 @@ jobs:
 - job: junit_jdk21
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -76,6 +76,9 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 - job: junit_jdk24
+  dependsOn:
+   - canary_jobs
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24:latest
@@ -86,9 +89,6 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 - job: junit_jdk25
-  dependsOn:
-   - canary_jobs
-   - junit_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -102,7 +102,7 @@ jobs:
 - job: nonjunit_jdk11
   dependsOn:
    - canary_jobs
-   - nonjunit_jdk24
+   - nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11:latest
@@ -114,7 +114,7 @@ jobs:
 - job: nonjunit_jdk17
   dependsOn:
    - canary_jobs
-   - nonjunit_jdk24
+   - nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -126,7 +126,7 @@ jobs:
 - job: nonjunit_jdk21
   dependsOn:
    - canary_jobs
-   - nonjunit_jdk24
+   - nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -136,6 +136,9 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-nonjunit.sh
     displayName: test-cftests-nonjunit.sh
 - job: nonjunit_jdk24
+  dependsOn:
+   - canary_jobs
+   - nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24:latest
@@ -145,9 +148,6 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-nonjunit.sh
     displayName: test-cftests-nonjunit.sh
 - job: nonjunit_jdk25
-  dependsOn:
-   - canary_jobs
-   - nonjunit_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -166,8 +166,8 @@ jobs:
 - job: inference_jdk17
   dependsOn:
    - canary_jobs
-   - inference_part1_jdk24
-   - inference_part2_jdk24
+   - inference_part1_jdk25
+   - inference_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -181,8 +181,8 @@ jobs:
 - job: inference_jdk21
   dependsOn:
    - canary_jobs
-   - inference_part1_jdk24
-   - inference_part2_jdk24
+   - inference_part1_jdk25
+   - inference_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -216,10 +216,6 @@ jobs:
     displayName: test-cftests-inference-part2.sh
 
 - job: inference_jdk25
-  dependsOn:
-   - canary_jobs
-   - inference_part1_jdk24
-   - inference_part2_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -237,8 +233,8 @@ jobs:
 - job: typecheck_jdk11
   dependsOn:
    - canary_jobs
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11-plus:latest
@@ -250,8 +246,8 @@ jobs:
 - job: typecheck_jdk17
   dependsOn:
    - canary_jobs
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17-plus:latest
@@ -263,8 +259,8 @@ jobs:
 - job: typecheck_jdk21
   dependsOn:
    - canary_jobs
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21-plus:latest
@@ -294,8 +290,8 @@ jobs:
 - job: typecheck_jdk25
   dependsOn:
    - canary_jobs
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25-plus:latest
@@ -308,8 +304,8 @@ jobs:
 - job: daikon_jdk11
   dependsOn:
    - canary_jobs
-   - daikon_part1_jdk24
-   - daikon_part2_jdk24
+   - daikon_part1_jdk25
+   - daikon_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11:latest
@@ -322,8 +318,8 @@ jobs:
 - job: daikon_jdk17
   dependsOn:
    - canary_jobs
-   - daikon_part1_jdk24
-   - daikon_part2_jdk24
+   - daikon_part1_jdk25
+   - daikon_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -336,8 +332,8 @@ jobs:
 - job: daikon_jdk21
   dependsOn:
    - canary_jobs
-   - daikon_part1_jdk24
-   - daikon_part2_jdk24
+   - daikon_part1_jdk25
+   - daikon_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -374,8 +370,8 @@ jobs:
 - job: daikon_jdk25
   dependsOn:
    - canary_jobs
-   - daikon_part1_jdk24
-   - daikon_part2_jdk24
+   - daikon_part1_jdk25
+   - daikon_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -390,7 +386,7 @@ jobs:
 - job: guava_jdk17
   dependsOn:
    - canary_jobs
-   - guava_jdk24
+   - guava_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -403,7 +399,7 @@ jobs:
 - job: guava_jdk21
   dependsOn:
    - canary_jobs
-   - guava_jdk24
+   - guava_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -416,6 +412,7 @@ jobs:
 - job: guava_jdk24
   dependsOn:
    - canary_jobs
+   - guava_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24:latest
@@ -428,7 +425,6 @@ jobs:
 - job: guava_jdk25
   dependsOn:
    - canary_jobs
-   - guava_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -442,7 +438,7 @@ jobs:
 - job: plume_lib_jdk11
   dependsOn:
    - canary_jobs
-   - plume_lib_jdk24
+   - plume_lib_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11:latest
@@ -454,7 +450,7 @@ jobs:
 - job: plume_lib_jdk17
   dependsOn:
    - canary_jobs
-   - plume_lib_jdk24
+   - plume_lib_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -466,7 +462,7 @@ jobs:
 - job: plume_lib_jdk21
   dependsOn:
    - canary_jobs
-   - plume_lib_jdk24
+   - plume_lib_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -478,6 +474,7 @@ jobs:
 - job: plume_lib_jdk24
   dependsOn:
    - canary_jobs
+   - plume_lib_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24:latest
@@ -489,7 +486,6 @@ jobs:
 - job: plume_lib_jdk25
   dependsOn:
    - canary_jobs
-   - plume_lib_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -23,13 +23,13 @@ jobs:
 
 - job: canary_jobs
   dependsOn:
-   - junit_jdk24
-   - nonjunit_jdk24
-   - inference_part1_jdk24
-   - inference_part2_jdk24
-   - typecheck_part1_jdk24
-   - typecheck_part2_jdk24
-   - misc_jdk24
+   - junit_jdk25
+   - nonjunit_jdk25
+   - inference_part1_jdk25
+   - inference_part2_jdk25
+   - typecheck_part1_jdk25
+   - typecheck_part2_jdk25
+   - misc_jdk25
    - misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
@@ -40,7 +40,7 @@ jobs:
 - job: junit_jdk11
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11:latest
@@ -53,7 +53,7 @@ jobs:
 - job: junit_jdk17
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17:latest
@@ -66,7 +66,7 @@ jobs:
 - job: junit_jdk21
   dependsOn:
    - canary_jobs
-   - junit_jdk24
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21:latest
@@ -77,6 +77,9 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 - job: junit_jdk24
+  dependsOn:
+   - canary_jobs
+   - junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24:latest
@@ -87,9 +90,6 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 - job: junit_jdk25
-  dependsOn:
-   - canary_jobs
-   - junit_jdk24
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk25:latest
@@ -100,14 +100,14 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 
-- job: nonjunit_jdk24
+- job: nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-nonjunit.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-nonjunit.sh
     displayName: test-cftests-nonjunit.sh
 
 # Sometimes one of the invocations of wpi-many in `./gradlew wpiManyTest`
@@ -115,25 +115,25 @@ jobs:
 # When there is a timeout, one cannot examine wpi or wpi-many logs.
 # So use a timeout of 90 minutes, and hope that is enough.
 # Split into part1 and part2 only for the inference job that "canary_jobs" depends on.
-- job: inference_part1_jdk24
+- job: inference_part1_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   timeoutInMinutes: 90
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-inference-part1.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-inference-part1.sh
     displayName: test-cftests-inference-part1.sh
-- job: inference_part2_jdk24
+- job: inference_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   timeoutInMinutes: 90
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-inference-part2.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-inference-part2.sh
     displayName: test-cftests-inference-part2.sh
 
 
@@ -141,7 +141,7 @@ jobs:
 - job: misc_jdk11
   dependsOn:
    - canary_jobs
-   - misc_jdk24
+   - misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk11-plus:latest
@@ -153,7 +153,7 @@ jobs:
 - job: misc_jdk17
   dependsOn:
    - canary_jobs
-   - misc_jdk24
+   - misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk17-plus:latest
@@ -165,7 +165,7 @@ jobs:
 - job: misc_jdk21
   dependsOn:
    - canary_jobs
-   - misc_jdk24
+   - misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk21-plus:latest
@@ -175,6 +175,9 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 - job: misc_jdk24
+  dependsOn:
+   - canary_jobs
+   - misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk24-plus:latest
@@ -193,74 +196,74 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
 
-- job: typecheck_part1_jdk24
+- job: typecheck_part1_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24-plus:latest
+  container: mdernst/cf-ubuntu-jdk25-plus:latest
   steps:
   - checkout: self
     fetchDepth: 1000
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-typecheck-part1.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-typecheck-part1.sh
     displayName: test-typecheck-part1.sh
-- job: typecheck_part2_jdk24
+- job: typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24-plus:latest
+  container: mdernst/cf-ubuntu-jdk25-plus:latest
   steps:
   - checkout: self
     fetchDepth: 1000
   - bash: ./checker/bin-devel/test-typecheck-part2.sh
     displayName: test-typecheck-part2.sh
 
-- job: daikon_part1_jdk24
+- job: daikon_part1_jdk25
   dependsOn:
    - canary_jobs
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   timeoutInMinutes: 70
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-daikon-part1.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-daikon-part1.sh
     displayName: test-daikon.sh
-- job: daikon_part2_jdk24
+- job: daikon_part2_jdk25
   dependsOn:
    - canary_jobs
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   timeoutInMinutes: 80
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-daikon.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-daikon.sh
     displayName: test-daikon-part2.sh
 
 ## I'm not sure why the guava_jdk11 job is failing (it's due to Error Prone).
-- job: guava_jdk24
+- job: guava_jdk25
   dependsOn:
    - canary_jobs
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   timeoutInMinutes: 70
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-guava.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-guava.sh
     displayName: test-guava.sh
 
-- job: plume_lib_jdk24
+- job: plume_lib_jdk25
   dependsOn:
    - canary_jobs
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
   steps:
   - checkout: self
     fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-plume-lib.sh
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-plume-lib.sh
     displayName: test-plume-lib.sh
 
 ## The downstream jobs are not currently needed because test-downstream.sh is empty.

--- a/.azure/defs.m4
+++ b/.azure/defs.m4
@@ -1,7 +1,7 @@
 changequote
 changequote(`[',`]')dnl
 ifelse([The "dnl" m4 macro means "discard to end of line",])dnl
-define([canary_version], [24])dnl
+define([canary_version], [25])dnl
 define([latest_version], [25])dnl
 define([docker_testing], [])dnl
 # define([docker_testing], [-testing])dnl


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI pipelines now target JDK 25 across canary and test suites, updating containers and dependencies for faster, more parallel runs.
  - Legacy JDK 24 paths remain where needed but are de-emphasized in favor of JDK 25.
- Tests
  - Test matrix migrated to JDK 25 (unit, non-unit, inference, typecheck, misc, and library suites).
  - JDK 11/17/21 jobs now depend on JDK 25 artifacts; JDK 24 jobs adjusted to reference JDK 25 where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->