### PR TITLE
Addresses issue 3211

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/checker/signedness/qual/BitPattern.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/signedness/qual/BitPattern.java
@@ -1,0 +1,24 @@
+package org.checkerframework.checker.signedness.qual;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.checkerframework.framework.qual.SubtypeOf;
+
+/**
+ * The value represents a bit pattern that should not be interpreted as a signed or unsigned number.
+ * It may only be used in bitwise operations, not in arithmetic operations.
+ *
+ * <p>This annotation is typically used on the return type of methods like {@code
+ * Double.doubleToLongBits()} and {@code Float.floatToIntBits()}, and on the parameter type of
+ * methods like {@code Double.longBitsToDouble()} and {@code Float.intBitsToFloat()}.
+ *
+ * @checker_framework.manual #signedness-checker Signedness Checker
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
+@SubtypeOf({UnknownSignedness.class})
+public @interface BitPattern {}

--- a/checker-qual/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
+++ b/checker-qual/src/main/java/org/checkerframework/checker/signedness/qual/SignednessBottom.java
@@ -21,5 +21,5 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
 @TargetLocations({TypeUseLocation.EXPLICIT_LOWER_BOUND, TypeUseLocation.EXPLICIT_UPPER_BOUND})
-@SubtypeOf({SignedPositive.class})
+@SubtypeOf({SignedPositive.class, BitPattern.class})
 public @interface SignednessBottom {}

--- a/checker/src/main/java/org/checkerframework/checker/signedness/SignednessChecker.java
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/SignednessChecker.java
@@ -25,7 +25,7 @@ import org.checkerframework.framework.source.SourceChecker;
   int.class,
   long.class,
 })
-@StubFiles({"junit-assertions.astub"})
+@StubFiles({"junit-assertions.astub", "jdk.astub"})
 public class SignednessChecker extends BaseTypeChecker {
 
   /** Creates a new SignednessChecker. */

--- a/checker/src/main/java/org/checkerframework/checker/signedness/jdk.astub
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/jdk.astub
@@ -1,0 +1,15 @@
+package java.lang;
+
+import org.checkerframework.checker.signedness.qual.BitPattern;
+
+class Double {
+    @BitPattern long doubleToLongBits(double value);
+    @BitPattern long doubleToRawLongBits(double value);
+    double longBitsToDouble(@BitPattern long bits);
+}
+
+class Float {
+    @BitPattern int floatToIntBits(float value);
+    @BitPattern int floatToRawIntBits(float value);
+    float intBitsToFloat(@BitPattern int bits);
+}

--- a/checker/src/main/java/org/checkerframework/checker/signedness/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/signedness/messages.properties
@@ -16,3 +16,7 @@ compound.assignment.mixed.unsigned.expression=%s operation has signed LHS and un
 compound.assignment.shift.signed=%s has unsigned LHS%nlhs: %s%nrhs: %s
 compound.assignment.shift.unsigned=%s has signed LHS%nlhs: %s%nrhs: %s
 unsigned.concat=string concatenation on an unsigned value
+operation.bitpattern=arithmetic operation on a @BitPattern value is forbidden
+compound.assignment.bitpattern=arithmetic compound assignment on a @BitPattern value is forbidden
+unary.bitpattern=increment/decrement on a @BitPattern value is forbidden
+bitpattern.concat=string concatenation on a @BitPattern value is forbidden

--- a/checker/tests/signedness/BitPatternOperations.java
+++ b/checker/tests/signedness/BitPatternOperations.java
@@ -1,4 +1,4 @@
-// @skip-test
+//
 
 import org.checkerframework.checker.signedness.qual.BitPattern;
 

--- a/failures.txt
+++ b/failures.txt
@@ -1,0 +1,3 @@
+At first, the LLM struggled to navigate across the massive codebase. I gave it a concise summary of the task at hand, the desired behavior, and what file(s) should probably be altered and how tests should be run.
+
+The LLM also repeatedly made changes that resulted in failed builds, but was able to fix these pretty quickly.

--- a/successes.txt
+++ b/successes.txt
@@ -1,0 +1,5 @@
+Going back and forth with an LLM within this codebase helped me better understand the codebase, the issue highlighted, and the task at hand. I asked cursor questions to gain a better understanding.
+
+There were a few times where the changes made by the LLM resulting in failed builds. Instead of asking it to fix the errors, I asked why the build failed in the first place. This helped the LLM find and fix issues with more success than simply telling it to fix issues itself (in my experience).
+
+Cursor was also far faster than I could have been at navigating the codebase, knowing what files needed to be edited, and where in these files the edits should have taken place.


### PR DESCRIPTION
Overview
- Adds @BitPattern for values treated as raw bit patterns (e.g., Double.doubleToLongBits).
- Permits bitwise ops and shifts; forbids arithmetic, compound assignments, ++/--, and string concatenation on @BitPattern.


Key updates
- Qualifiers: introduce @BitPattern (subtype of @UnknownSignedness); make @SignednessBottom a subtype of both @SignedPositive and @BitPattern.
- Factory: recognize @BitPattern, propagate through &, |, ^, ~, and shifts; prevent refinement from overriding @BitPattern; ensure compound assignments and ++/-- preserve operand qualifiers.
- Visitor: enforce forbidden operations on @BitPattern; avoid duplicate generic diagnostics.
- JDK stubs: annotate Double/Float bit-conversion methods to return/accept @BitPattern.
- Messages: add concise diagnostics for @BitPattern violations.
- Tests: enable BitPatternOperations negative test to validate behavior.

Behavior
- Allowed on @BitPattern: &, |, ^, ~, <<, >>, >>>.
- Forbidden on @BitPattern: +, -, , /, %, +=, -=, =, /=, %=, ++, --, string concatenation.