### PR TITLE
CHANGELOG: -AsuggestPureMethods does not require -AcheckPurityAnnotations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ### User-visible changes
 
+The `-AsuggestPureMethods` command-line option and the `purity.effectively.pure`
+warning no longer require `-AcheckPurityAnnotations` to also be supplied.
+
 ### Implementation details
 
 ### Closed issues


### PR DESCRIPTION
This documents long-standing behavior that was never announced; there is no accompanying code change.