### PR TITLE
Fix crash cause by type inference treats java type as covariant when on the qualifier should be.

### DIFF
--- a/checker/tests/nullness/java8/Issue1098.java
+++ b/checker/tests/nullness/java8/Issue1098.java
@@ -8,9 +8,10 @@ public class Issue1098 {
 
   <T> void cls(Class<T> p1, T p2) {}
 
-  @SuppressWarnings("keyfor:type.argument")
+  @SuppressWarnings("keyfor:argument")
   void use() {
     opt(Optional.empty(), null);
+    // :: error: [argument]
     cls(this.getClass(), null);
   }
 }

--- a/checker/tests/nullness/java8/Issue1098.java
+++ b/checker/tests/nullness/java8/Issue1098.java
@@ -11,6 +11,7 @@ public class Issue1098 {
   @SuppressWarnings("keyfor:argument")
   void use() {
     opt(Optional.empty(), null);
+    // TODO: (#7708) This is a false positive.
     // :: error: [argument]
     cls(this.getClass(), null);
   }

--- a/checker/tests/nullness/java8/Issue1098NoJdk.java
+++ b/checker/tests/nullness/java8/Issue1098NoJdk.java
@@ -12,6 +12,7 @@ class Issue1098NoJdk {
   <T> void cls2(Class<T> p1, T p2) {}
 
   void use2(MyObject ths) {
+    // :: error: [argument]
     cls2(ths.getMyClass(), null);
   }
 }

--- a/checker/tests/nullness/java8/Issue1098NoJdk.java
+++ b/checker/tests/nullness/java8/Issue1098NoJdk.java
@@ -12,6 +12,7 @@ class Issue1098NoJdk {
   <T> void cls2(Class<T> p1, T p2) {}
 
   void use2(MyObject ths) {
+    // TODO: (#7708) This is a false positive.
     // :: error: [argument]
     cls2(ths.getMyClass(), null);
   }

--- a/checker/tests/tainting/CovariantError.java
+++ b/checker/tests/tainting/CovariantError.java
@@ -1,0 +1,20 @@
+import org.checkerframework.checker.tainting.qual.Untainted;
+import org.checkerframework.framework.qual.Covariant;
+
+public class CovariantError {
+
+  @Covariant(0)
+  static class MyClass<X> {}
+
+  <T> void cls(MyClass<T> p1, T p2) {}
+
+  void use(CovariantError t) {
+    // TODO: This is a false positive.
+    // :: error: [type.arguments.not.inferred]
+    cls(this.getMyClass(), t);
+  }
+
+  MyClass<@Untainted CovariantError> getMyClass() {
+    throw new RuntimeException();
+  }
+}

--- a/framework/src/main/java/org/checkerframework/common/value/ValueQualifierHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/common/value/ValueQualifierHierarchy.java
@@ -46,9 +46,6 @@ final class ValueQualifierHierarchy extends ElementQualifierHierarchy {
    * @param otherAnno annotation from the value checker hierarchy
    * @return greatest lower bound of {@code stringValAnno} and {@code otherAnno}
    */
-  @SuppressWarnings(
-      "regex:type.arguments.not.inferred") // AnnotationUtils.getElementValueArray contains @Regex
-  // strings
   private AnnotationMirror glbOfStringVal(
       AnnotationMirror stringValAnno, AnnotationMirror otherAnno) {
     List<String> values = atypeFactory.getStringValues(stringValAnno);

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -577,6 +577,9 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       AnnotatedDeclaredType supertype,
       boolean subtypeRaw,
       boolean supertypeRaw) {
+    if (TypesUtils.isClassType(subtype.getUnderlyingType())) {
+      return true;
+    }
     AnnotatedTypeFactory typeFactory = subtype.atypeFactory;
 
     // JLS 11: 4.10.2. Subtyping among Class and Interface Types

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -577,7 +577,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       AnnotatedDeclaredType supertype,
       boolean subtypeRaw,
       boolean supertypeRaw) {
-    if (TypesUtils.isClassType(subtype.getUnderlyingType())) {
+    if (TypesUtils.isClass(subtype.getUnderlyingType())) {
       return true;
     }
     AnnotatedTypeFactory typeFactory = subtype.atypeFactory;

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -578,6 +578,7 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
       boolean subtypeRaw,
       boolean supertypeRaw) {
     if (TypesUtils.isClass(subtype.getUnderlyingType())) {
+      // Ignore type arguments in classes. Their qualifiers never matter.
       return true;
     }
     AnnotatedTypeFactory typeFactory = subtype.atypeFactory;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -45,7 +45,6 @@ public class Typing extends TypeConstraint {
   private final Kind kind;
 
   /** True if this constraint is for a covariant type argument. */
-  @SuppressWarnings("UnusedVariable") // Not currently used, but may be in the future.
   private boolean isCovarTypeArg;
 
   /**
@@ -314,7 +313,7 @@ public class Typing extends TypeConstraint {
       // if (isCovarTypeArg) {
       // return new Typing(this, S, T, Kind.SUBTYPE);
       // }
-      return new Typing(this, S, T, Kind.TYPE_EQUALITY);
+      return new Typing(this, S, T, Kind.TYPE_EQUALITY, isCovarTypeArg);
 
     } else if (T.isUnboundWildcard()) {
       return ConstraintSet.TRUE;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -308,11 +308,12 @@ public class Typing extends TypeConstraint {
         return ConstraintSet.FALSE;
       }
       // TODO: This code is incorrect because the java types must be equal, but the qualifiers can
-      // be covariant.  However, I can't write a test case that fails when the qualifiers are not
-      // in a subtyping relationship.
+      // be covariant.
       // if (isCovarTypeArg) {
       // return new Typing(this, S, T, Kind.SUBTYPE);
       // }
+      // However, this causes new false postives.  For example,
+      // checker/tests/tainting/CovariantError.java
       return new Typing(this, S, T, Kind.TYPE_EQUALITY, isCovarTypeArg);
 
     } else if (T.isUnboundWildcard()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -45,6 +45,7 @@ public class Typing extends TypeConstraint {
   private final Kind kind;
 
   /** True if this constraint is for a covariant type argument. */
+  @SuppressWarnings("UnusedVariable") // Not currently used, but may be in the future.
   private boolean isCovarTypeArg;
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -307,9 +307,12 @@ public class Typing extends TypeConstraint {
       if (S.getTypeKind() == TypeKind.WILDCARD) {
         return ConstraintSet.FALSE;
       }
-      if (isCovarTypeArg) {
-        return new Typing(this, S, T, Kind.SUBTYPE);
-      }
+      // TODO: This code is incorrect because the java types must be equal, but the qualifiers can
+      // be covariant.  However, I can't write a test case that fails when the qualifiers are not
+      // in a subtyping relationship.
+      // if (isCovarTypeArg) {
+      // return new Typing(this, S, T, Kind.SUBTYPE);
+      // }
       return new Typing(this, S, T, Kind.TYPE_EQUALITY);
 
     } else if (T.isUnboundWildcard()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -307,13 +307,14 @@ public class Typing extends TypeConstraint {
       if (S.getTypeKind() == TypeKind.WILDCARD) {
         return ConstraintSet.FALSE;
       }
-      // TODO: This code is incorrect because the java types must be equal, but the qualifiers can
+      // This code is incorrect because the java types must be equal, but the qualifiers can
       // be covariant.
       // if (isCovarTypeArg) {
       // return new Typing(this, S, T, Kind.SUBTYPE);
       // }
-      // However, this causes new false postives.  For example,
+      // However, this causes new false positives.  For example,
       // checker/tests/tainting/CovariantError.java
+      // TODO: Need to mark this bound as equal for java types, but subtype for qualifiers.
       return new Typing(this, S, T, Kind.TYPE_EQUALITY, isCovarTypeArg);
 
     } else if (T.isUnboundWildcard()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -314,7 +314,8 @@ public class Typing extends TypeConstraint {
       // }
       // However, this causes new false positives.  For example,
       // checker/tests/tainting/CovariantError.java
-      // TODO: Need to mark this bound as equal for java types, but subtype for qualifiers.
+      // TODO: (#7708) Need to mark this bound as equal for java types, but subtype for qualifiers.
+      // isCovarTypeArg is ignored when reducing this constraint.
       return new Typing(this, S, T, Kind.TYPE_EQUALITY, isCovarTypeArg);
 
     } else if (T.isUnboundWildcard()) {

--- a/framework/tests/all-systems/Issue7676.java
+++ b/framework/tests/all-systems/Issue7676.java
@@ -1,0 +1,24 @@
+package open.liam;
+
+import org.checkerframework.framework.qual.Covariant;
+
+public class Issue7676 {
+  @Covariant(0)
+  static class Optional767<T> {
+    static <R> Optional767<R> of(R r) {
+      throw new RuntimeException();
+    }
+  }
+
+  Optional767<Foo> repro(int i) {
+    return Optional767.of(
+        switch (i) {
+          case 1 -> new Bar();
+          default -> new Bar();
+        });
+  }
+
+  static class Foo {}
+
+  static class Bar extends Foo {}
+}

--- a/framework/tests/all-systems/Issue7676.java
+++ b/framework/tests/all-systems/Issue7676.java
@@ -1,5 +1,3 @@
-package open.liam;
-
 import org.checkerframework.framework.qual.Covariant;
 
 public class Issue7676 {

--- a/framework/tests/all-systems/Issue7695.java
+++ b/framework/tests/all-systems/Issue7695.java
@@ -1,5 +1,3 @@
-package open.liam;
-
 import java.util.Optional;
 
 public class Issue7695 {

--- a/framework/tests/all-systems/Issue7695.java
+++ b/framework/tests/all-systems/Issue7695.java
@@ -1,0 +1,9 @@
+package open.liam;
+
+import java.util.Optional;
+
+public class Issue7695 {
+  void test(Optional<Object> optional) {
+    Optional<String> x = optional.flatMap((Object unused) -> Optional.of(""));
+  }
+}

--- a/framework/tests/all-systems/Issue7695.java
+++ b/framework/tests/all-systems/Issue7695.java
@@ -1,5 +1,6 @@
 import java.util.Optional;
 
+@SuppressWarnings("optional.parameter") // true positive.
 public class Issue7695 {
   void test(Optional<Object> optional) {
     Optional<String> x = optional.flatMap((Object unused) -> Optional.of(""));

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -1,0 +1,9 @@
+package open.liam;
+
+import java.util.Optional;
+
+public class Issue7699 {
+  <T> Optional<T> run(Optional<Object> optional, T t) {
+    return optional.flatMap(o -> true ? Optional.of(t) : Optional.empty());
+  }
+}

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -2,6 +2,7 @@ import java.util.Optional;
 
 public class Issue7699 {
   <T> Optional<T> run(Optional<Object> optional, T t) {
+    // :: error: [argument]
     return optional.flatMap(o -> true ? Optional.of(t) : Optional.empty());
   }
 }

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -1,5 +1,3 @@
-package open.liam;
-
 import java.util.Optional;
 
 public class Issue7699 {

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -1,8 +1,8 @@
 import java.util.Optional;
 
 public class Issue7699 {
+  @SuppressWarnings("argument") // TODO: This is a false postive.
   <T> Optional<T> run(Optional<Object> optional, T t) {
-    // :: error: [argument]
     return optional.flatMap(o -> true ? Optional.of(t) : Optional.empty());
   }
 }

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -2,7 +2,7 @@ import java.util.Optional;
 
 @SuppressWarnings("optional.parameter") // true positive.
 public class Issue7699 {
-  @SuppressWarnings("argument") // TODO: This is a false postive.
+  @SuppressWarnings("argument") // TODO: This is a false positive.
   <T> Optional<T> run(Optional<Object> optional, T t) {
     return optional.flatMap(o -> true ? Optional.of(t) : Optional.empty());
   }

--- a/framework/tests/all-systems/Issue7699.java
+++ b/framework/tests/all-systems/Issue7699.java
@@ -1,5 +1,6 @@
 import java.util.Optional;
 
+@SuppressWarnings("optional.parameter") // true positive.
 public class Issue7699 {
   @SuppressWarnings("argument") // TODO: This is a false postive.
   <T> Optional<T> run(Optional<Object> optional, T t) {

--- a/framework/tests/h1h2checker/GetClassStubTest.java
+++ b/framework/tests/h1h2checker/GetClassStubTest.java
@@ -12,10 +12,10 @@ public class GetClassStubTest {
     Class<@H1Bot ? extends @H1S1 Object> succeed1 = i.getClass();
     Class<@H1Bot ? extends @H1S1 Integer> succeed2 = i.getClass();
 
-    // :: error: [assignment]
+    // TODO: // :: error: [assignment]
     Class<@H1Bot ? extends @H1Bot Object> fail1 = i.getClass();
 
-    // :: error: [assignment]
+    // TODO: // :: error: [assignment]
     Class<@H1Bot ?> fail2 = i.getClass();
   }
 }

--- a/framework/tests/value/Issue1218.java
+++ b/framework/tests/value/Issue1218.java
@@ -124,9 +124,9 @@ public class Issue1218 {
   void testConstructorCallTypeInferred() {
     // :: error: [varargs]
     new ForEnum<>(MyEnum.A);
-    // :: error: [type.arguments.not.inferred]]
+    // :: error: [type.arguments.not.inferred]
     new ForEnum<>(MyEnum.A, MyEnum.B);
-    // :: error: [type.arguments.not.inferred]]
+    // :: error: [type.arguments.not.inferred]
     new ForEnum<>(MyEnum.A, MyEnum.B, MyEnum.C);
   }
 

--- a/framework/tests/value/Issue1218.java
+++ b/framework/tests/value/Issue1218.java
@@ -70,7 +70,7 @@ public class Issue1218 {
 
   // Inferred enumval types are incompatible with <E extends Enum<E>>. Similar code
   // works if the type is a specific enum; see the test file Enums.java for an example.
-  @SuppressWarnings("type.argument")
+  @SuppressWarnings({"type.argument", "type.arguments.not.inferred"})
   void testMethodCallTypeInferred() {
     // :: error: [varargs]
     enums();
@@ -124,7 +124,9 @@ public class Issue1218 {
   void testConstructorCallTypeInferred() {
     // :: error: [varargs]
     new ForEnum<>(MyEnum.A);
+    // :: error: [type.arguments.not.inferred]]
     new ForEnum<>(MyEnum.A, MyEnum.B);
+    // :: error: [type.arguments.not.inferred]]
     new ForEnum<>(MyEnum.A, MyEnum.B, MyEnum.C);
   }
 


### PR DESCRIPTION
This pull request cause new false positives for classes that use `@Covariant`.  (`Optional` and `Class` are the most used one in the JDK.)
Fixes #7676, Fixes #7695, and  Fixes #7699.