### PR TITLE
Make `dot` available in every CI image, and diagnosable when missing

### DIFF
--- a/checker/bin-devel/Dockerfile-contents-ubuntu-base.m4
+++ b/checker/bin-devel/Dockerfile-contents-ubuntu-base.m4
@@ -30,6 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-contents-ubuntu-plus.m4
+++ b/checker/bin-devel/Dockerfile-contents-ubuntu-plus.m4
@@ -5,7 +5,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk17
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk17
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk17-plus
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk17-plus
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -54,7 +55,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk21
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk21
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk21-plus
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk21-plus
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -54,7 +55,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk25
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk25
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk25-plus
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk25-plus
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -54,7 +55,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk26
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk26
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdk26-plus
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdk26-plus
@@ -36,6 +36,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -54,7 +55,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdkbase
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdkbase
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubuntu-jdkplus
+++ b/checker/bin-devel/Dockerfile-ubuntu-jdkplus
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -53,7 +54,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/checker/bin-devel/Dockerfile-ubunturolling-jdkbase
+++ b/checker/bin-devel/Dockerfile-ubunturolling-jdkbase
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \

--- a/checker/bin-devel/Dockerfile-ubunturolling-jdkplus
+++ b/checker/bin-devel/Dockerfile-ubunturolling-jdkplus
@@ -35,6 +35,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   ant \
   cpp \
   git \
+  graphviz \
   jq \
   jtreg7 \
   libcurl3-gnutls \
@@ -53,7 +54,6 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   autoconf \
   devscripts \
   dia \
-  graphviz \
   hevea \
   imagemagick \
   junit \

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/visualize/CFGVisualizeLauncher.java
@@ -5,11 +5,13 @@ import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.util.Context;
 import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.util.Options;
+import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import javax.tools.JavaFileManager;
@@ -328,12 +330,23 @@ public final class CFGVisualizeLauncher {
   private static void producePDF(String file) {
     try {
       ProcessBuilder pb = new ProcessBuilder("dot", "-Tpdf", file, "-o", file + ".pdf");
+      // Without this, `dot` blocks forever if it writes more output than fits in a pipe buffer.
+      pb.inheritIO();
       Process child = pb.start();
       int exitCode = child.waitFor();
       if (exitCode != 0) {
         System.err.println("dot exited with status " + exitCode);
       }
     } catch (InterruptedException | IOException e) {
+      String msg = e.getMessage();
+      // JDK 21+ words this as "Exec failed, error: 2 (No such file or directory)", earlier JDKs as
+      // "error=2, No such file or directory".
+      if (msg != null && msg.contains("No such file or directory")) {
+        System.err.printf("Cannot find `dot` program.%n");
+        System.err.printf("PATH=%s%n", System.getenv("PATH"));
+        System.err.printf(
+            "Contents of /usr/bin/: %s%n", Arrays.toString(new File("/usr/bin/").listFiles()));
+      }
       e.printStackTrace();
       System.exit(1);
     }


### PR DESCRIPTION
Move graphviz from the "-plus" images to the base image, so that CFG visualization works everywhere.  In CFGVisualizeLauncher, inherit the child process's I/O so that `dot` does not block on a full pipe buffer, and report what went wrong when `dot` cannot be found.