### PR TITLE
Remove special case

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -304,9 +304,6 @@ public final class InferenceType extends AbstractType {
       context.typeFactory.initializeAtm(instantiation);
       mapping.put(alpha.getJavaType(), instantiation);
     }
-    if (map.isEmpty()) {
-      return this;
-    }
 
     AnnotatedTypeMirror newType = typeFactory.getTypeVarSubstitutor().substitute(mapping, type);
     return createIgnoreInstantiated(


### PR DESCRIPTION
Maybe instead of being removed, the test should be against `mapping`?  In any event, please add comments to clarify.