### PR TITLE
Implement `visitX_Primitive` where `visitX_Declared` exists

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -545,6 +545,12 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   }
 
   @Override
+  public Boolean visitArray_Primitive(
+      AnnotatedArrayType subtype, AnnotatedPrimitiveType supertype, Void p) {
+    return isPrimarySubtype(subtype, supertype);
+  }
+
+  @Override
   public Boolean visitArray_Typevar(
       AnnotatedArrayType subtype, AnnotatedTypeVariable supertype, Void p) {
     return visitType_Typevar(subtype, supertype);
@@ -1038,6 +1044,12 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
     // This case happens when checking that the inferred type argument is a subtype of the
     // declared type argument of method.
     // See org.checkerframework.common.basetype.BaseTypeVisitor#checkTypeArguments
+    return visitUnion_Type(subtype, supertype);
+  }
+
+  @Override
+  public Boolean visitUnion_Primitive(
+      AnnotatedUnionType subtype, AnnotatedPrimitiveType supertype, Void p) {
     return visitUnion_Type(subtype, supertype);
   }
 


### PR DESCRIPTION
In hopes of preventing more problems like https://github.com/typetools/checker-framework/issues/7806, this adds more overrides to `DefaultTypeHierarchy.java`.