### PR TITLE
Don't return a pair with null components

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -778,8 +778,9 @@ public class InferenceFactory {
 
   /**
    * Returns the pair of {@code a} as the least upper bound of {@code a} and {@code b} and {@code b}
-   * as the least upper bound of {@code a} and {@code b}, or null if that least upper bound is not a
-   * parameterized type.
+   * as the least upper bound of {@code a} and {@code b}. Returns null if that least upper bound is
+   * not a parameterized type or if either {@code a} or {@code b} has no supertype that is the same
+   * class as that least upper bound.
    *
    * @param a type
    * @param b type
@@ -798,8 +799,17 @@ public class InferenceFactory {
 
     Type asSuperOfA = context.types.asSuper((Type) aTypeMirror, ((Type) lubResult).asElement());
     Type asSuperOfB = context.types.asSuper((Type) bTypeMirror, ((Type) lubResult).asElement());
+    if (asSuperOfA == null || asSuperOfB == null) {
+      return null;
+    }
 
-    return IPair.of(a.asSuper(asSuperOfA), b.asSuper(asSuperOfB));
+    AbstractType aAsSuper = a.asSuper(asSuperOfA);
+    AbstractType bAsSuper = b.asSuper(asSuperOfB);
+    if (aAsSuper == null || bAsSuper == null) {
+      return null;
+    }
+
+    return IPair.of(aAsSuper, bAsSuper);
   }
 
   /**


### PR DESCRIPTION
`Types#asSuper` returns null when its argument has no supertype that is the given class, and `AbstractType#asSuper` is `@Nullable`, but both callers of `getParameterizedSupers` dereference the pair's components. Return null, as this method already does when the least upper bound is not a parameterized type.