### PR TITLE
Fix type-argument inference crash on MethodHandle.invokeExact; fixes #7702

### DIFF
--- a/checker/tests/nullness/java8inference/Issue7702.java
+++ b/checker/tests/nullness/java8inference/Issue7702.java
@@ -1,3 +1,6 @@
+// Test case for issue 7702:
+// https://github.com/typetools/checker-framework/issues/7702
+
 import java.lang.invoke.MethodHandle;
 
 public class Issue7702 {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ warning no longer require `-AcheckPurityAnnotations` to also be supplied.
 
 ### Closed issues
 
+\#7702.
+
 ## Version 4.2.2 (2026-08-06)
 
 ### Implementation details

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -2470,9 +2470,31 @@ public final class TreeUtils {
         TypeMirror type = TreeUtils.typeOf(invok.getArguments().get(numParameters - 1));
         return type.getKind().isPrimitive() || TypesUtils.isBoxedPrimitive(type);
       }
+      // MethodHandle.invokeExact is signature-polymorphic. javac does not set varargsElement,
+      // so a single non-array argument is otherwise treated as the Object[] array itself.
+      // Nested generic inference then uses Object[] as the target type and crashes
+      // (FalseBoundException). See issue 7702.
+      if (isMethodHandleInvokeExact(e)) {
+        TypeMirror type = TreeUtils.typeOf(invok.getArguments().get(numParameters - 1));
+        return type.getKind() != TypeKind.ARRAY;
+      }
     }
 
     return false;
+  }
+
+  /**
+   * Returns true if {@code method} is {@link java.lang.invoke.MethodHandle#invokeExact}.
+   *
+   * @param method a method
+   * @return true if {@code method} is {@code MethodHandle.invokeExact}
+   */
+  public static boolean isMethodHandleInvokeExact(ExecutableElement method) {
+    if (!method.isVarArgs() || !method.getSimpleName().contentEquals("invokeExact")) {
+      return false;
+    }
+    Name className = ElementUtils.getQualifiedClassName(method);
+    return className != null && className.contentEquals("java.lang.invoke.MethodHandle");
   }
 
   /**


### PR DESCRIPTION
## Summary

- `MethodHandle.invokeExact` is signature-polymorphic. javac does not set `varargsElement`, so a one-argument call was treated as passing the declared `Object[]` array itself.
- Nested generic inference then used `Object[]` as the target type of `foo.passthru(bar)` and crashed with `type.argument.inference.crashed` (`FalseBoundException`: `Bar <: Object[]`).
- Treat a single non-array argument to `MethodHandle.invokeExact` as a varargs actual, matching the existing `MethodHandle.invoke` workaround.

Fixes #7702.

The two-argument form (`invokeExact(o, foo.passthru(bar))`) already type-checks on master. This PR covers the still-crashing one-argument form from the issue.

## Test plan

- [x] `checker/bin/javac -processor nullness` on the issue repro **without** the `invokeExact` change: one-argument form fails with `type.argument.inference.crashed` / `Bar <: Object[]`; two-argument form already passes
- [x] Same javac command **with** the change: both forms exit 0
- [x] `./gradlew :checker:NullnessTest` (JDK 21) — BUILD SUCCESSFUL
- [x] Added `checker/tests/nullness/java8inference/Issue7702.java` and the one-argument call to `framework/tests/all-systems/Issue7702.java`
