### PR TITLE
Type inference: guard the cast to `UseOfVariable` in getCheckedExceptionConstraints

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -975,14 +975,23 @@ public class InferenceFactory {
     List<UseOfVariable> es = new ArrayList<>();
     List<ProperType> properTypes = new ArrayList<>();
 
+    AnnotatedTypeMirror functionalInterface = targetType.getAnnotatedType();
+    if (targetType.isWildcardParameterizedType()) {
+      // JLS 9.9: the function type of a wildcard-parameterized functional interface type is the
+      // function type of the type's non-wildcard parameterization.
+      functionalInterface =
+          AbstractType.makeGround((AnnotatedDeclaredType) functionalInterface, context.typeFactory);
+    }
     AnnotatedExecutableType functionType =
         AnnotatedTypes.asMemberOf(
-            context.modelTypes, context.typeFactory, targetType.getAnnotatedType(), ele);
+            context.modelTypes, context.typeFactory, functionalInterface, ele);
 
     for (AnnotatedTypeMirror thrownType : functionType.getThrownTypes()) {
       AbstractType ei = InferenceType.create(thrownType, map, context);
-      // JLS 18.2.5 uses only the proper types and the inference variables among the function
-      // type's thrown types; any other thrown type contributes nothing.
+      // JLS 18.2.5 uses the proper types and the inference variables among the function type's
+      // thrown types.  Every thrown type is one or the other, because no subclass of Throwable is
+      // generic (JLS 8.1.2) and because the function type is that of a non-wildcard
+      // parameterization; the `isUseOfVariable` test is defensive.
       if (ei.isProper()) {
         properTypes.add((ProperType) ei);
       } else if (ei.isUseOfVariable()) {

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/InferenceFactory.java
@@ -981,14 +981,17 @@ public class InferenceFactory {
 
     for (AnnotatedTypeMirror thrownType : functionType.getThrownTypes()) {
       AbstractType ei = InferenceType.create(thrownType, map, context);
+      // JLS 18.2.5 uses only the proper types and the inference variables among the function
+      // type's thrown types; any other thrown type contributes nothing.
       if (ei.isProper()) {
         properTypes.add((ProperType) ei);
-      } else {
+      } else if (ei.isUseOfVariable()) {
         UseOfVariable varEi = (UseOfVariable) ei;
-        if (varEi.getVariable().getInstantiation() != null) {
-          properTypes.add(varEi.getVariable().getInstantiation());
+        ProperType instantiation = varEi.getVariable().getInstantiation();
+        if (instantiation != null) {
+          properTypes.add(instantiation);
         } else {
-          es.add((UseOfVariable) ei);
+          es.add(varEi);
         }
       }
     }

--- a/framework/tests/all-systems/Issue7701.java
+++ b/framework/tests/all-systems/Issue7701.java
@@ -1,0 +1,26 @@
+@SuppressWarnings("all") // Just check for crashes.
+public class Issue7701 {
+  interface Iterator<E> {}
+
+  interface CheckedIterator<T, X extends Exception> {}
+
+  interface CheckedFunction<F, T, X extends Exception> {
+    T apply(F input) throws X;
+  }
+
+  <F, T, X extends Exception> CheckedIterator<T, X> transform(
+      Iterator<? extends F> fromIterator,
+      CheckedFunction<? super F, ? extends T, ? extends X> function) {
+    throw new UnsupportedOperationException();
+  }
+
+  interface Foo {
+    Bar toBar();
+  }
+
+  interface Bar {}
+
+  CheckedIterator<Bar, ?> run(Iterator<Foo> rows) {
+    return transform(rows, row -> row.toBar());
+  }
+}

--- a/framework/tests/all-systems/java8inference/CheckedExceptionWildcardThrows.java
+++ b/framework/tests/all-systems/java8inference/CheckedExceptionWildcardThrows.java
@@ -1,12 +1,10 @@
 // The type argument for the function type's thrown type is a wildcard that mentions an inference
-// variable.  The thrown type of the function type is therefore neither a proper type nor a use of
-// an inference variable; it is an `InferenceType`.
-// `InferenceFactory.getCheckedExceptionConstraints` must not assume that every thrown type that is
-// not proper is a use of an inference variable.
-//
-// This file must not be annotated with `@SuppressWarnings("all")`, because that also suppresses
-// the `type.argument.inference.crashed` error that this test checks for.
+// variable.  `InferenceFactory.getCheckedExceptionConstraints` must derive the function type from
+// the non-wildcard parameterization (JLS 9.9) of the target type.  Otherwise the thrown type is
+// neither a proper type nor a use of an inference variable, so no checked exception constraint is
+// created for it.
 
+@SuppressWarnings("all") // Just check for crashes.
 class CheckedExceptionWildcardThrows {
 
   interface ThrowingSupplier<T, E extends Exception> {
@@ -21,11 +19,27 @@ class CheckedExceptionWildcardThrows {
     return "";
   }
 
+  static String throwsCheckedException() throws java.io.IOException {
+    return "";
+  }
+
   static void useLambda() throws Exception {
     String s = call(() -> "");
   }
 
   static void useMemberReference() throws Exception {
     String s = call(CheckedExceptionWildcardThrows::id);
+  }
+
+  // The lambda body throws a checked exception, so the inference variable for the function type's
+  // thrown type gets a checked exception constraint and `E` is inferred as IOException.  (If `E`
+  // were inferred as its upper bound, Exception, then `call` would throw Exception, which this
+  // method does not declare.)
+  static void useThrowingLambda() throws java.io.IOException {
+    String s = call(() -> throwsCheckedException());
+  }
+
+  static void useThrowingMemberReference() throws java.io.IOException {
+    String s = call(CheckedExceptionWildcardThrows::throwsCheckedException);
   }
 }

--- a/framework/tests/all-systems/java8inference/CheckedExceptionWildcardThrows.java
+++ b/framework/tests/all-systems/java8inference/CheckedExceptionWildcardThrows.java
@@ -1,0 +1,31 @@
+// The type argument for the function type's thrown type is a wildcard that mentions an inference
+// variable.  The thrown type of the function type is therefore neither a proper type nor a use of
+// an inference variable; it is an `InferenceType`.
+// `InferenceFactory.getCheckedExceptionConstraints` must not assume that every thrown type that is
+// not proper is a use of an inference variable.
+//
+// This file must not be annotated with `@SuppressWarnings("all")`, because that also suppresses
+// the `type.argument.inference.crashed` error that this test checks for.
+
+class CheckedExceptionWildcardThrows {
+
+  interface ThrowingSupplier<T, E extends Exception> {
+    T get() throws E;
+  }
+
+  static <T, E extends Exception> T call(ThrowingSupplier<T, ? extends E> supplier) throws E {
+    return supplier.get();
+  }
+
+  static String id() {
+    return "";
+  }
+
+  static void useLambda() throws Exception {
+    String s = call(() -> "");
+  }
+
+  static void useMemberReference() throws Exception {
+    String s = call(CheckedExceptionWildcardThrows::id);
+  }
+}


### PR DESCRIPTION
A thrown type that is neither a proper type nor an inference variable threw a ClassCastException instead of being ignored, as JLS 18.2.5 says. Also reuse the local variable instead of recomputing the instantiation and repeating the cast.