### PR TITLE
Type inference: add missing `@Nullable` on parameters that may be null

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
@@ -104,28 +104,31 @@ public abstract class AbstractExecutableType {
   /**
    * Returns the return type of this.
    *
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @return the return type
    */
-  public abstract AbstractType getReturnType(Theta map);
+  public abstract AbstractType getReturnType(@Nullable Theta map);
 
   /**
    * Returns a list of the parameter types of {@code AbstractExecutableType} where the vararg
    * parameter has been replaced by individual parameters so the result has length {@code size}.
    *
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @param size the number of parameters to return; used to expand the vararg
    * @return a list of the parameter types of {@code AbstractExecutableType}, of length {@code size}
    */
-  public abstract List<AbstractType> getParameterTypes(Theta map, int size);
+  public abstract List<AbstractType> getParameterTypes(@Nullable Theta map, int size);
 
   /**
    * Returns the parameter types of this. (Varags are not expanded.)
    *
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @return the parameter types
    */
-  public List<AbstractType> getParameterTypes(Theta map) {
+  public List<AbstractType> getParameterTypes(@Nullable Theta map) {
     return getParameterTypes(map, annotatedExecutableType.getParameterTypes().size());
   }
 
@@ -135,7 +138,8 @@ public abstract class AbstractExecutableType {
    *
    * <p>This is a helper method for {@link #getParameterTypes(Theta, int)}.
    *
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @param size the number of parameters to return; used to expand the vararg
    * @param firstParam an extra first parameter to add at the beginning of the returned list, or
    *     null
@@ -144,7 +148,10 @@ public abstract class AbstractExecutableType {
    *     size}
    */
   protected final List<AbstractType> getParameterTypes(
-      Theta map, int size, @Nullable AnnotatedTypeMirror firstParam, boolean isVarargsCall) {
+      @Nullable Theta map,
+      int size,
+      @Nullable AnnotatedTypeMirror firstParam,
+      boolean isVarargsCall) {
     List<AnnotatedTypeMirror> params = new ArrayList<>(size);
     List<TypeMirror> paramsJava = new ArrayList<>(size);
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractInvocationType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractInvocationType.java
@@ -6,6 +6,7 @@ import com.sun.source.tree.NewClassTree;
 import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.ExecutableType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.typeinference8.util.Java8InferenceContext;
@@ -43,11 +44,12 @@ public class AbstractInvocationType extends AbstractExecutableType {
   /**
    * Returns the return type of this.
    *
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @return the return type of this
    */
   @Override
-  public AbstractType getReturnType(Theta map) {
+  public AbstractType getReturnType(@Nullable Theta map) {
     AnnotatedTypeMirror annotatedReturnType;
 
     if (TreeUtils.isDiamondTree(invocation)) {
@@ -67,7 +69,7 @@ public class AbstractInvocationType extends AbstractExecutableType {
   }
 
   @Override
-  public List<AbstractType> getParameterTypes(Theta map, int size) {
+  public List<AbstractType> getParameterTypes(@Nullable Theta map, int size) {
     return getParameterTypes(map, size, null, TreeUtils.isVarargsCall(invocation));
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CompileTimeDeclarationType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CompileTimeDeclarationType.java
@@ -4,6 +4,7 @@ import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberReferenceTree.ReferenceMode;
 import java.util.List;
 import javax.lang.model.type.ExecutableType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.typeinference8.util.Java8InferenceContext;
@@ -76,7 +77,7 @@ public class CompileTimeDeclarationType extends AbstractExecutableType {
   }
 
   @Override
-  public AbstractType getReturnType(Theta map) {
+  public AbstractType getReturnType(@Nullable Theta map) {
     AnnotatedTypeMirror annotatedReturnType;
 
     if (methodRef.getMode() == ReferenceMode.NEW) {
@@ -95,7 +96,7 @@ public class CompileTimeDeclarationType extends AbstractExecutableType {
   }
 
   @Override
-  public List<AbstractType> getParameterTypes(Theta map, int size) {
+  public List<AbstractType> getParameterTypes(@Nullable Theta map, int size) {
     AnnotatedTypeMirror receiverTM;
     if (MemberReferenceKind.getMemberReferenceKind(methodRef).isUnbound()) {
       // For unbound method references, i.e. Type::instanceMethod, the receiver is treated as the

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -1046,7 +1046,8 @@ public class InferenceFactory {
    * @param upperBound an abstract type or null
    * @return a wildcard with the provided upper and lower bounds
    */
-  public ProperType createWildcard(ProperType lowerBound, AbstractType upperBound) {
+  public ProperType createWildcard(
+      @Nullable ProperType lowerBound, @Nullable AbstractType upperBound) {
     TypeMirror wildcard =
         TypesUtils.createWildcard(
             lowerBound == null ? null : lowerBound.getJavaType(),

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceType.java
@@ -175,14 +175,15 @@ public final class InferenceType extends AbstractType {
    * variable, a {@link ProperType} is returned.
    *
    * @param types the annotated type mirrors
-   * @param map a mapping from type variable to inference variable
+   * @param map a mapping from type variable to inference variable, or null to treat no type
+   *     variable as an inference variable
    * @param qualifierVars a mapping from polymorphic annotation to {@link QualifierVar}
    * @param context the context
    * @return the abstract type for the given TypeMirror and AnnotatedTypeMirror
    */
   public static List<AbstractType> create(
       List<AnnotatedTypeMirror> types,
-      Theta map,
+      @Nullable Theta map,
       AnnotationMirrorMap<QualifierVar> qualifierVars,
       Java8InferenceContext context) {
     List<AbstractType> abstractTypes = new ArrayList<>();


### PR DESCRIPTION
`getReturnType(Theta)` and `getParameterTypes(Theta, int)` are called with a null map (see `Expression.reduceMethodRef`) and branch on `map == null`. `InferenceFactory.createWildcard` documents both parameters as "or null" and null-checks both.  Annotate them, and say in the Javadoc what a null `Theta` means.