### PR TITLE
Fix `updateContracts` diagnostic to match the method signature

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -412,8 +412,8 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
 
     if (store == null) {
       throw new BugInCF(
-          "updateContracts(%s, %s, null) for %s",
-          preOrPost, methodElt, atypeFactory.getClass().getSimpleName());
+          "updateContracts(%s, %s, %s, null) for %s",
+          className, preOrPost, methodElt, atypeFactory.getClass().getSimpleName());
     }
 
     if (!storage.hasStorageLocationForMethod(methodElt)) {


### PR DESCRIPTION
The `BugInCF` message rendered a three-argument call and omitted `className`, so the diagnostic could not be matched against the actual call.