### PR TITLE
Fix `getTypeParameterBounds` documentation of null returns

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
@@ -196,8 +196,10 @@ public abstract class AbstractType {
    * parameters. (A type parameter of a declared type, can't refer to any type being inferred, so
    * they are proper types.)
    *
-   * @return the upper bounds of the type parameter of this type, or null if this type is a use of
-   *     an inference variable
+   * <p>This implementation always returns a list. The return type is {@code @Nullable} only because
+   * {@link UseOfVariable#getTypeParameterBounds()} returns null.
+   *
+   * @return the upper bounds of the type parameters of this type
    */
   public @Nullable List<ProperType> getTypeParameterBounds() {
     TypeElement typeelem = (TypeElement) ((DeclaredType) getJavaType()).asElement();

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/UseOfVariable.java
@@ -88,6 +88,8 @@ public class UseOfVariable extends AbstractType {
    *
    * <p>An inference variable is not a declared type, so it has no type parameters; this
    * implementation returns null.
+   *
+   * @return null, because this type is a use of an inference variable
    */
   @Override
   public @Nullable List<ProperType> getTypeParameterBounds() {


### PR DESCRIPTION
`AbstractType.getTypeParameterBounds` never returns null; its return type is `@Nullable` only so that the `UseOfVariable` override can return null.