### PR TITLE
Use a deterministic set in Typing.getInferenceVariables

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Typing.java
@@ -2,8 +2,8 @@ package org.checkerframework.framework.util.typeinference8.constraint;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -121,7 +121,9 @@ public class Typing extends TypeConstraint {
 
   @Override
   public List<Variable> getInferenceVariables() {
-    Set<Variable> vars = new HashSet<>();
+    // Use a LinkedHashSet because the iteration order of the result affects the result of
+    // inference; see ConstraintSet#getClosedSubset.
+    Set<Variable> vars = new LinkedHashSet<>();
     vars.addAll(T.getInferenceVariables());
     vars.addAll(S.getInferenceVariables());
     return new ArrayList<>(vars);


### PR DESCRIPTION
The returned list flows into ConstraintSet.getAllInferenceVariables and ultimately Resolution.getSmallestDependencySet, whose tie-breaking is order-dependent.  Variable.hashCode derives in part from a tree's identity hash code, so a HashSet's iteration order can vary between runs.