### PR TITLE
Make AnnotatedTypeMirror.hashCode() consistent with equals()

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -75,9 +75,9 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
   protected final TypeMirror underlyingType;
 
   /**
-   * Saves the result of {@code underlyingType.toString().hashCode()} to use when computing the hash
-   * code of this. (Because AnnotatedTypeMirrors are mutable, the hash code for this cannot be
-   * saved.) Call {@link #getUnderlyingTypeHashCode()} rather than using the field directly.
+   * Saves the result of {@code underlyingType.hashCode()} to use when computing the hash code of
+   * this. (Because AnnotatedTypeMirrors are mutable, the hash code for this cannot be saved.) Call
+   * {@link #getUnderlyingTypeHashCode()} rather than using the field directly.
    */
   private int underlyingTypeHashCode = -1;
 
@@ -888,14 +888,21 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
   }
 
   /**
-   * Returns the result of calling {@code underlyingType.toString().hashcode()}. This method saves
-   * the result in a field so that it isn't recomputed each time.
+   * Returns the result of calling {@code underlyingType.hashCode()}. This method saves the result
+   * in a field so that it isn't recomputed each time.
    *
-   * @return the result of calling {@code underlyingType.toString().hashcode()}
+   * <p>This uses the underlying type's own hash code rather than the hash code of its string
+   * representation, because {@link #equals} compares underlying types with {@code
+   * TypeMirror.equals}, which in javac is reference equality (except for array types, whose {@code
+   * hashCode} is likewise structural). A string-based hash code makes every pair of distinct but
+   * identically-printing types collide, which turns hash sets of types into linear -- or, once a
+   * bin treeifies, worse than linear -- scans of failing structural comparisons.
+   *
+   * @return the result of calling {@code underlyingType.hashCode()}
    */
   public int getUnderlyingTypeHashCode() {
     if (underlyingTypeHashCode == -1) {
-      underlyingTypeHashCode = underlyingType.toString().hashCode();
+      underlyingTypeHashCode = underlyingType.hashCode();
     }
     return underlyingTypeHashCode;
   }

--- a/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/AnnotatedTypeMirror.java
@@ -76,10 +76,14 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
 
   /**
    * Saves the result of {@code underlyingType.hashCode()} to use when computing the hash code of
-   * this. (Because AnnotatedTypeMirrors are mutable, the hash code for this cannot be saved.) Call
-   * {@link #getUnderlyingTypeHashCode()} rather than using the field directly.
+   * this. (Because AnnotatedTypeMirrors are mutable, the hash code for this cannot be saved.) This
+   * field is meaningful only if {@link #underlyingTypeHashCodeComputed} is true. Call {@link
+   * #getUnderlyingTypeHashCode()} rather than using the field directly.
    */
-  private int underlyingTypeHashCode = -1;
+  private int underlyingTypeHashCode;
+
+  /** True if {@link #underlyingTypeHashCode} has been computed. */
+  private boolean underlyingTypeHashCodeComputed = false;
 
   /** The annotations on this type. */
   // AnnotationMirror doesn't override Object.hashCode, .equals, so we use
@@ -901,8 +905,9 @@ public abstract class AnnotatedTypeMirror implements DeepCopyable<AnnotatedTypeM
    * @return the result of calling {@code underlyingType.hashCode()}
    */
   public int getUnderlyingTypeHashCode() {
-    if (underlyingTypeHashCode == -1) {
+    if (!underlyingTypeHashCodeComputed) {
       underlyingTypeHashCode = underlyingType.hashCode();
+      underlyingTypeHashCodeComputed = true;
     }
     return underlyingTypeHashCode;
   }


### PR DESCRIPTION
getUnderlyingTypeHashCode() returned underlyingType.toString().hashCode(), a structural hash, but equals() compares underlying types with TypeMirror.equals, which in javac is reference equality (Type.equals is `this == t`; only Type.ArrayType overrides it, structurally over its element type, with a matching hashCode).

Every pair of distinct but identically-printing types therefore collided. Hash sets of types degenerated into scans of failing structural comparisons, and once a bin treeified, into scans of both subtrees -- treeified bins call equals at every node when the keys hash alike and are not Comparable.

On the Map.ofEntries test case from issue 7023, which repeats one Map.entry argument 25 times, this reduces AnnotatedTypeMirror.equals calls in a run from 37,910,695 to 61,438.