### PR TITLE
Type inference: do not apply theta to the type of a lambda parameter

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ Made the field `Java8InferenceContext.pathToExpression` private; use
 
 ### Closed issues
 
-\#7684.
+\#7684, #8047.
 
 ## Version 4.2.2 (2026-08-06)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,7 +17,7 @@ Made the field `Java8InferenceContext.pathToExpression` private; use
 
 ### Closed issues
 
-\#7684, #8047.
+\#7684.
 
 ## Version 4.2.2 (2026-08-06)
 

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
@@ -96,25 +96,9 @@ public class Expression extends TypeConstraint {
       return reduceProperType();
     } else if (TreeUtils.isStandaloneExpression(expression)) {
       AbstractType s;
-      if (!context.isLambdaParam(expression)) {
-        s = new ProperType(expression, context);
-      } else {
-        // javac does not record the type of an implicitly typed lambda parameter on its element,
-        // so ask the type factory, which consults inference for it.
-        AnnotatedTypeMirror atm = context.typeFactory.getAnnotatedType(expression);
-        // The result is a proper type, because it comes from the program's scope rather than from
-        // the declaration of the method or constructor whose type arguments are being inferred: a
-        // type variable in it denotes itself, so the substitution theta of JLS 18.5.1 must not be
-        // applied to it.  Applying theta would be wrong for a class instance creation expression
-        // that uses the diamond form, because JLS 15.9.3 makes the type parameters of the
-        // instantiated class type parameters of the constructor, so theta maps them, and those
-        // same type variables can also be in scope at the expression -- as they are when a generic
-        // class constructs itself with a diamond inside one of its own methods.  Applying theta
-        // there would replace such a type variable by the inference variable that stands for the
-        // class's type argument, silently discarding the constraint that the expression's type
-        // places on that variable.
-        s = new ProperType(atm, context);
-      }
+
+      s = new ProperType(expression, context);
+
       return new Typing(this, s, T, TypeConstraint.Kind.TYPE_COMPATIBILITY);
     }
     switch (expression.getKind()) {
@@ -244,19 +228,13 @@ public class Expression extends TypeConstraint {
         AbstractType targetReference = ps.remove(0);
         ExpressionTree preColonTree = memRef.getQualifierExpression();
         AbstractType referenceType;
-        if (context.isLambdaParam(preColonTree)) {
-          AnnotatedTypeMirror atm = context.typeFactory.getAnnotatedType(preColonTree);
-          // A proper type, for the reason given in reduce().
+        if (MemberReferenceKind.getMemberReferenceKind(memRef).isUnbound()) {
+          AnnotatedTypeMirror atm = context.typeFactory.getAnnotatedTypeFromTypeTree(preColonTree);
           referenceType = new ProperType(atm, context);
         } else {
-          if (MemberReferenceKind.getMemberReferenceKind(memRef).isUnbound()) {
-            AnnotatedTypeMirror atm =
-                context.typeFactory.getAnnotatedTypeFromTypeTree(preColonTree);
-            referenceType = new ProperType(atm, context);
-          } else {
-            referenceType = new ProperType(preColonTree, context);
-          }
+          referenceType = new ProperType(preColonTree, context);
         }
+
         constraintSet.add(
             new Typing(this, targetReference, referenceType, TypeConstraint.Kind.SUBTYPE));
       }

--- a/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
+++ b/framework/src/main/java/org/checkerframework/framework/util/typeinference8/constraint/Expression.java
@@ -99,8 +99,21 @@ public class Expression extends TypeConstraint {
       if (!context.isLambdaParam(expression)) {
         s = new ProperType(expression, context);
       } else {
+        // javac does not record the type of an implicitly typed lambda parameter on its element,
+        // so ask the type factory, which consults inference for it.
         AnnotatedTypeMirror atm = context.typeFactory.getAnnotatedType(expression);
-        s = getT().create(atm, false);
+        // The result is a proper type, because it comes from the program's scope rather than from
+        // the declaration of the method or constructor whose type arguments are being inferred: a
+        // type variable in it denotes itself, so the substitution theta of JLS 18.5.1 must not be
+        // applied to it.  Applying theta would be wrong for a class instance creation expression
+        // that uses the diamond form, because JLS 15.9.3 makes the type parameters of the
+        // instantiated class type parameters of the constructor, so theta maps them, and those
+        // same type variables can also be in scope at the expression -- as they are when a generic
+        // class constructs itself with a diamond inside one of its own methods.  Applying theta
+        // there would replace such a type variable by the inference variable that stands for the
+        // class's type argument, silently discarding the constraint that the expression's type
+        // places on that variable.
+        s = new ProperType(atm, context);
       }
       return new Typing(this, s, T, TypeConstraint.Kind.TYPE_COMPATIBILITY);
     }
@@ -233,7 +246,8 @@ public class Expression extends TypeConstraint {
         AbstractType referenceType;
         if (context.isLambdaParam(preColonTree)) {
           AnnotatedTypeMirror atm = context.typeFactory.getAnnotatedType(preColonTree);
-          referenceType = T.create(atm, false);
+          // A proper type, for the reason given in reduce().
+          referenceType = new ProperType(atm, context);
         } else {
           if (MemberReferenceKind.getMemberReferenceKind(memRef).isUnbound()) {
             AnnotatedTypeMirror atm =

--- a/framework/tests/all-systems/Issue8047.java
+++ b/framework/tests/all-systems/Issue8047.java
@@ -1,0 +1,63 @@
+// A diamond that instantiates the enclosing class, appearing in a lambda body, crashed inference.
+// The type parameters of the instantiated class are type parameters of the constructor (JLS
+// 15.9.3), so theta maps `Adapter`'s `T` to an inference variable.  `T` is also in scope at the
+// lambda body, so applying theta to the type of the lambda parameter `input` replaced `T` by that
+// inference variable, turning the constraint `input -> T#0` into `T#0 -> T#0`.  `T#0` was then left
+// with no lower bound and resolved to `Object`, and the resulting `Adapter<Object>` crashed
+// StructuralEqualityComparer when it was compared against the target type's `Adapter<T>`.
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Issue8047 {
+
+  static class Adapter<T> {
+    Adapter(T t) {}
+
+    List<Adapter<T>> viaStream(Stream<T> s) {
+      return s.map(input -> new Adapter<>(input)).collect(Collectors.toList());
+    }
+
+    List<Adapter<T>> viaList(List<T> l) {
+      return l.stream().map(input -> new Adapter<>(input)).collect(Collectors.toList());
+    }
+
+    // Spelling out the type argument instead of using a diamond did not crash.
+    List<Adapter<T>> explicitTypeArgument(Stream<T> s) {
+      return s.map(input -> new Adapter<T>(input)).collect(Collectors.toList());
+    }
+  }
+
+  // The same shape, without any JDK stream classes.
+
+  interface Str<E> {
+    <R> Str<R> map(Function<? super E, ? extends R> f);
+
+    <X> X collect(Coll<? super E, X> c);
+  }
+
+  interface Coll<E, X> {}
+
+  static <Y> Coll<Y, List<Y>> toList() {
+    throw new AssertionError();
+  }
+
+  static class Wrapper<T> {
+    Wrapper(T t) {}
+
+    List<Wrapper<T>> f(Str<T> s) {
+      return s.map(input -> new Wrapper<>(input)).collect(toList());
+    }
+  }
+
+  // A diamond for a class other than the enclosing one did not crash.
+  static class Other<T> {}
+
+  static class Holder<T> {
+    List<Other<T>> f(Stream<T> s) {
+      return s.map(input -> new Other<T>()).collect(Collectors.toList());
+    }
+  }
+}


### PR DESCRIPTION
Fixes #8047