### PR TITLE
Lock Checker: document why `@SideEffectsOnly` is not a SideEffectAnnotation

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/lock/LockAnnotatedTypeFactory.java
@@ -416,6 +416,9 @@ public class LockAnnotatedTypeFactory
     RELEASESNOLOCKS("@ReleasesNoLocks", ReleasesNoLocks.class),
     /** The method does not acquire or release any locks. */
     LOCKINGFREE("@LockingFree", LockingFree.class),
+    // `@SideEffectsOnly` is intentionally absent from this enum.  It constrains which expressions
+    // a method modifies, but it promises nothing about acquiring or releasing locks, so a
+    // `@SideEffectsOnly` method gets the same locking guarantee as an unannotated one.
     /** The method has no side effects. */
     SIDEEFFECTFREE("@SideEffectFree", SideEffectFree.class),
     /** The method has no side effects and is deterministic. */

--- a/checker/tests/lock/SideEffectsOnlyLock.java
+++ b/checker/tests/lock/SideEffectsOnlyLock.java
@@ -1,0 +1,22 @@
+// The Lock Checker ignores `@SideEffectsOnly`, which constrains which expressions a method
+// modifies but promises nothing about acquiring or releasing locks.  A `@SideEffectsOnly` method
+// therefore gets the same locking guarantee as an unannotated one, `@ReleasesNoLocks`.
+
+import org.checkerframework.dataflow.qual.SideEffectsOnly;
+
+public class SideEffectsOnlyLock {
+
+  Object field;
+
+  void unannotated() {}
+
+  @SideEffectsOnly("this")
+  void callsUnannotatedMethod() {
+    unannotated();
+  }
+
+  @SideEffectsOnly("this")
+  synchronized void synchronizedMethod() {
+    field = null;
+  }
+}


### PR DESCRIPTION
`@SideEffectsOnly` constrains which expressions a method modifies, but it promises nothing about acquiring or releasing locks, so a `@SideEffectsOnly` method gets the same locking guarantee as an unannotated one.