### PR TITLE
Make `gradlew clean` remove Emacs TAGS tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -196,6 +196,11 @@ allprojects { currentProj ->
   apply plugin: "net.ltgt.errorprone"
   // apply plugin: "pmd"
 
+  // Each project's `tags` task writes an Emacs TAGS table in the project directory.
+  tasks.named("clean") {
+    delete("TAGS")
+  }
+
   group = "org.checkerframework"
 
   // Keep in sync with "repositories { ... }" block above.
@@ -701,6 +706,10 @@ tasks.register("cleanManual") {
 clean.dependsOn(cleanManual)
 clean {
   delete(file("${rootDir}/docs/api"))
+  // Written by the `buildSrcTags` task.  The TAGS tables of the root project and of each
+  // subproject are deleted by the `clean` configuration in the `allprojects` block, and
+  // docs/manual/TAGS is deleted by `cleanCfManual`.
+  delete(file("${rootDir}/buildSrc/TAGS"))
   delete("${afuManualDir}/annotation-file-format.aux")
   delete("${afuManualDir}/annotation-file-format.blg")
   delete("${afuManualDir}/annotation-file-format.dvi")

--- a/docs/manual/Makefile
+++ b/docs/manual/Makefile
@@ -69,7 +69,7 @@ plume-bib:
 # Leaves manual.html, and .svg files that it references.
 .PHONY: clean
 clean:
-	@\rm -f *.aux *.blg *.dvi *.haux *.htoc *.idx *.ilg *.ind *.log *.out *.pdf *.ps *.toc manual.image.tex
+	@\rm -f *.aux *.blg *.dvi *.haux *.htoc *.idx *.ilg *.ind *.log *.out *.pdf *.ps *.toc manual.image.tex TAGS
 
 .PHONY: very-clean very_clean
 very-clean: very_clean


### PR DESCRIPTION
`gradlew tags` writes a TAGS table in the root project, in each subproject, in buildSrc, and in docs/manual, but `gradlew clean` removed none of them.

Delete each project's TAGS table from the `clean` task in the `allprojects` block, delete buildSrc/TAGS from the root `clean` task (buildSrc is a separate build with no `clean` task of its own), and delete docs/manual/TAGS from the manual Makefile's `clean` target, which `cleanCfManual` already invokes.

Fixes #7875