### PR TITLE
Do not swallow every exception when deferring an additional-arg constraint

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,10 @@ warning no longer require `-AcheckPurityAnnotations` to also be supplied.
 
 ### Implementation details
 
+When the target type of a lambda expression or method reference is not a
+functional interface, `AnnotatedTypeFactory` throws the new exception
+`NotFunctionalInterfaceException`, which is a subclass of `BugInCF`.
+
 ### Closed issues
 
 ## Version 4.2.2 (2026-08-06)

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeFactory.java
@@ -4763,7 +4763,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
   }
 
   /**
-   * Throws an exception if the type is not a functional interface.
+   * Throws a {@link NotFunctionalInterfaceException} if the type is not a functional interface.
    *
    * @param typeMirror a type that must be a functional interface
    * @param contextTree the tree that has the given type; used only for diagnostic messages
@@ -4789,7 +4789,7 @@ public class AnnotatedTypeFactory implements AnnotationProvider {
       }
     }
 
-    throw new BugInCF(
+    throw new NotFunctionalInterfaceException(
         "Expected the type of %s tree in assignment context to be a functional interface. "
             + "Found type: %s for tree: %s in lambda tree: %s",
         contextTree.getKind(), type, contextTree, tree);

--- a/framework/src/main/java/org/checkerframework/framework/type/NotFunctionalInterfaceException.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/NotFunctionalInterfaceException.java
@@ -1,0 +1,31 @@
+package org.checkerframework.framework.type;
+
+import org.checkerframework.checker.formatter.qual.FormatMethod;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.javacutil.BugInCF;
+
+/**
+ * Thrown when the target type of a lambda expression or a method reference is not a functional
+ * interface.
+ *
+ * <p>Usually that indicates a bug, which is why this class extends {@link BugInCF}. During Java 8
+ * type argument inference it is expected, though: the target type may be an inference variable that
+ * has not been resolved yet. {@link
+ * org.checkerframework.framework.util.typeinference8.InvocationTypeInference} catches this
+ * exception and defers the work that requires the target type.
+ */
+@SuppressWarnings("serial")
+public class NotFunctionalInterfaceException extends BugInCF {
+
+  /**
+   * Constructs a new {@code NotFunctionalInterfaceException} with a detail message composed from
+   * the given arguments.
+   *
+   * @param fmt the format string
+   * @param args the arguments for the format string
+   */
+  @FormatMethod
+  public NotFunctionalInterfaceException(String fmt, @Nullable Object... args) {
+    super(fmt, args);
+  }
+}

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
@@ -17,6 +17,7 @@ import javax.lang.model.type.ExecutableType;
 import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.NotFunctionalInterfaceException;
 import org.checkerframework.framework.util.typeinference8.bound.BoundSet;
 import org.checkerframework.framework.util.typeinference8.bound.CaptureBound;
 import org.checkerframework.framework.util.typeinference8.constraint.AdditionalArgument;
@@ -572,11 +573,13 @@ public class InvocationTypeInference {
         if (TreeUtils.isPolyExpression(expression)) {
           try {
             c.addAll(new AdditionalArgument(expression).reduce(context));
-          } catch (Exception e) {
-            // Sometimes in order to create the additional argument constraint, other inference
-            // variables must be resolved first. This happens when a lambda parameter is used in the
-            // additional argument constraint.
-            // See framework/tests/all-systems/SimpleLambdaParameter.java
+          } catch (NotFunctionalInterfaceException e) {
+            // Creating the additional argument constraint requires the type of an implicit lambda
+            // parameter, and that type is the type of an inference variable that has not been
+            // resolved yet.  (That is why the target type of the enclosing lambda is not yet a
+            // functional interface.)  Defer the constraint; it is reduced again after resolution.
+            // See framework/tests/all-systems/SimpleLambdaParameter.java and
+            // framework/tests/all-systems/java8inference/DeferredAdditionalArg.java .
             c.add(new AdditionalArgument(expression));
           }
         }


### PR DESCRIPTION
`InvocationTypeInference.createAdditionalArgConstraintsNoLambda` caught `Exception` and discarded it, so a `BugInCF` from a genuine defect became a silently deferred constraint with no trace.

The only condition that needs to be deferred is that the target type of the enclosing lambda is an inference variable rather than a functional interface. `AnnotatedTypeFactory.assertIsFunctionalInterface` now signals that with the new `NotFunctionalInterfaceException` (a subclass of `BugInCF`, so an uncaught occurrence still crashes as before), and the catch clause names only it.