### PR TITLE
Work around bug with `MethodHandle#invoke`

### DIFF
--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -122,6 +122,10 @@ tasks.register("copyAndMinimizeAnnotatedJdkFiles", JavaExec) {
 sourcesJar.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
 processResources.dependsOn(copyAndMinimizeAnnotatedJdkFiles)
 
+jar {
+  duplicatesStrategy = DuplicatesStrategy.WARN
+}
+
 tasks.register("allSourcesJar", Jar) {
   description = "Creates a sources jar that includes sources for all Checker Framework classes in framework.jar"
   group = "Build"

--- a/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/DefaultTypeHierarchy.java
@@ -862,12 +862,6 @@ public class DefaultTypeHierarchy extends AbstractAtmComboVisitor<Boolean, Void>
   // Primitive as subtype
 
   @Override
-  public Boolean visitPrimitive_Array(
-      AnnotatedPrimitiveType subtype, AnnotatedArrayType supertype, Void p) {
-    return isPrimarySubtype(subtype, supertype);
-  }
-
-  @Override
   public Boolean visitPrimitive_Declared(
       AnnotatedPrimitiveType subtype, AnnotatedDeclaredType supertype, Void p) {
     AnnotatedTypeFactory atypeFactory = subtype.atypeFactory;

--- a/framework/tests/all-systems/Issue6078.java
+++ b/framework/tests/all-systems/Issue6078.java
@@ -6,6 +6,8 @@ public class Issue6078 {
     // The vararg parameter disappears for the below method. It's some sort of bug in javac.
     // It is worked around in TreeUtils.isVarargsCall().
     methodHandle.invoke();
+    methodHandle.invoke(1L);
+
     // The vararg parameter does not disappaer for these method calls.
     methodHandle.invoke("");
     methodHandle.invoke(array);

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1874,7 +1874,7 @@ public final class TreeUtils {
         return (ExecutableType) element.asType();
       }
 
-      if (params.getFirst().getKind() != TypeKind.ARRAY) {
+      if (params.get(params.size() - 1).getKind() != TypeKind.ARRAY) {
         return (ExecutableType) element.asType();
       }
     }

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1861,15 +1861,16 @@ public final class TreeUtils {
 
     ExecutableElement element = elementFromUse(tree);
     if (element.isVarArgs()) {
+      // Sometimes when the method type is viewpoint-adapted, the vararg parameter disappears,
+      // just return the declared type.
+      // For example,
+      // static void call(MethodHandle methodHandle) throws Throwable {
+      //   methodHandle.invoke();
+      // }
+      // See framework/tests/all-systems/Issue6078.java.
       List<? extends TypeMirror> params = executableTypeFromUse.getParameterTypes();
 
       if (params.size() != element.getParameters().size()) {
-        // Sometimes when the method type is viewpoint-adapted, the vararg parameter disappears,
-        // just return the declared type.
-        // For example,
-        // static void call(MethodHandle methodHandle) throws Throwable {
-        //   methodHandle.invoke();
-        // }
         return (ExecutableType) element.asType();
       }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -1851,24 +1851,33 @@ public final class TreeUtils {
    */
   @Pure
   public static ExecutableType typeFromUse(MethodInvocationTree tree) {
-    TypeMirror type = typeOf(tree.getMethodSelect());
-    if (!(type instanceof ExecutableType executableType)) {
+    TypeMirror typeFromUse = typeOf(tree.getMethodSelect());
+    if (!(typeFromUse instanceof ExecutableType executableTypeFromUse)) {
       throw new BugInCF(
           "typeFromUse(MethodInvocationTree): type of method select in method"
               + " invocation should be ExecutableType. Found: %s",
-          type);
+          typeFromUse);
     }
+
     ExecutableElement element = elementFromUse(tree);
-    if (executableType.getParameterTypes().size() != element.getParameters().size()) {
-      // Sometimes when the method type is viewpoint-adapted, the vararg parameter disappears,
-      // just return the declared type.
-      // For example,
-      // static void call(MethodHandle methodHandle) throws Throwable {
-      //   methodHandle.invoke();
-      // }
-      return (ExecutableType) element.asType();
+    if (element.isVarArgs()) {
+      List<? extends TypeMirror> params = executableTypeFromUse.getParameterTypes();
+
+      if (params.size() != element.getParameters().size()) {
+        // Sometimes when the method type is viewpoint-adapted, the vararg parameter disappears,
+        // just return the declared type.
+        // For example,
+        // static void call(MethodHandle methodHandle) throws Throwable {
+        //   methodHandle.invoke();
+        // }
+        return (ExecutableType) element.asType();
+      }
+
+      if (params.getFirst().getKind() != TypeKind.ARRAY) {
+        return (ExecutableType) element.asType();
+      }
     }
-    return executableType;
+    return executableTypeFromUse;
   }
 
   /**
@@ -2453,6 +2462,12 @@ public final class TreeUtils {
     if (numParameters != invok.getArguments().size()) {
       if (numParameters > 0 && parameters.get(numParameters - 1).asType() instanceof ArrayType) {
         return true;
+      }
+    } else if (numParameters == invok.getArguments().size()) {
+      ExecutableElement e = elementFromUse(invok);
+      if (e.isVarArgs() && e.getSimpleName().contentEquals("invoke")) {
+        TypeMirror type = TreeUtils.typeOf(invok.getArguments().get(numParameters - 1));
+        return type.getKind().isPrimitive() || TypesUtils.isBoxedPrimitive(type);
       }
     }
 


### PR DESCRIPTION
This is a correction to the fix in #7806.  Arrays and primitives should not be compared, they were because of a bug in javac where the type of `MethodHandle#invoke` does not have the correct varargs parameter. 

