### PR TITLE
Simplify InferenceFactory.glb(Set)

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -889,16 +889,11 @@ public class InferenceFactory {
    * @return the greatest lower bound of {@code abstractTypes}, or null
    */
   public @Nullable AbstractType glb(Set<AbstractType> abstractTypes) {
-    AbstractType ti = null;
-    for (AbstractType liProperType : abstractTypes) {
-      AbstractType li = liProperType;
-      if (ti == null) {
-        ti = li;
-      } else {
-        ti = glb(ti, li);
-      }
+    AbstractType glb = null;
+    for (AbstractType abstractType : abstractTypes) {
+      glb = (glb == null) ? abstractType : glb(glb, abstractType);
     }
-    return ti;
+    return glb;
   }
 
   /**


### PR DESCRIPTION
Remove a pointless local variable and rename the loop variable, which was misleadingly named `liProperType` even though its type is `AbstractType`.