### PR TITLE
Apply the capture dependency rules only to captured wildcards

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/bound/BoundSet.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/bound/BoundSet.java
@@ -268,10 +268,26 @@ public class BoundSet implements ReductionResult {
     }
     Dependencies dependencies = new Dependencies();
 
+    // The two rules below apply only to a capture variable for a wildcard, though JLS 18.4 states
+    // them for every variable on the left-hand side of a capture bound.  This follows javac:
+    // Infer#generateReturnConstraints captures the return type and then adds an inference variable
+    // only for a type argument that capture conversion replaced, that is, only for a wildcard,
+    // whereas JLS 18.5.2.1 creates one for each of the n type arguments.
+    //
+    // The difference matters because these rules reverse the usual direction of a dependency.  For
+    // a non-wildcard type argument Ai, the bound alphai = Ai holds, so applying them makes every
+    // variable mentioned in Ai's bounds depend on alphai, and that can create a cycle where javac
+    // has none.  See tests/all-systems/Issue7694.java: applying them to the variable that captures
+    // `E` in `Collector<E, ?, List<E>>` puts the variable for `Optional.empty()` in the same
+    // resolution set as the variable it is a lower bound of, and resolution then discards that
+    // lower bound for not being proper.
     for (CaptureBound capture : captures) {
       List<? extends CaptureVariable> lhsVars = capture.getAllVariablesOnLHS();
       Set<Variable> rhsVars = capture.getAllVariablesOnRHS();
       for (Variable var : lhsVars) {
+        if (!var.isCapturedWildcard()) {
+          continue;
+        }
         // An inference variable alpha appearing on the left-hand side of a bound of the
         // form G<..., alpha, ...> = capture(G<...>) depends on the resolution of every
         // other inference variable mentioned in this bound (on both sides of the = sign).
@@ -285,7 +301,7 @@ public class BoundSet implements ReductionResult {
       LinkedHashSet<Variable> alphaDependencies =
           new LinkedHashSet<>(alpha.getBounds().getVariablesMentionedInBounds());
 
-      if (alpha.isCaptureVariable()) {
+      if (alpha.isCapturedWildcard()) {
         // If alpha appears on the left-hand side of another bound of the form
         // G<..., alpha, ...> = capture(G<...>), then beta depends on the resolution of
         // alpha.

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/bound/CaptureBound.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/bound/CaptureBound.java
@@ -77,6 +77,7 @@ public final class CaptureBound {
       AbstractType Ai = args.next();
 
       CaptureVariable alphai = (CaptureVariable) alphas.next();
+      alphai.setCapturedWildcard(Ai.getTypeKind() == TypeKind.WILDCARD);
       captureVariables.add(alphai);
       alphai.initialBounds(map);
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CaptureVariable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CaptureVariable.java
@@ -59,9 +59,7 @@ import org.checkerframework.framework.util.typeinference8.util.Theta;
   private boolean capturedWildcard = true;
 
   /**
-   * Sets whether the type argument that this variable captures is a wildcard. Called by {@link
-   * org.checkerframework.framework.util.typeinference8.bound.CaptureBound} while it builds the
-   * bound, because the type argument is not known when this variable is created.
+   * Sets whether the type argument that this variable captures is a wildcard.
    *
    * @param capturedWildcard true if the captured type argument is a wildcard
    */

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CaptureVariable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/CaptureVariable.java
@@ -55,8 +55,27 @@ import org.checkerframework.framework.util.typeinference8.util.Theta;
     return variableBounds.getWildcardConstraints(Ai, Bi);
   }
 
+  /** True if the type argument that this variable captures is a wildcard. */
+  private boolean capturedWildcard = true;
+
+  /**
+   * Sets whether the type argument that this variable captures is a wildcard. Called by {@link
+   * org.checkerframework.framework.util.typeinference8.bound.CaptureBound} while it builds the
+   * bound, because the type argument is not known when this variable is created.
+   *
+   * @param capturedWildcard true if the captured type argument is a wildcard
+   */
+  public void setCapturedWildcard(boolean capturedWildcard) {
+    this.capturedWildcard = capturedWildcard;
+  }
+
   @Override
   public boolean isCaptureVariable() {
     return true;
+  }
+
+  @Override
+  public boolean isCapturedWildcard() {
+    return capturedWildcard;
   }
 }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/Variable.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/types/Variable.java
@@ -216,6 +216,16 @@ import org.checkerframework.javacutil.TypesUtils;
   }
 
   /**
+   * Returns true if this variable was created for a capture bound and the type argument it captures
+   * is a wildcard.
+   *
+   * @return true if this variable was created for a captured wildcard
+   */
+  public boolean isCapturedWildcard() {
+    return false;
+  }
+
+  /**
    * The Java type variable.
    *
    * @return the Java type variable

--- a/framework/tests/all-systems/Issue7694.java
+++ b/framework/tests/all-systems/Issue7694.java
@@ -1,0 +1,40 @@
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+@SuppressWarnings({
+  "optional.as.element.type",
+  "optional.null.comparison",
+  "nulltest.redundant"
+}) // true positives
+public class Issue7694 {
+  static class Foo {}
+
+  interface Promise<T> {
+    <U> Promise<U> then(Function<? super T, ? extends U> function);
+  }
+
+  static <O, C> Promise<C> make(
+      Supplier<Promise<O>> function, Collector<? super O, ?, C> collector) {
+    throw new UnsupportedOperationException();
+  }
+
+  static <E> Collector<E, ?, List<E>> toImmutableList() {
+    throw new UnsupportedOperationException();
+  }
+
+  Promise<?> run(Promise<Optional<Foo>> promise) {
+    return make(
+        () ->
+            promise.then(
+                o -> {
+                  if (o != null) {
+                    return o;
+                  }
+                  return Optional.empty();
+                }),
+        toImmutableList());
+  }
+}


### PR DESCRIPTION
JLS 18.5.2.1 says that when the return type of a poly invocation is a parameterized type G<A1, ..., An> and one of A1, ..., An is a wildcard, fresh inference variables B1, ..., Bn are created along with the bound G<B1, ..., Bn> = capture(G<A1, ..., An>).  A variable is created for every type argument, not only for the wildcards.

javac creates fewer.  Infer#generateReturnConstraints captures the return type and then adds an inference variable only for a type argument that capture conversion replaced, which is only a wildcard.  For the return type `Collector<E, ?, List<E>>` of `toImmutableList()` in the new test case, javac adds one variable and the Checker Framework adds three.

The extra variables change inference, because the two dependency rules that JLS 18.4 states for a variable on the left-hand side of a capture bound reverse the usual direction of a dependency.  For a non-wildcard type argument Ai the bound alphai = Ai holds, so applying those rules makes every variable mentioned in Ai's bounds depend on alphai.  In the new test case that puts the variable for `Optional.empty()` in the same resolution set as the variable it is a lower bound of.  Resolution then instantiates them together, discards the lower bound `Optional<T>` because it is not proper, and derives the false bound `Optional<Object> <: Optional<Foo>`.  Inference reported "type.argument.inference.crashed"; it now infers `Optional<? extends Object>`, as javac does.

Apply the two rules only to a variable that captures a wildcard.

Fixes #7694.