### PR TITLE
Pass in cause exception when throwing BugInCF

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/ForwardAnalysisImpl.java
@@ -337,7 +337,7 @@ public class ForwardAnalysisImpl<
       initialStore = transferFunction.initialStore(underlyingAST, parameters);
     } catch (Exception e) {
       throw new BugInCF(
-          "Problem with initial store for " + underlyingAST + ", parameters=" + parameters);
+          "Problem with initial store for " + underlyingAST + ", parameters=" + parameters, e);
     }
     thenStores.put(entry, initialStore);
     elseStores.put(entry, initialStore);


### PR DESCRIPTION
This will help to debug the root cause when the exception is thrown (hitting this exceptional case due to a bug in NullAway)