### PR TITLE
New message key flowexpr.parse.error.contract for contract parse errors

### DIFF
--- a/checker/jtreg/nullness/issue1582/Foo.goal
+++ b/checker/jtreg/nullness/issue1582/Foo.goal
@@ -1,2 +1,2 @@
-Foo.java:15:18: compiler.err.proc.messager: [flowexpr.parse.error]
+Foo.java:15:18: compiler.err.proc.messager: [flowexpr.parse.error.contract]
 1 error

--- a/checker/jtreg/nullness/preciseErrorMsg/Class1.goal
+++ b/checker/jtreg/nullness/preciseErrorMsg/Class1.goal
@@ -1,2 +1,2 @@
-Class1.java:15:22: compiler.err.proc.messager: [flowexpr.parse.error]
+Class1.java:15:22: compiler.err.proc.messager: [flowexpr.parse.error.contract]
 1 error

--- a/checker/tests/lock/ClassLiterals.java
+++ b/checker/tests/lock/ClassLiterals.java
@@ -10,7 +10,7 @@ public class ClassLiterals {
 
   // a class literal may not terminate a JavaExpression string
   @Holding("ClassLiterals")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   static void method2() {}
 
   @Holding("ClassLiterals.method1()")
@@ -21,7 +21,7 @@ public class ClassLiterals {
 
   // a class literal may not terminate a JavaExpression string
   @Holding("testpackage.ClassLiterals")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   static void method5() {}
 
   @Holding("testpackage.ClassLiterals.method1()")

--- a/checker/tests/lock/Issue805.java
+++ b/checker/tests/lock/Issue805.java
@@ -5,7 +5,7 @@ import org.checkerframework.checker.lock.qual.Holding;
 
 public class Issue805 {
   @Holding("this.Issue805.class")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method() {}
 
   @Holding("Issue805.class")

--- a/checker/tests/nullness-asserts/NonNullMapValue.java
+++ b/checker/tests/nullness-asserts/NonNullMapValue.java
@@ -205,7 +205,7 @@ public class NonNullMapValue {
     @EnsuresNonNullIf(result = true, expression = "get(#1)")
     // The following error is issued because, unlike in interface MyMap2,
     // this interface has no get() method.
-    // :: error: [flowexpr.parse.error]
+    // :: error: [flowexpr.parse.error.contract]
     boolean containsKey(@Nullable Object a1);
   }
 }

--- a/checker/tests/nullness/Issue752.java
+++ b/checker/tests/nullness/Issue752.java
@@ -17,7 +17,7 @@ public class Issue752 {
 
   // A package name without a class name is not a valid JavaExpression string.
   @RequiresNonNull("java.lang")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method1() {}
 
   @RequiresNonNull("java.lang.String.class")
@@ -25,12 +25,12 @@ public class Issue752 {
 
   // A package name without a class name is not a valid JavaExpression string.
   @RequiresNonNull("a.b.c")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method3() {}
 
   // notaclass does not exist.
   @RequiresNonNull("a.b.c.notaclass")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method4() {}
 
   @RequiresNonNull("a.b.c.Issue752.class")
@@ -44,12 +44,12 @@ public class Issue752 {
 
   // field is an instance field, and Issue752 is a class.
   @RequiresNonNull("a.b.c.Issue752.field")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method8() {}
 
   // field is an instance field, and Issue752 is a class.
   @RequiresNonNull("a.b.c.Issue752.field.field")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method9() {}
 
   @RequiresNonNull("a.b.c.Issue752.staticMethod()")
@@ -60,11 +60,11 @@ public class Issue752 {
 
   // method() is an instance method, and Issue752 is a class.
   @RequiresNonNull("a.b.c.Issue752.method()")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method12() {}
 
   // method() is an instance method, and Issue752 is a class.
   @RequiresNonNull("a.b.c.Issue752.method().field")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void method13() {}
 }

--- a/checker/tests/nullness/NNOEMoreTests.java
+++ b/checker/tests/nullness/NNOEMoreTests.java
@@ -12,7 +12,7 @@ public class NNOEMoreTests {
     }
 
     @RequiresNonNull("xxx")
-    // :: error: [flowexpr.parse.error]
+    // :: error: [flowexpr.parse.error.contract]
     void test2() {
       // :: error: [dereference.of.nullable]
       nullable.toString();

--- a/checker/tests/nullness/NNOEStaticFields.java
+++ b/checker/tests/nullness/NNOEStaticFields.java
@@ -41,7 +41,7 @@ public class NNOEStaticFields {
   }
 
   @RequiresNonNull("NoClueWhatThisShouldBe")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void testF5() {
     // :: error: [dereference.of.nullable]
     NNOEStaticFields.nullable.toString();

--- a/checker/tests/nullness/ParameterExpression.java
+++ b/checker/tests/nullness/ParameterExpression.java
@@ -21,7 +21,7 @@ public class ParameterExpression {
   @SuppressWarnings("assert.postcondition")
   // "#0" is illegal syntax; it should be "#1"
   @EnsuresNonNull("#0")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m2(final @Nullable Object o) {}
 
   @SuppressWarnings("contracts.postcondition")
@@ -45,32 +45,32 @@ public class ParameterExpression {
   }
 
   @EnsuresNonNull("param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m6a(Object param) {
     param = new Object();
   }
 
   @EnsuresNonNull("param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m6b(Object param) {
     // :: error: [assignment]
     param = null;
   }
 
   @EnsuresNonNull("param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m6c(@Nullable Object param) {
     param = new Object();
   }
 
   @EnsuresNonNull("param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m6d(@Nullable Object param) {
     param = null;
   }
 
   @EnsuresNonNull("param.toString()")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m6e(@Nullable Object param) {
     param = null;
   }
@@ -109,7 +109,7 @@ public class ParameterExpression {
   public void m8() {}
 
   @RequiresNonNull("param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void m9(Object param) {}
 
   // Warning issued. 'field' is a field, but in this case what matters is that it is the name of a
@@ -126,7 +126,7 @@ public class ParameterExpression {
   }
 
   @EnsuresNonNullIf(result = true, expression = "param")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public boolean m12(Object param) {
     param = new Object();
     return true;

--- a/checker/tests/nullness/RequiresNonNullTest.java
+++ b/checker/tests/nullness/RequiresNonNullTest.java
@@ -148,6 +148,6 @@ public class RequiresNonNullTest {
   @RequiresNonNull("thisShouldIssue1Error")
   // Test case for Issue 1051
   // https://github.com/typetools/checker-framework/issues/1051
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void testIssue1051() {}
 }

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1238,6 +1238,72 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   }
 
   /**
+   * Returns a diagnostic message for an annotation expression that cannot be parsed, describing
+   * where the expression appears in addition to why it cannot be parsed.
+   *
+   * <p>The message for {@code messageKey} takes {@code contextArgs} followed by the arguments of
+   * the parse failure, so the description precedes the explanation of the failure.
+   *
+   * @param ex the parse failure
+   * @param messageKey a message key whose message describes where the expression appears
+   * @param contextArgs the arguments to {@code messageKey} that precede those of {@code ex}
+   * @return a diagnostic message about the unparseable expression
+   */
+  private static DiagMessage parseErrorInContext(
+      JavaExpressionParseException ex,
+      @CompilerMessageKey String messageKey,
+      Object... contextArgs) {
+    if (!ex.isFlowParseError()) {
+      // Some other message key, whose format string this method does not know.
+      return new DiagMessage(ex);
+    }
+    Object[] args = new Object[contextArgs.length + ex.args.length];
+    System.arraycopy(contextArgs, 0, args, 0, contextArgs.length);
+    System.arraycopy(ex.args, 0, args, contextArgs.length, ex.args.length);
+    return new DiagMessage(Diagnostic.Kind.ERROR, messageKey, args);
+  }
+
+  /**
+   * Returns a diagnostic message for a {@code @SideEffectsOnly} expression that cannot be parsed.
+   * The message names the method whose annotation contains the expression, because the message
+   * might be issued at a call site, which may be far from that method's declaration.
+   *
+   * @param ex the parse failure
+   * @param declaringMethod the method on whose declaration the annotation appears
+   * @param declExpr the expression as written in the annotation
+   * @return a diagnostic message about the unparseable expression
+   */
+  public static DiagMessage sideEffectsOnlyParseError(
+      JavaExpressionParseException ex, ExecutableElement declaringMethod, String declExpr) {
+    return parseErrorInContext(
+        ex,
+        "flowexpr.parse.error.sideeffectsonly",
+        declExpr,
+        ElementUtils.getSimpleDescription(declaringMethod));
+  }
+
+  /**
+   * Returns a diagnostic message for a contract expression that cannot be parsed. The message names
+   * the contract annotation and the method that it appears on, because a method declaration may
+   * carry several contract annotations.
+   *
+   * @param ex the parse failure
+   * @param contract the contract whose expression cannot be parsed
+   * @param methodTree the method declaration on which the contract annotation appears
+   * @return a diagnostic message about the unparseable expression
+   */
+  private static DiagMessage contractParseError(
+      JavaExpressionParseException ex, Contract contract, MethodTree methodTree) {
+    return parseErrorInContext(
+        ex,
+        "flowexpr.parse.error.contract",
+        contract.kind.errorKey,
+        contract.expressionString,
+        contract.contractAnnotation.getAnnotationType().asElement().getSimpleName(),
+        ElementUtils.getSimpleDescription(TreeUtils.elementFromDeclaration(methodTree)));
+  }
+
+  /**
    * Issues an error for each expression of the method's {@code @SideEffectsOnly} annotation that
    * cannot be parsed in the scope of the method declaration.
    *
@@ -1266,29 +1332,6 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             getCurrentPath(), sideEffectsOnlyParseError(ex, methodElement, expression));
       }
     }
-  }
-
-  /**
-   * Returns a diagnostic message for a {@code @SideEffectsOnly} expression that cannot be parsed.
-   * The message names the method whose annotation contains the expression, because the message
-   * might be issued at a call site, which may be far from that method's declaration.
-   *
-   * @param ex the parse failure
-   * @param declaringMethod the method on whose declaration the annotation appears
-   * @param declExpr the expression as written in the annotation
-   * @return a diagnostic message about the unparseable expression
-   */
-  public static DiagMessage sideEffectsOnlyParseError(
-      JavaExpressionParseException ex, ExecutableElement declaringMethod, String declExpr) {
-    if (!ex.isFlowParseError()) {
-      // Some other message key, whose format string this method does not know.
-      return new DiagMessage(ex);
-    }
-    Object[] args = new Object[ex.args.length + 2];
-    args[0] = declExpr;
-    args[1] = ElementUtils.getSimpleDescription(declaringMethod);
-    System.arraycopy(ex.args, 0, args, 2, ex.args.length);
-    return new DiagMessage(Diagnostic.Kind.ERROR, "flowexpr.parse.error.sideeffectsonly", args);
   }
 
   /**
@@ -1448,19 +1491,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
       try {
         exprJe = StringToJavaExpression.atMethodBody(expressionString, methodTree, checker);
       } catch (JavaExpressionParseException e) {
-        DiagMessage diagMessage = new DiagMessage(e);
-        if (diagMessage.getMessageKey().equals("flowexpr.parse.error")) {
-          String s =
-              String.format(
-                  "'%s' in the %s %s on the declaration of method '%s': ",
-                  expressionString,
-                  contract.kind.errorKey,
-                  contract.contractAnnotation.getAnnotationType().asElement().getSimpleName(),
-                  methodTree.getName().toString());
-          checker.reportError(methodTree, "flowexpr.parse.error", s + diagMessage.getArgs()[0]);
-        } else {
-          checker.report(methodTree, new DiagMessage(e));
-        }
+        checker.report(methodTree, contractParseError(e, contract, methodTree));
         continue;
       }
       if (!CFAbstractStore.canInsertJavaExpression(exprJe)) {

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -87,6 +87,7 @@ purity.viewpoint.adaptation=@SideEffectsOnly(..., "%s") annotation (here, it ref
 flowexpr.parse.index.too.big=the method has no parameter #%s (total %s parameters)
 flowexpr.parse.error=cannot parse the expression %s
 flowexpr.parse.error.postcondition=error parsing the postcondition expression for %s%ncannot parse the expression %s
+flowexpr.parse.error.contract=cannot parse the %s expression "%s" in @%s on the declaration of %s: %s
 flowexpr.parse.error.sideeffectsonly=cannot parse the @SideEffectsOnly expression "%s" on the declaration of %s: %s
 flowexpr.parse.context.not.determined=could not determine the context at '%s' with which to parse expressions
 flowexpr.parameter.not.final=parameter %s in '%s' is not effectively final (i.e., it gets re-assigned)

--- a/framework/tests/flow/MetaPostcondition.java
+++ b/framework/tests/flow/MetaPostcondition.java
@@ -27,11 +27,11 @@ public class MetaPostcondition {
   void oddF1_error() {}
 
   @EnsuresOdd("---")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error() {}
 
   @EnsuresOdd("#1.#2")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error2(final String p1, final String p2) {}
 
   @EnsuresOdd("f1")

--- a/framework/tests/flow/MetaPrecondition.java
+++ b/framework/tests/flow/MetaPrecondition.java
@@ -25,7 +25,7 @@ public class MetaPrecondition {
   }
 
   @RequiresOdd("---")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error() {
     // :: error: [assignment]
     @ValueTypeAnno String l1 = f1;

--- a/framework/tests/flow/Postcondition.java
+++ b/framework/tests/flow/Postcondition.java
@@ -43,11 +43,11 @@ public class Postcondition {
   void valueF1() {}
 
   @EnsuresQualifier(expression = "---", qualifier = ValueTypeAnno.class)
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error() {}
 
   @EnsuresQualifier(expression = "#1.#2", qualifier = ValueTypeAnno.class)
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error2(final String p1, final String p2) {}
 
   @EnsuresQualifier(expression = "f1", qualifier = ValueTypeAnno.class)
@@ -156,7 +156,7 @@ public class Postcondition {
   @EnsuresQualifier.List({
     @EnsuresQualifier(expression = "---", qualifier = Odd.class),
   })
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error2() {}
 
   // basic postcondition test

--- a/framework/tests/flow/Precondition.java
+++ b/framework/tests/flow/Precondition.java
@@ -33,7 +33,7 @@ public class Precondition {
   }
 
   @RequiresQualifier(expression = "---", qualifier = Odd.class)
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error() {
     // :: error: [assignment]
     @ValueTypeAnno String l1 = f1;
@@ -143,7 +143,7 @@ public class Precondition {
   }
 
   @RequiresQualifier.List({@RequiresQualifier(expression = "---", qualifier = ValueTypeAnno.class)})
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   void error2() {}
 
   void t5(@Odd String p1, String p2, @ValueTypeAnno String p3) {

--- a/framework/tests/flow/javaexpression-scope/Class2.java
+++ b/framework/tests/flow/javaexpression-scope/Class2.java
@@ -7,7 +7,7 @@ import pkg1.Class1;
 
 public class Class2 {
   @RequiresOdd("Class1.field")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void requiresOddParseError() {
     // :: error: [assignment]
     @Odd Object odd = Class1.field;
@@ -19,7 +19,7 @@ public class Class2 {
   }
 
   @EnsuresOdd("Class1.field")
-  // :: error: [flowexpr.parse.error]
+  // :: error: [flowexpr.parse.error.contract]
   public void ensuresOddParseError() {
     // :: warning: [cast.unsafe.constructor.invocation]
     Class1.field = new @Odd Object();


### PR DESCRIPTION
A parse error in a contract annotation now names the contract kind, the annotation, and the method, via a new helper parseErrorInContext that is shared with sideEffectsOnlyParseError, instead of prepending an ad-hoc string to a bare flowexpr.parse.error message.