### PR TITLE
Enforce @TargetLocations; fixes #8042

### DIFF
--- a/checker-qual/src/main/java/org/checkerframework/framework/qual/TargetLocations.java
+++ b/checker-qual/src/main/java/org/checkerframework/framework/qual/TargetLocations.java
@@ -7,11 +7,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * NOTE: This meta-annotation is <a
- * href="https://github.com/typetools/checker-framework/issues/1919"><b>not currently
- * enforced</b></a>.
- *
- * <p>A meta-annotation that restricts the type-use locations where a type qualifier may be written.
+ * A meta-annotation that restricts the type-use locations where a type qualifier may be written.
  * When written together with {@code @Target({ElementType.TYPE_USE})}, the given type qualifier may
  * be written only at locations listed in the {@code @TargetLocations(...)} meta-annotation.
  * {@code @Target({ElementType.TYPE_USE})} together with no {@code @TargetLocations(...)} means that

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@
 
 ### Changes for type system implementers
 
+The Checker Framework now enforces `@TargetLocations` restrictions on explicitly
+written type qualifiers.
+
 `AnnotatedTypeMirror.hashCode()` now hashes only the top-level type rather than
 recursively hashing component types.  Removed class `HashcodeAtmVisitor`, field
 `AnnotatedTypeMirror.HASHCODE_VISITOR`, and method

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -3008,6 +3008,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             case EXTENDS_WILDCARD -> TypeUseLocation.EXPLICIT_UPPER_BOUND;
             case SUPER_WILDCARD -> TypeUseLocation.EXPLICIT_LOWER_BOUND;
             case TYPE_PARAMETER -> TypeUseLocation.EXPLICIT_UPPER_BOUND;
+            case TYPE_CAST, INSTANCE_OF -> TypeUseLocation.LOCAL_VARIABLE;
             case METHOD -> TypeUseLocation.RETURN;
             case VARIABLE -> {
               VariableTree variableTree = (VariableTree) tree;
@@ -3020,7 +3021,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
               ElementKind kind = TreeUtils.elementFromDeclaration(variableTree).getKind();
               yield switch (kind) {
                 case FIELD -> TypeUseLocation.FIELD;
-                case LOCAL_VARIABLE -> TypeUseLocation.LOCAL_VARIABLE;
+                case LOCAL_VARIABLE, BINDING_VARIABLE -> TypeUseLocation.LOCAL_VARIABLE;
                 case RESOURCE_VARIABLE -> TypeUseLocation.RESOURCE_VARIABLE;
                 case EXCEPTION_PARAMETER -> TypeUseLocation.EXCEPTION_PARAMETER;
                 case PARAMETER -> TypeUseLocation.PARAMETER;

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -1047,6 +1047,7 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
       visitAnnotatedType(modifiers.getAnnotations(), returnType);
       warnRedundantAnnotations(returnType, methodType.getReturnType());
     } else if (TreeUtils.isConstructor(tree)) {
+      checkTargetLocations(modifiers.getAnnotations(), TypeUseLocation.CONSTRUCTOR_RESULT);
       maybeReportAnnoOnIrrelevant(
           modifiers, methodType.getReturnType().getUnderlyingType(), modifiers.getAnnotations());
     }
@@ -2957,6 +2958,12 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     if (location == null) {
       return;
     }
+    checkTargetLocations(annoTrees, location);
+  }
+
+  /** Checks that explicitly written qualifiers are permitted at {@code location}. */
+  private void checkTargetLocations(
+      List<? extends AnnotationTree> annoTrees, TypeUseLocation location) {
     for (AnnotationTree annoTree : annoTrees) {
       AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(annoTree);
       if (!atypeFactory.isSupportedQualifier(anno)) {
@@ -3003,7 +3010,14 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
             case TYPE_PARAMETER -> TypeUseLocation.EXPLICIT_UPPER_BOUND;
             case METHOD -> TypeUseLocation.RETURN;
             case VARIABLE -> {
-              ElementKind kind = TreeUtils.elementFromDeclaration((VariableTree) tree).getKind();
+              VariableTree variableTree = (VariableTree) tree;
+              TreePath parentPath = path.getParentPath();
+              if (parentPath != null
+                  && parentPath.getLeaf() instanceof MethodTree enclosingMethod
+                  && enclosingMethod.getReceiverParameter() == variableTree) {
+                yield TypeUseLocation.RECEIVER;
+              }
+              ElementKind kind = TreeUtils.elementFromDeclaration(variableTree).getKind();
               yield switch (kind) {
                 case FIELD -> TypeUseLocation.FIELD;
                 case LOCAL_VARIABLE -> TypeUseLocation.LOCAL_VARIABLE;

--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -109,6 +109,8 @@ import org.checkerframework.framework.flow.CFAbstractStore;
 import org.checkerframework.framework.flow.CFAbstractValue;
 import org.checkerframework.framework.qual.DefaultQualifier;
 import org.checkerframework.framework.qual.HasQualifierParameter;
+import org.checkerframework.framework.qual.TargetLocations;
+import org.checkerframework.framework.qual.TypeUseLocation;
 import org.checkerframework.framework.qual.Unused;
 import org.checkerframework.framework.source.DiagMessage;
 import org.checkerframework.framework.source.SourceVisitor;
@@ -2945,6 +2947,79 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
   public void visitAnnotatedType(
       @Nullable List<? extends AnnotationTree> annoTrees, Tree typeTree) {
     warnAboutIrrelevantJavaTypes(annoTrees, typeTree);
+    checkTargetLocations(
+        annoTrees != null ? annoTrees : ((AnnotatedTypeTree) typeTree).getAnnotations());
+  }
+
+  /** Checks that explicitly written qualifiers are permitted at their type-use location. */
+  private void checkTargetLocations(List<? extends AnnotationTree> annoTrees) {
+    TypeUseLocation location = currentTypeUseLocation();
+    if (location == null) {
+      return;
+    }
+    for (AnnotationTree annoTree : annoTrees) {
+      AnnotationMirror anno = TreeUtils.annotationFromAnnotationTree(annoTree);
+      if (!atypeFactory.isSupportedQualifier(anno)) {
+        continue;
+      }
+      TargetLocations targets =
+          anno.getAnnotationType().asElement().getAnnotation(TargetLocations.class);
+      if (targets != null && !targetLocationsContain(targets.value(), location)) {
+        checker.reportError(annoTree, "type.annotations.on.location", anno, location);
+      }
+    }
+  }
+
+  /** Returns true if {@code targets} permits {@code location}. */
+  private static boolean targetLocationsContain(
+      TypeUseLocation[] targets, TypeUseLocation location) {
+    for (TypeUseLocation target : targets) {
+      if (target == TypeUseLocation.ALL
+          || target == location
+          || (target == TypeUseLocation.LOWER_BOUND
+              && (location == TypeUseLocation.EXPLICIT_LOWER_BOUND
+                  || location == TypeUseLocation.IMPLICIT_LOWER_BOUND))
+          || (target == TypeUseLocation.UPPER_BOUND
+              && (location == TypeUseLocation.EXPLICIT_UPPER_BOUND
+                  || location == TypeUseLocation.IMPLICIT_UPPER_BOUND))) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Returns the type-use location containing the tree currently being visited. */
+  private @Nullable TypeUseLocation currentTypeUseLocation() {
+    for (TreePath path = getCurrentPath(); path != null; path = path.getParentPath()) {
+      Tree tree = path.getLeaf();
+      if (tree instanceof NewClassTree || tree instanceof NewArrayTree) {
+        // TypeUseLocation has no constant for an object or array creation expression.
+        return null;
+      }
+      TypeUseLocation location =
+          switch (tree.getKind()) {
+            case EXTENDS_WILDCARD -> TypeUseLocation.EXPLICIT_UPPER_BOUND;
+            case SUPER_WILDCARD -> TypeUseLocation.EXPLICIT_LOWER_BOUND;
+            case TYPE_PARAMETER -> TypeUseLocation.EXPLICIT_UPPER_BOUND;
+            case METHOD -> TypeUseLocation.RETURN;
+            case VARIABLE -> {
+              ElementKind kind = TreeUtils.elementFromDeclaration((VariableTree) tree).getKind();
+              yield switch (kind) {
+                case FIELD -> TypeUseLocation.FIELD;
+                case LOCAL_VARIABLE -> TypeUseLocation.LOCAL_VARIABLE;
+                case RESOURCE_VARIABLE -> TypeUseLocation.RESOURCE_VARIABLE;
+                case EXCEPTION_PARAMETER -> TypeUseLocation.EXCEPTION_PARAMETER;
+                case PARAMETER -> TypeUseLocation.PARAMETER;
+                default -> null;
+              };
+            }
+            default -> null;
+          };
+      if (location != null) {
+        return location;
+      }
+    }
+    return null;
   }
 
   /**

--- a/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
+++ b/framework/src/main/java/org/checkerframework/common/basetype/messages.properties
@@ -118,6 +118,7 @@ field.invariant.not.found.superclass=the field invariant annotation is missing f
 field.invariant.not.subtype.superclass=the qualifier for field %s is not a subtype of the qualifier in the superclass field invariant%nfound: %s%nsuperclass type: %s
 
 invalid.annotation.location.bytecode=found annotation in unexpected location in bytecode on element: %s %nUse -AignoreInvalidAnnotationLocations to suppress this warning
+type.annotations.on.location=annotation %s is not permitted at type-use location %s
 instanceof.unsafe='%s' instanceof '%s' cannot be statically verified.
 instanceof.pattern.unsafe=instanceof pattern binding '%s' to '%s' cannot be statically verified.
 

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
@@ -14,6 +14,7 @@ import org.checkerframework.framework.testchecker.h1h2checker.quals.H1S1;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H1S2;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H1Top;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Bot;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnLB;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Poly;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S1;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S2;
@@ -48,6 +49,7 @@ public class H1H2AnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         H2S1.class,
         H2S2.class,
         H2Bot.class,
+        H2OnlyOnLB.class,
         H1Poly.class,
         H2Poly.class,
         H1Invalid.class);

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
@@ -17,6 +17,7 @@ import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Bot;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnConstructorResult;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnLB;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnReceiver;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnReturn;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Poly;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S1;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S2;
@@ -54,6 +55,7 @@ public class H1H2AnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         H2OnlyOnLB.class,
         H2OnlyOnConstructorResult.class,
         H2OnlyOnReceiver.class,
+        H2OnlyOnReturn.class,
         H1Poly.class,
         H2Poly.class,
         H1Invalid.class);

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/H1H2AnnotatedTypeFactory.java
@@ -14,7 +14,9 @@ import org.checkerframework.framework.testchecker.h1h2checker.quals.H1S1;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H1S2;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H1Top;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Bot;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnConstructorResult;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnLB;
+import org.checkerframework.framework.testchecker.h1h2checker.quals.H2OnlyOnReceiver;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2Poly;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S1;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.H2S2;
@@ -50,6 +52,8 @@ public class H1H2AnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         H2S2.class,
         H2Bot.class,
         H2OnlyOnLB.class,
+        H2OnlyOnConstructorResult.class,
+        H2OnlyOnReceiver.class,
         H1Poly.class,
         H2Poly.class,
         H1Invalid.class);

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2Bot.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2Bot.java
@@ -12,6 +12,6 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({H2S1.class, H2S2.class})
+@SubtypeOf({H2S1.class, H2S2.class, H2OnlyOnLB.class})
 @DefaultFor(TypeUseLocation.LOWER_BOUND)
 public @interface H2Bot {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnConstructorResult.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnConstructorResult.java
@@ -5,19 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({
-  H2S1.class,
-  H2S2.class,
-  H2OnlyOnLB.class,
-  H2OnlyOnConstructorResult.class,
-  H2OnlyOnReceiver.class
-})
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
-public @interface H2Bot {}
+@TargetLocations(TypeUseLocation.CONSTRUCTOR_RESULT)
+@SubtypeOf(H2Top.class)
+public @interface H2OnlyOnConstructorResult {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnReceiver.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnReceiver.java
@@ -5,19 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({
-  H2S1.class,
-  H2S2.class,
-  H2OnlyOnLB.class,
-  H2OnlyOnConstructorResult.class,
-  H2OnlyOnReceiver.class
-})
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
-public @interface H2Bot {}
+@TargetLocations(TypeUseLocation.RECEIVER)
+@SubtypeOf(H2Top.class)
+public @interface H2OnlyOnReceiver {}

--- a/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnReturn.java
+++ b/framework/src/test/java/org/checkerframework/framework/testchecker/h1h2checker/quals/H2OnlyOnReturn.java
@@ -5,20 +5,13 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.checkerframework.framework.qual.DefaultFor;
 import org.checkerframework.framework.qual.SubtypeOf;
+import org.checkerframework.framework.qual.TargetLocations;
 import org.checkerframework.framework.qual.TypeUseLocation;
 
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, ElementType.TYPE_PARAMETER})
-@SubtypeOf({
-  H2S1.class,
-  H2S2.class,
-  H2OnlyOnLB.class,
-  H2OnlyOnConstructorResult.class,
-  H2OnlyOnReceiver.class,
-  H2OnlyOnReturn.class
-})
-@DefaultFor(TypeUseLocation.LOWER_BOUND)
-public @interface H2Bot {}
+@SubtypeOf(H2Top.class)
+@TargetLocations(TypeUseLocation.RETURN)
+public @interface H2OnlyOnReturn {}

--- a/framework/tests/h1h2checker/EnforceTargetLocation.java
+++ b/framework/tests/h1h2checker/EnforceTargetLocation.java
@@ -1,10 +1,8 @@
-// @skip-test until the bug is fixed
-
 import java.util.List;
 import org.checkerframework.framework.testchecker.h1h2checker.quals.*;
 
 // :: error: [type.annotations.on.location]
-public class EnforceTargetLocation<T extends @H2S1 Object> {
+public class EnforceTargetLocation<T extends @H2OnlyOnLB Object> {
   @H2S1 Object right;
 
   // :: error: [type.annotations.on.location]
@@ -17,8 +15,8 @@ public class EnforceTargetLocation<T extends @H2S1 Object> {
     return o;
   }
 
-  @H2OnlyOnLB
   // :: error: [type.annotations.on.location]
+  @H2OnlyOnLB
   Object incorrect() {
     // :: warning: (cast.unsafe.constructor.invocation)
     // :: error: [type.annotations.on.location]

--- a/framework/tests/h1h2checker/EnforceTargetLocation.java
+++ b/framework/tests/h1h2checker/EnforceTargetLocation.java
@@ -42,4 +42,19 @@ public class EnforceTargetLocation<T extends @H2OnlyOnLB Object> {
 
   // :: error: [type.annotations.on.location]
   void ordinaryParameter(@H2OnlyOnReceiver Object p1) {}
+
+  @H2OnlyOnReturn
+  Object returnOnly(Object value) {
+    // :: warning: [cast.unsafe]
+    // :: error: [type.annotations.on.location]
+    Object cast = (@H2OnlyOnReturn Object) value;
+    // :: warning: [instanceof.unsafe]
+    // :: error: [type.annotations.on.location]
+    boolean instanceOf = value instanceof @H2OnlyOnReturn String;
+    // :: error: [type.annotations.on.location]
+    if (value instanceof @H2OnlyOnReturn String pattern) {
+      return pattern;
+    }
+    return cast;
+  }
 }

--- a/framework/tests/h1h2checker/EnforceTargetLocation.java
+++ b/framework/tests/h1h2checker/EnforceTargetLocation.java
@@ -3,6 +3,17 @@ import org.checkerframework.framework.testchecker.h1h2checker.quals.*;
 
 // :: error: [type.annotations.on.location]
 public class EnforceTargetLocation<T extends @H2OnlyOnLB Object> {
+  @H2OnlyOnConstructorResult
+  // :: warning: [inconsistent.constructor.type]
+  // :: error: [super.invocation]
+  EnforceTargetLocation() {}
+
+  // :: error: [type.annotations.on.location]
+  @H2OnlyOnReceiver
+  // :: warning: [inconsistent.constructor.type]
+  // :: error: [super.invocation]
+  EnforceTargetLocation(int ignored) {}
+
   @H2S1 Object right;
 
   // :: error: [type.annotations.on.location]
@@ -26,4 +37,9 @@ public class EnforceTargetLocation<T extends @H2OnlyOnLB Object> {
 
   // :: error: [type.annotations.on.location]
   void incorrectUse2(@H2OnlyOnLB Object p1) {}
+
+  void receiver(@H2OnlyOnReceiver EnforceTargetLocation<T> this) {}
+
+  // :: error: [type.annotations.on.location]
+  void ordinaryParameter(@H2OnlyOnReceiver Object p1) {}
 }


### PR DESCRIPTION
## Summary

- I enforce `@TargetLocations` for explicitly written supported qualifiers.
- I map declaration and bound syntax to the corresponding `TypeUseLocation`, including aggregate upper/lower-bound targets.
- I enabled and updated the existing H1/H2 regression test and documented the behavior change.

## Validation

- `./gradlew --no-daemon :framework:test --tests org.checkerframework.framework.test.junit.H1H2CheckerTest`
- `./gradlew --no-daemon spotlessCheck`
- `git diff --check origin/master...HEAD`

I did not run the full test suite locally; CI can exercise the complete matrix.

Fixes #8042
