### PR TITLE
Get the type of lambda parameters from inference if it is running

### DIFF
--- a/checker/tests/nullness/LambdaParamTypeFromInference.java
+++ b/checker/tests/nullness/LambdaParamTypeFromInference.java
@@ -1,0 +1,26 @@
+// Test that an implicitly typed lambda parameter's type is taken from the running type argument
+// inference, rather than from javac's Java type plus default qualifiers.
+//
+// Additional test case in checker/tests/tainting/LambdaParamTypeFromInference.java
+
+import java.util.function.Function;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class LambdaParamTypeFromInference {
+
+  static <T, R> R map(T t, Function<T, R> f) {
+    return f.apply(t);
+  }
+
+  // The type of `p` is requested while inference for `map` is still running, so it cannot be
+  // computed through the usual target-type machinery.  Falling back to javac's Java type plus
+  // default qualifiers is unsound here, not merely imprecise: it would strengthen `p` from
+  // `@Nullable String` to `@NonNull String`, and the dereference below would go unreported.
+  //
+  // The error is issued while checking the lambda body, after inference has finished, because the
+  // type computed for the parameter during inference is cached and reused then.
+  void deref(@Nullable String s) {
+    // :: error: [dereference.of.nullable]
+    map(s, p -> p.hashCode());
+  }
+}

--- a/checker/tests/tainting/LambdaParamTypeFromInference.java
+++ b/checker/tests/tainting/LambdaParamTypeFromInference.java
@@ -1,0 +1,36 @@
+// Test that an implicitly typed lambda parameter's type is taken from the running type argument
+// inference, rather than from javac's Java type plus default qualifiers.
+//
+// Additional test case in checker/tests/nullness/LambdaParamTypeFromInference.java
+
+import java.util.function.Function;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+public class LambdaParamTypeFromInference {
+
+  static <T, R> R map(T t, Function<T, R> f) {
+    return f.apply(t);
+  }
+
+  static <T> T same(T t, Function<T, T> f) {
+    return f.apply(t);
+  }
+
+  // The type of `p` is requested while inference for `map` is still running, so it cannot be
+  // computed through the usual target-type machinery.  Falling back to javac's Java type plus
+  // default qualifiers would give `p` the type `@Tainted String`, even though the lambda's target
+  // type is `Function<@Untainted String, R>`, and that `@Tainted` would flow into R, causing both
+  // an `assignment` error and a `type.arguments.not.inferred` error here.
+  void m(@Untainted String s) {
+    @Untainted String r = map(s, p -> p);
+  }
+
+  // Two type variables are essential above.  With `Function<T, T>`, T is still uninstantiated when
+  // the lambda body's constraint is processed, so the running inference cannot supply the parameter
+  // type and the fallback applies.  JLS 18.5.2.2 makes the same distinction: the input variables of
+  // an implicitly typed lambda's constraint are the inference variables mentioned by the function
+  // type's parameter types, not those in its return type.
+  void parameterTypeNotYetKnown(@Untainted String s) {
+    @Untainted String r = same(s, p -> p);
+  }
+}

--- a/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/TypeFromMemberVisitor.java
@@ -14,6 +14,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -189,6 +190,22 @@ class TypeFromMemberVisitor extends TypeFromTreeVisitor {
         // settle on. See https://github.com/typetools/checker-framework/issues/7678 and
         // https://github.com/typetools/checker-framework/issues/7698. Fall back to the real,
         // already fully-resolved Java type that javac assigned to this parameter instead.
+        // First ask the in-progress inference for the type it has already computed for this
+        // parameter.  That type carries the qualifiers inference derived, which the fallback
+        // below cannot reproduce.
+        AnnotatedTypeMirror fromInference =
+            f.getTypeArgumentInference().getLambdaParameterType((VariableElement) paramElement);
+        // Use it only if its Java type is exactly the one javac assigned to this parameter.
+        // In-progress inference state is not merely incomplete: a variable may already be
+        // instantiated to a value that later constraints would have refined (see the note at the
+        // end of JLS 18.5.2.1), so the structure can disagree with javac's final answer, and
+        // callers of this method require the two to agree.
+        if (fromInference != null
+            && f.getProcessingEnv()
+                .getTypeUtils()
+                .isSameType(fromInference.getUnderlyingType(), paramElement.asType())) {
+          return fromInference;
+        }
         AnnotatedTypeMirror result = f.toAnnotatedType(paramElement.asType(), false);
         f.addDefaultAnnotations(result);
         return result;

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/DefaultTypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/DefaultTypeArgumentInference.java
@@ -14,12 +14,14 @@ import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.typeinference8.types.ContainsInferenceVariable;
 import org.checkerframework.framework.util.typeinference8.types.Variable;
@@ -136,6 +138,18 @@ public class DefaultTypeArgumentInference implements TypeArgumentInference {
   @Override
   public boolean isAnyInferenceInProgress() {
     return !java8InferenceStack.isEmpty();
+  }
+
+  @Override
+  public @Nullable AnnotatedTypeMirror getLambdaParameterType(VariableElement param) {
+    // Iteration order of an ArrayDeque used as a stack is innermost inference problem first.
+    for (InvocationTypeInference inference : java8InferenceStack) {
+      AnnotatedTypeMirror result = inference.getLambdaParameterType(param);
+      if (result != null) {
+        return result;
+      }
+    }
+    return null;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
@@ -13,9 +13,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ExecutableType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 import org.checkerframework.framework.util.typeinference8.bound.BoundSet;
 import org.checkerframework.framework.util.typeinference8.bound.CaptureBound;
@@ -133,6 +136,51 @@ public class InvocationTypeInference {
    */
   public Tree getInferenceExpression() {
     return inferenceExpression;
+  }
+
+  /**
+   * If {@code param} is an implicitly typed lambda parameter whose type this inference problem has
+   * already determined, returns that type. Otherwise, returns null.
+   *
+   * <p>Only the lambda's parameter types need be known, not its whole target type. <a
+   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.2">JLS
+   * 18.5.2.2</a> makes the same distinction: the input variables of an implicitly typed lambda's
+   * constraint are "the inference variables mentioned by the function type's parameter types", not
+   * those in its return type. Requiring the whole target type to be proper would give up whenever
+   * only the return type's variable is still uninstantiated, which is the common case.
+   *
+   * <p>This method never advances inference: it reports only instantiations that inference has
+   * already committed to, so it returns null while the parameter type is still uninstantiated.
+   *
+   * <p>The returned type is not guaranteed to agree with the type javac assigned to {@code param}:
+   * inference may have committed to an instantiation that later constraints would have refined (see
+   * the note at the end of <a
+   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.1">JLS
+   * 18.5.2.1</a>). Callers must check.
+   *
+   * @param param an element that might be an implicitly typed lambda parameter
+   * @return the type of {@code param}, or null if this inference problem cannot supply it
+   */
+  public @Nullable AnnotatedTypeMirror getLambdaParameterType(VariableElement param) {
+    Java8InferenceContext.LambdaParamTarget target = context.lambdaParamTargets.get(param);
+    if (target == null) {
+      return null;
+    }
+    AbstractType lambdaTarget = target.lambdaTargetType().applyInstantiations();
+    // getFunctionTypeParameterTypes() returns null if lambdaTarget is not a functional interface,
+    // which is the case while it is still just an inference variable.  It applies
+    // AbstractType.makeGround(), the non-wildcard parameterization of JLS 9.9 that JLS 15.27.3
+    // prescribes for an implicitly typed lambda; only implicitly typed lambdas are recorded in
+    // lambdaParamTargets, so that is the correct rule.
+    List<AbstractType> paramTypes = lambdaTarget.getFunctionTypeParameterTypes();
+    if (paramTypes == null || target.index() >= paramTypes.size()) {
+      return null;
+    }
+    AbstractType paramType = paramTypes.get(target.index()).applyInstantiations();
+    if (!paramType.isProper()) {
+      return null;
+    }
+    return paramType.getAnnotatedType();
   }
 
   /**
@@ -515,6 +563,11 @@ public class InvocationTypeInference {
       case LAMBDA_EXPRESSION -> {
         c.add(new CheckedExceptionConstraint(ei, fi, map));
         LambdaExpressionTree lambda = (LambdaExpressionTree) ei;
+        if (TreeUtils.isImplicitlyTypedLambda(lambda)) {
+          // Record where this lambda's parameters get their types from, so that
+          // getLambdaParameterType can answer for them while this inference is still running.
+          context.addLambdaParamTargets(lambda.getParameters(), fi);
+        }
         for (ExpressionTree expression : TreeUtils.getReturnedExpressions(lambda)) {
           c.addAll(createAdditionalArgConstraintsNoLambda(expression));
         }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/InvocationTypeInference.java
@@ -142,22 +142,6 @@ public class InvocationTypeInference {
    * If {@code param} is an implicitly typed lambda parameter whose type this inference problem has
    * already determined, returns that type. Otherwise, returns null.
    *
-   * <p>Only the lambda's parameter types need be known, not its whole target type. <a
-   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.2">JLS
-   * 18.5.2.2</a> makes the same distinction: the input variables of an implicitly typed lambda's
-   * constraint are "the inference variables mentioned by the function type's parameter types", not
-   * those in its return type. Requiring the whole target type to be proper would give up whenever
-   * only the return type's variable is still uninstantiated, which is the common case.
-   *
-   * <p>This method never advances inference: it reports only instantiations that inference has
-   * already committed to, so it returns null while the parameter type is still uninstantiated.
-   *
-   * <p>The returned type is not guaranteed to agree with the type javac assigned to {@code param}:
-   * inference may have committed to an instantiation that later constraints would have refined (see
-   * the note at the end of <a
-   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.1">JLS
-   * 18.5.2.1</a>). Callers must check.
-   *
    * @param param an element that might be an implicitly typed lambda parameter
    * @return the type of {@code param}, or null if this inference problem cannot supply it
    */

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/TypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/TypeArgumentInference.java
@@ -62,18 +62,6 @@ public interface TypeArgumentInference {
    * If {@code param} is an implicitly typed lambda parameter whose type an in-progress inference
    * has already determined, returns that type. Otherwise, returns null.
    *
-   * <p>This lets a caller that needs such a parameter's type while inference is running obtain the
-   * type the running inference computed, instead of re-deriving it through the normal target-type
-   * machinery, which would re-enter inference (see {@link #isAnyInferenceInProgress}).
-   *
-   * <p>This method never advances inference: it reports only instantiations that inference has
-   * already committed to, and returns null when the parameter's type is not yet determined, so
-   * callers must have a fallback. Callers must also verify that the returned type's underlying Java
-   * type is the one javac assigned to {@code param}: an in-progress inference may have committed to
-   * an instantiation that later constraints would have refined (see the note at the end of <a
-   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.1">JLS
-   * 18.5.2.1</a>), so the returned type's structure can differ from javac's.
-   *
    * @param param an element that might be an implicitly typed lambda parameter
    * @return the type of {@code param} as computed by an in-progress inference, or null
    */

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/TypeArgumentInference.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/TypeArgumentInference.java
@@ -1,7 +1,10 @@
 package org.checkerframework.framework.util.typeinference8;
 
 import com.sun.source.tree.ExpressionTree;
+import javax.lang.model.element.VariableElement;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
+import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
 
 /**
@@ -53,5 +56,28 @@ public interface TypeArgumentInference {
    */
   default boolean isAnyInferenceInProgress() {
     return false;
+  }
+
+  /**
+   * If {@code param} is an implicitly typed lambda parameter whose type an in-progress inference
+   * has already determined, returns that type. Otherwise, returns null.
+   *
+   * <p>This lets a caller that needs such a parameter's type while inference is running obtain the
+   * type the running inference computed, instead of re-deriving it through the normal target-type
+   * machinery, which would re-enter inference (see {@link #isAnyInferenceInProgress}).
+   *
+   * <p>This method never advances inference: it reports only instantiations that inference has
+   * already committed to, and returns null when the parameter's type is not yet determined, so
+   * callers must have a fallback. Callers must also verify that the returned type's underlying Java
+   * type is the one javac assigned to {@code param}: an in-progress inference may have committed to
+   * an instantiation that later constraints would have refined (see the note at the end of <a
+   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.2.1">JLS
+   * 18.5.2.1</a>), so the returned type's structure can differ from javac's.
+   *
+   * @param param an element that might be an implicitly typed lambda parameter
+   * @return the type of {@code param} as computed by an in-progress inference, or null
+   */
+  default @Nullable AnnotatedTypeMirror getLambdaParameterType(VariableElement param) {
+    return null;
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/util/Java8InferenceContext.java
@@ -19,6 +19,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeFactory;
 import org.checkerframework.framework.util.typeinference8.InvocationTypeInference;
+import org.checkerframework.framework.util.typeinference8.types.AbstractType;
 import org.checkerframework.framework.util.typeinference8.types.InferenceFactory;
 import org.checkerframework.framework.util.typeinference8.types.ProperType;
 import org.checkerframework.javacutil.TreePathUtil;
@@ -81,6 +82,41 @@ public class Java8InferenceContext {
 
   /** There's no way to tell if an element is a parameter of a lambda, so keep track of them. */
   public final Set<VariableElement> lambdaParms = new HashSet<>();
+
+  /**
+   * Where an implicitly typed lambda parameter's type comes from: the target type of the lambda
+   * that declares it, and the parameter's index in the lambda's parameter list.
+   *
+   * <p>The lambda's target type is stored rather than the parameter's own type because, when this
+   * is recorded, the target type may still mention inference variables.
+   *
+   * @param lambdaTargetType the target type of the lambda that declares the parameter
+   * @param index the index of the parameter in the lambda's parameter list
+   */
+  public record LambdaParamTarget(AbstractType lambdaTargetType, int index) {}
+
+  /**
+   * Maps each implicitly typed lambda parameter encountered by this inference problem to the
+   * information needed to compute its type once inference has progressed far enough.
+   *
+   * @see InvocationTypeInference#getLambdaParameterType(VariableElement)
+   */
+  public final Map<VariableElement, LambdaParamTarget> lambdaParamTargets = new HashMap<>();
+
+  /**
+   * Records where each parameter of an implicitly typed lambda gets its type from.
+   *
+   * @param parameters the formal parameters of an implicitly typed lambda
+   * @param lambdaTargetType the target type of that lambda
+   */
+  public void addLambdaParamTargets(
+      List<? extends VariableTree> parameters, AbstractType lambdaTargetType) {
+    for (int i = 0; i < parameters.size(); i++) {
+      lambdaParamTargets.put(
+          TreeUtils.elementFromDeclaration(parameters.get(i)),
+          new LambdaParamTarget(lambdaTargetType, i));
+    }
+  }
 
   /**
    * Creates a context.


### PR DESCRIPTION
This address false negatives added by #7969.
Review after https://github.com/smillst/checker-framework/pull/34 is merged.