### PR TITLE
Remove check for subnode in AbstractAnalysis.getValue

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/analysis/AbstractAnalysis.java
@@ -199,14 +199,8 @@ public abstract class AbstractAnalysis<
           || (currentTree != null && currentTree == n.getTree())) {
         return null;
       }
-      // check that 'n' is a subnode of 'currentNode'. Check immediate operands
-      // first for efficiency.
       assert !n.isLValue() : "Did not expect an lvalue, but got " + n;
-      if (!currentNode.getOperands().contains(n)
-          && !currentNode.getTransitiveOperands().contains(n)) {
-        return null;
-      }
-      // fall through when the current node is not 'n', and 'n' is not a subnode.
+      // fall through when the current node is not 'n'.
     }
     return nodeValues.get(n);
   }


### PR DESCRIPTION
Fixes #7726 

Removing this check does not impact any regression tests, and I'm not sure why it's needed.  We are overriding this method in NullAway to remove this check, and it works fine there.  