### PR TITLE
Scan nodeList backward in CFGTranslationPhaseOne.insertExtendedNodeAfter

### DIFF
--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -771,8 +771,14 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
    */
   @SuppressWarnings("ModifyCollectionInEnhancedForLoop")
   protected void insertExtendedNodeAfter(ExtendedNode n, @FindDistinct Node pred) {
+    // Search backward from the end because `pred` is almost always the node most recently
+    // appended or inserted (e.g. the chained conversions in box()/unbox()/widen()/narrow()), so
+    // it is at or near the tail of `nodeList`. Scanning forward from index 0 here made
+    // straight-line code with many conversions (e.g. autoboxing) quadratic in the number of
+    // statements, because this method is called a constant number of times per statement while
+    // each call scanned the entire, ever-growing list.
     int index = -1;
-    for (int i = 0; i < nodeList.size(); i++) {
+    for (int i = nodeList.size() - 1; i >= 0; i--) {
       ExtendedNode inList = nodeList.get(i);
       if (inList instanceof NodeHolder || inList instanceof NodeWithExceptionsHolder) {
         if (inList.getNode() == pred) {

--- a/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
+++ b/dataflow/src/main/java/org/checkerframework/dataflow/cfg/builder/CFGTranslationPhaseOne.java
@@ -773,10 +773,7 @@ public class CFGTranslationPhaseOne extends TreeScanner<Node, Void> {
   protected void insertExtendedNodeAfter(ExtendedNode n, @FindDistinct Node pred) {
     // Search backward from the end because `pred` is almost always the node most recently
     // appended or inserted (e.g. the chained conversions in box()/unbox()/widen()/narrow()), so
-    // it is at or near the tail of `nodeList`. Scanning forward from index 0 here made
-    // straight-line code with many conversions (e.g. autoboxing) quadratic in the number of
-    // statements, because this method is called a constant number of times per statement while
-    // each call scanned the entire, ever-growing list.
+    // it is at or near the tail of `nodeList`.
     int index = -1;
     for (int i = nodeList.size() - 1; i >= 0; i--) {
       ExtendedNode inList = nodeList.get(i);


### PR DESCRIPTION
Claude came up with this as a possible performance improvement.  It didn't help the test case, but I think it's good to merge anyways. 