### PR TITLE
Fix permit-nullness-assertion-exception.astub compile time warning

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/nullness/permit-nullness-assertion-exception.astub
+++ b/checker/src/main/java/org/checkerframework/checker/nullness/permit-nullness-assertion-exception.astub
@@ -3,6 +3,7 @@
 // guarantee that your program will not throw a NullPointerException.
 
 import org.checkerframework.checker.nullness.qual.EnsuresNonNull;
+import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.function.Supplier;
 


### PR DESCRIPTION
In #6884 I forgot to add import for `@EnsuresNonNullIf` annotation.

I found, it is required by doc https://checkerframework.org/manual/

> Import statements: Imports may appear at the beginning of the file or after any package declaration. The only required import statements are the ones to import type annotations. Import statements for types are optional. If you omit an import statement for an annotation, occurrences of that annotation are silently ignored; this is a common error in stub files.

This PR fixes compile time warning
```
[WARNING] permit-nullness-assertion-exception.astub:(line 19,col 5): Unknown annotation @EnsuresNonNullIf(expression = "#1", result = true)
[WARNING] permit-nullness-assertion-exception.astub:(line 21,col 5): Unknown annotation @EnsuresNonNullIf(expression = "#1", result = false)
```