### PR TITLE
Remove redundant emptiness check in `getPurityAnnotation`

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -897,9 +897,6 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
    */
   private @Nullable AnnotationMirror getPurityAnnotation(ExecutableElement methodElt) {
     AnnotationMirrorSet declAnnos = storage.getMethodDeclarationAnnotations(methodElt);
-    if (declAnnos.isEmpty()) {
-      return null;
-    }
     for (AnnotationMirror declAnno : declAnnos) {
       if (isPurityAnno(declAnno)) {
         return declAnno;


### PR DESCRIPTION
The subsequent loop already returns null for an empty set.