### PR TITLE
AbstractType.getWildcardUpperBound: remove dead computation

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
@@ -595,16 +595,14 @@ public abstract class AbstractType {
   }
 
   /**
-   * Returns if this type is a wildcard return its upper bound; otherwise, return null.
+   * Returns if this type is a wildcard return its upper bound; otherwise, return null. If the
+   * wildcard has no explicit upper bound, the returned type is the upper bound of the type variable
+   * to which the wildcard is bound; see {@link AnnotatedWildcardType#getExtendsBound()}.
    *
    * @return if this type is a wildcard return its upper bound; otherwise, return null
    */
   public @Nullable AbstractType getWildcardUpperBound() {
     if (getJavaType().getKind() == TypeKind.WILDCARD) {
-      TypeMirror upperBoundJava = ((WildcardType) getJavaType()).getExtendsBound();
-      if (upperBoundJava == null) {
-        upperBoundJava = context.object.getJavaType();
-      }
       return create(
           ((AnnotatedWildcardType) getAnnotatedType()).getExtendsBound(), ignoreAnnotations);
     } else {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
@@ -582,9 +582,9 @@ public abstract class AbstractType {
   }
 
   /**
-   * Returns if this type is a wildcard return its lower bound; otherwise, return null.
+   * If this type is a wildcard, returns its lower bound; otherwise, returns null.
    *
-   * @return if this type is a wildcard return its lower bound; otherwise, return null
+   * @return the lower bound of this wildcard type, or null if this type is not a wildcard
    */
   public @Nullable AbstractType getWildcardLowerBound() {
     if (getJavaType().getKind() == TypeKind.WILDCARD) {
@@ -595,11 +595,11 @@ public abstract class AbstractType {
   }
 
   /**
-   * If this type is a wildcard, return its upper bound; otherwise, return null. If the wildcard has
-   * no explicit upper bound, the returned type is the upper bound of the type variable to which the
-   * wildcard is bound; see {@link AnnotatedWildcardType#getExtendsBound()}.
+   * If this type is a wildcard, returns its upper bound; otherwise, returns null. If the wildcard
+   * has no explicit upper bound, the returned type is the upper bound of the type variable to which
+   * the wildcard is bound; see {@link AnnotatedWildcardType#getExtendsBound()}.
    *
-   * @return if this type is a wildcard return its upper bound; otherwise, return null
+   * @return the upper bound of this wildcard type, or null if this type is not a wildcard
    */
   public @Nullable AbstractType getWildcardUpperBound() {
     if (getJavaType().getKind() == TypeKind.WILDCARD) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
@@ -595,9 +595,9 @@ public abstract class AbstractType {
   }
 
   /**
-   * Returns if this type is a wildcard return its upper bound; otherwise, return null. If the
-   * wildcard has no explicit upper bound, the returned type is the upper bound of the type variable
-   * to which the wildcard is bound; see {@link AnnotatedWildcardType#getExtendsBound()}.
+   * If this type is a wildcard, return its upper bound; otherwise, return null. If the wildcard has
+   * no explicit upper bound, the returned type is the upper bound of the type variable to which the
+   * wildcard is bound; see {@link AnnotatedWildcardType#getExtendsBound()}.
    *
    * @return if this type is a wildcard return its upper bound; otherwise, return null
    */


### PR DESCRIPTION
The local variable held the wildcard's Java extends bound, with a fallback to Object when that bound is null, but it was never used: the returned type is built from the annotated extends bound, which is never null and which supplies the bound of the corresponding type variable when the wildcard declares no explicit upper bound.