### PR TITLE
Explain why some JavaExpression parse failures are not reported

### DIFF
--- a/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/util/coll/WrapperMap.java
+++ b/annotation-file-utilities/src/main/java/org/checkerframework/afu/scenelib/util/coll/WrapperMap.java
@@ -60,7 +60,10 @@ public class WrapperMap<K, V> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings({"keyfor:contracts.postcondition", "nullness:return"})
+  @SuppressWarnings({
+    "keyfor:contracts.postcondition", // backing map
+    "nullness:return" // generics lower bound problem
+  })
   @SideEffectsOnly("this")
   public V put(K key, V value) {
     return back.put(key, value);
@@ -73,7 +76,7 @@ public class WrapperMap<K, V> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings("nullness:return")
+  @SuppressWarnings("nullness:return") // generics lower bound problem
   @SideEffectsOnly("this")
   public V remove(Object key) {
     return back.remove(key);

--- a/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/inequality/LessThanAnnotatedTypeFactory.java
@@ -222,6 +222,9 @@ public class LessThanAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForInd
     try {
       expressionJe = valueAtypeFactory.parseJavaExpressionString(expression, path);
     } catch (JavaExpressionParseException e) {
+      // Do not report the error.  The argument is an offset equation such as "n + 1", which the
+      // parser does not handle, so failing to parse it is not necessarily a user error.
+      // Returning the least informative bound is conservative.
       return Long.MIN_VALUE;
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/samelen/SameLenTransfer.java
@@ -164,6 +164,9 @@ public class SameLenTransfer extends CFTransfer {
       try {
         je = atypeFactory.parseJavaExpressionString(exprString, currentPath);
       } catch (JavaExpressionParseException e) {
+        // Do not report the error here; that would duplicate the one that DependentTypesHelper
+        // issues for the `@SameLen` annotation, whose `value` element is a `@JavaExpression`.
+        // Skipping the expression only loses precision.
         continue;
       }
       store.clearValue(je);

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundAnnotatedTypeFactory.java
@@ -957,6 +957,9 @@ public class UpperBoundAnnotatedTypeFactory extends BaseAnnotatedTypeFactoryForI
       try {
         exprAndOffset = getExpressionAndOffsetFromJavaExpressionString(expression, treePath);
       } catch (JavaExpressionParseException e) {
+        // Do not report the error here; that would duplicate the one that DependentTypesHelper
+        // issues for the `@LessThan` annotation that supplied the expression.  Skipping the
+        // expression only loses precision.
         exprAndOffset = null;
       }
       if (exprAndOffset == null) {

--- a/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/index/upperbound/UpperBoundVisitor.java
@@ -367,6 +367,9 @@ public class UpperBoundVisitor extends BaseTypeVisitor<UpperBoundAnnotatedTypeFa
     try {
       result = atypeFactory.parseJavaExpressionString(s, currentPath);
     } catch (JavaExpressionParseException e) {
+      // Do not report the error.  As the Javadoc says, failing to parse is an ordinary outcome
+      // for a string that is not a Java expression, such as "n+1".  If the string does come from
+      // an annotation, DependentTypesHelper reports the error.
       result = null;
     }
     return result;

--- a/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
+++ b/checker/src/main/java/org/checkerframework/checker/resourceleak/MustCallConsistencyAnalyzer.java
@@ -1690,6 +1690,9 @@ public class MustCallConsistencyAnalyzer {
                     targetStrWithoutAdaptation, enclosingMethod, checker)
                 .toString();
       } catch (JavaExpressionParseException e) {
+        // Do not report the error here; that would duplicate the one that
+        // `CreatesMustCallForToJavaExpression` issues at the declaration of `enclosingMethod`,
+        // which is being compiled.  Compare the unadapted string instead.
         targetStr = targetStrWithoutAdaptation;
       }
       if (targetStr.equals(receiverString)) {


### PR DESCRIPTION
Also add justifications to two warning suppressions in WrapperMap. Comment-only; no behavior change.