### PR TITLE
Report an unparsable `@EnsuresCalledMethodsOnException` expression at the call site

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/calledmethods/CalledMethodsTransfer.java
@@ -28,6 +28,7 @@ import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.dataflow.expression.JavaExpression;
 import org.checkerframework.dataflow.expression.JavaExpressionParseException;
 import org.checkerframework.framework.flow.CFAbstractStore;
+import org.checkerframework.framework.source.DiagMessage;
 import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.util.StringToJavaExpression;
 import org.checkerframework.javacutil.AnnotationMirrorSet;
@@ -272,8 +273,18 @@ public class CalledMethodsTransfer extends AccumulationTransfer {
             StringToJavaExpression.atMethodInvocation(
                 postcond.expression(), node.getTree(), atypeFactory.getChecker());
       } catch (JavaExpressionParseException ex) {
-        // This parse error will be reported later. For now, we'll skip this malformed
-        // postcondition and move on to the others.
+        if (ex.isFlowParseError()) {
+          Object[] args = new Object[ex.args.length + 1];
+          args[0] = ElementUtils.getSimpleSignature(method);
+          System.arraycopy(ex.args, 0, args, 1, ex.args.length);
+          atypeFactory
+              .getChecker()
+              .reportError(node.getTree(), "flowexpr.parse.error.postcondition", args);
+        } else {
+          atypeFactory.getChecker().report(node.getTree(), new DiagMessage(ex));
+        }
+        // Skip this malformed postcondition and move on to the others.  Dropping it only removes
+        // facts from the store, which is conservative.
         continue;
       }
 

--- a/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionUnparsable.java
+++ b/checker/tests/calledmethods/EnsuresCalledMethodsOnExceptionUnparsable.java
@@ -1,0 +1,24 @@
+// An unparsable `@EnsuresCalledMethodsOnException` expression is reported at the call as well as
+// at the declaration.  The callee may be declared in a stub file or in another compilation unit,
+// in which case the declaration is never checked and the call is the only place to report it.
+
+import java.io.IOException;
+import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethodsOnException;
+
+public class EnsuresCalledMethodsOnExceptionUnparsable {
+
+  static class Resource {
+    void a() {}
+  }
+
+  @EnsuresCalledMethodsOnException(value = "nosuchthing", methods = "a")
+  // :: error: (flowexpr.parse.error)
+  void unparsable(Resource r) throws IOException {
+    throw new IOException();
+  }
+
+  void call(Resource r) throws IOException {
+    // :: error: (flowexpr.parse.error.postcondition)
+    unparsable(r);
+  }
+}


### PR DESCRIPTION
The callee may be declared in a stub file or in another compilation unit, in which case its declaration is never checked and the call site is the only place where the error can be reported.