### PR TITLE
Support intersection target types for method references (#7684)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ Made the field `Java8InferenceContext.pathToExpression` private; use
 
 ### Closed issues
 
+\#7684.
+
 ## Version 4.2.2 (2026-08-06)
 
 ### Implementation details

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/AbstractType.java
@@ -25,6 +25,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedIntersectionType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.AnnotatedTypeParameterBounds;
@@ -281,12 +282,46 @@ public abstract class AbstractType {
   @Nullable AnnotatedExecutableType getFunctionType() {
     if (functionType == null && TypesUtils.isFunctionalInterface(getJavaType(), context.env)) {
       ExecutableElement element = TypesUtils.findFunction(getJavaType(), context.env);
-      AnnotatedDeclaredType groundType =
-          makeGround((AnnotatedDeclaredType) getAnnotatedType(), typeFactory);
+      AnnotatedTypeMirror groundType = makeGroundTargetType(getAnnotatedType(), typeFactory);
       functionType =
           AnnotatedTypes.asMemberOf(context.modelTypes, typeFactory, groundType, element);
     }
     return functionType;
+  }
+
+  /**
+   * Returns the ground target type of {@code type}, which is a functional interface type. For an
+   * {@link AnnotatedDeclaredType}, this is {@link #makeGround(AnnotatedDeclaredType,
+   * AnnotatedTypeFactory)}. For an intersection type that induces a notional functional interface
+   * (<a href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-9.html#jls-9.9">JLS section
+   * 9.9</a>), each bound is made ground; this is the annotated-type analog of the notional
+   * interface that {@code TypesUtils.findFunction} creates for such a type. {@code
+   * AnnotatedTypes.asMemberOf} then finds the bound that declares the function, just as javac
+   * computes the function type as a member of the intersection type.
+   *
+   * @param type a functional interface type
+   * @param typeFactory the type factory
+   * @return the ground target type of {@code type}
+   */
+  private static AnnotatedTypeMirror makeGroundTargetType(
+      AnnotatedTypeMirror type, AnnotatedTypeFactory typeFactory) {
+    switch (type.getKind()) {
+      case DECLARED -> {
+        return makeGround((AnnotatedDeclaredType) type, typeFactory);
+      }
+      case INTERSECTION -> {
+        AnnotatedIntersectionType intersection = ((AnnotatedIntersectionType) type).shallowCopy();
+        List<AnnotatedTypeMirror> groundBounds = new ArrayList<>(intersection.getBounds().size());
+        for (AnnotatedTypeMirror bound : intersection.getBounds()) {
+          groundBounds.add(makeGroundTargetType(bound, typeFactory));
+        }
+        intersection.setBounds(groundBounds);
+        return intersection;
+      }
+      default -> {
+        return type;
+      }
+    }
   }
 
   /**

--- a/framework/tests/all-systems/Issue7684.java
+++ b/framework/tests/all-systems/Issue7684.java
@@ -1,0 +1,22 @@
+// Test case for Issue 7684:
+// https://github.com/typetools/checker-framework/issues/7684
+
+import java.io.Serializable;
+
+public class Issue7684<T> {
+  interface Consumer<T> {
+    void accept(T t);
+  }
+
+  static class SerializedOp<T> {
+    SerializedOp(Consumer<T> consumer) {}
+  }
+
+  static class Foo {
+    <T> void bar(T t) {}
+  }
+
+  void test(Foo foo) {
+    new SerializedOp<T>((Consumer<T> & Serializable) foo::bar);
+  }
+}

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TypesUtils.java
@@ -1,11 +1,13 @@
 package org.checkerframework.javacutil;
 
 import com.sun.tools.javac.code.BoundKind;
+import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
 import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.code.Type.CapturedType;
 import com.sun.tools.javac.code.Type.ClassType;
+import com.sun.tools.javac.code.Type.IntersectionClassType;
 import com.sun.tools.javac.code.TypeTag;
 import com.sun.tools.javac.code.Types.FunctionDescriptorLookupError;
 import com.sun.tools.javac.model.JavacTypes;
@@ -633,16 +635,57 @@ public final class TypesUtils {
   }
 
   /**
-   * Returns true if {@code type} is a functional interface type (as defined in JLS 9.8).
+   * Returns true if {@code type} is a functional interface type (as defined in JLS 9.9). This
+   * includes an intersection type that induces a notional functional interface, such as {@code
+   * Runnable & java.io.Serializable}.
    *
    * @param type possible functional interface type
    * @param env the processing environment
-   * @return true if {@code type} is a functional interface type (as defined in JLS 9.8)
+   * @return true if {@code type} is a functional interface type (as defined in JLS 9.9)
    */
   public static boolean isFunctionalInterface(TypeMirror type, ProcessingEnvironment env) {
     Context ctx = ((JavacProcessingEnvironment) env).getContext();
     com.sun.tools.javac.code.Types javacTypes = com.sun.tools.javac.code.Types.instance(ctx);
-    return javacTypes.isFunctionalInterface((Type) type);
+    Type javaType = (Type) type;
+    if (javaType.isIntersection()) {
+      javaType = notionalInterface((IntersectionClassType) javaType, javacTypes);
+    }
+    return javacTypes.isFunctionalInterface(javaType);
+  }
+
+  /**
+   * Returns the notional interface induced by the intersection type {@code type} (<a
+   * href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-4.html#jls-4.9">JLS 4.9</a>). Per
+   * <a href="https://docs.oracle.com/javase/specs/jls/se25/html/jls-9.html#jls-9.9">JLS 9.9</a>,
+   * the function type of an intersection type that induces a notional functional interface is the
+   * function type of that notional interface. If {@code type} has a component that is a class, then
+   * it induces a notional class rather than a notional interface, and {@code type} is returned
+   * unchanged.
+   *
+   * <p>javac does not represent the notional interface directly: the symbol of an intersection type
+   * is a synthetic compound class symbol that is never marked as an interface, so javac's function
+   * descriptor lookup rejects it. This method builds the notional interface the same way that
+   * {@code Attr.getTargetInfo} does when attributing a lambda expression or a method reference
+   * whose target type is an intersection type: it creates a fresh intersection of the non-wildcard
+   * parameterizations (JLS 9.9) of the components and marks its symbol as an interface. {@code
+   * type} itself is not modified.
+   *
+   * @param type an intersection type
+   * @param javacTypes the javac Types instance
+   * @return the notional interface induced by {@code type}, or {@code type} if it does not induce a
+   *     notional interface
+   */
+  private static Type notionalInterface(
+      IntersectionClassType type, com.sun.tools.javac.code.Types javacTypes) {
+    if (!type.allInterfaces) {
+      // The intersection induces a notional class, which is not a functional interface.
+      return type;
+    }
+    com.sun.tools.javac.util.List<Type> components =
+        type.getExplicitComponents().map(javacTypes::removeWildcards);
+    IntersectionClassType notionalInterface = javacTypes.makeIntersectionType(components);
+    notionalInterface.tsym.flags_field |= Flags.INTERFACE;
+    return notionalInterface;
   }
 
   /**
@@ -1346,7 +1389,9 @@ public final class TypesUtils {
 
   /**
    * This method returns the single abstract method declared by {@code functionalInterfaceType}.
-   * (The type of this method is referred to as the function type.)
+   * (The type of this method is referred to as the function type.) If {@code
+   * functionalInterfaceType} is an intersection type that induces a notional functional interface,
+   * then the single abstract method of that notional interface is returned (JLS 9.9).
    *
    * @param functionalInterfaceType a functional interface type
    * @param env the processing environment
@@ -1357,9 +1402,12 @@ public final class TypesUtils {
       TypeMirror functionalInterfaceType, ProcessingEnvironment env) {
     Context ctx = ((JavacProcessingEnvironment) env).getContext();
     com.sun.tools.javac.code.Types javacTypes = com.sun.tools.javac.code.Types.instance(ctx);
+    Type javaType = (Type) functionalInterfaceType;
+    if (javaType.isIntersection()) {
+      javaType = notionalInterface((IntersectionClassType) javaType, javacTypes);
+    }
     try {
-      return (ExecutableElement)
-          javacTypes.findDescriptorSymbol(((Type) functionalInterfaceType).asElement());
+      return (ExecutableElement) javacTypes.findDescriptorSymbol(javaType.asElement());
     } catch (FunctionDescriptorLookupError ex) {
       // FunctionDescriptorLookupError does not have a stack trace, so catch it here and throw a
       // BugInCF.


### PR DESCRIPTION
A method reference whose target type is an intersection type, such as `(Consumer<T> & Serializable) foo::bar`, crashed invocation type inference with "Target of method reference is not a functional interface".

`TypesUtils.isFunctionalInterface` delegated to javac's `Types.isFunctionalInterface(Type)`, which looks up the function descriptor of the type's symbol.  The symbol of an intersection type is a synthetic compound class symbol that is never marked as an interface, so that lookup always fails, even though JLS 9.9 lists "an intersection type that induces a notional functional interface" as one of the four kinds of functional interface type.

javac does not use that method for such a target type either: when attributing a lambda expression or method reference, `Attr.getTargetInfo` builds the notional interface induced by the intersection (JLS 4.9) and marks its symbol as an interface before looking up the descriptor.  Do the same in `TypesUtils.isFunctionalInterface` and `TypesUtils.findFunction`.

On the annotated-type side, `AbstractType.getFunctionType` cast the type to an `AnnotatedDeclaredType` in order to make it ground.  Instead, make each bound of an intersection type ground; `AnnotatedTypes.asMemberOf` then finds the bound that declares the function, just as javac computes the function type as a member of the intersection type.

Fixes #7684.