### PR TITLE
CI: don't run JDK 24 jobs

### DIFF
--- a/.azure/azure-pipelines-daily.yml
+++ b/.azure/azure-pipelines-daily.yml
@@ -19,8 +19,8 @@ variables:
 jobs:
 
 # The dependsOn clauses are:
-#  * Everything depends on the canary jobs (the main jdk24 jobs), except those jobs themselves.
-#  * Anything *_jdk11 or *_jdk17 or *_jdk21 or *_jdk25 depends on *_jdk24.
+#  * Everything depends on the canary jobs (the main jdk25 jobs), except those jobs themselves.
+#  * Any other *_jdkNN job depends on the corresponding *_jdk25 job.
 
 - job: canary_jobs
   dependsOn:
@@ -75,19 +75,6 @@ jobs:
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
-- job: junit_jdk24
-  dependsOn:
-   - canary_jobs
-   - junit_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 70
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-junit.sh
-    displayName: test-cftests-junit.sh
 - job: junit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
@@ -135,18 +122,6 @@ jobs:
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-nonjunit.sh
     displayName: test-cftests-nonjunit.sh
-- job: nonjunit_jdk24
-  dependsOn:
-   - canary_jobs
-   - nonjunit_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-nonjunit.sh
-    displayName: test-cftests-nonjunit.sh
 - job: nonjunit_jdk25
   pool:
     vmImage: 'ubuntu-latest'
@@ -161,6 +136,28 @@ jobs:
 # takes much longer to complete than normal, and this Azure job times out.
 # When there is a timeout, one cannot examine wpi or wpi-many logs.
 # So use a timeout of 90 minutes, and hope that is enough.
+# Split into part1 and part2 only for the inference job that "canary_jobs" depends on.
+- job: inference_part1_jdk25
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk25:latest
+  timeoutInMinutes: 90
+  steps:
+  - checkout: self
+    fetchDepth: 25
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-inference-part1.sh
+    displayName: test-cftests-inference-part1.sh
+- job: inference_part2_jdk25
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk25:latest
+  timeoutInMinutes: 90
+  steps:
+  - checkout: self
+    fetchDepth: 25
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-inference-part2.sh
+    displayName: test-cftests-inference-part2.sh
+
 # Inference on JDK 11 seems to be broken because do-like-javac doesn't pass --release.
 # inference_job(11)
 - job: inference_jdk17
@@ -193,43 +190,29 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-inference.sh
     displayName: test-cftests-inference.sh
 
-# Split into part1 and part2 only for the inference job that "canary_jobs" depends on.
-- job: inference_part1_jdk24
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 90
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-inference-part1.sh
-    displayName: test-cftests-inference-part1.sh
-- job: inference_part2_jdk24
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 90
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-inference-part2.sh
-    displayName: test-cftests-inference-part2.sh
-
-- job: inference_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk25:latest
-  timeoutInMinutes: 90
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-cftests-inference.sh
-    displayName: test-cftests-inference.sh
 
 
 # Do not run misc_job daily, because it does diffs that assume it is running in
 # a pull request.
 
+- job: typecheck_part1_jdk25
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk25-plus:latest
+  steps:
+  - checkout: self
+    fetchDepth: 1000
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-typecheck-part1.sh
+    displayName: test-typecheck-part1.sh
+- job: typecheck_part2_jdk25
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk25-plus:latest
+  steps:
+  - checkout: self
+    fetchDepth: 1000
+  - bash: ./checker/bin-devel/test-typecheck-part2.sh
+    displayName: test-typecheck-part2.sh
 - job: typecheck_jdk11
   dependsOn:
    - canary_jobs
@@ -269,38 +252,32 @@ jobs:
     fetchDepth: 1000
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-typecheck.sh
     displayName: test-typecheck.sh
-- job: typecheck_part1_jdk24
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24-plus:latest
-  steps:
-  - checkout: self
-    fetchDepth: 1000
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-typecheck-part1.sh
-    displayName: test-typecheck-part1.sh
-- job: typecheck_part2_jdk24
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24-plus:latest
-  steps:
-  - checkout: self
-    fetchDepth: 1000
-  - bash: ./checker/bin-devel/test-typecheck-part2.sh
-    displayName: test-typecheck-part2.sh
-- job: typecheck_jdk25
+
+
+- job: daikon_part1_jdk25
   dependsOn:
    - canary_jobs
-   - typecheck_part1_jdk25
-   - typecheck_part2_jdk25
   pool:
     vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk25-plus:latest
+  container: mdernst/cf-ubuntu-jdk25:latest
+  timeoutInMinutes: 70
   steps:
   - checkout: self
-    fetchDepth: 1000
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-typecheck.sh
-    displayName: test-typecheck.sh
-
+    fetchDepth: 25
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-daikon-part1.sh
+    displayName: test-daikon.sh
+- job: daikon_part2_jdk25
+  dependsOn:
+   - canary_jobs
+  pool:
+    vmImage: 'ubuntu-latest'
+  container: mdernst/cf-ubuntu-jdk25:latest
+  timeoutInMinutes: 80
+  steps:
+  - checkout: self
+    fetchDepth: 25
+  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-daikon.sh
+    displayName: test-daikon-part2.sh
 - job: daikon_jdk11
   dependsOn:
    - canary_jobs
@@ -343,30 +320,6 @@ jobs:
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-daikon.sh
     displayName: test-daikon.sh
-- job: daikon_part1_jdk24
-  dependsOn:
-   - canary_jobs
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 70
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-daikon-part1.sh
-    displayName: test-daikon.sh
-- job: daikon_part2_jdk24
-  dependsOn:
-   - canary_jobs
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 80
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-daikon.sh
-    displayName: test-daikon-part2.sh
 - job: daikon_jdk25
   dependsOn:
    - canary_jobs
@@ -408,19 +361,6 @@ jobs:
   - checkout: self
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-guava.sh
-    displayName: test-guava.sh
-- job: guava_jdk24
-  dependsOn:
-   - canary_jobs
-   - guava_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 70
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-guava.sh
     displayName: test-guava.sh
 - job: guava_jdk25
   dependsOn:
@@ -471,18 +411,6 @@ jobs:
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-plume-lib.sh
     displayName: test-plume-lib.sh
-- job: plume_lib_jdk24
-  dependsOn:
-   - canary_jobs
-   - plume_lib_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-plume-lib.sh
-    displayName: test-plume-lib.sh
 - job: plume_lib_jdk25
   dependsOn:
    - canary_jobs
@@ -495,52 +423,4 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-plume-lib.sh
     displayName: test-plume-lib.sh
 
-## The downstream jobs are not currently needed because test-downstream.sh is empty.
-# - job: downstream_jdk11
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk11:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk17
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk17:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk21
-#   dependsOn:
-#    - canary_jobs
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk21:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk24
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk24:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
 

--- a/.azure/azure-pipelines-daily.yml.m4
+++ b/.azure/azure-pipelines-daily.yml.m4
@@ -19,8 +19,8 @@ variables:
 jobs:
 
 # The dependsOn clauses are:
-#  * Everything depends on the canary jobs (the main jdk24 jobs), except those jobs themselves.
-#  * Anything *_jdk11 or *_jdk17 or *_jdk21 or *_jdk25 depends on *_jdk24.
+#  * Everything depends on the canary jobs (the main jdk25 jobs), except those jobs themselves.
+#  * Any other *_jdkNN job depends on the corresponding *_jdk25 job.
 
 - job: canary_jobs
   dependsOn:
@@ -39,102 +39,49 @@ jobs:
 junit_job(11)
 junit_job(17)
 junit_job(21)
-junit_job(24)
 junit_job(25)
 
 nonjunit_job(11)
 nonjunit_job(17)
 nonjunit_job(21)
-nonjunit_job(24)
 nonjunit_job(25)
 
 # Sometimes one of the invocations of wpi-many in `./gradlew wpiManyTest`
 # takes much longer to complete than normal, and this Azure job times out.
 # When there is a timeout, one cannot examine wpi or wpi-many logs.
 # So use a timeout of 90 minutes, and hope that is enough.
+inference_job_split(canary_version)
 # Inference on JDK 11 seems to be broken because do-like-javac doesn't pass --release.
 # inference_job(11)
 inference_job(17)
 inference_job(21)
-inference_job_split(24)
 inference_job(25)
 
 # Do not run misc_job daily, because it does diffs that assume it is running in
 # a pull request.
 
+typecheck_job_split(canary_version)
 typecheck_job(11)
 typecheck_job(17)
 typecheck_job(21)
-typecheck_job_split(24)
 typecheck_job(25)
 
+daikon_job_split(canary_version)
 daikon_job(11)
 daikon_job(17)
 daikon_job(21)
-daikon_job_split(24)
 daikon_job(25)
 
 ## I think the guava_jdk11 job is failing due to Error Prone not supporting JDK 11.
 guava_job(17)
 guava_job(21)
-guava_job(24)
 guava_job(25)
 
 plume_lib_job(11)
 plume_lib_job(17)
 plume_lib_job(21)
-plume_lib_job(24)
 plume_lib_job(25)
 
-## The downstream jobs are not currently needed because test-downstream.sh is empty.
-# - job: downstream_jdk11
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk11:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk17
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk17:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk21
-#   dependsOn:
-#    - canary_jobs
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk21:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk24
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk24:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-dnl
 ifelse([
 Local Variables:
 eval: (make-local-variable 'after-save-hook)

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -18,8 +18,8 @@ variables:
 jobs:
 
 # The dependsOn clauses are:
-#  * Everything depends on the canary jobs (the main jdk21 jobs), except those jobs themselves.
-#  * Anything *_jdk11 or *_jdk17 or *_jdk21 depends on *_jdk24.
+#  * Everything depends on the canary jobs (the main jdk25 jobs), except those jobs themselves.
+#  * Any other *_jdkNN job depends on the corresponding *_jdk25 job.
 
 - job: canary_jobs
   dependsOn:
@@ -75,19 +75,6 @@ jobs:
   - checkout: self
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-cftests-junit.sh
-    displayName: test-cftests-junit.sh
-- job: junit_jdk24
-  dependsOn:
-   - canary_jobs
-   - junit_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24:latest
-  timeoutInMinutes: 70
-  steps:
-  - checkout: self
-    fetchDepth: 25
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-cftests-junit.sh
     displayName: test-cftests-junit.sh
 - job: junit_jdk25
   pool:
@@ -174,18 +161,6 @@ jobs:
     fetchDepth: 0
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=21 && ./checker/bin-devel/test-misc.sh
     displayName: test-misc.sh
-- job: misc_jdk24
-  dependsOn:
-   - canary_jobs
-   - misc_jdk25
-  pool:
-    vmImage: 'ubuntu-latest'
-  container: mdernst/cf-ubuntu-jdk24-plus:latest
-  steps:
-  - checkout: self
-    fetchDepth: 0
-  - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=24 && ./checker/bin-devel/test-misc.sh
-    displayName: test-misc.sh
 - job: misc_jdk25
   pool:
     vmImage: 'ubuntu-latest'
@@ -266,52 +241,4 @@ jobs:
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=25 && ./checker/bin-devel/test-plume-lib.sh
     displayName: test-plume-lib.sh
 
-## The downstream jobs are not currently needed because test-downstream.sh is empty.
-# - job: downstream_jdk11
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk11:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk17
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk17:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk21
-#   dependsOn:
-#    - canary_jobs
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk21:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk24
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk24:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
 

--- a/.azure/azure-pipelines.yml.m4
+++ b/.azure/azure-pipelines.yml.m4
@@ -18,8 +18,8 @@ variables:
 jobs:
 
 # The dependsOn clauses are:
-#  * Everything depends on the canary jobs (the main jdk21 jobs), except those jobs themselves.
-#  * Anything *_jdk11 or *_jdk17 or *_jdk21 depends on *_jdk24.
+#  * Everything depends on the canary jobs (the main jdk25 jobs), except those jobs themselves.
+#  * Any other *_jdkNN job depends on the corresponding *_jdk25 job.
 
 - job: canary_jobs
   dependsOn:
@@ -40,7 +40,6 @@ jobs:
 junit_job(11)
 junit_job(17)
 junit_job(21)
-junit_job(24)
 junit_job(25)
 
 nonjunit_job(canary_version)
@@ -55,7 +54,6 @@ inference_job_split(canary_version)
 misc_job(11)
 misc_job(17)
 misc_job(21)
-misc_job(24)
 misc_job(25)
 
 typecheck_job_split(canary_version)
@@ -67,55 +65,6 @@ guava_job(canary_version)
 
 plume_lib_job(canary_version)
 
-## The downstream jobs are not currently needed because test-downstream.sh is empty.
-# - job: downstream_jdk11
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk11:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk17
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk17:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk21
-#   dependsOn:
-#    - canary_jobs
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk21:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-# - job: downstream_jdk24
-#   dependsOn:
-#    - canary_jobs
-#    - downstream_jdk21
-#   pool:
-#     vmImage: 'ubuntu-latest'
-#   container: mdernst/cf-ubuntu-jdk24:latest
-#   steps:
-#   - checkout: self
-#     fetchDepth: 25
-#   - bash: ./checker/bin-devel/test-downstream.sh
-#     displayName: test-downstream.sh
-dnl
 ifelse([
 Local Variables:
 eval: (make-local-variable 'after-save-hook)

--- a/.azure/defs.m4
+++ b/.azure/defs.m4
@@ -63,12 +63,11 @@ define([inference_job_split], [dnl
 ])dnl
 dnl
 define([inference_job], [dnl
-- job: inference_jdk$1
-ifelse($1,canary_version,,[  dependsOn:
+ifelse($1,canary_version,,[- job: inference_jdk$1
+  dependsOn:
    - canary_jobs
    - inference_part1_jdk[]canary_version
    - inference_part2_jdk[]canary_version
-])dnl
   pool:
     vmImage: 'ubuntu-latest'
   container: mdernst/cf-ubuntu-jdk$1[]docker_testing:latest
@@ -78,6 +77,7 @@ ifelse($1,canary_version,,[  dependsOn:
     fetchDepth: 25
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=$1 && ./checker/bin-devel/test-cftests-inference.sh
     displayName: test-cftests-inference.sh
+])dnl
 ])dnl
 dnl
 define([misc_job], [dnl
@@ -116,7 +116,7 @@ define([typecheck_job_split], [dnl
     displayName: test-typecheck-part2.sh])dnl
 dnl
 define([typecheck_job], [dnl
-- job: typecheck_jdk$1
+ifelse($1,canary_version,,[- job: typecheck_jdk$1
   dependsOn:
    - canary_jobs
    - typecheck_part1_jdk[]canary_version
@@ -128,7 +128,7 @@ define([typecheck_job], [dnl
   - checkout: self
     fetchDepth: 1000
   - bash: export ORG_GRADLE_PROJECT_jdkTestVersion=$1 && ./checker/bin-devel/test-typecheck.sh
-    displayName: test-typecheck.sh])dnl
+    displayName: test-typecheck.sh])])dnl
 dnl
 define([daikon_job_split], [dnl
 - job: daikon_part1_jdk$1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - CI standardized on JDK 25; all JDK 24 and downstream jobs removed.
  - Updated container images to newer “plus” variants where applicable.
- Refactor
  - Reorganized daily and main pipelines around a JDK 25 canary baseline.
  - Introduced split tasks for heavy jobs (inference/typecheck/daikon) to improve throughput.
- Tests
  - Consolidated test matrix to focus on JDK 25 paths.
- Documentation
  - Updated pipeline comments to reflect the JDK 25 baseline and dependency rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->