### PR TITLE
JavaExpression: add `containsAsReceiver()` and `superToThis()`

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ArrayAccess.java
@@ -98,6 +98,12 @@ public class ArrayAccess extends JavaExpression {
   }
 
   @Override
+  public boolean containsAsReceiver(AnnotationProvider provider, JavaExpression other) {
+    // The index is not consulted: `a[i]` is reached through `a`, but not through `i`.
+    return syntacticEquals(other) || array.containsAsReceiver(provider, other);
+  }
+
+  @Override
   public boolean containsModifiableAliasOf(Store<?> store, JavaExpression other) {
     if (array.containsModifiableAliasOf(store, other)) {
       return true;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/FieldAccess.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/FieldAccess.java
@@ -131,6 +131,11 @@ public class FieldAccess extends JavaExpression {
   }
 
   @Override
+  public boolean containsAsReceiver(AnnotationProvider provider, JavaExpression other) {
+    return syntacticEquals(other) || receiver.containsAsReceiver(provider, other);
+  }
+
+  @Override
   public boolean containsModifiableAliasOf(Store<?> store, JavaExpression other) {
     return super.containsModifiableAliasOf(store, other)
         || receiver.containsModifiableAliasOf(store, other);

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/JavaExpression.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/JavaExpression.java
@@ -228,9 +228,9 @@ public abstract class JavaExpression {
    * {@code a} as a receiver, but not the converse. Callers must therefore pass the arguments in the
    * intended order, and must not rely on it as an equivalence relation.
    *
-   * <p>A {@link MethodCall} whose method is not side-effect-free contains only itself: {@code
-   * a.m()} may evaluate to an object that has nothing to do with {@code a}, so its result is not
-   * reached through {@code a}.
+   * <p>A {@link MethodCall} whose method is not pure contains only itself: {@code a.m()} may
+   * evaluate to an object that has nothing to do with {@code a}, so its result is not reached
+   * through {@code a}.
    *
    * @param provider how to get annotations
    * @param receiver a JavaExpression that might be the receiver of this

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/JavaExpression.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/JavaExpression.java
@@ -45,6 +45,7 @@ import org.checkerframework.dataflow.cfg.node.UnaryOperationNode;
 import org.checkerframework.dataflow.cfg.node.ValueLiteralNode;
 import org.checkerframework.dataflow.cfg.node.WideningConversionNode;
 import org.checkerframework.dataflow.qual.Pure;
+import org.checkerframework.dataflow.qual.SideEffectFree;
 import org.checkerframework.javacutil.AnnotationProvider;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.ElementUtils;
@@ -217,6 +218,56 @@ public abstract class JavaExpression {
       List<? extends @Nullable JavaExpression> list, JavaExpression other) {
     return list.stream()
         .anyMatch(je -> je != null && je.containsSyntacticEqualJavaExpression(other));
+  }
+
+  /**
+   * Returns true if the given expression is equal to this or equal to the receiver of this,
+   * recursively. For example, {@code a.f.g} contains {@code a.f} and {@code a} as receivers.
+   *
+   * <p>This relation is reflexive and transitive, but <b>not symmetric</b>: {@code a.f} contains
+   * {@code a} as a receiver, but not the converse. Callers must therefore pass the arguments in the
+   * intended order, and must not rely on it as an equivalence relation.
+   *
+   * <p>A {@link MethodCall} whose method is not side-effect-free contains only itself: {@code
+   * a.m()} may evaluate to an object that has nothing to do with {@code a}, so its result is not
+   * reached through {@code a}.
+   *
+   * @param provider how to get annotations
+   * @param receiver a JavaExpression that might be the receiver of this
+   * @return true if the given expression is equal to this or equal to the receiver of this,
+   *     recursively
+   */
+  @Pure
+  public boolean containsAsReceiver(AnnotationProvider provider, JavaExpression receiver) {
+    return syntacticEquals(receiver);
+  }
+
+  /**
+   * Returns the given expression with every use of {@code super} replaced by {@code this}. The two
+   * denote the same object, and a {@link FieldAccess} or {@link MethodCall} stores the element it
+   * refers to, so the result denotes exactly what the argument does.
+   *
+   * <p>This is useful for an expression that was view-adapted to a call site of the form {@code
+   * super.m()}, which yields a {@link SuperReference} even though the caller would write the same
+   * object as {@code this}. Rewriting makes such an expression comparable to expressions written in
+   * the caller, which never mention the callee's {@code super}.
+   *
+   * @param expr an expression
+   * @return the expression, with every use of {@code super} replaced by {@code this}
+   */
+  @SideEffectFree
+  public static JavaExpression superToThis(JavaExpression expr) {
+    if (!expr.containsOfClass(SuperReference.class)) {
+      return expr;
+    }
+    JavaExpressionConverter converter =
+        new JavaExpressionConverter() {
+          @Override
+          protected JavaExpression visitSuperReference(SuperReference superExpr, Void unused) {
+            return new ThisReference(superExpr.getType());
+          }
+        };
+    return converter.convert(expr);
   }
 
   /**

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/MethodCall.java
@@ -157,6 +157,23 @@ public class MethodCall extends JavaExpression {
   }
 
   @Override
+  public boolean containsAsReceiver(AnnotationProvider provider, JavaExpression other) {
+    if (syntacticEquals(other)) {
+      return true;
+    }
+    // A method that is not side-effect-free may create the object it returns, or may fetch it from
+    // state that has nothing to do with the receiver, so its result is not reached through the
+    // receiver.  A side-effect-free method is assumed to return a part of its receiver, such as
+    // the view that `List.subList` returns.  That assumption is unsound for a side-effect-free
+    // method that returns pre-existing state that the receiver does not reach, such as a static
+    // field; no annotation expresses the difference.
+    if (!PurityUtils.isSideEffectFree(provider, method) && !provider.isSideEffectFree(method)) {
+      return false;
+    }
+    return receiver.containsAsReceiver(provider, other);
+  }
+
+  @Override
   public boolean containsModifiableAliasOf(Store<?> store, JavaExpression other) {
     if (receiver.containsModifiableAliasOf(store, other)) {
       return true;

--- a/dataflow/src/main/java/org/checkerframework/dataflow/expression/ThisReference.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/expression/ThisReference.java
@@ -68,6 +68,9 @@ public class ThisReference extends JavaExpression {
     return this.syntacticEquals(other);
   }
 
+  // containsAsReceiver is not overridden: `this` has no receiver, so the inherited
+  // implementation (a syntactic equality test) is already correct.
+
   @Override
   public boolean containsModifiableAliasOf(Store<?> store, JavaExpression other) {
     return false; // 'this' is not modifiable


### PR DESCRIPTION
containsAsReceiver() tests whether one expression is reached through another as a receiver.  superToThis() rewrites every use of `super` as `this`.

Tests will be added in a later commit; this pull request is intentionally small.