### PR TITLE
Type inference: consider `ignoreAnnotations` in `equals` and `hashCode`

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -868,14 +868,20 @@ public class InferenceFactory {
         if (properType.ignoreAnnotations == ignoreAnnotations) {
           lubATM = AnnotatedTypes.leastUpperBound(typeFactory, lubATM, atm, lubTM);
         } else if (properType.ignoreAnnotations) {
+          // Only `lubATM`'s annotations are meaningful, so keep them.
           lubATM =
               AnnotatedTypes.asSuper(
                   typeFactory, lubATM, AnnotatedTypeMirror.createType(lubTM, typeFactory, false));
         } else {
+          // Only `atm`'s annotations are meaningful, so keep them.
           lubATM =
               AnnotatedTypes.asSuper(
                   typeFactory, atm, AnnotatedTypeMirror.createType(lubTM, typeFactory, false));
         }
+        // The annotations of a type that ignores annotations put no constraint on the result, so
+        // the result ignores annotations only if every type does.  This is the same rule as in
+        // `glb`.
+        ignoreAnnotations = ignoreAnnotations && properType.ignoreAnnotations;
       }
     }
     return new ProperType(lubATM, context, ignoreAnnotations);

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -208,10 +208,10 @@ public final class InferenceType extends AbstractType {
     }
 
     InferenceType variable = (InferenceType) o;
-    if (map != variable.map) {
+    if (!sameInferenceProblem(variable)) {
       return false;
     }
-    if (!type.equals(variable.type)) {
+    if (map != variable.map) {
       return false;
     }
     return type.equals(variable.type);
@@ -219,7 +219,8 @@ public final class InferenceType extends AbstractType {
 
   @Override
   public int hashCode() {
-    int result = type.hashCode();
+    int result = inferenceProblemHashCode();
+    result = 31 * result + type.hashCode();
     result = 31 * result + Kind.INFERENCE_TYPE.hashCode();
     return result;
   }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -214,12 +214,17 @@ public final class InferenceType extends AbstractType {
     if (map != variable.map) {
       return false;
     }
+    // Two types with different qualifierVars have different qualifiers, as getQualifiers() shows.
+    if (!qualifierVars.equals(variable.qualifierVars)) {
+      return false;
+    }
     return type.equals(variable.type);
   }
 
   @Override
   public int hashCode() {
     int result = inferenceProblemHashCode();
+    result = 31 * result + qualifierVars.hashCode();
     result = 31 * result + type.hashCode();
     result = 31 * result + Kind.INFERENCE_TYPE.hashCode();
     return result;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -210,6 +210,14 @@ public final class InferenceType extends AbstractType {
     }
 
     InferenceType that = (InferenceType) o;
+    if (!sameInferenceProblem(that)) {
+      return false;
+    }
+    // Two types with different qualifierVars have different qualifiers, as getQualifiers() shows.
+    if (!qualifierVars.equals(that.qualifierVars)) {
+      return false;
+    }
+
     return map == that.map && type.equals(that.type);
   }
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -214,11 +214,7 @@ public final class InferenceType extends AbstractType {
 
   @Override
   public int hashCode() {
-    int result = inferenceProblemHashCode();
-    result = 31 * result + qualifierVars.hashCode();
-    result = 31 * result + type.hashCode();
-    result = 31 * result + Kind.INFERENCE_TYPE.hashCode();
-    return result;
+    return Objects.hash(inferenceProblemHashCode(), qualifierVars, type, Kind.INFERENCE_TYPE);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
@@ -209,6 +209,10 @@ public class ProperType extends AbstractType {
     if (!sameInferenceProblem(that)) {
       return false;
     }
+    // Two types with different qualifierVars have different qualifiers, as getQualifiers() shows.
+    if (!qualifierVars.equals(that.qualifierVars)) {
+      return false;
+    }
 
     // Comparing the annotated types also compares the Java types: AnnotatedTypeMirror#equals
     // requires the underlying types to be the same object, and the Java type of a proper type is
@@ -218,7 +222,7 @@ public class ProperType extends AbstractType {
 
   @Override
   public int hashCode() {
-    return Objects.hash(inferenceProblemHashCode(), type, Kind.PROPER);
+    return Objects.hash(inferenceProblemHashCode(), qualifierVars, type, Kind.PROPER);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/ProperType.java
@@ -205,15 +205,20 @@ public class ProperType extends AbstractType {
       return false;
     }
 
+    ProperType that = (ProperType) o;
+    if (!sameInferenceProblem(that)) {
+      return false;
+    }
+
     // Comparing the annotated types also compares the Java types: AnnotatedTypeMirror#equals
     // requires the underlying types to be the same object, and the Java type of a proper type is
     // the underlying type of its annotated type.
-    return type.equals(((ProperType) o).type);
+    return type.equals(that.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, Kind.PROPER);
+    return Objects.hash(inferenceProblemHashCode(), type, Kind.PROPER);
   }
 
   @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
@@ -241,12 +241,17 @@ public class UseOfVariable extends AbstractType {
     if (!tops.equals(that.tops)) {
       return false;
     }
+    // Two types with different qualifierVars have different qualifiers, as getQualifiers() shows.
+    if (!qualifierVars.equals(that.qualifierVars)) {
+      return false;
+    }
 
     return type.equals(that.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(inferenceProblemHashCode(), variable, hasPrimaryAnno, bots, tops, type);
+    return Objects.hash(
+        inferenceProblemHashCode(), variable, hasPrimaryAnno, bots, tops, qualifierVars, type);
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
@@ -19,6 +19,7 @@ import org.checkerframework.framework.util.typeinference8.constraint.Typing;
 import org.checkerframework.framework.util.typeinference8.util.Java8InferenceContext;
 import org.checkerframework.javacutil.BugInCF;
 import org.checkerframework.javacutil.TypesUtils;
+import org.plumelib.util.CollectionsP;
 import org.plumelib.util.IPair;
 
 /** Data structure that stores the bounds of a variable. */

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
@@ -677,11 +677,7 @@ public class VariableBounds {
   private static List<AnnotatedTypeMirror> annotatedTypeArguments(AbstractType type) {
     List<AbstractType> typeArgs = type.getTypeArguments();
     assert typeArgs != null : "@AssumeAssertion(nullness): the caller passes a declared type";
-    List<AnnotatedTypeMirror> result = new ArrayList<>(typeArgs.size());
-    for (AbstractType typeArg : typeArgs) {
-      result.add(typeArg.getAnnotatedType());
-    }
-    return result;
+    return CollectionsP.mapList(AbstractType::getAnnotatedType, typeArgs);
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/VariableBounds.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.typeinference8.constraint.Constraint;
 import org.checkerframework.framework.util.typeinference8.constraint.Constraint.Kind;
 import org.checkerframework.framework.util.typeinference8.constraint.ConstraintSet;
@@ -642,15 +643,35 @@ public class VariableBounds {
         if (supers == null) {
           continue;
         }
-        List<AbstractType> s1TypeArgs = supers.first.getTypeArguments();
-        List<AbstractType> s2TypeArgs = supers.second.getTypeArguments();
-        if (!s1TypeArgs.equals(s2TypeArgs)) {
+        if (!annotatedTypeArguments(supers.first).equals(annotatedTypeArguments(supers.second))) {
           return true;
         }
       }
     }
 
     return false;
+  }
+
+  /**
+   * Returns the annotated types of the type arguments of {@code type}.
+   *
+   * <p>This is a helper method for {@link #hasLowerBoundDifferentParam}. It compares the annotated
+   * types rather than the {@link AbstractType}s because {@link AbstractType#equals} also compares
+   * {@code ignoreAnnotations}, which is a property of a bound rather than of a parameterization:
+   * two bounds that differ only in whether their annotations are ignored are the same
+   * parameterization.
+   *
+   * @param type a declared type
+   * @return the annotated types of the type arguments of {@code type}
+   */
+  private static List<AnnotatedTypeMirror> annotatedTypeArguments(AbstractType type) {
+    List<AbstractType> typeArgs = type.getTypeArguments();
+    assert typeArgs != null : "@AssumeAssertion(nullness): the caller passes a declared type";
+    List<AnnotatedTypeMirror> result = new ArrayList<>(typeArgs.size());
+    for (AbstractType typeArg : typeArgs) {
+      result.add(typeArg.getAnnotatedType());
+    }
+    return result;
   }
 
   /**

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/lubglb/LubGlbChecker.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/lubglb/LubGlbChecker.java
@@ -18,14 +18,20 @@ import org.checkerframework.framework.testchecker.lubglb.quals.LubglbE;
 import org.checkerframework.framework.testchecker.lubglb.quals.LubglbF;
 import org.checkerframework.framework.testchecker.lubglb.quals.PolyLubglb;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.util.typeinference8.InvocationTypeInference;
 import org.checkerframework.framework.util.typeinference8.constraint.Constraint.Kind;
 import org.checkerframework.framework.util.typeinference8.constraint.ConstraintSet;
 import org.checkerframework.framework.util.typeinference8.constraint.QualifierTyping;
 import org.checkerframework.framework.util.typeinference8.types.AbstractQualifier;
+import org.checkerframework.framework.util.typeinference8.types.AbstractType;
+import org.checkerframework.framework.util.typeinference8.types.InferenceFactory;
+import org.checkerframework.framework.util.typeinference8.types.ProperType;
 import org.checkerframework.framework.util.typeinference8.types.Qualifier;
 import org.checkerframework.framework.util.typeinference8.types.QualifierVar;
+import org.checkerframework.framework.util.typeinference8.types.VariableBounds;
+import org.checkerframework.framework.util.typeinference8.types.VariableBounds.BoundKind;
 import org.checkerframework.framework.util.typeinference8.util.Java8InferenceContext;
 import org.checkerframework.javacutil.AnnotationBuilder;
 import org.checkerframework.javacutil.AnnotationMirrorMap;
@@ -50,6 +56,9 @@ public class LubGlbChecker extends BaseTypeChecker {
 
   /** True if {@link #runConstraintEqualityTests} has already run. It only needs to run once. */
   private boolean ranConstraintEqualityTests = false;
+
+  /** True if {@link #runAbstractTypeTests} has already run. It only needs to run once. */
+  private boolean ranAbstractTypeTests = false;
 
   @Override
   public void initChecker() {
@@ -91,6 +100,10 @@ public class LubGlbChecker extends BaseTypeChecker {
     if (!ranConstraintEqualityTests && path != null) {
       ranConstraintEqualityTests = true;
       runConstraintEqualityTests(path);
+    }
+    if (!ranAbstractTypeTests && path != null) {
+      ranAbstractTypeTests = true;
+      runAbstractTypeTests(path);
     }
     super.typeProcess(element, path);
   }
@@ -263,6 +276,112 @@ public class LubGlbChecker extends BaseTypeChecker {
     if (!condition) {
       throw new AssertionError(message);
     }
+  }
+
+  /**
+   * Tests how {@link AbstractType} treats the two of its properties that are not part of its
+   * annotated type: {@code ignoreAnnotations} and {@code qualifierVars}. Two types that differ in
+   * either one are not interchangeable, so they are not {@code equals} and a set of bounds retains
+   * both. Then tests that the operations that consume such a set of bounds -- {@link
+   * InferenceFactory#lub} and {@link VariableBounds#hasLowerBoundDifferentParam} -- handle a set
+   * that holds both. Throws an {@code AssertionError} if a test fails.
+   *
+   * <p>Like the other tests in this class, these tests need a {@link Java8InferenceContext}, which
+   * needs a {@code TreePath}, so they cannot be ordinary JUnit tests.
+   *
+   * @param path a path to the class currently being processed; any path will do
+   */
+  private void runAbstractTypeTests(TreePath path) {
+    AnnotatedTypeFactory factory = ((BaseTypeVisitor<?>) visitor).getTypeFactory();
+    Java8InferenceContext context =
+        new Java8InferenceContext(factory, path, new InvocationTypeInference(factory, path));
+    AnnotatedTypeMirror object = context.object.getAnnotatedType();
+
+    // Two proper types that differ only in `ignoreAnnotations` are not equal, because
+    // `checkAnnotationSubtype` returns TRUE without comparing qualifiers when either type sets it.
+    ProperType compared = new ProperType(object, context, false);
+    ProperType ignored = new ProperType(object, context, true);
+    check(!compared.equals(ignored), "types that differ in ignoreAnnotations are equal");
+    check(!ignored.equals(compared), "AbstractType.equals is not symmetric");
+    ProperType compared2 = new ProperType(object, context, false);
+    check(compared.equals(compared2), "types that differ in nothing are not equal");
+    check(compared.hashCode() == compared2.hashCode(), "equal types have different hash codes");
+
+    // Two proper types that differ only in `qualifierVars` are not equal, because they have
+    // different qualifiers, as `getQualifiers()` shows.
+    ExpressionTree invocation = new TreeParser(processingEnv).parseTree("dummy()");
+    AnnotationMirrorMap<QualifierVar> qualifierVars1 = new AnnotationMirrorMap<>();
+    qualifierVars1.put(POLY, new QualifierVar(invocation, POLY, context));
+    AnnotationMirrorMap<QualifierVar> qualifierVars2 = new AnnotationMirrorMap<>();
+    qualifierVars2.put(POLY, new QualifierVar(invocation, POLY, context));
+    ProperType withVar1 = new ProperType(object, qualifierVars1, context, false);
+    ProperType withVar2 = new ProperType(object, qualifierVars2, context, false);
+    check(!withVar1.equals(withVar2), "types with different qualifier variables are equal");
+    check(!withVar1.equals(compared), "a type with a qualifier variable equals one without");
+    check(!compared.equals(withVar1), "a type without a qualifier variable equals one with");
+    ProperType withVar1Again = new ProperType(object, qualifierVars1, context, false);
+    check(withVar1.equals(withVar1Again), "types with the same qualifier variable are not equal");
+    check(
+        withVar1.hashCode() == withVar1Again.hashCode(),
+        "equal types with qualifier variables have different hash codes");
+
+    Set<AbstractType> types = new LinkedHashSet<>();
+    types.add(compared);
+    types.add(ignored);
+    types.add(withVar1);
+    types.add(withVar2);
+    check(types.size() == 4, "a set of four unequal types is " + types);
+
+    // The least upper bound of a set of proper types ignores annotations only if every type in the
+    // set does; otherwise, the annotations of the types that do not ignore them are meaningful.
+    // The result must not depend on the iteration order of the set.
+    check(
+        !lubIgnoresAnnotations(context, ignored, compared),
+        "lub of a mixed set whose first element ignores annotations ignores annotations");
+    check(
+        !lubIgnoresAnnotations(context, compared, ignored),
+        "lub of a mixed set whose second element ignores annotations ignores annotations");
+    check(!lubIgnoresAnnotations(context, compared, withVar1), "lub of compared types ignores");
+    ProperType ignored2 = new ProperType(object, qualifierVars1, context, true);
+    check(
+        lubIgnoresAnnotations(context, ignored, ignored2),
+        "lub of types that both ignore annotations does not ignore");
+
+    // Two lower bounds that differ only in `ignoreAnnotations` are the same parameterization.
+    AnnotatedTypeMirror list =
+        factory.getAnnotatedType(processingEnv.getElementUtils().getTypeElement("java.util.List"));
+    ProperType comparedList = new ProperType(list.asUse(), context, false);
+    ProperType ignoredList = new ProperType(list.asUse(), context, true);
+    check(comparedList.isParameterizedType(), "java.util.List is not a parameterized type");
+    // `hasLowerBoundDifferentParam` reads only the bounds and the context, so the variable whose
+    // bounds these are does not matter.
+    VariableBounds bounds = new VariableBounds(null, context);
+    Set<AbstractType> lowerBounds = bounds.bounds.get(BoundKind.LOWER);
+    lowerBounds.add(comparedList);
+    lowerBounds.add(ignoredList);
+    check(lowerBounds.size() == 2, "a set of two unequal lower bounds is " + lowerBounds);
+    check(
+        !bounds.hasLowerBoundDifferentParam(),
+        "two lower bounds that differ only in ignoreAnnotations are different parameterizations");
+  }
+
+  /**
+   * Returns the {@code ignoreAnnotations} field of the least upper bound of the two given types.
+   *
+   * @param context the inference context
+   * @param first the first type to lub; it is first in the set's iteration order
+   * @param second the second type to lub
+   * @return true if the least upper bound of the two types ignores annotations
+   */
+  private boolean lubIgnoresAnnotations(
+      Java8InferenceContext context, ProperType first, ProperType second) {
+    Set<ProperType> properTypes = new LinkedHashSet<>();
+    properTypes.add(first);
+    properTypes.add(second);
+    check(properTypes.size() == 2, "the two types to lub are equal: " + properTypes);
+    ProperType lub = context.inferenceTypeFactory.lub(properTypes);
+    check(lub != null, "lub of a nonempty set is null");
+    return lub.ignoreAnnotations;
   }
 
   /**


### PR DESCRIPTION
`ProperType.equals` compared only the annotated type, and `InferenceType.equals` compared only the map and the annotated type.  Neither considered `ignoreAnnotations`, even though it changes behavior: `checkAnnotationSubtype` returns TRUE without comparing qualifiers when either type sets it.  Two such types are therefore not interchangeable, and treating them as equal caused one of them to be discarded when both were added to a set of bounds -- as `UseOfVariable.addBound` does for a use with a primary annotation.

Both methods now use `sameInferenceProblem` and `inferenceProblemHashCode`, as `UseOfVariable` does and as the contract in `AbstractType` suggests.