### PR TITLE
Type inference: a nested construct's exceptions are not the lambda's

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
@@ -1,6 +1,7 @@
 package org.checkerframework.framework.util.typeinference8.util;
 
 import com.sun.source.tree.CatchTree;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.LambdaExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.NewClassTree;
@@ -50,13 +51,17 @@ public final class CheckedExceptionsUtil {
    */
   public static List<ThrownCheckedException> thrownCheckedExceptions(
       LambdaExpressionTree lambda, Java8InferenceContext context) {
-    return nullToEmptyList(new CheckedExceptionVisitor(context).scan(lambda, null));
+    // Scan the body rather than the lambda itself, because the visitor stops at a nested lambda.
+    return nullToEmptyList(new CheckedExceptionVisitor(context).scan(lambda.getBody(), null));
   }
 
   /**
-   * Helper class for gathering the types of checked exceptions in a lambda. See <a
+   * Helper class for gathering the types of checked exceptions that a lambda body can throw. See <a
    * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-11.html#jls-11.2.2">JLS section
-   * 11.2.2</a>.
+   * 11.2.2</a>. Apply this visitor to the body of the lambda, not to the lambda itself.
+   *
+   * <p>The visitor does not descend into a nested lambda or class body, because an exception thrown
+   * there is attributed to that construct rather than to the lambda being scanned.
    */
   private static final class CheckedExceptionVisitor
       extends TreeScanner<@Nullable List<ThrownCheckedException>, Void> {
@@ -84,6 +89,35 @@ public final class CheckedExceptionsUtil {
       }
       r1.addAll(r2);
       return r1;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>An exception thrown by the body of a nested lambda is attributed to the nested lambda, so
+     * this method returns null without scanning the nested lambda.
+     */
+    @Override
+    public @Nullable List<ThrownCheckedException> visitLambdaExpression(
+        LambdaExpressionTree node, Void aVoid) {
+      return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>An exception thrown within a class body is attributed to the method, constructor, or
+     * initializer that throws it, so this method returns null without scanning the class body.
+     *
+     * <p>JLS 11.2.1 does attribute to a class instance creation expression the exceptions that the
+     * instance initializers of its anonymous class body throw. That does not matter here, because
+     * javac's inference does not do so either: javac rejects a lambda whose only checked exception
+     * comes from the instance initializer of an anonymous class, unless the type argument is given
+     * explicitly.
+     */
+    @Override
+    public @Nullable List<ThrownCheckedException> visitClass(ClassTree node, Void aVoid) {
+      return null;
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/CheckedExceptionsUtil.java
@@ -58,10 +58,11 @@ public final class CheckedExceptionsUtil {
   /**
    * Helper class for gathering the types of checked exceptions that a lambda body can throw. See <a
    * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-11.html#jls-11.2.2">JLS section
-   * 11.2.2</a>. Apply this visitor to the body of the lambda, not to the lambda itself.
+   * 11.2.2</a>.
    *
-   * <p>The visitor does not descend into a nested lambda or class body, because an exception thrown
-   * there is attributed to that construct rather than to the lambda being scanned.
+   * <p>Apply this visitor to the body of the lambda, not to the lambda itself. The visitor does not
+   * descend into a nested lambda or class body, because an exception thrown there is attributed to
+   * that construct rather than to the lambda being scanned.
    */
   private static final class CheckedExceptionVisitor
       extends TreeScanner<@Nullable List<ThrownCheckedException>, Void> {

--- a/framework/tests/all-systems/java8inference/LambdaNestedConstructs.java
+++ b/framework/tests/all-systems/java8inference/LambdaNestedConstructs.java
@@ -30,7 +30,10 @@ public class LambdaNestedConstructs {
     void run() throws IOException;
   }
 
-  /** The {@code throws E} makes inference generate a checked-exception constraint for a lambda. */
+  /**
+   * The {@code throws E} on {@code UncheckedRunnable.run()} makes inference generate a
+   * checked-exception constraint for a lambda.
+   */
   static <E extends RuntimeException> void runUnchecked(UncheckedRunnable<E> r) {}
 
   /** The {@code throws E} makes inference generate a checked-exception constraint for a lambda. */

--- a/framework/tests/all-systems/java8inference/LambdaNestedConstructs.java
+++ b/framework/tests/all-systems/java8inference/LambdaNestedConstructs.java
@@ -1,0 +1,112 @@
+// Test case for the JLS 11.2.2 checked-exception constraints that are generated for a lambda whose
+// body contains a nested lambda, an anonymous class, or a local class.  An exception thrown in the
+// body of a nested lambda, or in a method of a nested class, is attributed to that construct rather
+// than to the enclosing lambda.
+//
+// In the methods that call `runUnchecked`, the inference variable's declared upper bound is
+// RuntimeException.  Attributing a checked exception thrown by a nested construct to the lambda
+// gives the inference variable the lower bound IOException, which is inconsistent with that upper
+// bound; that is reported as a "type.argument.inference.crashed" error.
+//
+// The methods that call `runChecked` show the exceptions that are attributed to the lambda: the
+// inference variable's upper bound is Exception, and inference succeeds with IOException.
+
+import java.io.IOException;
+
+public class LambdaNestedConstructs {
+
+  @FunctionalInterface
+  interface UncheckedRunnable<E extends RuntimeException> {
+    void run() throws E;
+  }
+
+  @FunctionalInterface
+  interface ThrowingRunnable<E extends Exception> {
+    void run() throws E;
+  }
+
+  @FunctionalInterface
+  interface IoOperation {
+    void run() throws IOException;
+  }
+
+  /** The {@code throws E} makes inference generate a checked-exception constraint for a lambda. */
+  static <E extends RuntimeException> void runUnchecked(UncheckedRunnable<E> r) {}
+
+  /** The {@code throws E} makes inference generate a checked-exception constraint for a lambda. */
+  static <E extends Exception> void runChecked(ThrowingRunnable<E> r) throws E {}
+
+  static void readIt() throws IOException {
+    throw new IOException();
+  }
+
+  /**
+   * Returns a string.
+   *
+   * @return a string
+   * @throws IOException always
+   */
+  static String readItAndReturn() throws IOException {
+    throw new IOException();
+  }
+
+  /** The nested lambda's body throws IOException, but the outer lambda's body does not. */
+  static void nestedLambda() {
+    runUnchecked(
+        () -> {
+          IoOperation nested = () -> readIt();
+        });
+  }
+
+  /** The nested lambda's body throws IOException by a class instance creation expression. */
+  static void nestedLambdaNewClass() {
+    runUnchecked(
+        () -> {
+          IoOperation nested = () -> new StringBuilder(readItAndReturn());
+        });
+  }
+
+  /** A method of the anonymous class throws IOException, but the outer lambda's body does not. */
+  static void anonymousClassMethod() {
+    runUnchecked(
+        () -> {
+          IoOperation nested =
+              new IoOperation() {
+                @Override
+                public void run() throws IOException {
+                  readIt();
+                }
+              };
+        });
+  }
+
+  /** A method of the local class throws IOException, but the outer lambda's body does not. */
+  static void localClassMethod() {
+    runUnchecked(
+        () -> {
+          class Local {
+            void m() throws IOException {
+              readIt();
+            }
+          }
+        });
+  }
+
+  /**
+   * An argument to a class instance creation expression in the lambda's body throws IOException.
+   */
+  static void newClassArgument() throws IOException {
+    runChecked(
+        () -> {
+          Object o = new StringBuilder(readItAndReturn());
+        });
+  }
+
+  /** A method invocation in the lambda's body throws IOException. */
+  static void methodInvocation() throws IOException {
+    runChecked(
+        () -> {
+          readIt();
+        });
+  }
+}


### PR DESCRIPTION
`CheckedExceptionVisitor` descended into a nested lambda body, an anonymous class body, and a local class declaration.  JLS 11.2.2 attributes an exception thrown there to that construct, not to the enclosing lambda.  Attributing it to the lambda gives the inference variable in the function type's throws clause a spurious lower bound, which can make inference fail on code that javac accepts.