### PR TITLE
Don't use multi-string dependency syntax in Gradle

### DIFF
--- a/annotation-file-utilities/build.gradle
+++ b/annotation-file-utilities/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     exclude group: 'org.checkerframework'
   }
   implementation 'org.ow2.asm:asm:9.8'
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+  testImplementation 'junit:junit:4.13.2'
   testImplementation project(':checker-qual')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -191,11 +191,11 @@ allprojects { currentProj ->
   }
 
   dependencies {
-    errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: versions.errorprone
+    errorprone "com.google.errorprone:error_prone_core:${versions.errorprone}"
 
-    javacJar group: 'com.google.errorprone', name: 'javac', version: "9+181-r4173-1"
+    javacJar 'com.google.errorprone:javac:9+181-r4173-1'
 
-    errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+    errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 
     allProjects subprojects
   }

--- a/checker-util/build.gradle
+++ b/checker-util/build.gradle
@@ -6,7 +6,7 @@ dependencies {
   api project(':checker-qual')
   // Don't add implementation dependencies; checker-util.jar should have no dependencies.
 
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+  testImplementation 'junit:junit:4.13.2'
 }
 
 jar {

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -68,7 +68,7 @@ dependencies {
   // see https://github.com/typetools/checker-framework/issues/6396
   testImplementation 'org.apache.spark:spark-sql_2.12:3.3.2'
 
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+  testImplementation 'junit:junit:4.13.2'
   testImplementation project(':framework-test')
   testImplementation sourceSets.testannotations.output
 

--- a/dataflow/build.gradle
+++ b/dataflow/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
   implementation "org.plumelib:hashmap-util:${versions.hashmapUtil}"
 
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+  testImplementation 'junit:junit:4.13.2'
 
   // External dependencies:
   // If you add an external dependency, you must shadow its packages both in the dataflow-shaded

--- a/framework-test/build.gradle
+++ b/framework-test/build.gradle
@@ -3,7 +3,7 @@ sourceSets {
 }
 
 dependencies {
-  implementation group: 'junit', name: 'junit', version: '4.13.2'
+  implementation 'junit:junit:4.13.2'
   implementation project(':javacutil')
   implementation project(':checker-qual')
 

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -54,7 +54,7 @@ dependencies {
   implementation "org.plumelib:reflection-util:${versions.reflectionUtil}"
   implementation 'io.github.classgraph:classgraph:4.8.181'
 
-  testImplementation group: 'junit', name: 'junit', version: '4.13.2'
+  testImplementation 'junit:junit:4.13.2'
   testImplementation project(':framework-test')
   testImplementation sourceSets.testannotations.output
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized Gradle dependency notation to concise coordinates across modules for consistency.
  - Unified declarations for testing and static analysis dependencies; no runtime or feature changes.
- Build
  - Streamlined build configuration to improve readability and align with Gradle best practices.
  - Harmonized compiler/tooling dependency references for clearer maintenance.
- Refactor
  - Syntax-only cleanup of dependency declarations; behavior and resolved artifacts remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->