### PR TITLE
Document the `size` contract of AbstractExecutableType.getParameterTypes

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
+++ b/framework/src/main/java/org/checkerframework/framework/flow/CFAbstractTransfer.java
@@ -437,7 +437,11 @@ public abstract class CFAbstractTransfer<
               .getTypeFactoryOfSubcheckerOrNull(AliasingChecker.class);
       if (aliasingAtf != null) {
         int indexOfLambdaActual = invok.getArguments().indexOf(lambdaTree);
-        VariableElement lambdaFormal = methodElt.getParameters().get(indexOfLambdaActual);
+        List<? extends VariableElement> formals = methodElt.getParameters();
+        // In a varargs invocation, the lambda may be an element of the vararg array, in which
+        // case its index among the arguments is beyond the last formal parameter.
+        VariableElement lambdaFormal =
+            formals.get(Math.min(indexOfLambdaActual, formals.size() - 1));
         return aliasingAtf.getAnnotatedType(lambdaFormal).getAnnotation(NonLeaked.class) == null;
       }
     }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
@@ -157,7 +157,9 @@ public abstract class AbstractExecutableType {
       int size,
       @Nullable AnnotatedTypeMirror firstParam,
       boolean isVarargsCall) {
-    List<AnnotatedTypeMirror> params = new ArrayList<>(size);
+    List<AnnotatedTypeMirror> params =
+        new ArrayList<>(
+            annotatedExecutableType.getParameterTypes().size() + (firstParam == null ? 0 : 1));
 
     if (firstParam != null) {
       params.add(firstParam);

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
@@ -110,38 +110,45 @@ public abstract class AbstractExecutableType {
   public abstract AbstractType getReturnType(Theta map);
 
   /**
-   * Returns a list of the parameter types of {@code AbstractExecutableType} where the vararg
-   * parameter has been replaced by individual parameters so the result has length {@code size}.
+   * Returns the formal parameter types of this executable.
+   *
+   * <p>If this invocation uses varargs, then the vararg parameter is replaced by individual
+   * parameters and the result has length {@code size}. Otherwise, {@code size} is ignored and the
+   * result contains one element per declared formal parameter, plus one for the receiver if this is
+   * an unbound method reference.
    *
    * @param map a mapping from type variable to inference variable
-   * @param size the number of parameters to return; used to expand the vararg
-   * @return a list of the parameter types of {@code AbstractExecutableType}, of length {@code size}
+   * @param size the number of parameters to return; used to expand the vararg. It is ignored if
+   *     this invocation does not use varargs.
+   * @return the formal parameter types of this executable
    */
   public abstract List<AbstractType> getParameterTypes(Theta map, int size);
 
   /**
-   * Returns the parameter types of this. (Varags are not expanded.)
+   * Returns the formal parameter types of this executable, without expanding the vararg parameter.
+   * Call this method only for an invocation that does not use varargs.
    *
    * @param map a mapping from type variable to inference variable
-   * @return the parameter types
+   * @return the formal parameter types of this executable
    */
   public List<AbstractType> getParameterTypes(Theta map) {
     return getParameterTypes(map, annotatedExecutableType.getParameterTypes().size());
   }
 
   /**
-   * Returns a list of the parameter types of {@code InferenceExecutableType} where the vararg
-   * parameter has been replaced by individual parameters so the result has length {@code size}.
+   * Returns the formal parameter types of this executable. If {@code isVarargsCall} is true, then
+   * the vararg parameter is replaced by individual parameters so that the result has length {@code
+   * size}; otherwise, {@code size} is ignored.
    *
    * <p>This is a helper method for {@link #getParameterTypes(Theta, int)}.
    *
    * @param map a mapping from type variable to inference variable
-   * @param size the number of parameters to return; used to expand the vararg
+   * @param size the number of parameters to return; used to expand the vararg. It is ignored if
+   *     {@code isVarargsCall} is false.
    * @param firstParam an extra first parameter to add at the beginning of the returned list, or
    *     null
    * @param isVarargsCall true if this invocation uses varargs
-   * @return a list of the parameter types of {@code InferenceExecutableType}, of length {@code
-   *     size}
+   * @return the formal parameter types of this executable
    */
   protected final List<AbstractType> getParameterTypes(
       Theta map, int size, @Nullable AnnotatedTypeMirror firstParam, boolean isVarargsCall) {
@@ -164,6 +171,12 @@ public abstract class AbstractExecutableType {
         params.add(eltATM);
         paramsJava.add(eltTM);
       }
+      // A varargs invocation passes at least as many arguments as the method has formal
+      // parameters, not counting the vararg parameter itself, so the loop above never leaves
+      // `params` longer than `size`.
+      assert params.size() == size
+          : String.format(
+              "Expected %d parameters but found %d in %s", size, params.size(), executableType);
     }
 
     return InferenceType.create(params, map, qualifierVars, context);

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractExecutableType.java
@@ -5,10 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
@@ -153,23 +151,18 @@ public abstract class AbstractExecutableType {
   protected final List<AbstractType> getParameterTypes(
       Theta map, int size, @Nullable AnnotatedTypeMirror firstParam, boolean isVarargsCall) {
     List<AnnotatedTypeMirror> params = new ArrayList<>(size);
-    List<TypeMirror> paramsJava = new ArrayList<>(size);
 
     if (firstParam != null) {
       params.add(firstParam);
-      paramsJava.add(firstParam.getUnderlyingType());
     }
 
     params.addAll(annotatedExecutableType.getParameterTypes());
-    paramsJava.addAll(executableType.getParameterTypes());
 
     if (isVarargsCall) {
       AnnotatedTypeMirror eltATM =
           ((AnnotatedArrayType) params.remove(params.size() - 1)).getComponentType();
-      TypeMirror eltTM = ((ArrayType) paramsJava.remove(paramsJava.size() - 1)).getComponentType();
       for (int i = params.size(); i < size; i++) {
         params.add(eltATM);
-        paramsJava.add(eltTM);
       }
       // A varargs invocation passes at least as many arguments as the method has formal
       // parameters, not counting the vararg parameter itself, so the loop above never leaves

--- a/framework/tests/all-systems/java8inference/VarargsExpansion.java
+++ b/framework/tests/all-systems/java8inference/VarargsExpansion.java
@@ -1,0 +1,79 @@
+// Exercises the varargs expansion in AbstractExecutableType.getParameterTypes, which replaces the
+// vararg formal parameter by one copy of its component type per actual argument.
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@SuppressWarnings("unused") // the locals exist only to supply a target type
+public class VarargsExpansion {
+
+  void zeroVarargs() {
+    List<String> l = listOf();
+  }
+
+  void oneVararg() {
+    List<String> l = listOf("a");
+  }
+
+  void manyVarargs() {
+    List<String> l = listOf("a", "b", "c");
+  }
+
+  void arrayArgument() {
+    // Not a varargs invocation: the array is passed directly as the vararg formal parameter.
+    List<String> l = listOf(new String[] {"a", "b"});
+  }
+
+  void nonVarargFormalBeforeVararg() {
+    List<String> l = prepend("a", "b", "c");
+  }
+
+  void nestedGenericVarargs() {
+    List<List<String>> l = listOf(listOf("a"), listOf("b"));
+  }
+
+  void lambdaVarargs() {
+    List<Supplier<String>> l = listOf(() -> "a", () -> "b");
+  }
+
+  void varargsConstructor() {
+    Box<String> b = new Box<>("a", "b");
+  }
+
+  void varargsMethodReference() {
+    Function<String, List<String>> f = VarargsExpansion::listOf;
+  }
+
+  void unboundVarargsMethodReference() {
+    // The function type's first parameter is the receiver, so the compile-time declaration has one
+    // more parameter than the method itself declares.
+    BiFunction<VarargsExpansion, String, List<String>> f = VarargsExpansion::instanceListOf;
+  }
+
+  void varargsConstructorReference() {
+    Function<String, Box<String>> f = Box::new;
+  }
+
+  @SafeVarargs
+  static <T> List<T> listOf(T... ts) {
+    return new ArrayList<>();
+  }
+
+  @SafeVarargs
+  static <T> List<T> prepend(T first, T... rest) {
+    return new ArrayList<>();
+  }
+
+  @SafeVarargs
+  private final <T> List<T> instanceListOf(T... ts) {
+    return new ArrayList<>();
+  }
+
+  static class Box<T> {
+    @SafeVarargs
+    Box(T... ts) {}
+  }
+}

--- a/framework/tests/all-systems/java8inference/VarargsExpansion.java
+++ b/framework/tests/all-systems/java8inference/VarargsExpansion.java
@@ -39,8 +39,8 @@ public class VarargsExpansion {
     List<Supplier<String>> l = listOf(() -> "a", () -> "b");
   }
 
-  void varargsConstructor() {
-    Box<String> b = new Box<>("a", "b");
+  void varargsConstructor(String s, String t) {
+    Box<String> b = new Box<>(s, t);
   }
 
   void varargsMethodReference() {


### PR DESCRIPTION
The Javadoc promised a result "of length size", but `size` only controls how many copies of the vararg element type to create; it is ignored for an invocation that does not use varargs.  Document that, and assert that the varargs expansion does produce a list of length `size`.

Also correct two references to the nonexistent class InferenceExecutableType.