### PR TITLE
InferenceType.equals: remove duplicated comparison

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -207,14 +207,8 @@ public final class InferenceType extends AbstractType {
       return false;
     }
 
-    InferenceType variable = (InferenceType) o;
-    if (map != variable.map) {
-      return false;
-    }
-    if (!type.equals(variable.type)) {
-      return false;
-    }
-    return type.equals(variable.type);
+    InferenceType that = (InferenceType) o;
+    return map == that.map && type.equals(that.type);
   }
 
   @Override


### PR DESCRIPTION
The second comparison of `type` was always true.